### PR TITLE
feat: structured output for dtctl apply command

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -61,6 +61,15 @@ Examples:
   # See what changed when updating
   dtctl apply -f dashboard.yaml --show-diff
 
+  # Apply and get JSON output (for scripting/CI)
+  dtctl apply -f dashboard.yaml -o json
+
+  # Apply and get YAML output
+  dtctl apply -f workflow.yaml -o yaml
+
+  # Apply with wide table (includes URL for dashboards/notebooks)
+  dtctl apply -f notebook.yaml -o wide
+
 Note: To update a dashboard via command line, use the apply command with a file
 that contains the dashboard ID. The 'create' command always creates new resources.
 `,
@@ -118,7 +127,21 @@ that contains the dashboard ID. The 'create' command always creates new resource
 			ShowDiff:     showDiff,
 		}
 
-		return applier.Apply(fileData, opts)
+		result, err := applier.Apply(fileData, opts)
+		if err != nil {
+			return err
+		}
+
+		// dry-run returns nil result (output handled internally on stderr)
+		if result == nil {
+			return nil
+		}
+
+		// Print structured output using the global -o flag
+		// The concrete type (DashboardApplyResult, WorkflowApplyResult, etc.)
+		// determines which columns/fields appear in the output.
+		printer := NewPrinter()
+		return printer.Print(result)
 	},
 }
 

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -27,6 +27,15 @@ import (
 // uuidRegex matches UUID-formatted strings (the Documents API rejects these for ID during creation)
 var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
+// stderrWarn writes a note to stderr and appends it to the warnings slice.
+func stderrWarn(warnings *[]string, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	fmt.Fprintf(os.Stderr, "Note: %s\n", msg)
+	if warnings != nil {
+		*warnings = append(*warnings, msg)
+	}
+}
+
 // isUUID checks if a string is a UUID format
 func isUUID(s string) bool {
 	return uuidRegex.MatchString(s)
@@ -95,18 +104,18 @@ const (
 )
 
 // Apply applies a resource configuration from file
-func (a *Applier) Apply(fileData []byte, opts ApplyOptions) error {
+func (a *Applier) Apply(fileData []byte, opts ApplyOptions) (ApplyResult, error) {
 	// Convert to JSON if needed
 	jsonData, err := format.ValidateAndConvert(fileData)
 	if err != nil {
-		return fmt.Errorf("invalid file format: %w", err)
+		return nil, fmt.Errorf("invalid file format: %w", err)
 	}
 
 	// Apply template rendering if variables provided
 	if len(opts.TemplateVars) > 0 {
 		rendered, err := template.RenderTemplate(string(jsonData), opts.TemplateVars)
 		if err != nil {
-			return fmt.Errorf("template rendering failed: %w", err)
+			return nil, fmt.Errorf("template rendering failed: %w", err)
 		}
 		jsonData = []byte(rendered)
 	}
@@ -114,11 +123,11 @@ func (a *Applier) Apply(fileData []byte, opts ApplyOptions) error {
 	// Detect resource type
 	resourceType, err := detectResourceType(jsonData)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if opts.DryRun {
-		return a.dryRun(resourceType, jsonData)
+		return nil, a.dryRun(resourceType, jsonData)
 	}
 
 	// Apply based on resource type
@@ -144,7 +153,7 @@ func (a *Applier) Apply(fileData []byte, opts ApplyOptions) error {
 	case ResourceGCPMonitoringConfig:
 		return a.applyGCPMonitoringConfig(jsonData)
 	default:
-		return fmt.Errorf("unsupported resource type: %s", resourceType)
+		return nil, fmt.Errorf("unsupported resource type: %s", resourceType)
 	}
 }
 
@@ -299,11 +308,11 @@ func detectResourceType(data []byte) (ResourceType, error) {
 }
 
 // applyWorkflow applies a workflow resource
-func (a *Applier) applyWorkflow(data []byte) error {
+func (a *Applier) applyWorkflow(data []byte) (ApplyResult, error) {
 	// Parse to check for ID
 	var wf map[string]interface{}
 	if err := json.Unmarshal(data, &wf); err != nil {
-		return fmt.Errorf("failed to parse workflow JSON: %w", err)
+		return nil, fmt.Errorf("failed to parse workflow JSON: %w", err)
 	}
 
 	handler := workflow.NewHandler(a.client)
@@ -313,15 +322,21 @@ func (a *Applier) applyWorkflow(data []byte) error {
 		// Create new workflow
 		// Safety check for create operation
 		if err := a.checkSafety(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
-			return err
+			return nil, err
 		}
 
 		result, err := handler.Create(data)
 		if err != nil {
-			return fmt.Errorf("failed to create workflow: %w", err)
+			return nil, fmt.Errorf("failed to create workflow: %w", err)
 		}
-		fmt.Printf("Workflow %q (%s) created successfully\n", result.Title, result.ID)
-		return nil
+		return &WorkflowApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       ActionCreated,
+				ResourceType: "workflow",
+				ID:           result.ID,
+				Name:         result.Title,
+			},
+		}, nil
 	}
 
 	// Check if workflow exists
@@ -330,47 +345,60 @@ func (a *Applier) applyWorkflow(data []byte) error {
 		// Workflow doesn't exist, create it
 		// Safety check for create operation
 		if err := a.checkSafety(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
-			return err
+			return nil, err
 		}
 
 		result, err := handler.Create(data)
 		if err != nil {
-			return fmt.Errorf("failed to create workflow: %w", err)
+			return nil, fmt.Errorf("failed to create workflow: %w", err)
 		}
-		fmt.Printf("Workflow %q (%s) created successfully\n", result.Title, result.ID)
-		return nil
+		return &WorkflowApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       ActionCreated,
+				ResourceType: "workflow",
+				ID:           result.ID,
+				Name:         result.Title,
+			},
+		}, nil
 	}
 
 	// Safety check for update operation - determine ownership from existing workflow
 	ownership := a.determineOwnership(existing.Owner)
 	if err := a.checkSafety(safety.OperationUpdate, ownership); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Update existing workflow
 	result, err := handler.Update(id, data)
 	if err != nil {
-		return fmt.Errorf("failed to update workflow: %w", err)
+		return nil, fmt.Errorf("failed to update workflow: %w", err)
 	}
 
-	fmt.Printf("Workflow %q (%s) updated successfully\n", result.Title, result.ID)
-	return nil
+	return &WorkflowApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionUpdated,
+			ResourceType: "workflow",
+			ID:           result.ID,
+			Name:         result.Title,
+		},
+	}, nil
 }
 
 // applyDocument applies a document resource (dashboard or notebook)
-func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) error {
+func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) (ApplyResult, error) {
 	// Parse to check for ID and name
 	var doc map[string]interface{}
 	if err := json.Unmarshal(data, &doc); err != nil {
-		return fmt.Errorf("failed to parse %s JSON: %w", docType, err)
+		return nil, fmt.Errorf("failed to parse %s JSON: %w", docType, err)
 	}
 
 	// Extract and validate content - handle round-trippable format from 'get' command
-	contentData, name, description, warnings := extractDocumentContent(doc, docType)
+	contentData, name, description, validationWarnings := extractDocumentContent(doc, docType)
 
-	// Show validation warnings
-	for _, w := range warnings {
-		fmt.Fprintf(os.Stderr, "Warning: %s\n", w)
+	// Show validation warnings on stderr and collect for result
+	var resultWarnings []string
+	for _, w := range validationWarnings {
+		stderrWarn(&resultWarnings, "%s", w)
 	}
 
 	// Count tiles/sections for feedback
@@ -383,7 +411,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 		// No ID provided - create new document
 		// Safety check for create operation
 		if err := a.checkSafety(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
-			return err
+			return nil, err
 		}
 
 		if name == "" {
@@ -397,7 +425,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 			Content:     contentData,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to create %s: %w", docType, err)
+			return nil, fmt.Errorf("failed to create %s: %w", docType, err)
 		}
 
 		// Use name from input if result doesn't have it
@@ -410,15 +438,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 			resultID = "(ID not returned)"
 		}
 
-		fmt.Printf("%s %q (%s) created successfully", capitalize(docType), resultName, resultID)
-		if tileCount > 0 {
-			fmt.Printf(" [%d %s]", tileCount, itemName(docType))
-		}
-		fmt.Println()
-		if result.ID != "" {
-			fmt.Printf("URL: %s\n", a.documentURL(docType, result.ID))
-		}
-		return nil
+		return a.buildDocumentResult(ActionCreated, docType, resultID, resultName, tileCount, resultWarnings), nil
 	}
 
 	// Check if document exists
@@ -427,7 +447,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 		// Document doesn't exist, create it
 		// Safety check for create operation
 		if err := a.checkSafety(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
-			return err
+			return nil, err
 		}
 
 		if name == "" {
@@ -439,7 +459,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 		createID := id
 		if isUUID(id) {
 			createID = ""
-			fmt.Fprintf(os.Stderr, "Note: Creating new %s (UUID IDs cannot be reused across tenants)\n", docType)
+			stderrWarn(&resultWarnings, "Creating new %s (UUID IDs cannot be reused across tenants)", docType)
 		}
 
 		result, err := handler.Create(document.CreateRequest{
@@ -450,7 +470,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 			Content:     contentData,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to create %s: %w", docType, err)
+			return nil, fmt.Errorf("failed to create %s: %w", docType, err)
 		}
 
 		// Use name from input if result doesn't have it
@@ -463,21 +483,13 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 			resultID = id
 		}
 
-		fmt.Printf("%s %q (%s) created successfully", capitalize(docType), resultName, resultID)
-		if tileCount > 0 {
-			fmt.Printf(" [%d %s]", tileCount, itemName(docType))
-		}
-		fmt.Println()
-		if result.ID != "" {
-			fmt.Printf("URL: %s\n", a.documentURL(docType, result.ID))
-		}
-		return nil
+		return a.buildDocumentResult(ActionCreated, docType, resultID, resultName, tileCount, resultWarnings), nil
 	}
 
 	// Safety check for update operation - determine ownership from metadata
 	ownership := a.determineOwnership(metadata.Owner)
 	if err := a.checkSafety(safety.OperationUpdate, ownership); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Show diff if requested
@@ -491,7 +503,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 	// Update the existing document (including metadata if name or description provided)
 	result, err := handler.UpdateWithMetadata(id, metadata.Version, contentData, "application/json", name, description)
 	if err != nil {
-		return fmt.Errorf("failed to apply %s: %w", docType, err)
+		return nil, fmt.Errorf("failed to apply %s: %w", docType, err)
 	}
 
 	// Use name from input/metadata if result doesn't have it
@@ -507,15 +519,35 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 		resultID = id
 	}
 
-	fmt.Printf("%s %q (%s) updated successfully", capitalize(docType), resultName, resultID)
-	if tileCount > 0 {
-		fmt.Printf(" [%d %s]", tileCount, itemName(docType))
+	return a.buildDocumentResult(ActionUpdated, docType, resultID, resultName, tileCount, resultWarnings), nil
+}
+
+// buildDocumentResult constructs the appropriate document result type based on docType
+func (a *Applier) buildDocumentResult(action, docType, id, name string, itemCount int, warnings []string) ApplyResult {
+	if docType == "notebook" {
+		return &NotebookApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       action,
+				ResourceType: "notebook",
+				ID:           id,
+				Name:         name,
+				Warnings:     warnings,
+			},
+			URL:          a.documentURL(docType, id),
+			SectionCount: itemCount,
+		}
 	}
-	fmt.Println()
-	if resultID != "" {
-		fmt.Printf("URL: %s\n", a.documentURL(docType, resultID))
+	return &DashboardApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       action,
+			ResourceType: "dashboard",
+			ID:           id,
+			Name:         name,
+			Warnings:     warnings,
+		},
+		URL:       a.documentURL(docType, id),
+		TileCount: itemCount,
 	}
-	return nil
 }
 
 // extractDocumentContent extracts the content from a document, handling various input formats
@@ -618,7 +650,7 @@ func showJSONDiff(oldData, newData []byte, resourceType string) {
 	oldLines := strings.Split(oldPretty.String(), "\n")
 	newLines := strings.Split(newPretty.String(), "\n")
 
-	fmt.Printf("\n--- existing %s\n+++ new %s\n", resourceType, resourceType)
+	fmt.Fprintf(os.Stderr, "\n--- existing %s\n+++ new %s\n", resourceType, resourceType)
 
 	// Simple line-by-line diff
 	maxLines := len(oldLines)
@@ -638,19 +670,19 @@ func showJSONDiff(oldData, newData []byte, resourceType string) {
 
 		if oldLine != newLine {
 			if oldLine != "" {
-				fmt.Printf("- %s\n", oldLine)
+				fmt.Fprintf(os.Stderr, "- %s\n", oldLine)
 			}
 			if newLine != "" {
-				fmt.Printf("+ %s\n", newLine)
+				fmt.Fprintf(os.Stderr, "+ %s\n", newLine)
 			}
 			changes++
 		}
 	}
 
 	if changes == 0 {
-		fmt.Println("(no changes)")
+		fmt.Fprintln(os.Stderr, "(no changes)")
 	}
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
 }
 
 // documentURL returns the UI URL for a document
@@ -755,11 +787,11 @@ func (a *Applier) dryRunDocument(resourceType ResourceType, doc map[string]inter
 }
 
 // applySLO applies an SLO resource
-func (a *Applier) applySLO(data []byte) error {
+func (a *Applier) applySLO(data []byte) (ApplyResult, error) {
 	// Parse to check for ID
 	var s map[string]interface{}
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("failed to parse SLO JSON: %w", err)
+		return nil, fmt.Errorf("failed to parse SLO JSON: %w", err)
 	}
 
 	handler := slo.NewHandler(a.client)
@@ -769,10 +801,16 @@ func (a *Applier) applySLO(data []byte) error {
 		// Create new SLO
 		result, err := handler.Create(data)
 		if err != nil {
-			return fmt.Errorf("failed to create SLO: %w", err)
+			return nil, fmt.Errorf("failed to create SLO: %w", err)
 		}
-		fmt.Printf("SLO %q (%s) created successfully\n", result.Name, result.ID)
-		return nil
+		return &SLOApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       ActionCreated,
+				ResourceType: "slo",
+				ID:           result.ID,
+				Name:         result.Name,
+			},
+		}, nil
 	}
 
 	// Check if SLO exists
@@ -781,27 +819,39 @@ func (a *Applier) applySLO(data []byte) error {
 		// SLO doesn't exist, create it
 		result, err := handler.Create(data)
 		if err != nil {
-			return fmt.Errorf("failed to create SLO: %w", err)
+			return nil, fmt.Errorf("failed to create SLO: %w", err)
 		}
-		fmt.Printf("SLO %q (%s) created successfully\n", result.Name, result.ID)
-		return nil
+		return &SLOApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       ActionCreated,
+				ResourceType: "slo",
+				ID:           result.ID,
+				Name:         result.Name,
+			},
+		}, nil
 	}
 
 	// Update existing SLO
 	if err := handler.Update(id, existing.Version, data); err != nil {
-		return fmt.Errorf("failed to update SLO: %w", err)
+		return nil, fmt.Errorf("failed to update SLO: %w", err)
 	}
 
 	name, _ := s["name"].(string)
-	fmt.Printf("SLO %q (%s) updated successfully\n", name, id)
-	return nil
+	return &SLOApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionUpdated,
+			ResourceType: "slo",
+			ID:           id,
+			Name:         name,
+		},
+	}, nil
 }
 
 // applyBucket applies a bucket resource
-func (a *Applier) applyBucket(data []byte) error {
+func (a *Applier) applyBucket(data []byte) (ApplyResult, error) {
 	var b bucket.BucketCreate
 	if err := json.Unmarshal(data, &b); err != nil {
-		return fmt.Errorf("failed to parse bucket JSON: %w", err)
+		return nil, fmt.Errorf("failed to parse bucket JSON: %w", err)
 	}
 
 	handler := bucket.NewHandler(a.client)
@@ -812,11 +862,20 @@ func (a *Applier) applyBucket(data []byte) error {
 		// Bucket doesn't exist, create it
 		result, err := handler.Create(b)
 		if err != nil {
-			return fmt.Errorf("failed to create bucket: %w", err)
+			return nil, fmt.Errorf("failed to create bucket: %w", err)
 		}
-		fmt.Printf("Bucket %q created (status: %s)\n", result.BucketName, result.Status)
-		fmt.Println("Note: Bucket creation can take up to 1 minute to complete")
-		return nil
+		var warnings []string
+		stderrWarn(&warnings, "Bucket creation can take up to 1 minute to complete")
+		return &BucketApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       ActionCreated,
+				ResourceType: "bucket",
+				ID:           result.BucketName,
+				Name:         result.BucketName,
+				Warnings:     warnings,
+			},
+			Status: result.Status,
+		}, nil
 	}
 
 	// Update existing bucket
@@ -826,18 +885,25 @@ func (a *Applier) applyBucket(data []byte) error {
 	}
 
 	if err := handler.Update(b.BucketName, existing.Version, update); err != nil {
-		return fmt.Errorf("failed to update bucket: %w", err)
+		return nil, fmt.Errorf("failed to update bucket: %w", err)
 	}
 
-	fmt.Printf("Bucket %q updated successfully\n", b.BucketName)
-	return nil
+	return &BucketApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionUpdated,
+			ResourceType: "bucket",
+			ID:           b.BucketName,
+			Name:         b.BucketName,
+		},
+		Status: existing.Status,
+	}, nil
 }
 
 // applySettings applies a settings object resource
-func (a *Applier) applySettings(data []byte) error {
+func (a *Applier) applySettings(data []byte) (ApplyResult, error) {
 	var setting map[string]interface{}
 	if err := json.Unmarshal(data, &setting); err != nil {
-		return fmt.Errorf("failed to parse settings JSON: %w", err)
+		return nil, fmt.Errorf("failed to parse settings JSON: %w", err)
 	}
 
 	handler := settings.NewHandler(a.client)
@@ -857,16 +923,16 @@ func (a *Applier) applySettings(data []byte) error {
 
 	value, ok := setting["value"].(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("settings object missing 'value' field or value is not an object")
+		return nil, fmt.Errorf("settings object missing 'value' field or value is not an object")
 	}
 
 	// If no objectID, create new settings object
 	if objectID == "" {
 		if schemaID == "" {
-			return fmt.Errorf("schemaId is required to create a settings object")
+			return nil, fmt.Errorf("schemaId is required to create a settings object")
 		}
 		if scope == "" {
-			return fmt.Errorf("scope is required to create a settings object")
+			return nil, fmt.Errorf("scope is required to create a settings object")
 		}
 
 		req := settings.SettingsObjectCreate{
@@ -877,14 +943,20 @@ func (a *Applier) applySettings(data []byte) error {
 
 		result, err := handler.Create(req)
 		if err != nil {
-			return fmt.Errorf("failed to create settings object: %w", err)
+			return nil, fmt.Errorf("failed to create settings object: %w", err)
 		}
 
-		fmt.Printf("Settings object created successfully\n")
-		fmt.Printf("  Schema: %s\n", schemaID)
-		fmt.Printf("  Scope: %s\n", scope)
-		fmt.Printf("  ObjectID: %s\n", result.ObjectID)
-		return nil
+		return &SettingsApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       ActionCreated,
+				ResourceType: "settings",
+				ID:           result.ObjectID,
+				Name:         schemaID,
+			},
+			SchemaID: schemaID,
+			Scope:    scope,
+			ObjectID: result.ObjectID,
+		}, nil
 	}
 
 	// Check if settings object exists
@@ -892,10 +964,10 @@ func (a *Applier) applySettings(data []byte) error {
 	if err != nil {
 		// Doesn't exist - try to create it
 		if schemaID == "" {
-			return fmt.Errorf("schemaId is required to create a settings object (objectId %q not found)", objectID)
+			return nil, fmt.Errorf("schemaId is required to create a settings object (objectId %q not found)", objectID)
 		}
 		if scope == "" {
-			return fmt.Errorf("scope is required to create a settings object (objectId %q not found)", objectID)
+			return nil, fmt.Errorf("scope is required to create a settings object (objectId %q not found)", objectID)
 		}
 
 		req := settings.SettingsObjectCreate{
@@ -906,35 +978,44 @@ func (a *Applier) applySettings(data []byte) error {
 
 		result, err := handler.Create(req)
 		if err != nil {
-			return fmt.Errorf("failed to create settings object: %w", err)
+			return nil, fmt.Errorf("failed to create settings object: %w", err)
 		}
 
-		fmt.Printf("Settings object created successfully\n")
-		fmt.Printf("  Schema: %s\n", schemaID)
-		fmt.Printf("  Scope: %s\n", scope)
-		fmt.Printf("  ObjectID: %s\n", result.ObjectID)
-		return nil
+		return &SettingsApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       ActionCreated,
+				ResourceType: "settings",
+				ID:           result.ObjectID,
+				Name:         schemaID,
+			},
+			SchemaID: schemaID,
+			Scope:    scope,
+			ObjectID: result.ObjectID,
+		}, nil
 	}
 
 	// Update existing settings object
 	updated, err := handler.UpdateWithContext(objectID, value, schemaID, scope)
 	if err != nil {
-		return fmt.Errorf("failed to update settings object: %w", err)
+		return nil, fmt.Errorf("failed to update settings object: %w", err)
 	}
 
-	fmt.Printf("Settings object updated successfully\n")
-	fmt.Printf("  Schema: %s\n", updated.SchemaID)
-	fmt.Printf("  Scope: %s\n", updated.Scope)
-	fmt.Printf("  ObjectID: %s\n", updated.ObjectID)
-	if updated.Summary != "" {
-		fmt.Printf("  Summary: %s\n", updated.Summary)
-	}
-
-	return nil
+	return &SettingsApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionUpdated,
+			ResourceType: "settings",
+			ID:           updated.ObjectID,
+			Name:         updated.SchemaID,
+		},
+		SchemaID: updated.SchemaID,
+		Scope:    updated.Scope,
+		ObjectID: updated.ObjectID,
+		Summary:  updated.Summary,
+	}, nil
 }
 
 // applyAzureConnection applies Azure connection (credential)
-func (a *Applier) applyAzureConnection(data []byte) error {
+func (a *Applier) applyAzureConnection(data []byte) (ApplyResult, error) {
 	// Azure connection input might be a single object or a list of setting objects
 	var items []map[string]interface{}
 
@@ -944,13 +1025,15 @@ func (a *Applier) applyAzureConnection(data []byte) error {
 		// Not an array, try parsing as single object
 		var item map[string]interface{}
 		if errSingle := json.Unmarshal(data, &item); errSingle != nil {
-			return fmt.Errorf("failed to parse Azure connection JSON: %w", errSingle)
+			return nil, fmt.Errorf("failed to parse Azure connection JSON: %w", errSingle)
 		}
 		items = []map[string]interface{}{item}
 	}
 
 	handler := azureconnection.NewHandler(a.client)
 
+	var lastResult ApplyResult
+	var resultWarnings []string
 	for _, item := range items {
 		objectID, _ := item["objectId"].(string)
 		if objectID == "" {
@@ -970,29 +1053,29 @@ func (a *Applier) applyAzureConnection(data []byte) error {
 
 		valueMap, ok := item["value"].(map[string]interface{})
 		if !ok {
-			return fmt.Errorf("Azure connection missing 'value' field")
+			return nil, fmt.Errorf("Azure connection missing 'value' field")
 		}
 
 		// Convert valueMap to Value struct
 		valueJSON, err := json.Marshal(valueMap)
 		if err != nil {
-			return fmt.Errorf("failed to marshal value: %w", err)
+			return nil, fmt.Errorf("failed to marshal value: %w", err)
 		}
 
 		var value azureconnection.Value
 		if err := json.Unmarshal(valueJSON, &value); err != nil {
-			return fmt.Errorf("failed to unmarshal value: %w", err)
+			return nil, fmt.Errorf("failed to unmarshal value: %w", err)
 		}
 
 		// Auto-lookup for Federated Credentials if ObjectID is missing
 		if objectID == "" && value.Type == "federatedIdentityCredential" {
 			existing, err := handler.FindByNameAndType(value.Name, value.Type)
 			if err != nil {
-				// Log warning but proceed to try create (or maybe return error? usually API error means stop)
-				fmt.Printf("Warning: Failed to lookup existing connection: %v\n", err)
+				// Log warning but proceed to try create
+				stderrWarn(&resultWarnings, "Failed to lookup existing connection: %v", err)
 			} else if existing != nil {
 				objectID = existing.ObjectID
-				fmt.Printf("Found existing Federated Credential connection %q (ID: %s), switching to update mode.\n", value.Name, objectID)
+				stderrWarn(&resultWarnings, "Found existing Federated Credential connection %q (ID: %s), switching to update mode", value.Name, objectID)
 			}
 		}
 
@@ -1005,13 +1088,24 @@ func (a *Applier) applyAzureConnection(data []byte) error {
 			}
 			res, err := handler.Create(req)
 			if err != nil {
-				return fmt.Errorf("failed to create Azure connection: %w", err)
+				return nil, fmt.Errorf("failed to create Azure connection: %w", err)
 			}
-			fmt.Printf("Azure connection created: %s\n", res.ObjectID)
 
 			// Check for federated identity to print instructions
 			if value.Type == "federatedIdentityCredential" {
-				printFederatedInstructions(a.baseURL, res.ObjectID)
+				printFederatedInstructions(a.baseURL, res.ObjectID, &resultWarnings)
+			}
+
+			lastResult = &ConnectionApplyResult{
+				ApplyResultBase: ApplyResultBase{
+					Action:       ActionCreated,
+					ResourceType: "azure_connection",
+					ID:           res.ObjectID,
+					Name:         value.Name,
+				},
+				SchemaID: schemaID,
+				Scope:    scope,
+				ObjectID: res.ObjectID,
 			}
 		} else {
 			// Update
@@ -1027,7 +1121,7 @@ func (a *Applier) applyAzureConnection(data []byte) error {
 						fedCred := value.FederatedIdentityCredential
 						if fedCred == nil || fedCred.ApplicationID == "" || fedCred.DirectoryID == "" {
 							printFederatedCompleteInstructions(a.baseURL, objectID, value.Name)
-							return fmt.Errorf("Azure connection requires additional configuration: %w", err)
+							return nil, fmt.Errorf("Azure connection requires additional configuration: %w", err)
 						}
 					}
 				}
@@ -1036,25 +1130,47 @@ func (a *Applier) applyAzureConnection(data []byte) error {
 				if strings.Contains(errMsg, "AADSTS70025") || strings.Contains(errMsg, "AADSTS700213") {
 					if value.FederatedIdentityCredential != nil && value.FederatedIdentityCredential.ApplicationID != "" {
 						printFederatedErrorSnippet(a.baseURL, objectID, value.FederatedIdentityCredential.ApplicationID)
-						return fmt.Errorf("Azure connection requires federation setup on Azure side: %w", err)
+						return nil, fmt.Errorf("Azure connection requires federation setup on Azure side: %w", err)
 					}
 				}
-				return fmt.Errorf("failed to update Azure connection %s: %w", objectID, err)
+				return nil, fmt.Errorf("failed to update Azure connection %s: %w", objectID, err)
 			}
-			fmt.Printf("Azure connection updated: %s\n", objectID)
+
+			lastResult = &ConnectionApplyResult{
+				ApplyResultBase: ApplyResultBase{
+					Action:       ActionUpdated,
+					ResourceType: "azure_connection",
+					ID:           objectID,
+					Name:         value.Name,
+				},
+				SchemaID: schemaID,
+				Scope:    scope,
+				ObjectID: objectID,
+			}
 		}
 	}
-	return nil
+
+	// Add warning when multiple items were applied (only last result is returned)
+	if len(items) > 1 {
+		stderrWarn(&resultWarnings, "Applied %d connection objects (showing last)", len(items))
+	}
+
+	// Attach collected warnings to the result
+	if cr, ok := lastResult.(*ConnectionApplyResult); ok && len(resultWarnings) > 0 {
+		cr.Warnings = resultWarnings
+	}
+
+	return lastResult, nil
 }
 
 // applyAzureMonitoringConfig applies Azure monitoring configuration
-func (a *Applier) applyAzureMonitoringConfig(data []byte) error {
+func (a *Applier) applyAzureMonitoringConfig(data []byte) (ApplyResult, error) {
 	handler := azuremonitoringconfig.NewHandler(a.client)
 
 	// Unmarshal to struct to handle casing properly via json tags
 	var config azuremonitoringconfig.AzureMonitoringConfig
 	if err := json.Unmarshal(data, &config); err != nil {
-		return fmt.Errorf("failed to parse Azure monitoring config JSON: %w", err)
+		return nil, fmt.Errorf("failed to parse Azure monitoring config JSON: %w", err)
 	}
 
 	objectID := config.ObjectID
@@ -1063,11 +1179,13 @@ func (a *Applier) applyAzureMonitoringConfig(data []byte) error {
 		config.Value.Version = config.Version
 	}
 
+	var warnings []string
+
 	// Lookup by name if ID is missing (Feature 1: naming convention lookup)
 	if objectID == "" && config.Value.Description != "" {
 		existing, err := handler.FindByName(config.Value.Description)
 		if err == nil && existing != nil {
-			fmt.Printf("Found existing Azure monitoring config %q with ID: %s\n", config.Value.Description, existing.ObjectID)
+			stderrWarn(&warnings, "Found existing Azure monitoring config %q with ID: %s", config.Value.Description, existing.ObjectID)
 			objectID = existing.ObjectID
 			config.ObjectID = objectID // Set ID for update
 		}
@@ -1077,67 +1195,88 @@ func (a *Applier) applyAzureMonitoringConfig(data []byte) error {
 		if config.Value.Version == "" {
 			latestVersion, err := handler.GetLatestVersion()
 			if err != nil {
-				return fmt.Errorf("failed to determine extension version for azure_monitoring_config: %w", err)
+				return nil, fmt.Errorf("failed to determine extension version for azure_monitoring_config: %w", err)
 			}
 			config.Value.Version = latestVersion
 			config.Version = latestVersion
-			fmt.Printf("Using latest extension version: %s\n", latestVersion)
+			stderrWarn(&warnings, "Using latest extension version: %s", latestVersion)
 		}
 
 		// New creation
 		cleanData, err := json.Marshal(config)
 		if err != nil {
-			return fmt.Errorf("failed to marshal clean config: %w", err)
+			return nil, fmt.Errorf("failed to marshal clean config: %w", err)
 		}
 
 		res, err := handler.Create(cleanData)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		fmt.Printf("Azure monitoring config created: %s\n", res.ObjectID)
-	} else {
-		// Update existing
-
-		// Feature 2: If version is missing in YAML, preserve existing version
-		if config.Value.Version == "" {
-			existing, err := handler.Get(objectID)
-			if err != nil {
-				return fmt.Errorf("failed to fetch existing config to preserve version: %w", err)
-			} else {
-				fmt.Printf("Preserving existing version: %s\n", existing.Value.Version)
-				config.Value.Version = existing.Value.Version
-				config.Version = existing.Value.Version
-			}
-		}
-
-		cleanData, err := json.Marshal(config)
-		if err != nil {
-			return fmt.Errorf("failed to marshal clean config: %w", err)
-		}
-
-		res, err := handler.Update(objectID, cleanData)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("Azure monitoring config updated: %s\n", res.ObjectID)
+		return &MonitoringConfigApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       ActionCreated,
+				ResourceType: "azure_monitoring_config",
+				ID:           res.ObjectID,
+				Name:         config.Value.Description,
+				Warnings:     warnings,
+			},
+			Scope:    config.Scope,
+			ObjectID: res.ObjectID,
+		}, nil
 	}
-	return nil
+
+	// Update existing
+
+	// Feature 2: If version is missing in YAML, preserve existing version
+	if config.Value.Version == "" {
+		existing, err := handler.Get(objectID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch existing config to preserve version: %w", err)
+		} else {
+			stderrWarn(&warnings, "Preserving existing version: %s", existing.Value.Version)
+			config.Value.Version = existing.Value.Version
+			config.Version = existing.Value.Version
+		}
+	}
+
+	cleanData, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal clean config: %w", err)
+	}
+
+	res, err := handler.Update(objectID, cleanData)
+	if err != nil {
+		return nil, err
+	}
+	return &MonitoringConfigApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionUpdated,
+			ResourceType: "azure_monitoring_config",
+			ID:           res.ObjectID,
+			Name:         config.Value.Description,
+			Warnings:     warnings,
+		},
+		Scope:    config.Scope,
+		ObjectID: res.ObjectID,
+	}, nil
 }
 
 // applyGCPConnection applies GCP connection configuration
-func (a *Applier) applyGCPConnection(data []byte) error {
+func (a *Applier) applyGCPConnection(data []byte) (ApplyResult, error) {
 	var items []map[string]interface{}
 
 	if err := json.Unmarshal(data, &items); err != nil {
 		var item map[string]interface{}
 		if errSingle := json.Unmarshal(data, &item); errSingle != nil {
-			return fmt.Errorf("failed to parse GCP connection JSON: %w", errSingle)
+			return nil, fmt.Errorf("failed to parse GCP connection JSON: %w", errSingle)
 		}
 		items = []map[string]interface{}{item}
 	}
 
 	handler := gcpconnection.NewHandler(a.client)
 
+	var lastResult ApplyResult
+	var resultWarnings []string
 	for _, item := range items {
 		objectID, _ := item["objectId"].(string)
 		if objectID == "" {
@@ -1156,17 +1295,17 @@ func (a *Applier) applyGCPConnection(data []byte) error {
 
 		valueMap, ok := item["value"].(map[string]interface{})
 		if !ok {
-			return fmt.Errorf("GCP connection missing 'value' field")
+			return nil, fmt.Errorf("GCP connection missing 'value' field")
 		}
 
 		valueJSON, err := json.Marshal(valueMap)
 		if err != nil {
-			return fmt.Errorf("failed to marshal value: %w", err)
+			return nil, fmt.Errorf("failed to marshal value: %w", err)
 		}
 
 		var value gcpconnection.Value
 		if err := json.Unmarshal(valueJSON, &value); err != nil {
-			return fmt.Errorf("failed to unmarshal value: %w", err)
+			return nil, fmt.Errorf("failed to unmarshal value: %w", err)
 		}
 		if value.Type == "" {
 			value.Type = "serviceAccountImpersonation"
@@ -1186,28 +1325,60 @@ func (a *Applier) applyGCPConnection(data []byte) error {
 				Value:    value,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to create GCP connection: %w", err)
+				return nil, fmt.Errorf("failed to create GCP connection: %w", err)
 			}
-			fmt.Printf("GCP connection created: %s\n", res.ObjectID)
+
+			lastResult = &ConnectionApplyResult{
+				ApplyResultBase: ApplyResultBase{
+					Action:       ActionCreated,
+					ResourceType: "gcp_connection",
+					ID:           res.ObjectID,
+					Name:         value.Name,
+				},
+				SchemaID: schemaID,
+				Scope:    scope,
+				ObjectID: res.ObjectID,
+			}
 		} else {
 			_, err := handler.Update(objectID, value)
 			if err != nil {
-				return fmt.Errorf("failed to update GCP connection %s: %w", objectID, err)
+				return nil, fmt.Errorf("failed to update GCP connection %s: %w", objectID, err)
 			}
-			fmt.Printf("GCP connection updated: %s\n", objectID)
+
+			lastResult = &ConnectionApplyResult{
+				ApplyResultBase: ApplyResultBase{
+					Action:       ActionUpdated,
+					ResourceType: "gcp_connection",
+					ID:           objectID,
+					Name:         value.Name,
+				},
+				SchemaID: schemaID,
+				Scope:    scope,
+				ObjectID: objectID,
+			}
 		}
 	}
 
-	return nil
+	// Add warning when multiple items were applied (only last result is returned)
+	if len(items) > 1 {
+		stderrWarn(&resultWarnings, "Applied %d connection objects (showing last)", len(items))
+	}
+
+	// Attach collected warnings to the result
+	if cr, ok := lastResult.(*ConnectionApplyResult); ok && len(resultWarnings) > 0 {
+		cr.Warnings = resultWarnings
+	}
+
+	return lastResult, nil
 }
 
 // applyGCPMonitoringConfig applies GCP monitoring configuration
-func (a *Applier) applyGCPMonitoringConfig(data []byte) error {
+func (a *Applier) applyGCPMonitoringConfig(data []byte) (ApplyResult, error) {
 	handler := gcpmonitoringconfig.NewHandler(a.client)
 
 	var config gcpmonitoringconfig.GCPMonitoringConfig
 	if err := json.Unmarshal(data, &config); err != nil {
-		return fmt.Errorf("failed to parse GCP monitoring config JSON: %w", err)
+		return nil, fmt.Errorf("failed to parse GCP monitoring config JSON: %w", err)
 	}
 
 	objectID := config.ObjectID
@@ -1216,10 +1387,12 @@ func (a *Applier) applyGCPMonitoringConfig(data []byte) error {
 		config.Value.Version = config.Version
 	}
 
+	var warnings []string
+
 	if objectID == "" && config.Value.Description != "" {
 		existing, err := handler.FindByName(config.Value.Description)
 		if err == nil && existing != nil {
-			fmt.Printf("Found existing GCP monitoring config %q with ID: %s\n", config.Value.Description, existing.ObjectID)
+			stderrWarn(&warnings, "Found existing GCP monitoring config %q with ID: %s", config.Value.Description, existing.ObjectID)
 			objectID = existing.ObjectID
 			config.ObjectID = objectID
 		}
@@ -1229,47 +1402,65 @@ func (a *Applier) applyGCPMonitoringConfig(data []byte) error {
 		if config.Value.Version == "" {
 			latestVersion, err := handler.GetLatestVersion()
 			if err != nil {
-				return fmt.Errorf("failed to determine extension version for gcp_monitoring_config: %w", err)
+				return nil, fmt.Errorf("failed to determine extension version for gcp_monitoring_config: %w", err)
 			}
 			config.Value.Version = latestVersion
 			config.Version = latestVersion
-			fmt.Printf("Using latest extension version: %s\n", latestVersion)
+			stderrWarn(&warnings, "Using latest extension version: %s", latestVersion)
 		}
 
 		cleanData, err := json.Marshal(config)
 		if err != nil {
-			return fmt.Errorf("failed to marshal clean config: %w", err)
+			return nil, fmt.Errorf("failed to marshal clean config: %w", err)
 		}
 
 		res, err := handler.Create(cleanData)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		fmt.Printf("GCP monitoring config created: %s\n", res.ObjectID)
-	} else {
-		if config.Value.Version == "" {
-			existing, err := handler.Get(objectID)
-			if err != nil {
-				return fmt.Errorf("failed to fetch existing config to preserve version: %w", err)
-			}
-			fmt.Printf("Preserving existing version: %s\n", existing.Value.Version)
-			config.Value.Version = existing.Value.Version
-			config.Version = existing.Value.Version
-		}
-
-		cleanData, err := json.Marshal(config)
-		if err != nil {
-			return fmt.Errorf("failed to marshal clean config: %w", err)
-		}
-
-		res, err := handler.Update(objectID, cleanData)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("GCP monitoring config updated: %s\n", res.ObjectID)
+		return &MonitoringConfigApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       ActionCreated,
+				ResourceType: "gcp_monitoring_config",
+				ID:           res.ObjectID,
+				Name:         config.Value.Description,
+				Warnings:     warnings,
+			},
+			Scope:    config.Scope,
+			ObjectID: res.ObjectID,
+		}, nil
 	}
 
-	return nil
+	if config.Value.Version == "" {
+		existing, err := handler.Get(objectID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch existing config to preserve version: %w", err)
+		}
+		stderrWarn(&warnings, "Preserving existing version: %s", existing.Value.Version)
+		config.Value.Version = existing.Value.Version
+		config.Version = existing.Value.Version
+	}
+
+	cleanData, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal clean config: %w", err)
+	}
+
+	res, err := handler.Update(objectID, cleanData)
+	if err != nil {
+		return nil, err
+	}
+	return &MonitoringConfigApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionUpdated,
+			ResourceType: "gcp_monitoring_config",
+			ID:           res.ObjectID,
+			Name:         config.Value.Description,
+			Warnings:     warnings,
+		},
+		Scope:    config.Scope,
+		ObjectID: res.ObjectID,
+	}, nil
 }
 
 // capitalize capitalizes the first letter of a string
@@ -1280,12 +1471,12 @@ func capitalize(s string) string {
 	return string(s[0]-32) + s[1:]
 }
 
-// printFederatedInstructions prints configuration instructions for Federated Identity Credential
-func printFederatedInstructions(baseURL, objectID string) {
+// printFederatedInstructions prints configuration instructions for Federated Identity Credential to stderr
+func printFederatedInstructions(baseURL, objectID string, warnings *[]string) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		// Should not happen if client is initialized correctly, but fail gracefully
-		fmt.Printf("Warning: Could not parse base URL for instructions: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: Could not parse base URL for instructions: %v\n", err)
 		return
 	}
 	host := u.Host
@@ -1297,17 +1488,21 @@ func printFederatedInstructions(baseURL, objectID string) {
 		issuer = "https://dev.token.dynatracelabs.com"
 	}
 
-	fmt.Println("\nFurther configuration required in Azure Portal (Federated Credentials):")
-	fmt.Printf("  Issuer:    %s\n", issuer)
-	fmt.Printf("  Subject:   dt:connection-id/%s\n", objectID)
-	fmt.Printf("  Audiences: %s/svc-id/com.dynatrace.da\n", host)
+	fmt.Fprintf(os.Stderr, "\nFurther configuration required in Azure Portal (Federated Credentials):\n")
+	fmt.Fprintf(os.Stderr, "  Issuer:    %s\n", issuer)
+	fmt.Fprintf(os.Stderr, "  Subject:   dt:connection-id/%s\n", objectID)
+	fmt.Fprintf(os.Stderr, "  Audiences: %s/svc-id/com.dynatrace.da\n", host)
+
+	if warnings != nil {
+		*warnings = append(*warnings, "Azure federated credential requires additional portal setup")
+	}
 }
 
-// printFederatedCompleteInstructions prints full configuration instructions for Federated Identity Credential
+// printFederatedCompleteInstructions prints full configuration instructions for Federated Identity Credential to stderr
 func printFederatedCompleteInstructions(baseURL, objectID, connectionName string) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
-		fmt.Printf("Warning: Could not parse base URL for instructions: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: Could not parse base URL for instructions: %v\n", err)
 		return
 	}
 	host := u.Host
@@ -1318,22 +1513,22 @@ func printFederatedCompleteInstructions(baseURL, objectID, connectionName string
 		issuer = "https://dev.token.dynatracelabs.com"
 	}
 
-	fmt.Println("\nTo complete the configuration, additional setup is required in the Azure Portal (Federated Credentials).")
-	fmt.Println("Details for Azure configuration:")
-	fmt.Printf("  Issuer:    %s\n", issuer)
-	fmt.Printf("  Subject:   dt:connection-id/%s\n", objectID)
-	fmt.Printf("  Audiences: %s/svc-id/com.dynatrace.da\n", host)
-	fmt.Println()
-	fmt.Println("Azure CLI commands:")
-	fmt.Println("1. Create Service Principal (if not created yet):")
-	fmt.Printf("   az ad sp create-for-rbac --name %q --create-password false --query \"{CLIENT_ID:appId, TENANT_ID:tenant}\" --output table", connectionName)
-	fmt.Println()
-	fmt.Println("2. Create Federated Credential:")
-	fmt.Printf("   az ad app federated-credential create --id \"<CLIENT_ID>\" --parameters \"{'name': 'fd-Federated-Credential', 'issuer': '%s', 'subject': 'dt:connection-id/%s', 'audiences': ['%s/svc-id/com.dynatrace.da']}\"\n", issuer, objectID, host)
-	fmt.Println()
+	fmt.Fprintf(os.Stderr, "\nTo complete the configuration, additional setup is required in the Azure Portal (Federated Credentials).\n")
+	fmt.Fprintf(os.Stderr, "Details for Azure configuration:\n")
+	fmt.Fprintf(os.Stderr, "  Issuer:    %s\n", issuer)
+	fmt.Fprintf(os.Stderr, "  Subject:   dt:connection-id/%s\n", objectID)
+	fmt.Fprintf(os.Stderr, "  Audiences: %s/svc-id/com.dynatrace.da\n", host)
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "Azure CLI commands:\n")
+	fmt.Fprintf(os.Stderr, "1. Create Service Principal (if not created yet):\n")
+	fmt.Fprintf(os.Stderr, "   az ad sp create-for-rbac --name %q --create-password false --query \"{CLIENT_ID:appId, TENANT_ID:tenant}\" --output table", connectionName)
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "2. Create Federated Credential:\n")
+	fmt.Fprintf(os.Stderr, "   az ad app federated-credential create --id \"<CLIENT_ID>\" --parameters \"{'name': 'fd-Federated-Credential', 'issuer': '%s', 'subject': 'dt:connection-id/%s', 'audiences': ['%s/svc-id/com.dynatrace.da']}\"\n", issuer, objectID, host)
+	fmt.Fprintln(os.Stderr)
 }
 
-// printFederatedErrorSnippet prints az cli snippet for AADSTS70025 error
+// printFederatedErrorSnippet prints az cli snippet for AADSTS70025 error to stderr
 func printFederatedErrorSnippet(baseURL, objectID, clientID string) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
@@ -1347,8 +1542,8 @@ func printFederatedErrorSnippet(baseURL, objectID, clientID string) {
 		issuer = "https://dev.token.dynatracelabs.com"
 	}
 
-	fmt.Println("\nTo fix the Federated Identity error, run the following command:")
+	fmt.Fprintf(os.Stderr, "\nTo fix the Federated Identity error, run the following command:\n")
 	// Use format validated by user: "{'key': 'value'}"
-	fmt.Printf("az ad app federated-credential create --id %q --parameters \"{'name': 'fd-Federated-Credential', 'issuer': '%s', 'subject': 'dt:connection-id/%s', 'audiences': ['%s/svc-id/com.dynatrace.da']}\"\n", clientID, issuer, objectID, host)
-	fmt.Println()
+	fmt.Fprintf(os.Stderr, "az ad app federated-credential create --id %q --parameters \"{'name': 'fd-Federated-Credential', 'issuer': '%s', 'subject': 'dt:connection-id/%s', 'audiences': ['%s/svc-id/com.dynatrace.da']}\"\n", clientID, issuer, objectID, host)
+	fmt.Fprintln(os.Stderr)
 }

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -535,15 +535,15 @@ func TestShowJSONDiff(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Capture stdout
-			old := os.Stdout
+			// Capture stderr
+			old := os.Stderr
 			r, w, _ := os.Pipe()
-			os.Stdout = w
+			os.Stderr = w
 
 			showJSONDiff([]byte(tt.oldData), []byte(tt.newData), tt.resourceType)
 
 			_ = w.Close()
-			os.Stdout = old
+			os.Stderr = old
 
 			var buf bytes.Buffer
 			_, _ = io.Copy(&buf, r)

--- a/pkg/apply/result.go
+++ b/pkg/apply/result.go
@@ -1,0 +1,81 @@
+package apply
+
+// ApplyResult is the interface implemented by all apply result types.
+// Each resource type has its own concrete struct embedding ApplyResultBase.
+type ApplyResult interface {
+	applyResult() // unexported marker method — prevents external implementation
+}
+
+// ApplyResultBase contains fields common to all apply results.
+// Embed this in every per-resource result type.
+type ApplyResultBase struct {
+	Action       string   `json:"action"       yaml:"action"       table:"ACTION"`
+	ResourceType string   `json:"resourceType" yaml:"resourceType" table:"TYPE"`
+	ID           string   `json:"id"           yaml:"id"           table:"ID"`
+	Name         string   `json:"name"         yaml:"name"         table:"NAME"`
+	Warnings     []string `json:"warnings,omitempty" yaml:"warnings,omitempty" table:"-"`
+}
+
+func (ApplyResultBase) applyResult() {} // satisfies ApplyResult interface
+
+// Action constants
+const (
+	ActionCreated   = "created"
+	ActionUpdated   = "updated"
+	ActionUnchanged = "unchanged"
+)
+
+// WorkflowApplyResult is the result of applying a workflow resource.
+type WorkflowApplyResult struct {
+	ApplyResultBase `yaml:",inline"`
+}
+
+// DashboardApplyResult is the result of applying a dashboard resource.
+type DashboardApplyResult struct {
+	ApplyResultBase `yaml:",inline"`
+	URL             string `json:"url,omitempty"       yaml:"url,omitempty"       table:"URL,wide"`
+	TileCount       int    `json:"tileCount,omitempty" yaml:"tileCount,omitempty" table:"TILES"`
+}
+
+// NotebookApplyResult is the result of applying a notebook resource.
+type NotebookApplyResult struct {
+	ApplyResultBase `yaml:",inline"`
+	URL             string `json:"url,omitempty"          yaml:"url,omitempty"          table:"URL,wide"`
+	SectionCount    int    `json:"sectionCount,omitempty" yaml:"sectionCount,omitempty" table:"SECTIONS"`
+}
+
+// SLOApplyResult is the result of applying an SLO resource.
+type SLOApplyResult struct {
+	ApplyResultBase `yaml:",inline"`
+}
+
+// BucketApplyResult is the result of applying a bucket resource.
+type BucketApplyResult struct {
+	ApplyResultBase `yaml:",inline"`
+	Status          string `json:"status,omitempty" yaml:"status,omitempty" table:"STATUS"`
+}
+
+// SettingsApplyResult is the result of applying a settings object.
+type SettingsApplyResult struct {
+	ApplyResultBase `yaml:",inline"`
+	SchemaID        string `json:"schemaId"          yaml:"schemaId"          table:"SCHEMA"`
+	Scope           string `json:"scope"             yaml:"scope"             table:"SCOPE"`
+	ObjectID        string `json:"objectId"          yaml:"objectId"          table:"OBJECT_ID"`
+	Summary         string `json:"summary,omitempty" yaml:"summary,omitempty" table:"-"`
+}
+
+// ConnectionApplyResult is the result of applying a cloud connection (Azure or GCP).
+type ConnectionApplyResult struct {
+	ApplyResultBase `yaml:",inline"`
+	SchemaID        string `json:"schemaId,omitempty" yaml:"schemaId,omitempty" table:"SCHEMA"`
+	Scope           string `json:"scope,omitempty"    yaml:"scope,omitempty"    table:"SCOPE"`
+	ObjectID        string `json:"objectId"           yaml:"objectId"           table:"OBJECT_ID"`
+}
+
+// MonitoringConfigApplyResult is the result of applying a monitoring config (Azure or GCP).
+type MonitoringConfigApplyResult struct {
+	ApplyResultBase `yaml:",inline"`
+	SchemaID        string `json:"schemaId,omitempty" yaml:"schemaId,omitempty" table:"SCHEMA"`
+	Scope           string `json:"scope,omitempty"    yaml:"scope,omitempty"    table:"SCOPE"`
+	ObjectID        string `json:"objectId"           yaml:"objectId"           table:"OBJECT_ID"`
+}

--- a/pkg/apply/result_test.go
+++ b/pkg/apply/result_test.go
@@ -1,0 +1,559 @@
+package apply
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestWorkflowApplyResultJSON(t *testing.T) {
+	result := &WorkflowApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionCreated,
+			ResourceType: "workflow",
+			ID:           "wf-123",
+			Name:         "My Workflow",
+		},
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed["action"] != "created" {
+		t.Errorf("expected action=created, got %v", parsed["action"])
+	}
+	if parsed["resourceType"] != "workflow" {
+		t.Errorf("expected type=workflow, got %v", parsed["resourceType"])
+	}
+	if parsed["id"] != "wf-123" {
+		t.Errorf("expected id=wf-123, got %v", parsed["id"])
+	}
+	if parsed["name"] != "My Workflow" {
+		t.Errorf("expected name=My Workflow, got %v", parsed["name"])
+	}
+	// Should NOT contain dashboard-specific fields
+	if _, ok := parsed["tileCount"]; ok {
+		t.Error("workflow result should not have tileCount")
+	}
+	if _, ok := parsed["url"]; ok {
+		t.Error("workflow result should not have url")
+	}
+}
+
+func TestDashboardApplyResultJSON(t *testing.T) {
+	result := &DashboardApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionCreated,
+			ResourceType: "dashboard",
+			ID:           "dash-123",
+			Name:         "My Dashboard",
+		},
+		URL:       "https://env.dt.com/ui/document/v0/#/dashboards/dash-123",
+		TileCount: 5,
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed["url"] != "https://env.dt.com/ui/document/v0/#/dashboards/dash-123" {
+		t.Errorf("unexpected url: %v", parsed["url"])
+	}
+	if parsed["tileCount"] != float64(5) {
+		t.Errorf("expected tileCount=5, got %v", parsed["tileCount"])
+	}
+}
+
+func TestNotebookApplyResultJSON(t *testing.T) {
+	result := &NotebookApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionUpdated,
+			ResourceType: "notebook",
+			ID:           "nb-456",
+			Name:         "My Notebook",
+		},
+		URL:          "https://env.dt.com/ui/document/v0/#/notebooks/nb-456",
+		SectionCount: 3,
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed["action"] != "updated" {
+		t.Errorf("expected action=updated, got %v", parsed["action"])
+	}
+	if parsed["url"] != "https://env.dt.com/ui/document/v0/#/notebooks/nb-456" {
+		t.Errorf("unexpected url: %v", parsed["url"])
+	}
+	if parsed["sectionCount"] != float64(3) {
+		t.Errorf("expected sectionCount=3, got %v", parsed["sectionCount"])
+	}
+}
+
+func TestSLOApplyResultJSON(t *testing.T) {
+	result := &SLOApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionCreated,
+			ResourceType: "slo",
+			ID:           "slo-789",
+			Name:         "Availability SLO",
+		},
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed["action"] != "created" {
+		t.Errorf("expected action=created, got %v", parsed["action"])
+	}
+	if parsed["resourceType"] != "slo" {
+		t.Errorf("expected type=slo, got %v", parsed["resourceType"])
+	}
+	// SLO has no extra fields
+	if _, ok := parsed["url"]; ok {
+		t.Error("slo result should not have url")
+	}
+}
+
+func TestSettingsApplyResultJSON(t *testing.T) {
+	result := &SettingsApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionCreated,
+			ResourceType: "settings",
+			ID:           "obj-123",
+			Name:         "",
+		},
+		SchemaID: "builtin:openpipeline.logs.pipelines",
+		Scope:    "environment",
+		ObjectID: "obj-123",
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed["schemaId"] != "builtin:openpipeline.logs.pipelines" {
+		t.Errorf("unexpected schemaId: %v", parsed["schemaId"])
+	}
+	if parsed["scope"] != "environment" {
+		t.Errorf("unexpected scope: %v", parsed["scope"])
+	}
+	if parsed["objectId"] != "obj-123" {
+		t.Errorf("unexpected objectId: %v", parsed["objectId"])
+	}
+}
+
+func TestSettingsApplyResultWithSummaryJSON(t *testing.T) {
+	result := &SettingsApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionUpdated,
+			ResourceType: "settings",
+			ID:           "obj-456",
+			Name:         "Alert Profile",
+		},
+		SchemaID: "builtin:alerting.profile",
+		Scope:    "environment",
+		ObjectID: "obj-456",
+		Summary:  "Alert profile for production",
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed["summary"] != "Alert profile for production" {
+		t.Errorf("unexpected summary: %v", parsed["summary"])
+	}
+}
+
+func TestBucketApplyResultJSON(t *testing.T) {
+	result := &BucketApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionCreated,
+			ResourceType: "bucket",
+			ID:           "my-bucket",
+			Name:         "my-bucket",
+			Warnings:     []string{"Bucket creation can take up to 1 minute to complete"},
+		},
+		Status: "creating",
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed["status"] != "creating" {
+		t.Errorf("unexpected status: %v", parsed["status"])
+	}
+	warnings, ok := parsed["warnings"].([]interface{})
+	if !ok {
+		t.Fatal("warnings should be an array")
+	}
+	if len(warnings) != 1 {
+		t.Errorf("expected 1 warning, got %d", len(warnings))
+	}
+	if warnings[0] != "Bucket creation can take up to 1 minute to complete" {
+		t.Errorf("unexpected warning: %v", warnings[0])
+	}
+}
+
+func TestConnectionApplyResultJSON(t *testing.T) {
+	result := &ConnectionApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionCreated,
+			ResourceType: "gcp-connection",
+			ID:           "conn-123",
+			Name:         "GCP Production",
+		},
+		SchemaID: "builtin:hyperscaler-authentication.connections.gcp",
+		Scope:    "environment",
+		ObjectID: "conn-123",
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed["schemaId"] != "builtin:hyperscaler-authentication.connections.gcp" {
+		t.Errorf("unexpected schemaId: %v", parsed["schemaId"])
+	}
+	if parsed["objectId"] != "conn-123" {
+		t.Errorf("unexpected objectId: %v", parsed["objectId"])
+	}
+}
+
+func TestMonitoringConfigApplyResultJSON(t *testing.T) {
+	result := &MonitoringConfigApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionCreated,
+			ResourceType: "gcp-monitoring-config",
+			ID:           "mc-789",
+			Name:         "GCP Monitoring",
+		},
+		SchemaID: "builtin:cloud.gcp",
+		Scope:    "integration-gcp",
+		ObjectID: "mc-789",
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed["resourceType"] != "gcp-monitoring-config" {
+		t.Errorf("unexpected resourceType: %v", parsed["resourceType"])
+	}
+	if parsed["schemaId"] != "builtin:cloud.gcp" {
+		t.Errorf("unexpected schemaId: %v", parsed["schemaId"])
+	}
+	if parsed["scope"] != "integration-gcp" {
+		t.Errorf("unexpected scope: %v", parsed["scope"])
+	}
+}
+
+func TestOmitEmptyFields(t *testing.T) {
+	// Workflow has no extra fields — verify dashboard-specific fields are absent
+	result := &WorkflowApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionUpdated,
+			ResourceType: "workflow",
+			ID:           "wf-1",
+			Name:         "Test",
+		},
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := string(data)
+	for _, field := range []string{"url", "tileCount", "schemaId", "scope", "objectId", "status", "warnings"} {
+		if strings.Contains(s, field) {
+			t.Errorf("workflow JSON should not contain %q, got: %s", field, s)
+		}
+	}
+}
+
+func TestDashboardOmitEmptyOptionalFields(t *testing.T) {
+	// Dashboard with no URL and zero TileCount — URL should be omitted, TileCount should be omitted
+	result := &DashboardApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionCreated,
+			ResourceType: "dashboard",
+			ID:           "dash-1",
+			Name:         "Test",
+		},
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := string(data)
+	if strings.Contains(s, "url") {
+		t.Errorf("empty url should be omitted, got: %s", s)
+	}
+	if strings.Contains(s, "tileCount") {
+		t.Errorf("zero tileCount should be omitted, got: %s", s)
+	}
+}
+
+func TestWarningsOmittedWhenEmpty(t *testing.T) {
+	result := &BucketApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionCreated,
+			ResourceType: "bucket",
+			ID:           "b-1",
+			Name:         "test-bucket",
+		},
+		Status: "active",
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(string(data), "warnings") {
+		t.Errorf("nil warnings should be omitted from JSON, got: %s", string(data))
+	}
+}
+
+func TestSettingsSummaryOmittedWhenEmpty(t *testing.T) {
+	result := &SettingsApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionCreated,
+			ResourceType: "settings",
+			ID:           "s-1",
+			Name:         "",
+		},
+		SchemaID: "builtin:alerting.profile",
+		Scope:    "environment",
+		ObjectID: "s-1",
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(string(data), "summary") {
+		t.Errorf("empty summary should be omitted from JSON, got: %s", string(data))
+	}
+}
+
+func TestApplyResultInterface(t *testing.T) {
+	// All types satisfy ApplyResult interface (compile-time check)
+	var _ ApplyResult = &WorkflowApplyResult{}
+	var _ ApplyResult = &DashboardApplyResult{}
+	var _ ApplyResult = &NotebookApplyResult{}
+	var _ ApplyResult = &SLOApplyResult{}
+	var _ ApplyResult = &BucketApplyResult{}
+	var _ ApplyResult = &SettingsApplyResult{}
+	var _ ApplyResult = &ConnectionApplyResult{}
+	var _ ApplyResult = &MonitoringConfigApplyResult{}
+}
+
+func TestActionConstants(t *testing.T) {
+	if ActionCreated != "created" {
+		t.Errorf("ActionCreated = %q, want %q", ActionCreated, "created")
+	}
+	if ActionUpdated != "updated" {
+		t.Errorf("ActionUpdated = %q, want %q", ActionUpdated, "updated")
+	}
+	if ActionUnchanged != "unchanged" {
+		t.Errorf("ActionUnchanged = %q, want %q", ActionUnchanged, "unchanged")
+	}
+}
+
+func TestYAMLSerialization(t *testing.T) {
+	tests := []struct {
+		name   string
+		result ApplyResult
+		checks map[string]interface{}
+	}{
+		{
+			name: "workflow",
+			result: &WorkflowApplyResult{
+				ApplyResultBase: ApplyResultBase{
+					Action:       ActionCreated,
+					ResourceType: "workflow",
+					ID:           "wf-1",
+					Name:         "Test WF",
+				},
+			},
+			checks: map[string]interface{}{
+				"action":       "created",
+				"resourceType": "workflow",
+				"id":           "wf-1",
+				"name":         "Test WF",
+			},
+		},
+		{
+			name: "dashboard with url",
+			result: &DashboardApplyResult{
+				ApplyResultBase: ApplyResultBase{
+					Action:       ActionUpdated,
+					ResourceType: "dashboard",
+					ID:           "dash-1",
+					Name:         "Test Dash",
+				},
+				URL:       "https://env.dt.com/dash/1",
+				TileCount: 7,
+			},
+			checks: map[string]interface{}{
+				"action":       "updated",
+				"resourceType": "dashboard",
+				"url":          "https://env.dt.com/dash/1",
+				"tileCount":    7,
+			},
+		},
+		{
+			name: "settings",
+			result: &SettingsApplyResult{
+				ApplyResultBase: ApplyResultBase{
+					Action:       ActionCreated,
+					ResourceType: "settings",
+					ID:           "s-1",
+					Name:         "",
+				},
+				SchemaID: "builtin:alerting.profile",
+				Scope:    "environment",
+				ObjectID: "s-1",
+			},
+			checks: map[string]interface{}{
+				"schemaId": "builtin:alerting.profile",
+				"scope":    "environment",
+				"objectId": "s-1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(tt.result)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var parsed map[string]interface{}
+			if err := yaml.Unmarshal(data, &parsed); err != nil {
+				t.Fatal(err)
+			}
+
+			for key, expected := range tt.checks {
+				got := parsed[key]
+				if got != expected {
+					t.Errorf("YAML key %q = %v (%T), want %v (%T)", key, got, got, expected, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestJSONRoundTrip(t *testing.T) {
+	original := &DashboardApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionCreated,
+			ResourceType: "dashboard",
+			ID:           "dash-rt",
+			Name:         "Round Trip Dashboard",
+			Warnings:     []string{"warning 1", "warning 2"},
+		},
+		URL:       "https://env.dt.com/ui/document/v0/#/dashboards/dash-rt",
+		TileCount: 12,
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded DashboardApplyResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded.Action != original.Action {
+		t.Errorf("Action = %q, want %q", decoded.Action, original.Action)
+	}
+	if decoded.ResourceType != original.ResourceType {
+		t.Errorf("ResourceType = %q, want %q", decoded.ResourceType, original.ResourceType)
+	}
+	if decoded.ID != original.ID {
+		t.Errorf("ID = %q, want %q", decoded.ID, original.ID)
+	}
+	if decoded.Name != original.Name {
+		t.Errorf("Name = %q, want %q", decoded.Name, original.Name)
+	}
+	if decoded.URL != original.URL {
+		t.Errorf("URL = %q, want %q", decoded.URL, original.URL)
+	}
+	if decoded.TileCount != original.TileCount {
+		t.Errorf("TileCount = %d, want %d", decoded.TileCount, original.TileCount)
+	}
+	if len(decoded.Warnings) != len(original.Warnings) {
+		t.Errorf("Warnings len = %d, want %d", len(decoded.Warnings), len(original.Warnings))
+	}
+	for i, w := range decoded.Warnings {
+		if w != original.Warnings[i] {
+			t.Errorf("Warnings[%d] = %q, want %q", i, w, original.Warnings[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Refactor `Apply()` and all internal methods to return typed `ApplyResult` structs instead of printing to stdout
- Add `ApplyResult` interface and 8 per-resource result types with json/yaml/table tags
- Move warnings/notes to stderr, wire up `cmd/apply.go` to use `NewPrinter().Print(result)`
- Add `result_test.go` with 17 tests covering serialization, omitempty, and interface compliance

Closes #45

## Details

The apply command now supports `-o json`, `-o yaml`, `-o table`, and `-o wide` like all other dtctl commands, making it usable in scripting and CI/CD pipelines.

### New types in `pkg/apply/result.go`:
- `WorkflowApplyResult`, `DashboardApplyResult`, `NotebookApplyResult`
- `SLOApplyResult`, `BucketApplyResult`, `SettingsApplyResult`
- `ConnectionApplyResult`, `MonitoringConfigApplyResult`

### Example output:
```bash
dtctl apply -f dashboard.yaml -o json
{"action":"created","resourceType":"dashboard","id":"dash-123","name":"My Dashboard","url":"https://...","tileCount":5}
```