### PR TITLE
skills(dtctl): expand dtctl skill with command/resource references

### DIFF
--- a/skills/dtctl/SKILL.md
+++ b/skills/dtctl/SKILL.md
@@ -1,157 +1,269 @@
 ---
 name: dtctl
-description: Use dtctl CLI tool for querying observability data in Dynatrace via DQL (logs, metrics, traces, ...) and to manage Dynatrace platform resources (workflows, dashboards, notebooks, SLOs, settings, buckets, lookup tables).
-license: Apache-2.0
+description: Manage Dynatrace environments using dtctl - install/update the CLI, configure authentication with OS keyring tokens, and run kubectl-style operations (get/describe/edit/apply/delete/query/exec) for workflows, dashboards, notebooks, DQL, SLOs, settings, buckets, lookups, OpenPipeline, and Davis AI. Use when the user wants to control Dynatrace resources via dtctl.
 ---
 
-# dtctl Command Reference
+# Dynatrace Control with dtctl
 
-## Syntax
+Operate `dtctl`, the kubectl-style CLI for Dynatrace. This skill teaches core dtctl command patterns and operations.
+
+## Recommended Initialization
+
+At the start of a task, run these checks to establish context and permissions:
+
 ```bash
-dtctl <verb> <resource> [name/id] [flags]
+# Show current context
+dtctl config current-context
+
+# Show context details
+dtctl config describe-context $(dtctl config current-context) --plain
+
+# Show authenticated user
+dtctl auth whoami --plain
 ```
 
-**Verbs:** get, describe, create, edit, apply, delete, exec, query, logs, wait, history, restore, share/unshare, find, open
+This displays:
+- Current context name and environment URL
+- Safety level (readonly, readwrite-mine, readwrite-all, dangerously-unrestricted)
+- Authenticated user identity (name, email, UUID)
 
-**Key Resources:** workflow (wf), dashboard (dash), notebook (nb), slo, bucket (bkt), lookup (lkup), settings, function (fn), intent, analyzer (az), copilot (cp)
+## DQL Reference Usage
 
-**Global Flags:**
-- `--context` - Switch environment
-- `-o, --output` - json|yaml|table|wide|csv|chart|sparkline|barchart
-- `--dry-run` - Preview without executing
-- `--plain` - Machine-readable output
+Before writing, modifying, or executing any DQL that fetches Dynatrace data (for example via `dtctl query`, `dtctl wait query`, or query files), you MUST consult `references/DQL-reference.md` and follow its documented syntax and templates.
 
-## Setup
+If there is any conflict between memory/assumptions and the reference, prefer the reference.
+
+## Prerequisites
+
+If dtctl is not installed or not working, see [references/troubleshooting.md](references/troubleshooting.md) for installation and setup.
+
+## Resources & Commands
+
+### Available Resources
+
+dtctl uses a uniform pattern for all resource types. Discover schema from actual output with `dtctl describe <resource> <id> -o json --plain`.
+
+| Resource | Aliases |
+|----------|---------|
+| analyzer | analyzers |
+| app | apps |
+| bucket | bkt |
+| copilot-skill | copilot-skills |
+| dashboard | dash |
+| edgeconnect | ec |
+| function | fn, func |
+| group | groups |
+| intent | intents |
+| lookup | lookups, lkup |
+| notebook | nb |
+| notification | notifications |
+| sdk-version | sdk-versions |
+| settings | setting |
+| settings-schema | schema |
+| slo | - |
+| slo-template | slo-templates |
+| trash | deleted |
+| user | users |
+| workflow | wf |
+| workflow-execution | wfe |
+
+Use IDs whenever possible instead of names to avoid ambiguity.
+
+### Command Verbs
+
+| Verb | Description | Example |
+|------|-------------|---------|
+| **get** | List resources | `dtctl get workflows --mine` |
+| **describe** | Show resource details | `dtctl describe workflow <id>` |
+| **edit** | Edit resource interactively | `dtctl edit dashboard <id>` |
+| **apply** | Create/update from file | `dtctl apply -f workflow.yaml --set env=prod` |
+| **delete** | Delete resource | `dtctl delete workflow <id>` |
+| **exec** | Execute workflow/function/analyzer/copilot | `dtctl exec workflow <id>` |
+| **query** | Run DQL query | `dtctl query "fetch logs \| limit 10"` |
+| **logs** | Print resource logs | `dtctl logs workflow-execution <id>` |
+| **wait** | Wait for conditions | `dtctl wait query "fetch logs" --for=any` |
+| **history** | Show document history | `dtctl history dashboard <id>` |
+| **restore** | Restore document version | `dtctl restore dashboard <id> --version 3` |
+| **share** | Share document | `dtctl share dashboard <id> --user email@example.com` |
+| **unshare** | Remove sharing | `dtctl unshare dashboard <id> --user email@example.com` |
+| **find** | Discover resources | `dtctl find intents --data trace.id=abc` |
+| **open** | Open in browser | `dtctl open intent <app/intent> --data key=value` |
+| **diff** | Compare resources | `dtctl diff -f workflow.yaml` |
+| **verify** | Validate without executing | `dtctl verify query 'fetch logs' --fail-on-warn` |
+
+## Key Concepts for AI Agents
+
+### Output Modes
+
 ```bash
-# Configure context
-dtctl config set-context prod --environment "https://abc.apps.dynatrace.com" --token-ref prod-token --safety-level readonly
-dtctl config set-credentials prod-token --token "dt0s16.YOUR_TOKEN"
-dtctl config use-context prod
+# Machine-readable formats (use these for AI agents)
+-o json          # JSON output
+-o yaml          # YAML output
+-o csv           # CSV output
+-o chart         # ASCII chart (for time series)
+-o sparkline     # ASCII sparkline (for time series)
+-o barchart      # ASCII bar chart (for time series)
 
-# Safety levels: readonly | readwrite-mine | readwrite-all | dangerously-unrestricted
+# Human-readable formats
+-o table         # Table format (default)
+-o wide          # Wide table with more columns
+
+# Always use --plain flag for AI consumption
+--plain          # Strips colors and prompts, best for parsing
 ```
 
