### PR TITLE
fix: lookup table export silently truncates data at 1000 records

### DIFF
--- a/cmd/describe_lookups.go
+++ b/cmd/describe_lookups.go
@@ -45,7 +45,7 @@ Examples:
 		}
 
 		// Get preview data (first 5 rows)
-		data, err := handler.GetData(path, 5)
+		dataResult, err := handler.GetData(path, 5)
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ Examples:
 				PreviewData []map[string]interface{} `json:"previewData"`
 			}{
 				Lookup:      lu,
-				PreviewData: data,
+				PreviewData: dataResult.Records,
 			}
 			return printer.Print(lookupData)
 		}
@@ -88,9 +88,9 @@ Examples:
 		}
 
 		// Print data preview
-		if len(data) > 0 {
+		if len(dataResult.Records) > 0 {
 			fmt.Println()
-			fmt.Printf("Data Preview (first %d rows):\n", len(data))
+			fmt.Printf("Data Preview (first %d rows):\n", len(dataResult.Records))
 
 			// Create table header
 			if len(lu.Columns) > 0 {
@@ -98,7 +98,7 @@ Examples:
 			}
 
 			// Print rows
-			for _, row := range data {
+			for _, row := range dataResult.Records {
 				var values []string
 				for _, col := range lu.Columns {
 					val := fmt.Sprintf("%v", row[col])

--- a/cmd/get_lookups.go
+++ b/cmd/get_lookups.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/prompt"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/lookup"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
@@ -62,27 +64,30 @@ Examples:
 		if len(args) > 0 {
 			// For table output, show the actual lookup table data (not metadata)
 			if outputFormat == "table" || outputFormat == "wide" {
-				data, err := handler.GetData(args[0], 0)
+				dataResult, err := handler.GetData(args[0], 0)
 				if err != nil {
 					return err
 				}
-				return printer.PrintList(data)
+				printLookupNotifications(c, dataResult.Notifications)
+				return printer.PrintList(dataResult.Records)
 			}
 
 			// For CSV/JSON output, return full data
 			if outputFormat == "csv" || outputFormat == "json" {
-				fullData, err := handler.GetData(args[0], 0)
+				dataResult, err := handler.GetData(args[0], 0)
 				if err != nil {
 					return err
 				}
-				return printer.PrintList(fullData)
+				printLookupNotifications(c, dataResult.Notifications)
+				return printer.PrintList(dataResult.Records)
 			}
 
 			// For YAML output, return full structure (metadata + data)
-			lookupData, err := handler.GetWithData(args[0], 0)
+			lookupData, notifications, err := handler.GetWithData(args[0], 0)
 			if err != nil {
 				return err
 			}
+			printLookupNotifications(c, notifications)
 			return printer.Print(lookupData)
 		}
 
@@ -167,4 +172,13 @@ Examples:
 func init() {
 	// Delete confirmation flags
 	deleteLookupCmd.Flags().BoolVarP(&forceDelete, "yes", "y", false, "Skip confirmation prompt")
+}
+
+// printLookupNotifications surfaces DQL query notifications (e.g., truncation warnings) to stderr
+func printLookupNotifications(c *client.Client, notifications []exec.QueryNotification) {
+	if len(notifications) == 0 {
+		return
+	}
+	executor := exec.NewDQLExecutor(c)
+	executor.PrintNotifications(notifications)
 }

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -372,8 +372,8 @@ func getHintForNotification(notificationType, message string) string {
 	return ""
 }
 
-// printNotifications prints query notifications/warnings to stderr
-func (e *DQLExecutor) printNotifications(notifications []QueryNotification) {
+// PrintNotifications prints query notifications/warnings to stderr
+func (e *DQLExecutor) PrintNotifications(notifications []QueryNotification) {
 	useColor := isStderrTerminal()
 
 	for _, n := range notifications {
@@ -418,7 +418,7 @@ func (e *DQLExecutor) printNotifications(notifications []QueryNotification) {
 func (e *DQLExecutor) printResults(result *DQLQueryResponse, opts DQLExecuteOptions) error {
 	// Print any notifications/warnings first
 	if notifications := result.GetNotifications(); len(notifications) > 0 {
-		e.printNotifications(notifications)
+		e.PrintNotifications(notifications)
 	}
 
 	// Extract records from result

--- a/pkg/resources/lookup/lookup.go
+++ b/pkg/resources/lookup/lookup.go
@@ -227,8 +227,19 @@ func (h *Handler) Get(path string) (*Lookup, error) {
 	return lookup, nil
 }
 
+// maxLookupRecords is the maximum number of records to retrieve from a lookup table.
+// The DQL API defaults to 1000 records if not specified, which silently truncates
+// large lookup tables. We set this to 1,000,000 to effectively retrieve all records.
+const maxLookupRecords = 1_000_000
+
+// GetDataResult contains the data records and any DQL notifications
+type GetDataResult struct {
+	Records       []map[string]interface{}
+	Notifications []exec.QueryNotification
+}
+
 // GetData retrieves the full data of a lookup table
-func (h *Handler) GetData(path string, limit int) ([]map[string]interface{}, error) {
+func (h *Handler) GetData(path string, limit int) (*GetDataResult, error) {
 	// Validate path
 	if err := ValidatePath(path); err != nil {
 		return nil, err
@@ -240,8 +251,13 @@ func (h *Handler) GetData(path string, limit int) ([]map[string]interface{}, err
 		query += fmt.Sprintf(" | limit %d", limit)
 	}
 
+	// Set a high MaxResultRecords to avoid silent truncation at the DQL default of 1000.
+	opts := exec.DQLExecuteOptions{
+		MaxResultRecords: maxLookupRecords,
+	}
+
 	executor := exec.NewDQLExecutor(h.client)
-	result, err := executor.ExecuteQuery(query)
+	result, err := executor.ExecuteQueryWithOptions(query, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get lookup data %q: %w", path, err)
 	}
@@ -251,25 +267,28 @@ func (h *Handler) GetData(path string, limit int) ([]map[string]interface{}, err
 		records = result.Result.Records
 	}
 
-	return records, nil
+	return &GetDataResult{
+		Records:       records,
+		Notifications: result.GetNotifications(),
+	}, nil
 }
 
 // GetWithData retrieves a lookup table with its data
-func (h *Handler) GetWithData(path string, limit int) (*LookupData, error) {
+func (h *Handler) GetWithData(path string, limit int) (*LookupData, []exec.QueryNotification, error) {
 	lookup, err := h.Get(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	data, err := h.GetData(path, limit)
+	dataResult, err := h.GetData(path, limit)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	return &LookupData{
 		Lookup: *lookup,
-		Data:   data,
-	}, nil
+		Data:   dataResult.Records,
+	}, dataResult.Notifications, nil
 }
 
 // Create creates a new lookup table

--- a/test/e2e/lookup_test.go
+++ b/test/e2e/lookup_test.go
@@ -108,18 +108,18 @@ func TestLookupLifecycle(t *testing.T) {
 
 	// Step 4: Get lookup data
 	t.Log("Step 4: Getting lookup data...")
-	data, err := handler.GetData(lookupPath, 0)
+	dataResult, err := handler.GetData(lookupPath, 0)
 	if err != nil {
 		t.Fatalf("Failed to get lookup data: %v", err)
 	}
-	if len(data) != 6 {
-		t.Errorf("GetData() record count = %v, want 6", len(data))
+	if len(dataResult.Records) != 6 {
+		t.Errorf("GetData() record count = %v, want 6", len(dataResult.Records))
 	}
-	t.Logf("✓ Got lookup data: %d records", len(data))
+	t.Logf("✓ Got lookup data: %d records", len(dataResult.Records))
 
 	// Verify first record
-	if len(data) > 0 {
-		firstRecord := data[0]
+	if len(dataResult.Records) > 0 {
+		firstRecord := dataResult.Records[0]
 		if code, ok := firstRecord["code"].(string); ok {
 			if code != "200" {
 				t.Errorf("First record code = %v, want '200'", code)
@@ -158,16 +158,16 @@ func TestLookupLifecycle(t *testing.T) {
 
 	// Step 6: Verify update
 	t.Log("Step 6: Verifying update...")
-	updatedData, err := handler.GetData(lookupPath, 0)
+	updatedDataResult, err := handler.GetData(lookupPath, 0)
 	if err != nil {
 		t.Fatalf("Failed to get updated lookup data: %v", err)
 	}
-	if len(updatedData) != 4 {
-		t.Errorf("Updated data record count = %v, want 4", len(updatedData))
+	if len(updatedDataResult.Records) != 4 {
+		t.Errorf("Updated data record count = %v, want 4", len(updatedDataResult.Records))
 	}
 	// Check if new column exists
-	if len(updatedData) > 0 {
-		if _, hasCategory := updatedData[0]["category"]; !hasCategory {
+	if len(updatedDataResult.Records) > 0 {
+		if _, hasCategory := updatedDataResult.Records[0]["category"]; !hasCategory {
 			t.Error("Updated data missing 'category' column")
 		}
 	}
@@ -369,18 +369,18 @@ func TestLookupCreate_CustomParsePattern(t *testing.T) {
 
 	// Verify data
 	time.Sleep(2 * time.Second)
-	data, err := handler.GetData(lookupPath, 0)
+	dataResult, err := handler.GetData(lookupPath, 0)
 	if err != nil {
 		t.Fatalf("Failed to get data: %v", err)
 	}
 
-	if len(data) != 3 {
-		t.Errorf("Data length = %d, want 3", len(data))
+	if len(dataResult.Records) != 3 {
+		t.Errorf("Data length = %d, want 3", len(dataResult.Records))
 	}
 
 	// Check first record has expected columns
-	if len(data) > 0 {
-		first := data[0]
+	if len(dataResult.Records) > 0 {
+		first := dataResult.Records[0]
 		if _, hasID := first["id"]; !hasID {
 			t.Error("First record missing 'id' column")
 		}


### PR DESCRIPTION
## Summary

- Fixes silent data truncation when exporting lookup tables with >1000 records
- Sets `MaxResultRecords` to 1,000,000 in `GetData()` to retrieve all records instead of relying on DQL's default limit of 1000
- Surfaces DQL truncation notifications to stderr so users are warned if results are still capped

## Validated

Tested against live environment:
- **Before fix:** lookup with 2083 records returned only 1000 (silent truncation)
- **After fix:** all 2083 records returned correctly
- Also validated with 3790-record lookup table — all records returned

Fixes #57