### PR TITLE
fix: readwrite-mine safety level now works for edit and apply commands

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -234,9 +234,16 @@ Examples:
 			return err
 		}
 
+		// Get metadata separately for ownership check - the multipart response
+		// from Get() may not include the owner field
+		metadata, err := handler.GetMetadata(dashboardID)
+		if err != nil {
+			return err
+		}
+
 		// Determine ownership for safety check
 		currentUserID, _ := c.CurrentUserID() // Ignore error - will be empty string
-		ownership := safety.DetermineOwnership(doc.Owner, currentUserID)
+		ownership := safety.DetermineOwnership(metadata.Owner, currentUserID)
 
 		// Safety check with actual ownership
 		checker, err := NewSafetyChecker(cfg)
@@ -327,8 +334,9 @@ Examples:
 			return nil
 		}
 
-		// Get current metadata for version (optimistic locking)
-		metadata, err := handler.GetMetadata(dashboardID)
+		// Re-fetch metadata for version (optimistic locking) - the document may have been
+		// modified since we fetched it for the ownership check
+		metadata, err = handler.GetMetadata(dashboardID)
 		if err != nil {
 			return err
 		}
@@ -394,9 +402,16 @@ Examples:
 			return err
 		}
 
+		// Get metadata separately for ownership check - the multipart response
+		// from Get() may not include the owner field
+		metadata, err := handler.GetMetadata(notebookID)
+		if err != nil {
+			return err
+		}
+
 		// Determine ownership for safety check
 		currentUserID, _ := c.CurrentUserID() // Ignore error - will be empty string
-		ownership := safety.DetermineOwnership(doc.Owner, currentUserID)
+		ownership := safety.DetermineOwnership(metadata.Owner, currentUserID)
 
 		// Safety check with actual ownership
 		checker, err := NewSafetyChecker(cfg)
@@ -487,8 +502,9 @@ Examples:
 			return nil
 		}
 
-		// Get current metadata for version (optimistic locking)
-		metadata, err := handler.GetMetadata(notebookID)
+		// Re-fetch metadata for version (optimistic locking) - the document may have been
+		// modified since we fetched it for the ownership check
+		metadata, err = handler.GetMetadata(notebookID)
 		if err != nil {
 			return err
 		}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	version = "0.7.0"
+	version = "0.7.1"
 	commit  = "unknown"
 	date    = "unknown"
 )


### PR DESCRIPTION
## Problem

The `readwrite-mine` safety level was completely broken for `edit` and `apply` commands - they would always fail with permission errors, even when editing/applying your own resources.

This is a critical bug that makes the `readwrite-mine` safety level unusable in practice.

## Root Causes

### 1. Edit commands (`cmd/edit.go`)
- Used `Get()` which returns a multipart response
- The multipart response does **not** include the `owner` field
- This caused `DetermineOwnership()` to always return `OwnershipUnknown`
- `readwrite-mine` blocks updates with `OwnershipUnknown`
- Result: **All edit operations failed**

### 2. Apply command (`cmd/apply.go`)
- Performed safety check **before** knowing if operation was create or update
- Always used `OwnershipUnknown` for the check
- `readwrite-mine` blocks updates with `OwnershipUnknown`
- Result: **All apply operations that update existing resources failed**

## Solution

### Edit Commands
- Now call `GetMetadata()` separately to get the owner field
- Pass actual ownership to safety checker
- Updates to own resources are allowed

### Apply Command
- Removed premature safety check from `cmd/apply.go`
- Moved safety checks **into** the applier methods where we know:
  - Whether it's a create or update operation
  - The actual resource owner (from metadata)
- Creates use `OwnershipUnknown` (allowed in `readwrite-mine`)
- Updates determine ownership from metadata and only proceed if owned by user

## Testing

Added comprehensive regression tests in `pkg/apply/applier_test.go`:
- `TestApplierSafetyCheckMethods`: Tests ownership determination logic
- `TestApplierOwnershipDeterminationRegression`: Documents the bug scenario and verifies the fix

All existing tests pass.

## Changes

- `cmd/edit.go`: Use `GetMetadata()` for ownership checks
- `cmd/apply.go`: Remove premature safety check, pass checker to applier
- `cmd/version.go`: Bump to 0.7.1
- `pkg/apply/applier.go`: Add proper safety checking with ownership determination
- `pkg/apply/applier_test.go`: Add regression tests

## Fixes

Closes #[issue-number] (if there's an issue)
