### PR TITLE
fix: update document URLs to use app-based format

### DIFF
--- a/cmd/create_documents.go
+++ b/cmd/create_documents.go
@@ -227,7 +227,7 @@ func createDocumentRunE(docType string) func(cmd *cobra.Command, args []string) 
 			fmt.Printf("  %s: %d\n", capitalize(itemName(docType)), tileCount)
 		}
 		if result.ID != "" {
-			fmt.Printf("  URL:  %s/ui/document/v0/#/%ss/%s\n", c.BaseURL(), docType, result.ID)
+			fmt.Printf("  URL:  %s/ui/apps/dynatrace.%ss/%s/%s\n", c.BaseURL(), docType, docType, result.ID)
 		}
 		return nil
 	}

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -770,7 +770,7 @@ dtctl apply -f dashboard.yaml
 
 # Both commands show tile count and URL:
 # Dashboard "My Dashboard" (abc-123) created successfully [18 tiles]
-# URL: https://env.apps.dynatrace.com/ui/document/v0/#/dashboards/abc-123
+# URL: https://env.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/abc-123
 ```
 
 **When to use which:**

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -655,15 +655,15 @@ func showJSONDiff(oldData, newData []byte, resourceType string) {
 
 // documentURL returns the UI URL for a document
 func (a *Applier) documentURL(docType, id string) string {
-	// Convert base API URL to apps URL
-	// e.g., https://abc12345.apps.dynatrace.com -> https://abc12345.apps.dynatrace.com/ui/document/<type>/<id>
+	// Build the app-based URL for the document
+	// e.g., https://abc12345.apps.dynatrace.com -> https://abc12345.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/<id>
 	switch docType {
 	case "dashboard":
-		return fmt.Sprintf("%s/ui/document/v0/#/dashboards/%s", a.baseURL, id)
+		return fmt.Sprintf("%s/ui/apps/dynatrace.dashboards/dashboard/%s", a.baseURL, id)
 	case "notebook":
-		return fmt.Sprintf("%s/ui/document/v0/#/notebooks/%s", a.baseURL, id)
+		return fmt.Sprintf("%s/ui/apps/dynatrace.notebooks/notebook/%s", a.baseURL, id)
 	default:
-		return fmt.Sprintf("%s/ui/document/v0/#/%ss/%s", a.baseURL, docType, id)
+		return fmt.Sprintf("%s/ui/apps/dynatrace.%ss/%s/%s", a.baseURL, docType, docType, id)
 	}
 }
 

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -571,21 +571,21 @@ func TestDocumentURL(t *testing.T) {
 			baseURL:  "https://abc12345.apps.dynatrace.com",
 			docType:  "dashboard",
 			id:       "doc-123",
-			expected: "https://abc12345.apps.dynatrace.com/ui/document/v0/#/dashboards/doc-123",
+			expected: "https://abc12345.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/doc-123",
 		},
 		{
 			name:     "notebook URL",
 			baseURL:  "https://abc12345.apps.dynatrace.com",
 			docType:  "notebook",
 			id:       "nb-456",
-			expected: "https://abc12345.apps.dynatrace.com/ui/document/v0/#/notebooks/nb-456",
+			expected: "https://abc12345.apps.dynatrace.com/ui/apps/dynatrace.notebooks/notebook/nb-456",
 		},
 		{
 			name:     "other document type URL",
 			baseURL:  "https://tenant.apps.dynatrace.com",
 			docType:  "report",
 			id:       "rpt-789",
-			expected: "https://tenant.apps.dynatrace.com/ui/document/v0/#/reports/rpt-789",
+			expected: "https://tenant.apps.dynatrace.com/ui/apps/dynatrace.reports/report/rpt-789",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Fixes outdated document URLs that used the legacy `/ui/document/v0/#/` path
- Dashboard and notebook URLs now use the current app-based routing (`/ui/apps/dynatrace.dashboards/dashboard/`, `/ui/apps/dynatrace.notebooks/notebook/`)

Closes #50