-## Common Commands
+**For AI agents, always use:** `dtctl <command> -o json --plain`
 
-### Workflows
-```bash
-dtctl get workflows --mine
-dtctl edit workflow <id>
-dtctl apply -f workflow.yaml --set env=prod
-dtctl exec workflow <id> --wait --timeout 10m
-dtctl logs wfe <execution-id> --follow
-dtctl history workflow <id>
+### Template Variables
+
+In YAML/DQL files, use Go template syntax:
+
+```yaml
+# workflow.yaml
+title: "{{.environment}} Deployment"
+owner: "{{.team}}"
+trigger:
+  schedule:
+    cron: "{{.schedule | default "0 0 * * *"}}"
 ```
 
-### Dashboards/Notebooks
-```bash
-dtctl get dashboards --mine
-dtctl edit dashboard <id>
-dtctl share dashboard <id> --user user@example.com --access read-write
-dtctl history dashboard <id>
-dtctl restore dashboard <id> 3
-```
-
-### DQL Queries
-```bash
-dtctl query 'fetch logs | filter status="ERROR" | limit 100'
-dtctl query -f query.dql --set host=h-123 --set timerange=2h
-dtctl query 'timeseries avg(dt.host.cpu.usage)' -o chart
-dtctl wait query 'fetch spans | filter test_id == "test-123"' --for=count=1 --timeout 5m
-```
-
-**Wait conditions:** count=N, count-gte=N, count-gt=N, count-lte=N, count-lt=N, any, none
-
-**Template syntax in .dql files:**
 ```dql
+# query.dql
 fetch logs
-| filter host.name = "{{.host}}"
+| filter host.name == "{{.host}}"
 | filter timestamp > now() - {{.timerange | default "1h"}}
 ```
 
-### Query Verification
+Execute with: `dtctl apply -f file.yaml --set environment=prod --set team=platform`
+
+### Copilot, Functions, Analyzers
+
 ```bash
-# Verify query syntax without execution
-dtctl verify query 'fetch logs | filter status="ERROR"'
-dtctl verify query -f query.dql --fail-on-warn
+# Copilot skills
+dtctl get copilot-skills -o json --plain
 
-# Get canonical query format
-dtctl verify query 'fetch logs' --canonical -o json
+# Functions
+dtctl get functions -o json --plain
+dtctl exec function <id-or-name> --payload '{"key":"value"}' --plain
 
