### PR TITLE
Refactor safety checks and remove override functionality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,9 +169,6 @@ if err != nil {
 if err := checker.CheckError(safety.OperationXXX, safety.OwnershipUnknown); err != nil {
     return err
 }
-if checker.IsOverridden() {
-    fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationXXX))
-}
 
 // Now proceed with operation...
 c, err := NewClientFromConfig(cfg)
@@ -219,11 +216,9 @@ Before submitting code with a new/modified command:
 - [ ] Added `safety` package import
 - [ ] Safety check placed after `LoadConfig()` and before operations
 - [ ] Correct `Operation` type chosen
-- [ ] Override warning shown if `checker.IsOverridden()`
 - [ ] Code compiles: `go build .`
 - [ ] Tests pass: `go test ./pkg/safety/...`
 - [ ] Manually tested with `readonly` context (should block)
-- [ ] Manually tested with `--override-safety` (should warn)
 
 ### Examples
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -106,9 +106,6 @@ that contains the dashboard ID. The 'create' command always creates new resource
 			if err := checker.CheckError(safety.OperationUpdate, safety.OwnershipUnknown); err != nil {
 				return err
 			}
-			if checker.IsOverridden() {
-				fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationUpdate))
-			}
 		}
 
 		c, err := NewClientFromConfig(cfg)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -98,9 +98,6 @@ Examples:
 		if err := checker.CheckError(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
 			return err
 		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationCreate))
-		}
 
 		c, err := NewClientFromConfig(cfg)
 		if err != nil {
@@ -295,9 +292,6 @@ func createDocumentRunE(docType string) func(cmd *cobra.Command, args []string) 
 		}
 		if err := checker.CheckError(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationCreate))
 		}
 
 		c, err := NewClientFromConfig(cfg)
@@ -539,9 +533,6 @@ Examples:
 		if err := checker.CheckError(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
 			return err
 		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationCreate))
-		}
 
 		c, err := NewClientFromConfig(cfg)
 		if err != nil {
@@ -692,9 +683,6 @@ Examples:
 		if err := checker.CheckError(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
 			return err
 		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationCreate))
-		}
 
 		c, err := NewClientFromConfig(cfg)
 		if err != nil {
@@ -801,9 +789,6 @@ Examples:
 		if err := checker.CheckError(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
 			return err
 		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationCreate))
-		}
 
 		c, err := NewClientFromConfig(cfg)
 		if err != nil {
@@ -901,9 +886,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationCreate))
 		}
 
 		c, err := NewClientFromConfig(cfg)
@@ -1014,9 +996,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationCreate))
 		}
 
 		c, err := NewClientFromConfig(cfg)

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -86,9 +86,6 @@ Examples:
 		if err := checker.CheckError(safety.OperationUpdate, ownership); err != nil {
 			return err
 		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationUpdate))
-		}
 
 		// Get the workflow as raw JSON
 		data, err := handler.GetRaw(workflowID)
@@ -248,9 +245,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationUpdate, ownership); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationUpdate))
 		}
 
 		// Get format preference
@@ -412,9 +406,6 @@ Examples:
 		if err := checker.CheckError(safety.OperationUpdate, ownership); err != nil {
 			return err
 		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationUpdate))
-		}
 
 		// Get format preference
 		editFormat, _ := cmd.Flags().GetString("format")
@@ -556,9 +547,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationUpdate, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationUpdate))
 		}
 
 		c, err := NewClientFromConfig(cfg)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/dynatrace-oss/dtctl/pkg/prompt"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/analyzer"
@@ -361,9 +360,6 @@ Examples:
 		if err := checker.CheckError(safety.OperationDelete, safety.OwnershipUnknown); err != nil {
 			return err
 		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationDelete))
-		}
 
 		c, err := NewClientFromConfig(cfg)
 		if err != nil {
@@ -436,9 +432,6 @@ Examples:
 		if err := checker.CheckError(safety.OperationDelete, safety.OwnershipUnknown); err != nil {
 			return err
 		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationDelete))
-		}
 
 		c, err := NewClientFromConfig(cfg)
 		if err != nil {
@@ -510,9 +503,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationDelete, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationDelete))
 		}
 
 		c, err := NewClientFromConfig(cfg)
@@ -748,9 +738,6 @@ Examples:
 		if err := checker.CheckError(safety.OperationDelete, safety.OwnershipUnknown); err != nil {
 			return err
 		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationDelete))
