### PR TITLE
Fix `make install` with empty $GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Compatible with GitHub Copilot, Claude Code, and other Agent Skills tools.
 # Or build from source:
 # git clone https://github.com/dynatrace-oss/dtctl.git && cd dtctl
 # make build && make install
+# If `dtctl` is not found afterwards, add Go bin to PATH:
+# export PATH="$PATH:$(go env GOPATH)/bin"
 
 # Configure your environment
 dtctl config set-context my-env \

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -109,6 +109,11 @@ dtctl version
 
 This installs to `$GOPATH/bin/dtctl` (typically `~/go/bin/dtctl`). Ensure `$GOPATH/bin` is in your `$PATH`.
 
+```bash
+# Add Go bin to PATH (zsh/bash)
+export PATH="$PATH:$(go env GOPATH)/bin"
+```
+
 ### Option 3: Copy to System PATH
 
 Install system-wide:

--- a/makefile
+++ b/makefile
@@ -8,6 +8,7 @@ DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 COVERAGE_THRESHOLD ?= 60
 
 LDFLAGS = -ldflags "-X github.com/dynatrace-oss/dtctl/cmd.version=$(VERSION) -X github.com/dynatrace-oss/dtctl/cmd.commit=$(COMMIT) -X github.com/dynatrace-oss/dtctl/cmd.date=$(DATE) -s -w"
+INSTALL_BIN_DIR ?= $(if $(GOBIN),$(GOBIN),$(shell go env GOPATH)/bin)
 
 MD_LINT_CLI_IMAGE := "ghcr.io/igorshubovych/markdownlint-cli:v0.31.1"
 
@@ -91,8 +92,15 @@ test-coverage:
 
 # Install locally
 install:
-	@echo "Installing dtctl..."
-	@go install $(LDFLAGS) .
+	@echo "Installing dtctl to $(INSTALL_BIN_DIR)..."
+	@mkdir -p "$(INSTALL_BIN_DIR)"
+	@go build $(LDFLAGS) -o "$(INSTALL_BIN_DIR)/dtctl" .
+	@if case ":$$PATH:" in *":$(INSTALL_BIN_DIR):"*) false;; *) true;; esac; then \
+		echo ""; \
+		echo "dtctl installed, but $(INSTALL_BIN_DIR) is not in PATH."; \
+		echo "Add it with:"; \
+		echo '  export PATH="$$PATH:$(INSTALL_BIN_DIR)"'; \
+	fi
 
 # Clean build artifacts
 clean:


### PR DESCRIPTION
`$GOPATH` was empty for me with a fresh go installation (on Mac using `brew`). This adapts ``make install`` and instructions to handle that case.