### PR TITLE
fix: prevent config tests from overwriting real user config

### DIFF
--- a/cmd/config_custom_test.go
+++ b/cmd/config_custom_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/adrg/xdg"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/spf13/viper"
 )
@@ -25,6 +26,8 @@ func TestConfigFlagRespected(t *testing.T) {
 	// Mock XDG_CONFIG_HOME to point to our temp default dir
 	// This ensures valid Load() calls would go here if --config is ignored
 	t.Setenv("XDG_CONFIG_HOME", defaultConfigDir)
+	xdg.Reload()
+	defer xdg.Reload()
 
 	// Save original cfgFile value and restore after test
 	originalCfgFile := cfgFile

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/adrg/xdg"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 )
 
@@ -15,12 +16,9 @@ func TestConfigSetCmd(t *testing.T) {
 	configPath := filepath.Join(tmpDir, "config")
 
 	// Set the config path
-	if err := os.Setenv("XDG_CONFIG_HOME", tmpDir); err != nil {
-		t.Fatalf("failed to set XDG_CONFIG_HOME: %v", err)
-	}
-	defer func() {
-		_ = os.Unsetenv("XDG_CONFIG_HOME")
-	}()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	xdg.Reload()
+	defer xdg.Reload()
 
 	tests := []struct {
 		name      string
@@ -96,12 +94,9 @@ func TestConfigDeleteContextCmd(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Set the config path
-	if err := os.Setenv("XDG_CONFIG_HOME", tmpDir); err != nil {
-		t.Fatalf("failed to set XDG_CONFIG_HOME: %v", err)
-	}
-	defer func() {
-		_ = os.Unsetenv("XDG_CONFIG_HOME")
-	}()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	xdg.Reload()
+	defer xdg.Reload()
 
 	tests := []struct {
 		name         string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/adrg/xdg"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -296,28 +298,18 @@ func TestConfig_MultipleContexts(t *testing.T) {
 
 func TestConfig_Save(t *testing.T) {
 	// Create temp directory
-	tmpDir, err := os.MkdirTemp("", "dtctl-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
+	tmpDir := t.TempDir()
 
 	// Override XDG for this test
-	origXDG := os.Getenv("XDG_CONFIG_HOME")
-	if err := os.Setenv("XDG_CONFIG_HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set XDG_CONFIG_HOME: %v", err)
-	}
-	defer func() {
-		_ = os.Setenv("XDG_CONFIG_HOME", origXDG)
-	}()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	xdg.Reload()
+	defer xdg.Reload()
 
 	cfg := NewConfig()
 	cfg.SetContext("test", "https://test.dt.com", "token")
 
 	// Save should work (creates directory if needed)
-	err = cfg.Save()
+	err := cfg.Save()
 	if err != nil {
 		t.Errorf("Save() error = %v", err)
 	}


### PR DESCRIPTION
## Summary

- Call `xdg.Reload()` after `t.Setenv("XDG_CONFIG_HOME", ...)` so the cached config path updates before `cfg.Save()` runs
- Modernize tests to use `t.Setenv()` (auto-restore) and `t.TempDir()` (auto-cleanup) instead of manual `os.Setenv`/`defer` patterns

Fixes #46

## Problem

The `adrg/xdg` package caches `xdg.ConfigHome` at init time. Without `xdg.Reload()`, `cfg.Save()` writes to the **real** `~/.config/dtctl/config` even though the test set `XDG_CONFIG_HOME` to a temp dir.

## Files Changed

- `cmd/config_test.go` — 2 test functions modernized + xdg.Reload()
- `cmd/config_custom_test.go` — add xdg.Reload()
- `pkg/config/config_test.go` — modernize Save test + remove deleted oauth tests