-# CI/CD integration
-for f in queries/*.dql; do
-  dtctl verify query -f "$f" --fail-on-warn || exit 1
-done
+# Analyzers
+dtctl get analyzers -o json --plain
+dtctl exec analyzer <id-or-name> --input '{"timeframe":"now-2h"}' --plain
 ```
 
-### Lookup Tables
-```bash
-dtctl create lookup -f data.csv --path /lookups/grail/pm/errors --lookup-field code
-dtctl get lookups
-dtctl get lookup /lookups/grail/pm/errors -o csv > backup.csv
+Prefer `get ... -o json --plain` first, then `describe`/`exec` with explicit IDs.
 
-# Use in DQL
-dtctl query "fetch logs | lookup [load '/lookups/grail/pm/errors'], lookupField:status_code"
+### Authentication & Permissions
+
+```bash
+# Check current user and permissions
+dtctl auth whoami --plain
+dtctl auth can-i create workflows
+dtctl auth can-i delete dashboards
 ```
 
-### Settings API
+Use `can-i` to verify permissions before attempting operations.
+
+## Quick Reference: DQL Queries
+
+**Required workflow for DQL data fetching:**
+1. First consult `references/DQL-reference.md`
+2. Build/validate the query using the documented patterns
+3. Execute with `dtctl query ... -o json --plain` (or `dtctl wait query ...` when waiting for results)
+
 ```bash
-dtctl get settings-schemas | grep openpipeline
-dtctl get settings --schema builtin:openpipeline.logs.pipelines
-dtctl edit setting <object-id>
-dtctl apply -f config.yaml --set env=prod
+# Inline query
+dtctl query "fetch logs | filter status='ERROR' | limit 100" -o json --plain
+
+# Query from file with variables
+dtctl query -f query.dql --set host=h-123 --set timerange=2h -o json --plain
+
+# Wait for query results
+dtctl wait query "fetch spans | filter test_id='test-123'" --for=count=1 --timeout 5m
+
+# Query with chart output
+dtctl query "timeseries avg(dt.host.cpu.usage)" -o chart --plain
 ```
 
-### SLOs
-```bash
-dtctl get slos
-dtctl describe slo <id>
-dtctl exec slo <id> -o json
-dtctl apply -f slo.yaml
+
+
+## Dashboards
+
+For full examples and field-level gotchas, see [references/resources/dashboards.md](references/resources/dashboards.md).
+
+Create/update: `dtctl apply -f dashboard.yaml --plain`. Export for reference: `dtctl get dashboard <id> -o yaml --plain`.
+
+### YAML skeleton
+
+```yaml
+name: "Dashboard Name"
+type: dashboard
+content:
+  annotations: []
+  importedWithCode: false
+  settings:
+    defaultTimeframe:
+      enabled: true
+      value: { from: now()-2h, to: now() }
+  layouts:
+    "1":                    # string key, must match a tile key
+      x: 0                 # 24-column grid (full=24, half=12, third=8)
+      "y": 0               # MUST quote "y" to avoid YAML boolean parse
+      w: 12
+      h: 6
+  tiles:
+    "1":
+      title: "Tile Title"
+      type: data            # data | markdown
+      query: |
+        fetch logs | limit 10
+      visualization: lineChart
+      visualizationSettings:
+        autoSelectVisualization: false
+      davis: { enabled: false, davisVisualization: { isAvailable: true } }
 ```
 
-### Davis AI
-```bash
-dtctl get analyzers
-dtctl exec analyzer dt.statistics.GenericForecastAnalyzer --query "timeseries avg(dt.host.cpu.usage)" -o chart
-dtctl exec copilot "What caused the CPU spike?"
-dtctl exec copilot nl2dql "show error logs from last hour"
-```
+### Tile types & visualizations
 
-### App Functions
-```bash
-dtctl get functions                                       # List all functions
-dtctl get functions --app dynatrace.slack                 # Filter by app
-dtctl get functions -o wide                               # Show descriptions
-dtctl describe function dynatrace.slack/slack-send-message
-dtctl exec function dynatrace.slack/slack-send-message --method POST --payload '{"channel":"#alerts","message":"test"}'
-dtctl exec function dynatrace.automations/execute-dql-query --method POST --data @query.json
-```
+- **`type: data`** — DQL tile with `query` + `visualization`: `singleValue`, `lineChart`, `areaChart`, `barChart`, `pieChart`, `table`, `honeycomb`, `scatterplot`
+- **`type: markdown`** — static text via `content` field (supports markdown)
 
-### App Intents
-```bash
-dtctl get intents                                         # List all intents
-dtctl get intents --app dynatrace.distributedtracing      # Filter by app
-dtctl describe intent dynatrace.distributedtracing/view-trace
-dtctl find intents --data trace_id=abc123                 # Find matching intents
-dtctl open intent dynatrace.distributedtracing/view-trace --data trace_id=abc123
-dtctl open intent dynatrace.distributedtracing/view-trace --data trace_id=abc123 --browser
-```
+For detailed visualizationSettings (singleValue, charts, tables, thresholds, unit overrides), see [references/resources/dashboards.md](references/resources/dashboards.md).
 
-## Template Variables
-```bash
-# In YAML files: {{.variable}} or {{.variable | default "value"}}
-dtctl apply -f workflow.yaml --set environment=prod --set owner=team-a
-```
+### Gotchas
+- Always set `davis.enabled: false` on data tiles.
+- Use `makeTimeseries` for log/span time series; `timeseries` for metrics.
+- `version` field warning on create is benign.
+- No `id` field → creates new; with `id` field → updates existing.
 
-## Troubleshooting
-```bash
-dtctl auth whoami                          # Check auth
-dtctl auth can-i create workflows          # Check permissions
-dtctl config set-credentials <context> --token "dt0s16.NEW_TOKEN"
-dtctl --help                               # Command help
-```
+## Common Issues
 
-**Name resolution:** Use IDs instead of names if ambiguous (`dtctl get dashboards` to find ID)
-**Safety blocks:** Adjust context safety level or switch context
-**Permissions:** Check token scopes at https://github.com/dynatrace-oss/dtctl/blob/main/docs/TOKEN_SCOPES.md
+**Name resolution ambiguity:**
+- If a name matches multiple resources, dtctl will fail
+- Solution: Use IDs instead of names
+- Find ID: `dtctl get <resource> -o json --plain | jq -r '.[] | "\(.id) | \(.name)"'`
+
+**Permission denied:**
+- Check token scopes: https://github.com/dynatrace-oss/dtctl/blob/main/docs/TOKEN_SCOPES.md
+- Verify permissions: `dtctl auth can-i <verb> <resource>`
+- Check safety level: `dtctl config describe-context $(dtctl config current-context) --plain`
+
+**Context/safety blocks:**
+- Destructive operations may be blocked by safety level
+- Switch context: `dtctl config use-context <name>`
+- Adjust safety level when creating context
+
+## Additional Resources
+
+- **Troubleshooting**: [references/troubleshooting.md](references/troubleshooting.md)
+- **Multi-tenant setup**: [references/config-management.md](references/config-management.md)
+- **DQL syntax and templates**: [references/DQL-reference.md](references/DQL-reference.md)
+- **Notebooks**: [references/resources/notebooks.md](references/resources/notebooks.md)
+- **CLI help**: `dtctl --help`, `dtctl <command> --help`
+
+## Safety Reminders
+
+- Use `--plain` for machine/AI consumption
+- Confirm context + safety level before destructive ops; prefer `get/describe` first
+- Use `--mine` flag to filter resources you own
+- For multi-tenant work, see [references/config-management.md](references/config-management.md)

--- a/skills/dtctl/references/DQL-reference.md
+++ b/skills/dtctl/references/DQL-reference.md
@@ -1,0 +1,167 @@
+# DQL Syntax Guide
+
+## Copy These Templates Exactly
+
+**Filter multiple values:**
+```dql
+filter in(loglevel, array("ERROR", "WARN", "SEVERE"))
+```
+
+**Aggregation with grouping:**
+```dql
+summarize cnt = count(), by:{loglevel}
+```
+
+**String length:**
+```dql
+fieldsAdd len = stringLength(content)
+```
+
+**Entity fields:**
+```dql
+fetch dt.entity.service
+| fields id, entity.name
+```
+
+**Format timestamp:**
+```dql
+fieldsAdd ts = formatTimestamp(timestamp, format:"yyyy-MM-dd HH:mm:ss")
+```
+
+## Data Sources
+
+```dql
+fetch logs, from:now()-1h           -- Log records
+fetch events                        -- System events
+fetch bizevents                     -- Business events
+fetch spans                         -- Trace spans
+fetch dt.entity.service             -- Entities (service, host, etc.)
+fetch security.events               -- Security/vulnerability events
+smartscapeEdges "*"                 -- Entity relationships (calls, runs_on, etc.)
+smartscapeNodes SERVICE             -- Entity graph nodes
+timeseries avg(dt.host.cpu.usage)   -- Metrics (NOT fetch metrics)
+```
+
+## Essential Patterns
+
+### Filter and select
+```dql
+fetch logs, from:now()-1h
+| filter loglevel == "ERROR"
+| fields timestamp, content, loglevel
+| sort timestamp desc
+| limit 100
+```
+
+### Aggregate with grouping (alias required for sort)
+```dql
+fetch logs, from:now()-2h
+| summarize cnt = count(), by:{loglevel}
+| sort cnt desc
+```
+
+### Multiple values
+```dql
+filter loglevel == "ERROR" or loglevel == "WARN" or loglevel == "SEVERE"
+-- OR --
+filter in(loglevel, array("ERROR", "WARN", "SEVERE"))
+```
+
+### Metrics (timeseries command, NOT fetch)
+```dql
+timeseries avg(dt.host.cpu.usage), by:{dt.entity.host}, from:now()-6h, interval:5m
+```
+
+### Log time-series (makeTimeseries, NOT summarize)
+```dql
+fetch logs, from:now()-4h
+| filter loglevel == "ERROR"
+| makeTimeseries cnt = count(), interval:10m, by:{k8s.namespace.name}
+```
+
+### Entity search
+```dql
+fetch dt.entity.service
+| filter contains(entity.name, "payment") or startsWith(entity.name, "api-")
+| fields id, entity.name
+```
+
+### Array expansion (after expand, use brackets)
+```dql
+fetch spans
+| filter isNotNull(span.events)
+| expand span.events
+| filter span.events[span_event.name] == "exception"
+| fields span.events[exception.message], span.events[exception.type]
+```
+Note: After `expand arr`, access fields via `arr[field]` NOT `arr.field`
+
+### String functions
+```dql
+filter contains(content, "timeout") or contains(content, "connection refused")
+filter endsWith(log.source, ".log")
+filter startsWith(name, "api-")
+```
+
+### Absolute timestamps
+```dql
+fetch events, from:"2025-01-01T00:00:00Z", to:"2025-01-02T00:00:00Z"
+-- OR in filter --
+filter timestamp >= toTimestamp("2025-01-01T00:00:00Z")
+```
+
+### Computed fields
+```dql
+fetch logs
+| fieldsAdd msg_len = stringLength(content)
+| fieldsAdd time_str = formatTimestamp(timestamp, format:"yyyy-MM-dd HH:mm:ss")
+| fields timestamp, time_str, msg_len, content
+```
+
+### Business events aggregation
+```dql
+fetch bizevents, from:now()-1h
+| summarize total = count(), sum_amt = sum(amount), avg_amt = avg(amount), by:{event.type}
+```
+
+### Field escaping (hyphens/special chars)
+```dql
+filter `error-code` == "404"
+```
+
+### Security vulnerabilities
+```dql
+fetch security.events
+| filter event.type == "VULNERABILITY_STATE_REPORT_EVENT"
+| filter vulnerability.resolution.status == "OPEN"
+| sort vulnerability.risk.score desc
+```
+
+### Smartscape relationships
+```dql
+smartscapeEdges "*"
+| filter type == "calls"
+| fields source_id, target_id, type
+| limit 100
+```
+
+## Key Functions
+
+| Function | Usage |
+|----------|-------|
+| `count()` | `cnt = count()` |
+| `sum(field)` | `total = sum(amount)` |
+| `avg(field)` | `average = avg(duration)` |
+| `contains(str, sub)` | `contains(content, "error")` |
+| `startsWith(str, pre)` | `startsWith(name, "api-")` |
+| `endsWith(str, suf)` | `endsWith(source, ".log")` |
+| `lower(str)` | `lower(loglevel) == "error"` |
+| `in(val, arr)` | `in(level, array("A","B"))` |
+| `stringLength(str)` | `stringLength(content)` |
+| `formatTimestamp(ts, format:f)` | `formatTimestamp(timestamp, format:"HH:mm")` |
+| `toTimestamp(str)` | `toTimestamp("2025-01-01T00:00:00Z")` |
+| `isNotNull(field)` | `isNotNull(span.events)` |
+| `matchesValue(str, pattern)` | `matchesValue(name, "*payment*")` |
+| `countIf(condition)` | `errors = countIf(loglevel == "ERROR")` |
+| `countDistinct(field)` | `unique_hosts = countDistinct(dt.entity.host)` |
+| `percentile(field, pct)` | `p95 = percentile(duration, 95)` |

--- a/skills/dtctl/references/config-management.md
+++ b/skills/dtctl/references/config-management.md
@@ -1,0 +1,49 @@
+# dtctl Configuration Management
+
+## Configuration Discovery
+
+dtctl checks three locations in priority order:
+1. Command-line flags
+2. Local project `.dtctl.yaml`
+3. Global `$XDG_CONFIG_HOME/dtctl/config`
+
+Recommendation: local `.dtctl.yaml` for project-specific contexts, global config for personal tenants.
+
+## .dtctl.yaml Files
+
+Can be committed to git (no secrets). Credentials stored separately in OS keyring.
+
+**Team conflict note:** `use-context` modifies the config file. Workarounds:
+- Exclude from version control
+- Use `--context` flag per command instead of switching
+- Accept individual context preferences in commits
+
+## Credential Management
+
+```bash
+# Store token (use --token flag, not stdin)
+dtctl config set-credentials "prod-token" --token "$TOKEN"
+
+# Create context
+dtctl config set-context "prod" \
+  --environment "https://tenant.apps.dynatrace.com" \
+  --token-ref "prod-token" \
+  --safety-level readwrite-mine
+
+# Switch context
+dtctl config use-context "prod"
+
+# Per-command context override
+dtctl get workflows --context staging --plain
+```
+
+## Safety Levels
+
+| Level | Use Case |
+|-------|----------|
+| `readonly` | Production monitoring |
+| `readwrite-mine` | Development (recommended default) |
+| `readwrite-all` | Shared environments |
+| `dangerously-unrestricted` | Emergency admin |
+
+Actual permissions depend on API token scopes, not just safety level.

--- a/skills/dtctl/references/resources/dashboards.md
+++ b/skills/dtctl/references/resources/dashboards.md
@@ -1,0 +1,305 @@
+# Dashboards Resource
+
+## List
+```bash
+dtctl get dashboards -o json --plain
+```
+
+## Metadata Schema (from `get`)
+```json
+{
+  "id": "string",
+  "name": "string (NOT title)",
+  "type": "dashboard",
+  "owner": "string (user UUID)",
+  "isPrivate": boolean,
+  "version": number,
+  "modificationInfo": {
+    "createdBy": "string",
+    "createdTime": "ISO 8601",
+    "lastModifiedBy": "string",
+    "lastModifiedTime": "ISO 8601"
+  }
+}
+```
+
+## Operations
+```bash
+dtctl describe dashboard <id> --plain
+dtctl get dashboards -o json --plain | jq '.[] | select(.name | test("keyword"; "i")) | "\(.id) | \(.name)"'
+dtctl share dashboard <id> --user <email> --access read-write --plain
+dtctl unshare dashboard <id> --all --plain
+
+# Export existing dashboard as YAML template
+dtctl get dashboard <id> -o yaml --plain > dashboard.yaml
+
+# Create new (omit id field) or update existing (include id field)
+dtctl apply -f dashboard.yaml --plain
+
+# Preview without applying
+dtctl apply -f dashboard.yaml --dry-run --plain
+
+# Delete
+dtctl delete dashboard <id> --plain
+```
+
+## Creating Dashboards
+
+Write a YAML file and apply with `dtctl apply -f dashboard.yaml --plain`.
+
+### Full YAML structure
+```yaml
+name: "Dashboard Name"
+type: dashboard
+content:
+  annotations: []
+  importedWithCode: false
+  settings:
+    defaultTimeframe:
+      enabled: true
+      value:
+        from: now()-2h
+        to: now()
+  layouts:
+    "1":                    # string key, must match a key in tiles
+      x: 0                 # column position (0-23)
+      "y": 0               # MUST quote "y" — YAML parses bare y as boolean
+      w: 12                # width in grid columns
+      h: 6                 # height in grid rows
+  tiles:
+    "1":
+      title: "Tile Title"
+      type: data            # "data" for DQL tiles, "markdown" for text
+      query: |
+        fetch logs | limit 10
+      visualization: lineChart
+      visualizationSettings:
+        autoSelectVisualization: false
+      davis:
+        enabled: false
+        davisVisualization:
+          isAvailable: true
+```
+
+### Layout grid
+- **24 columns** wide. Common widths: full=24, half=12, third=8, quarter=6.
+- Tiles must not overlap. Rows extend vertically as needed.
+- Tile height `h` in grid units (1 unit ≈ 40px). Typical: KPIs h:3, charts h:6, tables h:6.
+
+### Tile types
+
+**`type: data`** — DQL-powered tile. Requires `query` and `visualization`.
+
+**`type: markdown`** — Static text/section headers. Uses `content` field:
+```yaml
+"1":
+  title: ""
+  type: markdown
+  content: "## Section Title\nDescription text"
+```
+
+### Visualizations
+
+| Value | Use |
+|---|---|
+| `singleValue` | KPI cards |
+| `lineChart` | Time series trends |
+| `areaChart` | Stacked time series |
+| `barChart` | Categorical comparisons |
+| `pieChart` | Proportional breakdowns |
+| `table` | Multi-column data |
+| `honeycomb` | Entity health grids |
+| `scatterplot` | Two-variable correlation |
+
+### visualizationSettings by type
+
+**singleValue** — `recordField` must match the alias in the query:
+```yaml
+visualization: singleValue
+visualizationSettings:
+  autoSelectVisualization: false
+  singleValue:
+    showLabel: true
+    label: "Errors"
+    recordField: errors
+```
+
+**lineChart / areaChart / barChart**:
+```yaml
+visualization: areaChart
+visualizationSettings:
+  autoSelectVisualization: false
+  chartSettings:
+    legend:
+      position: bottom      # top | bottom | right
+      showLegend: true
+    stacked: true            # for stacked area/bar
+  axes:
+    yAxis:
+      label: "Count"
+```
+
+**table**:
+```yaml
+visualization: table
+visualizationSettings:
+  autoSelectVisualization: false
+  table:
+    linewrapEnabled: true
+    columnWidths:
+      '["content"]': 500    # key format: '["field_name"]'
+    columnOrder:
+      - '["field1"]'
+      - '["field2"]'
+```
+
+### Thresholds (color rules)
+
+Apply to tables, single values, or chart baselines. Comparators: `<=`, `>=`, `=`, `<`, `>`.
+```yaml
+visualizationSettings:
+  thresholds:
+    - field: errors
+      id: 1
+      isEnabled: true
+      rules:
+        - { color: { Default: "var(--dt-colors-charts-status-ideal-default, #2f6862)" }, comparator: "<=", id: 0, value: 100 }
+        - { color: { Default: "var(--dt-colors-charts-status-warning-default, #eea53c)" }, comparator: "<=", id: 1, value: 500 }
+        - { color: { Default: "var(--dt-colors-charts-status-critical-default, #c62239)" }, comparator: ">", id: 2, value: 500 }
+```
+
+Theme colors: green `#2f6862`, yellow `#eea53c`, red `#c62239`.
+
+### Unit overrides (for duration fields)
+```yaml
+visualizationSettings:
+  unitsOverrides:
+    - identifier: p99        # must match query alias
+      baseUnit: nanosecond   # nanosecond | millisecond | second
+      displayUnit: null      # null = auto-format
+      decimals: 1
+```
+
+## Choosing Visualizations
+
+Pick the visualization based on data shape, not aesthetics:
+
+| Data shape | Use | Avoid |
+|---|---|---|
+| Single aggregated number | `singleValue` | |
+| Time series (makeTimeseries) | `lineChart` or `areaChart` (stacked) | `barChart` (hard to read over time) |
+| Categorical proportions (few groups) | `pieChart` | `barChart` (renders poorly with string categories) |
+| Categorical comparison (many groups) | `table` | `barChart` (axis labels overlap) |
+| Multi-field rows (latencies, rates) | `table` | |
+| Entity status grid | `honeycomb` | |
+
+**Key rule**: `barChart` expects a numeric or time x-axis. If your x-axis is string categories (namespace, container name, service name), use `pieChart` for proportions or `table` for precise values.
+
+## Testing Queries Before Deploying
+
+**Always validate tile queries with `dtctl query` before embedding in a dashboard.** A broken query shows as an empty or errored tile with no useful feedback.
+
+```bash
+# Test the exact query you plan to use in a tile
+dtctl query 'fetch logs, from:now()-30m | filter loglevel == "ERROR" | summarize cnt = count()' -o json --plain
+
+# Verify time series output has the expected shape
+dtctl query 'fetch logs, from:now()-30m | makeTimeseries cnt = count(), interval:2m, by:{k8s.container.name}' -o json --plain
+```
+
+Check that:
+- The query returns records (not an empty `[]`)
+- Field names/aliases match what `recordField`, `identifier`, or `field` reference in visualizationSettings
+- Time series queries use `makeTimeseries` (not `summarize`) for charts
+
+## DQL Patterns for Dashboard Tiles
+
+### Named parameters are required for optional args
+
+Many DQL functions require named parameters. Positional args cause `TOO_MANY_POSITIONAL_PARAMETERS_WITH_OPTIONS` errors.
+
+```dql
+-- WRONG: positional params
+fieldsAdd short = substring(content, 0, 100)
+fieldsAdd result = if(x > 10, "high", "low")
+
+-- CORRECT: named params
+fieldsAdd short = substring(content, from:0, to:100)
+fieldsAdd result = if(x > 10, then:"high", else:"low")
+```
+
+### Use HTTP status codes for error rates on HTTP services
+
+Span `status == "ERROR"` captures application-level errors (exceptions, gRPC failures) but is **not reliably populated for HTTP services** — it can return 0 errors even when services return thousands of 5xx responses. For HTTP services, always use `http.response.status_code`:
+
+```dql
+-- For HTTP services: use status codes (reliable)
+fetch spans | summarize errors_5xx = countIf(http.response.status_code >= 500), total = count()
+             | fieldsAdd error_rate = 100.0 * errors_5xx / total
+
+-- For non-HTTP/gRPC services: span status may work
+fetch spans | summarize errors = countIf(status == "ERROR")
+
+-- Best coverage: combine both signals
+fetch spans | summarize errors = countIf(status == "ERROR" or http.response.status_code >= 500), total = count()
+             | fieldsAdd error_rate = 100.0 * errors / total
+```
+
+### countIf() inside makeTimeseries for error rate trends
+
+```dql
+fetch spans, from:now()-30m
+| filter dt.entity.service == "SERVICE-xxx"
+| makeTimeseries cnt_5xx = countIf(http.response.status_code >= 500), cnt_total = count(), interval:2m
+```
+
+### Smartscape IDs are not strings
+
+`startsWith()` / `endsWith()` fail on smartscape ID fields with a `DATATYPE_MISMATCH` warning and return empty results. This is despite CoPilot claiming they work — tested and confirmed broken. Use `matchesValue()` with `toString()`:
+
+```dql
+-- WRONG: returns warning "should be a string, but was a smartscape id" + empty results
+smartscapeEdges "*" | filter startsWith(source_id, "SERVICE-")
+
+-- CORRECT: cast to string first, then use pattern matching
+smartscapeEdges "*" | filter matchesValue(toString(source_id), "SERVICE-*")
+```
+
+## Thresholds vs Coloring Rules
+
+The YAML `thresholds` format works on create/apply, but the UI may rewrite it to `coloring.colorRules` when you export. Both formats are valid:
+
+```yaml
+# Format 1: thresholds (recommended for authoring)
+visualizationSettings:
+  thresholds:
+    - field: error_rate
+      id: 1
+      isEnabled: true
+      rules:
+        - { color: { Default: "#2f6862" }, comparator: "<=", id: 0, value: 1 }
+        - { color: { Default: "#eea53c" }, comparator: "<=", id: 1, value: 5 }
+        - { color: { Default: "#c62239" }, comparator: ">", id: 2, value: 5 }
+
+# Format 2: coloring.colorRules (UI-exported format)
+visualizationSettings:
+  coloring:
+    colorRules:
+      - colorMode: custom-color
+        comparator: ">"
+        customColor:
+          Default: "#c62239"
+        field: error_rate
+        value: 5
+```
+
+If round-tripping (export → edit → apply), keep whichever format the export uses.
+
+## Important Notes
+- Field is `.name` NOT `.title` (opposite of workflows).
+- **Always quote `"y"`** in layout YAML to prevent boolean parsing.
+- Always set `davis: { enabled: false, davisVisualization: { isAvailable: true } }` on data tiles.
+- Use `makeTimeseries` for log/span-based time series in tile queries; `timeseries` for metrics.
+- The `version` field warning on create is benign — can be ignored.
+- No `id` field in YAML → creates new dashboard; with `id` → updates existing.
+- To learn from an existing dashboard: `dtctl get dashboard <id> -o yaml --plain`.

--- a/skills/dtctl/references/resources/notebooks.md
+++ b/skills/dtctl/references/resources/notebooks.md
@@ -1,0 +1,222 @@
+# Notebooks Resource
+
+## List
+```bash
+dtctl get notebooks -o json --plain
+```
+
+## Metadata Schema (from `get`)
+```json
+{
+  "id": "string (UUID)",
+  "name": "string",
+  "type": "notebook",
+  "owner": "string (user UUID)",
+  "isPrivate": boolean,
+  "version": number,
+  "modificationInfo": {
+    "createdBy": "string",
+    "createdTime": "ISO 8601",
+    "lastModifiedBy": "string",
+    "lastModifiedTime": "ISO 8601"
+  }
+}
+```
+
+## Operations
+```bash
+dtctl describe notebook <id> --plain
+dtctl get notebooks -o json --plain | jq '.[] | select(.name | test("keyword"; "i")) | "\(.id) | \(.name)"'
+
+# Export existing notebook as YAML template
+dtctl get notebook <id> -o yaml --plain > notebook.yaml
+
+# Create new (omit id field) or update existing (include id field)
+dtctl apply -f notebook.yaml --plain
+
+# Delete
+dtctl delete notebook <id> --plain
+```
+
+## Creating Notebooks
+
+Write a YAML file and apply with `dtctl apply -f notebook.yaml --plain`.
+
+### Full YAML structure
+
+**Use the `sections` format.** dtctl recognizes `content.sections[]` and reports section count on create. A `content.cells[]` format exists in the API but dtctl warns "notebook content has no 'sections' field" and may produce empty notebooks.
+
+```yaml
+name: "Notebook Name"
+type: notebook
+content:
+  defaultSegments: []
+  defaultTimeframe:
+    from: now()-2h
+    to: now()
+  sections:
+    - id: header-001
+      markdown: |-
+        # Notebook Title
+        Description text here.
+      type: markdown
+    - id: query-001
+      showTitle: true
+      drilldownPath: []
+      filterSegments: []
+      previousFilterSegments: []
+      state:
+        davis:
+          davisVisualization:
+            isAvailable: true
+          includeLogs: true
+        input:
+          timeframe:
+            from: now()-2h
+            to: now()
+          value: |-
+            fetch logs, from:now()-2h
+            | filter loglevel == "ERROR"
+            | summarize error_count = count(), by:{k8s.namespace.name}
+            | sort error_count desc
+            | limit 10
+        querySettings:
+          defaultSamplingRatio: 10
+          defaultScanLimitGbytes: 500
+          enableSampling: false
+          maxResultMegaBytes: 1
+          maxResultRecords: 1000
+```
+
+### Section types
+
+**Markdown section** — for headers, notes, and narrative text:
+```yaml
+- id: section-01
+  markdown: |-
+    ## Section Header
+    Explanation of findings.
+  type: markdown
+```
+
+**DQL query section** — executes a query with optional visualization:
+```yaml
+- id: query-01
+  showTitle: true
+  drilldownPath: []
+  filterSegments: []
+  previousFilterSegments: []
+  state:
+    davis:
+      davisVisualization:
+        isAvailable: true
+      includeLogs: true
+    input:
+      timeframe:
+        from: now()-30m
+        to: now()
+      value: |-
+        fetch logs, from:now()-30m
+        | filter loglevel == "ERROR"
+        | makeTimeseries cnt = count(), interval:2m, by:{k8s.container.name}
+    querySettings:
+      defaultSamplingRatio: 10
+      defaultScanLimitGbytes: 500
+      enableSampling: false
+      maxResultMegaBytes: 1
+      maxResultRecords: 1000
+    visualization:
+      type: areaChart
+      chartSettings:
+        legend:
+          position: bottom
+          showLegend: true
+```
+
+### Visualization settings
+
+Visualization goes under `state.visualization` (NOT `visualizationSettings` like dashboards).
+
+```yaml
+# Table (default if no visualization specified)
+state:
+  visualization:
+    type: table
+
+# Area chart (stacked time series)
+state:
+  visualization:
+    type: areaChart
+    chartSettings:
+      legend: { position: bottom, showLegend: true }
+      stacked: true
+
+# Line chart
+state:
+  visualization:
+    type: lineChart
+    chartSettings:
+      legend: { position: bottom, showLegend: true }
+
+# Single value
+state:
+  visualization:
+    type: singleValue
+    singleValue:
+      showLabel: true
+      label: "Error Count"
+      recordField: errors
+
+# Pie chart
+state:
+  visualization:
+    type: pieChart
+```
+
+Available types: `table`, `lineChart`, `areaChart`, `barChart`, `pieChart`, `singleValue`, `honeycomb`, `scatterplot`.
+
+## Notebooks vs Dashboards
+
+Use the right tool for the job:
+
+| Aspect | Notebook | Dashboard |
+|--------|----------|-----------|
+| **Layout** | Linear, top-to-bottom | Grid-based (24 columns) |
+| **Purpose** | Investigation, analysis, runbooks | Monitoring, at-a-glance status |
+| **DQL location** | `state.input.value` | `query` |
+| **Viz config location** | `state.visualization` | `visualizationSettings` |
+| **Davis config** | `state.davis` (per section) | `davis` (per tile) |
+| **Query settings** | `state.querySettings` (per section) | `querySettings` (per tile, auto-added) |
+| **Timeframe** | `content.defaultTimeframe` + per-section `state.input.timeframe` | `content.settings.defaultTimeframe` |
+| **Layout config** | None needed (linear) | `content.layouts` with x/y/w/h |
+| **Result caching** | Can store `state.result` | No result storage |
+
+**When to use notebooks**: RCA investigations, runbook documentation, step-by-step analysis with markdown narrative between queries.
+
+**When to use dashboards**: Operational monitoring, KPI displays, alerting overviews with multiple tiles visible simultaneously.
+
+## DQL Patterns — Same Gotchas as Dashboards
+
+All DQL issues that affect dashboards also affect notebooks. See [dashboards.md](dashboards.md) for full details. Key reminders:
+
+- **Named params required**: `substring(str, from:0, to:100)`, `if(cond, then:val, else:val)`
+- **HTTP 5xx for error rates**: `countIf(http.response.status_code >= 500)` is more reliable than `countIf(status == "ERROR")` for HTTP services
+- **Smartscape IDs**: Use `matchesValue(toString(source_id), "SERVICE-*")`, not `startsWith(source_id, "SERVICE-")`
+- **Time series**: Use `makeTimeseries` for logs/spans, `timeseries` for metrics
+- **Test queries first**: Run with `dtctl query '...' -o json --plain` before embedding in a notebook
+
+## Authoring Tips
+
+1. **Alternate markdown and query sections** — explain what each query investigates before showing it
+2. **Use unique section IDs** — any string works (`header-001`, `query-latency`, `note-findings`)
+3. **Set per-section timeframes** — override `state.input.timeframe` for queries that need different windows
+4. **Keep `querySettings` consistent** — copy the standard block to avoid unexpected sampling or limits
+5. **Export before editing** — use `dtctl get notebook <id> -o yaml --plain` to see the current state, especially after manual UI edits add `state.result` blocks
+
+## Important Notes
+- Field is `.name` for notebooks (same as dashboards).
+- No `id` field in YAML → creates new; with `id` → updates existing.
+- The `version` field warning on create is benign.
+- Deleted notebooks go to trash (can be restored).
+- Sections are rendered top-to-bottom in the order they appear in the YAML array.
+- The `state.result` block (cached query output) is optional — omit it when authoring; the UI populates it on execution.

--- a/skills/dtctl/references/troubleshooting.md
+++ b/skills/dtctl/references/troubleshooting.md
@@ -1,0 +1,81 @@
+# dtctl Troubleshooting
+
+## Installation
+
+Install from https://github.com/dynatrace-oss/dtctl. Verify with `dtctl version`.
+
+```bash
+ARCH=$(uname -m | sed 's/x86_64/amd64/; s/arm64/arm64/')
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+TAG=$(curl -s -I -L https://github.com/dynatrace-oss/dtctl/releases/latest | tr -d '\r' | awk -F/ '/^location: /{print $NF}' | tail -n1)
+TARBALL="dtctl_${TAG#v}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/dynatrace-oss/dtctl/releases/download/${TAG}/${TARBALL}"
+mkdir -p /tmp/dtctl && cd /tmp/dtctl
+curl -L "$URL" -o "$TARBALL"
+tar -xzf "$TARBALL"
+sudo mv dtctl /usr/local/bin/
+dtctl version
+```
+
+If no sudo: place in `~/bin/` and ensure it's on PATH.
+
+## Initial Setup
+
+```bash
+# Store credentials (use --token flag directly, NOT stdin piping)
+dtctl config set-credentials "my-token" --token "$DYNATRACE_API_TOKEN"
+dtctl config set-context "default" \
+  --environment "$DYNATRACE_BASE_URL" \
+  --token-ref "my-token"
+dtctl config use-context "default"
+
+# Verify
+dtctl auth whoami --plain
+```
+
+**Note:** Always use `--token "$TOKEN"` directly. Stdin piping does not work reliably and stores corrupted values in the keychain.
+
+## Common Issues
+
+### 401/403 Authentication Errors
+```bash
+# Re-store credentials
+dtctl config set-credentials "my-token" --token "$TOKEN"
+
+# Verify identity
+dtctl auth whoami --plain
+
+# Check permissions
+dtctl auth can-i <verb> <resource>
+```
+
+### Wrong Tenant
+```bash
+dtctl config get-contexts --plain
+dtctl config use-context <name>
+```
+
+### Safety Level Blocks
+Safety levels are client-side protections: `readonly`, `readwrite-mine`, `readwrite-all`, `dangerously-unrestricted`. API token scopes determine actual permissions.
+
+### dtctl Not Found
+Ensure binary is on PATH. Check `~/bin/dtctl` or `/usr/local/bin/dtctl`.
+
+### Corrupted Keychain Entry (macOS)
+```bash
+security delete-generic-password -s "dtctl" -a "<token-ref>"
+dtctl config set-credentials "<token-ref>" --token "$TOKEN"
+```
+
+## Debugging
+
+```bash
+# Verbose output
+dtctl <command> -v     # Details
+dtctl <command> -vv    # Full debug including auth headers
+```
+
+## Platform Notes
+- **macOS**: Keychain must be unlocked
+- **Linux**: Requires gnome-keyring or similar
+- **Windows**: Uses Credential Manager


### PR DESCRIPTION
## Summary
- consolidate `skills/dtctl` around high-value docs and remove low-value per-resource stubs
- keep and reference only:
  - `skills/dtctl/SKILL.md`
  - `skills/dtctl/references/DQL-reference.md`
  - `skills/dtctl/references/resources/dashboards.md`
  - `skills/dtctl/references/resources/notebooks.md`
  - `skills/dtctl/references/troubleshooting.md`
  - `skills/dtctl/references/config-management.md`

## Review Feedback Addressed
- removed redundant command reference and per-resource stub files
- changed skill initialization from mandatory framing to recommended checks
- reduced indirection and token footprint by keeping only docs with non-obvious gotchas
- merged Copilot/Functions/Analyzers usage guidance into `SKILL.md`
- updated frontmatter name to `dtctl`

## Notes
- this PR still uses force-add under `skills/dtctl/...` because repository `.gitignore` contains `dtctl`; this follows existing repo behavior for this path