-		}
 
 		c, err := NewClientFromConfig(cfg)
 		if err != nil {
@@ -811,9 +798,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationDelete, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationDelete))
 		}
 
 		c, err := NewClientFromConfig(cfg)
@@ -1247,9 +1231,6 @@ Examples:
 		if err := checker.CheckError(safety.OperationDelete, safety.OwnershipUnknown); err != nil {
 			return err
 		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationDelete))
-		}
 
 		c, err := NewClientFromConfig(cfg)
 		if err != nil {
@@ -1311,9 +1292,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationDelete, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationDelete))
 		}
 
 		c, err := NewClientFromConfig(cfg)
@@ -1381,9 +1359,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationDeleteBucket, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationDeleteBucket))
 		}
 
 		c, err := NewClientFromConfig(cfg)
@@ -1456,9 +1431,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationDelete, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationDelete))
 		}
 
 		c, err := NewClientFromConfig(cfg)
@@ -1533,9 +1505,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationDelete, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationDelete))
 		}
 
 		c, err := NewClientFromConfig(cfg)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/dynatrace-oss/dtctl/pkg/prompt"
@@ -60,9 +59,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationUpdate, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationUpdate))
 		}
 
 		c, err := NewClientFromConfig(cfg)
@@ -148,9 +144,6 @@ Examples:
 		if err := checker.CheckError(safety.OperationUpdate, safety.OwnershipUnknown); err != nil {
 			return err
 		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationUpdate))
-		}
 
 		c, err := NewClientFromConfig(cfg)
 		if err != nil {
@@ -234,9 +227,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationUpdate, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationUpdate))
 		}
 
 		c, err := NewClientFromConfig(cfg)

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/document"
@@ -86,9 +85,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationUpdate, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationUpdate))
 		}
 
 		c, err := NewClientFromConfig(cfg)
@@ -199,9 +195,6 @@ Examples:
 		}
 		if err := checker.CheckError(safety.OperationUpdate, safety.OwnershipUnknown); err != nil {
 			return err
-		}
-		if checker.IsOverridden() {
-			fmt.Fprintln(os.Stderr, "⚠️ ", checker.OverrideWarning(safety.OperationUpdate))
 		}
 
 		c, err := NewClientFromConfig(cfg)

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -105,6 +105,39 @@ Use a different context without switching:
 dtctl get workflows --context prod
 ```
 
+### Per-Project Configuration
+
+dtctl supports per-project configuration files. Create a `.dtctl.yaml` file in your project directory:
+
+```yaml
+# .dtctl.yaml - per-project configuration
+apiVersion: v1
+kind: Config
+current-context: project-env
+contexts:
+  - name: project-env
+    context:
+      environment: https://project.apps.dynatrace.com
+      token-ref: project-token
+      safety-level: readwrite-all
+```
+
+**Search Order:**
+1. `--config` flag (explicit path)
+2. `.dtctl.yaml` in current directory or any parent directory (walks up to root)
+3. Global config (`~/.config/dtctl/config`)
+
+This allows teams to commit `.dtctl.yaml` files to repositories (without tokens!) and have dtctl automatically use the correct environment settings.
+
+```bash
+# In a project directory with .dtctl.yaml
+cd my-project/
+dtctl get workflows  # Uses .dtctl.yaml automatically
+
+# Override with global config
+dtctl --config ~/.config/dtctl/config get workflows
+```
+
 ### Safety Levels
 
 Safety levels provide **client-side** protection against accidental destructive operations:
@@ -125,9 +158,6 @@ dtctl config set-context prod \
 
 # View context details including safety level
 dtctl config describe-context prod
-
-# Bypass safety for a single operation (use with caution)
-dtctl delete dashboard old-dash --override-safety
 ```
 
 > **Important**: Safety levels are client-side only. For actual security, configure your API tokens with minimum required scopes. See [Token Scopes](TOKEN_SCOPES.md) for scope requirements and [Context Safety Levels](dev/context-safety-levels.md) for details.

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -961,10 +961,6 @@ dtctl config set-context dev \
 # View context details including safety level
 dtctl config describe-context prod-viewer
 
