### PR TITLE
Adding scope email:emails:send

### DIFF
--- a/docs/TOKEN_SCOPES.md
+++ b/docs/TOKEN_SCOPES.md
@@ -53,7 +53,8 @@ iam:groups:read,
 notifications:read,
 vulnerabilities:read,
 davis:analyzers:read,
-app-engine:apps:run
+app-engine:apps:run,
+email:emails:send
 ```
 
 ### `readwrite-mine`
@@ -90,7 +91,8 @@ davis:analyzers:read,
 davis:analyzers:execute,
 davis-copilot:conversations:execute,
 app-engine:apps:run,
-app-engine:functions:run
+app-engine:functions:run,
+email:emails:send
 ```
 
 ### `readwrite-all`
@@ -148,7 +150,8 @@ app-engine:apps:run,
 app-engine:apps:delete,
 app-engine:functions:run,
 app-engine:edge-connects:read,
-app-engine:edge-connects:write
+app-engine:edge-connects:write,
+email:emails:send
 ```
 
 ### `dangerously-unrestricted`
@@ -218,7 +221,8 @@ app-engine:apps:run,
 app-engine:apps:delete,
 app-engine:functions:run,
 app-engine:edge-connects:read,
-app-engine:edge-connects:write
+app-engine:edge-connects:write,
+email:emails:send
 ```
 
 ---


### PR DESCRIPTION
## Description

* While trying to execute send-email function of app dynatrace.email, I was lacking the scope. This is missing in the TOKEN_SCOPES.md as well. I added it to all. Feel free to adapt.

<!-- How did you test this? -->

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
