### PR TITLE
fix: include proper version in User-Agent header

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,9 +19,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/dynatrace-oss/dtctl/cmd.version={{.Version}}
-      - -X github.com/dynatrace-oss/dtctl/cmd.commit={{.ShortCommit}}
-      - -X github.com/dynatrace-oss/dtctl/cmd.date={{.Date}}
+      - -X github.com/dynatrace-oss/dtctl/pkg/version.Version={{.Version}}
+      - -X github.com/dynatrace-oss/dtctl/pkg/version.Commit={{.ShortCommit}}
+      - -X github.com/dynatrace-oss/dtctl/pkg/version.Date={{.Date}}
 
 archives:
   - format: tar.gz

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,13 +3,8 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/dynatrace-oss/dtctl/pkg/version"
 	"github.com/spf13/cobra"
-)
-
-var (
-	version = "0.7.3"
-	commit  = "unknown"
-	date    = "unknown"
 )
 
 // versionCmd represents the version command
@@ -18,9 +13,9 @@ var versionCmd = &cobra.Command{
 	Short: "Print version information",
 	Long:  `Print the version, commit, and build date of dtctl.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("dtctl version %s\n", version)
-		fmt.Printf("commit: %s\n", commit)
-		fmt.Printf("built: %s\n", date)
+		fmt.Printf("dtctl version %s\n", version.Version)
+		fmt.Printf("commit: %s\n", version.Commit)
+		fmt.Printf("built: %s\n", version.Date)
 	},
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/version"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 )
@@ -59,7 +60,7 @@ func New(baseURL, token string) (*Client, error) {
 		SetRetryMaxWaitTime(10*time.Second).
 		AddRetryCondition(isRetryable).
 		SetTimeout(6*time.Minute). // Allow for long-running Grail queries (up to 5 min)
-		SetHeader("User-Agent", "dtctl/dev")
+		SetHeader("User-Agent", fmt.Sprintf("dtctl/%s", version.Version))
 
 	return &Client{
 		http:    httpClient,

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2,10 +2,13 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/dynatrace-oss/dtctl/pkg/version"
 )
 
 func TestNew(t *testing.T) {
@@ -340,7 +343,8 @@ func TestClient_UserAgent(t *testing.T) {
 		t.Fatalf("Request failed: %v", err)
 	}
 
-	if receivedUA != "dtctl/dev" {
-		t.Errorf("User-Agent = %v, want dtctl/dev", receivedUA)
+	expectedUA := fmt.Sprintf("dtctl/%s", version.Version)
+	if receivedUA != expectedUA {
+		t.Errorf("User-Agent = %v, want %v", receivedUA, expectedUA)
 	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+// Version is the current version of dtctl
+// This can be overridden at build time with -ldflags
+var Version = "0.7.3"
+
+// Commit is the git commit hash (set at build time)
+var Commit = "unknown"
+
+// Date is the build date (set at build time)
+var Date = "unknown"


### PR DESCRIPTION
## Summary

- Updates User-Agent header to include actual version number instead of hardcoded "dev"
- Creates new `pkg/version` package to centralize version information and avoid import cycles
- Updates build configuration to inject version at build time

## Changes

### Before
- User-Agent: `dtctl/dev`

### After  
- User-Agent: `dtctl/0.7.3` (or whatever version is set at build time)

## Technical Details

1. **New version package** (`pkg/version/version.go`):
   - Centralized version information to avoid import cycles
   - Exported `Version`, `Commit`, and `Date` variables that can be set at build time

2. **Updated HTTP client** (`pkg/client/client.go`):
   - Changed from hardcoded `"dtctl/dev"` to `fmt.Sprintf("dtctl/%s", version.Version)`

3. **Updated build configuration** (`.goreleaser.yaml`):
   - Updated ldflags to inject version info into `pkg/version` instead of `cmd`

4. **Updated tests**:
   - Tests now verify proper version format in User-Agent header

## Testing

✅ All existing tests pass  
✅ User-Agent header verified: `dtctl/0.7.3`  
✅ Build-time version injection works correctly  
✅ No import cycles or compilation errors

This makes it easier to track client versions in server logs and analytics.