-# Bypass safety for a single operation (use with caution)
-dtctl delete bucket temp-data --override-safety --confirm=temp-data
-```
-
 See [Context Safety Levels](context-safety-levels.md) for detailed documentation.
 
 ### Context Management Commands

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -16,7 +16,7 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] Context safety levels (readonly, readwrite-mine, readwrite-all, dangerously-unrestricted)
 - [x] HTTP client with retry, rate limiting, error handling
 - [x] Output formatters: JSON, YAML, table, wide, CSV, chart, sparkline, barchart
-- [x] Global flags: `--context`, `--output`, `--verbose`, `--dry-run`, `--chunk-size`, `--show-diff`, `--override-safety`
+- [x] Global flags: `--context`, `--output`, `--verbose`, `--dry-run`, `--chunk-size`, `--show-diff`
 - [x] Shell completion (bash, zsh, fish)
 - [x] Automatic pagination with `--chunk-size` (default 500)
 - [x] User identity: `dtctl auth whoami` (via metadata API with JWT fallback)

--- a/docs/dev/context-safety-levels.md
+++ b/docs/dev/context-safety-levels.md
@@ -8,7 +8,7 @@ Context safety levels provide **client-side** protection against accidental dest
 
 > **Important: Client-Side Only**
 >
-> Safety levels are enforced by dtctl on your local machine. They are a convenience feature to prevent accidental mistakes, **not a security boundary**. A determined user can bypass them with `--override-safety` or by using the API directly.
+> Safety levels are enforced by dtctl on your local machine. They are a convenience feature to prevent accidental mistakes, **not a security boundary**. A determined user can bypass them by using the API directly.
 >
 > **For actual security, use proper API token scopes.** Configure your Dynatrace API tokens with the minimum required permissions. See [TOKEN_SCOPES.md](../TOKEN_SCOPES.md) for:
 > - Complete scope lists for each safety level (copy-pasteable)
@@ -187,27 +187,6 @@ dtctl delete bucket test-bucket --confirm=test-bucket
 dtctl delete dashboard any-dashboard -y
 ```
 
-## Bypass Mechanisms
-
-### --override-safety Flag
-
-Bypass safety level checks for a single operation:
-
-```bash
-dtctl delete bucket logs-bucket --override-safety --confirm=logs-bucket
-# ⚠️  Safety check bypassed: bucket deletion requires 'dangerously-unrestricted' level
-# Type the bucket name 'logs-bucket' to confirm: logs-bucket
-```
-
-**Use Cases**:
-- Emergency operations
-- Exceptional circumstances
-- When you know what you're doing
-
-**Behavior**:
-- Prints a warning showing what safety was bypassed
-- Still requires normal confirmation (typing name for buckets, -y for others)
-
 ## Context Management Commands
 
 ```bash
@@ -254,13 +233,12 @@ Operation Requested
 Clear, actionable error messages:
 
 ```
-❌ Operation not allowed:
+Operation not allowed:
    Context: production (readwrite-all)
    Reason: Bucket deletion requires 'dangerously-unrestricted' safety level
 
 Suggestions:
   • Switch to a dangerously-unrestricted context
-  • Use --override-safety (if you have permission)
   • Contact your administrator
 ```
 


### PR DESCRIPTION
## Summary

This PR refactors the safety check system and removes the override functionality in favor of project-specific `.dtctl.yaml` configuration files and a new `--config` flag.

### Key Changes

- **Removed override functionality**: Eliminated the ability to override safety checks via flags from individual commands (apply, create, edit, delete, restore, share)
- **Added project-specific config support**: Introduced `.dtctl.yaml` files that can be placed in project directories to define context configurations
- **Added `--config` global flag**: Users can now specify custom config files via the `--config` flag
- **Simplified safety check logic**: Removed complex override logic and associated tests
- **Updated documentation**: Updated QUICK_START.md, context-safety-levels.md, API_DESIGN.md, and AGENTS.md to reflect new patterns

### Files Changed

- `cmd/apply.go`, `cmd/create.go`, `cmd/edit.go`, `cmd/get.go`, `cmd/restore.go`, `cmd/share.go`: Removed override flags and logic
- `cmd/root.go`: Added `--config` global flag
- `cmd/safety_test.go`: Removed override-related tests
- `pkg/config/config.go`: Added support for finding and loading local `.dtctl.yaml` files
- `pkg/config/config_test.go`: Added tests for local config discovery
- `pkg/safety/checker.go`: Removed override logic
- `pkg/safety/checker_test.go`: Removed override tests
- Documentation files: Updated to reflect new configuration approach

### Benefits

- Cleaner, more maintainable codebase
- Better separation of concerns (config vs. runtime safety)
- More flexible configuration via project-specific config files
- Reduced complexity in command implementations

### Testing

- All unit tests pass
- Build completes successfully
- Safety checks continue to work as expected with new configuration approach