### PR TITLE
feat: add agent output envelope (--agent / -A flag)

### DIFF
--- a/cmd/agent_helpers.go
+++ b/cmd/agent_helpers.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/dtctl/pkg/apply"
+)
+
+// extractApplyBase extracts the embedded ApplyResultBase from any ApplyResult
+// concrete type using a type switch. Returns nil if the type is unrecognized.
+func extractApplyBase(result apply.ApplyResult) *apply.ApplyResultBase {
+	switch r := result.(type) {
+	case *apply.WorkflowApplyResult:
+		return &r.ApplyResultBase
+	case apply.WorkflowApplyResult:
+		return &r.ApplyResultBase
+	case *apply.DashboardApplyResult:
+		return &r.ApplyResultBase
+	case apply.DashboardApplyResult:
+		return &r.ApplyResultBase
+	case *apply.NotebookApplyResult:
+		return &r.ApplyResultBase
+	case apply.NotebookApplyResult:
+		return &r.ApplyResultBase
+	case *apply.SLOApplyResult:
+		return &r.ApplyResultBase
+	case apply.SLOApplyResult:
+		return &r.ApplyResultBase
+	case *apply.BucketApplyResult:
+		return &r.ApplyResultBase
+	case apply.BucketApplyResult:
+		return &r.ApplyResultBase
+	case *apply.SettingsApplyResult:
+		return &r.ApplyResultBase
+	case apply.SettingsApplyResult:
+		return &r.ApplyResultBase
+	case *apply.ConnectionApplyResult:
+		return &r.ApplyResultBase
+	case apply.ConnectionApplyResult:
+		return &r.ApplyResultBase
+	case *apply.MonitoringConfigApplyResult:
+		return &r.ApplyResultBase
+	case apply.MonitoringConfigApplyResult:
+		return &r.ApplyResultBase
+	default:
+		return nil
+	}
+}
+
+// buildApplySuggestions returns agent-mode suggestions based on apply results.
+func buildApplySuggestions(results []apply.ApplyResult) []string {
+	if len(results) == 0 {
+		return nil
+	}
+
+	// Determine the action from the first result
+	base := extractApplyBase(results[0])
+	if base == nil {
+		return nil
+	}
+
+	switch base.Action {
+	case apply.ActionCreated:
+		return []string{
+			fmt.Sprintf("Created successfully. Verify with 'dtctl describe %s %s'", base.ResourceType, base.ID),
+			fmt.Sprintf("Monitor with 'dtctl get %s --watch'", base.ResourceType),
+		}
+	case apply.ActionUpdated:
+		return []string{
+			fmt.Sprintf("Updated successfully. Review history with 'dtctl history %s %s'", base.ResourceType, base.ID),
+			"Compare with 'dtctl diff' to verify changes",
+		}
+	case apply.ActionUnchanged:
+		return []string{
+			"No changes detected. The resource is already up to date.",
+		}
+	default:
+		return nil
+	}
+}

--- a/cmd/agent_helpers_test.go
+++ b/cmd/agent_helpers_test.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/apply"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+func TestExtractApplyBase_PointerTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		result apply.ApplyResult
+		want   string // expected ResourceType
+	}{
+		{
+			name: "WorkflowApplyResult pointer",
+			result: &apply.WorkflowApplyResult{
+				ApplyResultBase: apply.ApplyResultBase{
+					Action: apply.ActionCreated, ResourceType: "workflow", ID: "w1",
+				},
+			},
+			want: "workflow",
+		},
+		{
+			name: "DashboardApplyResult pointer",
+			result: &apply.DashboardApplyResult{
+				ApplyResultBase: apply.ApplyResultBase{
+					Action: apply.ActionUpdated, ResourceType: "dashboard", ID: "d1",
+				},
+			},
+			want: "dashboard",
+		},
+		{
+			name: "SettingsApplyResult pointer",
+			result: &apply.SettingsApplyResult{
+				ApplyResultBase: apply.ApplyResultBase{
+					Action: apply.ActionUnchanged, ResourceType: "settings", ID: "s1",
+				},
+			},
+			want: "settings",
+		},
+		{
+			name: "BucketApplyResult pointer",
+			result: &apply.BucketApplyResult{
+				ApplyResultBase: apply.ApplyResultBase{
+					Action: apply.ActionCreated, ResourceType: "bucket", ID: "b1",
+				},
+			},
+			want: "bucket",
+		},
+		{
+			name: "ConnectionApplyResult pointer",
+			result: &apply.ConnectionApplyResult{
+				ApplyResultBase: apply.ApplyResultBase{
+					Action: apply.ActionCreated, ResourceType: "connection", ID: "c1",
+				},
+			},
+			want: "connection",
+		},
+		{
+			name: "MonitoringConfigApplyResult pointer",
+			result: &apply.MonitoringConfigApplyResult{
+				ApplyResultBase: apply.ApplyResultBase{
+					Action: apply.ActionCreated, ResourceType: "monitoring-config", ID: "m1",
+				},
+			},
+			want: "monitoring-config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := extractApplyBase(tt.result)
+			if base == nil {
+				t.Fatal("expected non-nil base")
+			}
+			if base.ResourceType != tt.want {
+				t.Errorf("expected ResourceType=%q, got %q", tt.want, base.ResourceType)
+			}
+		})
+	}
+}
+
+func TestExtractApplyBase_ValueTypes(t *testing.T) {
+	// Verify value types (not pointers) also work — this was the panic scenario
+	result := apply.WorkflowApplyResult{
+		ApplyResultBase: apply.ApplyResultBase{
+			Action: apply.ActionCreated, ResourceType: "workflow", ID: "w1",
+		},
+	}
+
+	base := extractApplyBase(result)
+	if base == nil {
+		t.Fatal("expected non-nil base for value type")
+	}
+	if base.ResourceType != "workflow" {
+		t.Errorf("expected ResourceType=workflow, got %q", base.ResourceType)
+	}
+}
+
+func TestExtractApplyBase_NilResult(t *testing.T) {
+	// Type assertion on nil interface should not panic
+	var result apply.ApplyResult
+	if result != nil {
+		base := extractApplyBase(result)
+		if base != nil {
+			t.Error("expected nil base for nil input")
+		}
+	}
+	// If result is nil, callers should not call extractApplyBase — this is fine
+}
+
+func TestBuildApplySuggestions_Created(t *testing.T) {
+	results := []apply.ApplyResult{
+		&apply.WorkflowApplyResult{
+			ApplyResultBase: apply.ApplyResultBase{
+				Action: apply.ActionCreated, ResourceType: "workflow", ID: "abc-123",
+			},
+		},
+	}
+
+	suggestions := buildApplySuggestions(results)
+	if len(suggestions) != 2 {
+		t.Fatalf("expected 2 suggestions for created, got %d", len(suggestions))
+	}
+	if suggestions[0] != "Created successfully. Verify with 'dtctl describe workflow abc-123'" {
+		t.Errorf("unexpected suggestion[0]: %q", suggestions[0])
+	}
+	if suggestions[1] != "Monitor with 'dtctl get workflow --watch'" {
+		t.Errorf("unexpected suggestion[1]: %q", suggestions[1])
+	}
+}
+
+func TestBuildApplySuggestions_Updated(t *testing.T) {
+	results := []apply.ApplyResult{
+		&apply.DashboardApplyResult{
+			ApplyResultBase: apply.ApplyResultBase{
+				Action: apply.ActionUpdated, ResourceType: "dashboard", ID: "d-456",
+			},
+		},
+	}
+
+	suggestions := buildApplySuggestions(results)
+	if len(suggestions) != 2 {
+		t.Fatalf("expected 2 suggestions for updated, got %d", len(suggestions))
+	}
+	if suggestions[0] != "Updated successfully. Review history with 'dtctl history dashboard d-456'" {
+		t.Errorf("unexpected suggestion[0]: %q", suggestions[0])
+	}
+}
+
+func TestBuildApplySuggestions_Unchanged(t *testing.T) {
+	results := []apply.ApplyResult{
+		&apply.SLOApplyResult{
+			ApplyResultBase: apply.ApplyResultBase{
+				Action: apply.ActionUnchanged, ResourceType: "slo", ID: "s-789",
+			},
+		},
+	}
+
+	suggestions := buildApplySuggestions(results)
+	if len(suggestions) != 1 {
+		t.Fatalf("expected 1 suggestion for unchanged, got %d", len(suggestions))
+	}
+	if suggestions[0] != "No changes detected. The resource is already up to date." {
+		t.Errorf("unexpected suggestion: %q", suggestions[0])
+	}
+}
+
+func TestBuildApplySuggestions_EmptyResults(t *testing.T) {
+	suggestions := buildApplySuggestions(nil)
+	if suggestions != nil {
+		t.Errorf("expected nil suggestions for empty results, got %v", suggestions)
+	}
+
+	suggestions = buildApplySuggestions([]apply.ApplyResult{})
+	if suggestions != nil {
+		t.Errorf("expected nil suggestions for empty slice, got %v", suggestions)
+	}
+}
+
+func TestEnrichAgent_AgentPrinter(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := &output.ResponseContext{}
+	printer := output.NewAgentPrinter(&buf, ctx)
+
+	ap := enrichAgent(printer, "get", "workflow")
+	if ap == nil {
+		t.Fatal("expected non-nil AgentPrinter from enrichAgent")
+	}
+	if ap.Context().Verb != "get" {
+		t.Errorf("expected verb=get, got %q", ap.Context().Verb)
+	}
+	if ap.Context().Resource != "workflow" {
+		t.Errorf("expected resource=workflow, got %q", ap.Context().Resource)
+	}
+}
+
+func TestEnrichAgent_NonAgentPrinter(t *testing.T) {
+	// When not in agent mode, enrichAgent should return nil
+	printer := output.NewPrinterWithOptions("json", &bytes.Buffer{}, false)
+
+	ap := enrichAgent(printer, "get", "workflow")
+	if ap != nil {
+		t.Error("expected nil for non-AgentPrinter")
+	}
+}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -141,6 +141,28 @@ that contains the dashboard ID. The 'create' command always creates new resource
 		// The concrete type (DashboardApplyResult, WorkflowApplyResult, etc.)
 		// determines which columns/fields appear in the output.
 		printer := NewPrinter()
+
+		// Enrich agent output with apply-specific context
+		resourceType := ""
+		if base := extractApplyBase(results[0]); base != nil {
+			resourceType = base.ResourceType
+		}
+		if ap := enrichAgent(printer, "apply", resourceType); ap != nil {
+			ap.SetTotal(len(results))
+			suggestions := buildApplySuggestions(results)
+			ap.SetSuggestions(suggestions)
+			// Forward any warnings from apply results
+			var warnings []string
+			for _, r := range results {
+				if base := extractApplyBase(r); base != nil && len(base.Warnings) > 0 {
+					warnings = append(warnings, base.Warnings...)
+				}
+			}
+			if len(warnings) > 0 {
+				ap.SetWarnings(warnings)
+			}
+		}
+
 		if len(results) == 1 {
 			return printer.Print(results[0])
 		}

--- a/cmd/get_workflows.go
+++ b/cmd/get_workflows.go
@@ -46,12 +46,19 @@ Examples:
 
 		handler := workflow.NewHandler(c)
 		printer := NewPrinter()
+		ap := enrichAgent(printer, "get", "workflow")
 
 		// Get specific workflow if ID provided
 		if len(args) > 0 {
 			wf, err := handler.Get(args[0])
 			if err != nil {
 				return err
+			}
+			if ap != nil {
+				ap.SetSuggestions([]string{
+					fmt.Sprintf("Run 'dtctl exec workflow %s' to trigger this workflow", args[0]),
+					fmt.Sprintf("Run 'dtctl get workflow-executions --workflow %s' to see past executions", args[0]),
+				})
 			}
 			return printer.Print(wf)
 		}
@@ -86,6 +93,20 @@ Examples:
 		list, err := handler.List(filters)
 		if err != nil {
 			return err
+		}
+
+		if ap != nil {
+			ap.SetTotal(len(list.Results))
+			suggestions := []string{
+				"Run 'dtctl describe workflow <id>' for details",
+				"Run 'dtctl exec workflow <id>' to trigger a workflow",
+			}
+			// If count from API exceeds returned results, more data exists
+			if list.Count > len(list.Results) {
+				ap.SetHasMore(true)
+				suggestions = append(suggestions, "More results available. Use '--chunk-size 0' to retrieve all, or filter with DQL")
+			}
+			ap.SetSuggestions(suggestions)
 		}
 
 		return printer.PrintList(list.Results)
@@ -127,12 +148,18 @@ Examples:
 
 		handler := workflow.NewExecutionHandler(c)
 		printer := NewPrinter()
+		ap := enrichAgent(printer, "get", "workflow-execution")
 
 		// Get specific execution if ID provided
 		if len(args) > 0 {
 			exec, err := handler.Get(args[0])
 			if err != nil {
 				return err
+			}
+			if ap != nil {
+				ap.SetSuggestions([]string{
+					fmt.Sprintf("Run 'dtctl logs workflow-execution %s' to view execution logs", args[0]),
+				})
 			}
 			return printer.Print(exec)
 		}
@@ -141,6 +168,14 @@ Examples:
 		list, err := handler.List(workflowFilter)
 		if err != nil {
 			return err
+		}
+
+		if ap != nil {
+			ap.SetTotal(len(list.Results))
+			ap.SetSuggestions([]string{
+				"Run 'dtctl get workflow-executions <id>' for execution details",
+				"Run 'dtctl logs workflow-execution <id>' to view execution logs",
+			})
 		}
 
 		return printer.PrintList(list.Results)
@@ -214,6 +249,22 @@ Examples:
 
 		if err := handler.Delete(workflowID); err != nil {
 			return err
+		}
+
+		// In agent mode, output structured response
+		if agentMode {
+			printer := NewPrinter()
+			ap := enrichAgent(printer, "delete", "workflow")
+			if ap != nil {
+				ap.SetSuggestions([]string{
+					"Deleted. Verify with 'dtctl get workflows'",
+				})
+			}
+			return printer.Print(map[string]string{
+				"id":     workflowID,
+				"title":  wf.Title,
+				"status": "deleted",
+			})
 		}
 
 		fmt.Printf("Workflow %q deleted\n", wf.Title)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/dynatrace-oss/dtctl/pkg/aidetect"
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
@@ -24,6 +25,8 @@ var (
 	dryRun       bool
 	plainMode    bool
 	chunkSize    int64
+	agentMode    bool // --agent/-A flag: wrap output in machine-readable envelope
+	noAgent      bool // --no-agent flag: opt out of auto-detected agent mode
 )
 
 // rootCmd represents the base command
@@ -206,9 +209,31 @@ func NewSafetyChecker(cfg *config.Config) (*safety.Checker, error) {
 	return safety.NewChecker(cfg.CurrentContext, ctx), nil
 }
 
-// NewPrinter creates a new printer respecting plain mode setting
+// NewPrinter creates a new printer respecting agent and plain mode settings
 func NewPrinter() output.Printer {
+	if agentMode {
+		ctx := &output.ResponseContext{}
+		return output.NewAgentPrinter(os.Stdout, ctx)
+	}
 	return output.NewPrinterWithOptions(outputFormat, os.Stdout, plainMode)
+}
+
+// enrichAgent configures agent-mode metadata on the printer if agent mode is active.
+// It is a no-op when the printer is not an AgentPrinter. Returns the AgentPrinter
+// for further customization (or nil if not in agent mode).
+func enrichAgent(printer output.Printer, verb, resource string) *output.AgentPrinter {
+	ap, ok := printer.(*output.AgentPrinter)
+	if !ok {
+		return nil
+	}
+	ap.Context().Verb = verb
+	ap.SetResource(resource)
+	return ap
+}
+
+// GetAgentMode returns the current agent mode setting
+func GetAgentMode() bool {
+	return agentMode
 }
 
 // LoadConfig loads the config and applies the --context flag override if provided
@@ -261,6 +286,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "enable debug mode (full HTTP request/response logging, equivalent to -vv)")
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "print what would be done without doing it")
 	rootCmd.PersistentFlags().BoolVar(&plainMode, "plain", false, "plain output for machine processing (no colors, no interactive prompts)")
+	rootCmd.PersistentFlags().BoolVarP(&agentMode, "agent", "A", false, "agent output mode: wrap output in a structured JSON envelope with metadata")
+	rootCmd.PersistentFlags().BoolVar(&noAgent, "no-agent", false, "disable auto-detected agent mode")
 	rootCmd.PersistentFlags().Int64Var(&chunkSize, "chunk-size", 500, "Return large lists in chunks rather than all at once. Pass 0 to disable.")
 
 	// Bind flags to viper
@@ -271,6 +298,22 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set
 func initConfig() {
+	// Auto-detect AI agent environment and enable agent mode
+	if !agentMode && !noAgent {
+		if info := aidetect.Detect(); info.Detected {
+			// Only auto-enable if user hasn't explicitly chosen a non-JSON output format
+			outputFlag := rootCmd.PersistentFlags().Lookup("output")
+			if outputFlag == nil || !outputFlag.Changed {
+				agentMode = true
+			}
+		}
+	}
+
+	// Agent mode implies plain mode (no colors, no interactive prompts)
+	if agentMode {
+		plainMode = true
+	}
+
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
 	} else {

--- a/pkg/output/agent.go
+++ b/pkg/output/agent.go
@@ -1,0 +1,149 @@
+package output
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// Response is the agent mode envelope that wraps all CLI output.
+// Success responses have OK=true with Result populated.
+// Error responses have OK=false with Error populated.
+type Response struct {
+	OK      bool             `json:"ok"`
+	Result  interface{}      `json:"result"`
+	Error   *ErrorDetail     `json:"error,omitempty"`
+	Context *ResponseContext `json:"context,omitempty"`
+}
+
+// ResponseContext provides operational metadata alongside the result.
+type ResponseContext struct {
+	Total       *int              `json:"total,omitempty"`
+	HasMore     bool              `json:"has_more,omitempty"`
+	Verb        string            `json:"verb,omitempty"`
+	Resource    string            `json:"resource,omitempty"`
+	Suggestions []string          `json:"suggestions,omitempty"`
+	Warnings    []string          `json:"warnings,omitempty"`
+	Duration    string            `json:"duration,omitempty"`
+	Links       map[string]string `json:"links,omitempty"`
+}
+
+// ErrorDetail is a structured error for machine consumption.
+// It lives in the Response envelope when ok=false.
+type ErrorDetail struct {
+	Code        string   `json:"code"`
+	Message     string   `json:"message"`
+	Operation   string   `json:"operation,omitempty"`
+	StatusCode  int      `json:"status_code,omitempty"`
+	RequestID   string   `json:"request_id,omitempty"`
+	Suggestions []string `json:"suggestions,omitempty"`
+}
+
+// ClassifyHTTPError maps an HTTP status code to a machine-readable error code.
+func ClassifyHTTPError(statusCode int) string {
+	switch statusCode {
+	case 400:
+		return "bad_request"
+	case 401:
+		return "auth_required"
+	case 403:
+		return "permission_denied"
+	case 404:
+		return "not_found"
+	case 409:
+		return "conflict"
+	case 429:
+		return "rate_limited"
+	default:
+		if statusCode >= 500 {
+			return "server_error"
+		}
+		return "error"
+	}
+}
+
+// AgentPrinter wraps CLI output in a Response envelope for machine consumers.
+// It implements the Printer interface.
+type AgentPrinter struct {
+	writer io.Writer
+	ctx    *ResponseContext
+}
+
+// NewAgentPrinter creates an AgentPrinter that writes envelope-wrapped JSON to writer.
+func NewAgentPrinter(writer io.Writer, ctx *ResponseContext) *AgentPrinter {
+	if ctx == nil {
+		ctx = &ResponseContext{}
+	}
+	return &AgentPrinter{writer: writer, ctx: ctx}
+}
+
+// Print writes a single result wrapped in the agent envelope.
+func (p *AgentPrinter) Print(data interface{}) error {
+	resp := Response{
+		OK:      true,
+		Result:  data,
+		Context: p.ctx,
+	}
+	enc := json.NewEncoder(p.writer)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
+}
+
+// PrintList writes a list result wrapped in the agent envelope.
+// If Total has been set via SetTotal, it is included in the context.
+func (p *AgentPrinter) PrintList(data interface{}) error {
+	return p.Print(data)
+}
+
+// SetTotal sets the total item count in the response context.
+func (p *AgentPrinter) SetTotal(total int) {
+	p.ctx.Total = &total
+}
+
+// SetResource sets the resource type in the response context.
+func (p *AgentPrinter) SetResource(resource string) {
+	p.ctx.Resource = resource
+}
+
+// SetSuggestions sets the follow-up suggestions in the response context.
+func (p *AgentPrinter) SetSuggestions(suggestions []string) {
+	p.ctx.Suggestions = suggestions
+}
+
+// SetWarnings sets non-fatal warnings in the response context.
+func (p *AgentPrinter) SetWarnings(warnings []string) {
+	p.ctx.Warnings = warnings
+}
+
+// SetDuration sets the operation duration in the response context.
+// Only use for commands where timing is meaningful (wait, query, exec).
+func (p *AgentPrinter) SetDuration(duration string) {
+	p.ctx.Duration = duration
+}
+
+// SetLinks sets deep links to the Dynatrace UI in the response context.
+func (p *AgentPrinter) SetLinks(links map[string]string) {
+	p.ctx.Links = links
+}
+
+// SetHasMore indicates whether more results exist beyond the current page.
+func (p *AgentPrinter) SetHasMore(hasMore bool) {
+	p.ctx.HasMore = hasMore
+}
+
+// Context returns the response context for direct manipulation.
+func (p *AgentPrinter) Context() *ResponseContext {
+	return p.ctx
+}
+
+// PrintError writes an error response to the given writer in agent envelope format.
+// This is a package-level function because errors are handled centrally in cmd/root.go,
+// not through the printer instance.
+func PrintError(writer io.Writer, detail *ErrorDetail) error {
+	resp := Response{
+		OK:    false,
+		Error: detail,
+	}
+	enc := json.NewEncoder(writer)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
+}

--- a/pkg/output/agent_test.go
+++ b/pkg/output/agent_test.go
@@ -1,0 +1,383 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestAgentPrinter_Print_WrapsInEnvelope(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := &ResponseContext{Verb: "get", Resource: "workflow"}
+	p := NewAgentPrinter(&buf, ctx)
+
+	data := map[string]string{"id": "abc-123", "title": "My Workflow"}
+	if err := p.Print(data); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	if !resp.OK {
+		t.Error("expected ok=true")
+	}
+	if resp.Context == nil {
+		t.Fatal("expected context to be present")
+	}
+	if resp.Context.Verb != "get" {
+		t.Errorf("expected verb=get, got %q", resp.Context.Verb)
+	}
+	if resp.Context.Resource != "workflow" {
+		t.Errorf("expected resource=workflow, got %q", resp.Context.Resource)
+	}
+	if resp.Error != nil {
+		t.Error("expected no error on success response")
+	}
+
+	// Verify result contains our data
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected result to be a map, got %T", resp.Result)
+	}
+	if result["id"] != "abc-123" {
+		t.Errorf("expected id=abc-123, got %v", result["id"])
+	}
+}
+
+func TestAgentPrinter_PrintList_SetsTotal(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := &ResponseContext{Verb: "get", Resource: "workflow"}
+	p := NewAgentPrinter(&buf, ctx)
+
+	items := []map[string]string{
+		{"id": "1", "title": "WF 1"},
+		{"id": "2", "title": "WF 2"},
+		{"id": "3", "title": "WF 3"},
+	}
+
+	p.SetTotal(3)
+	if err := p.PrintList(items); err != nil {
+		t.Fatalf("PrintList failed: %v", err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	if !resp.OK {
+		t.Error("expected ok=true")
+	}
+	if resp.Context.Total == nil {
+		t.Fatal("expected total to be set")
+	}
+	if *resp.Context.Total != 3 {
+		t.Errorf("expected total=3, got %d", *resp.Context.Total)
+	}
+}
+
+func TestAgentPrinter_SetSuggestions(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewAgentPrinter(&buf, &ResponseContext{})
+
+	p.SetSuggestions([]string{
+		"Run 'dtctl describe workflow abc' for details",
+		"Run 'dtctl exec workflow abc' to trigger",
+	})
+
+	if err := p.Print(map[string]string{"id": "abc"}); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	if len(resp.Context.Suggestions) != 2 {
+		t.Fatalf("expected 2 suggestions, got %d", len(resp.Context.Suggestions))
+	}
+	if resp.Context.Suggestions[0] != "Run 'dtctl describe workflow abc' for details" {
+		t.Errorf("unexpected suggestion: %q", resp.Context.Suggestions[0])
+	}
+}
+
+func TestAgentPrinter_SetWarnings(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewAgentPrinter(&buf, &ResponseContext{})
+
+	p.SetWarnings([]string{"API deprecated, will be removed in v2"})
+
+	if err := p.Print("data"); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	if len(resp.Context.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(resp.Context.Warnings))
+	}
+	if resp.Context.Warnings[0] != "API deprecated, will be removed in v2" {
+		t.Errorf("unexpected warning: %q", resp.Context.Warnings[0])
+	}
+}
+
+func TestAgentPrinter_SetHasMore(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewAgentPrinter(&buf, &ResponseContext{})
+
+	p.SetHasMore(true)
+
+	if err := p.Print([]string{"item1"}); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	if !resp.Context.HasMore {
+		t.Error("expected has_more=true")
+	}
+}
+
+func TestAgentPrinter_SetDuration(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewAgentPrinter(&buf, &ResponseContext{})
+
+	p.SetDuration("2.5s")
+
+	if err := p.Print("result"); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	if resp.Context.Duration != "2.5s" {
+		t.Errorf("expected duration=2.5s, got %q", resp.Context.Duration)
+	}
+}
+
+func TestAgentPrinter_SetLinks(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewAgentPrinter(&buf, &ResponseContext{})
+
+	p.SetLinks(map[string]string{
+		"ui": "https://env.dynatrace.com/ui/workflows/abc",
+	})
+
+	if err := p.Print("data"); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	if resp.Context.Links == nil {
+		t.Fatal("expected links to be present")
+	}
+	if resp.Context.Links["ui"] != "https://env.dynatrace.com/ui/workflows/abc" {
+		t.Errorf("unexpected link: %q", resp.Context.Links["ui"])
+	}
+}
+
+func TestAgentPrinter_NilContext(t *testing.T) {
+	var buf bytes.Buffer
+	// NewAgentPrinter initializes ctx if nil
+	p := NewAgentPrinter(&buf, nil)
+
+	if err := p.Print("data"); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	if !resp.OK {
+		t.Error("expected ok=true")
+	}
+	if resp.Context == nil {
+		t.Error("expected context to be initialized")
+	}
+}
+
+func TestAgentPrinter_ImplementsPrinterInterface(t *testing.T) {
+	var _ Printer = (*AgentPrinter)(nil)
+}
+
+func TestAgentPrinter_EmptyContextFieldsOmitted(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewAgentPrinter(&buf, &ResponseContext{Verb: "get"})
+
+	if err := p.Print("data"); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	output := buf.String()
+
+	// Fields with zero values should be omitted from JSON
+	if containsKey(output, "total") {
+		t.Error("total should be omitted when nil")
+	}
+	if containsKey(output, "has_more") {
+		t.Error("has_more should be omitted when false")
+	}
+	if containsKey(output, "suggestions") {
+		t.Error("suggestions should be omitted when nil")
+	}
+	if containsKey(output, "warnings") {
+		t.Error("warnings should be omitted when nil")
+	}
+	if containsKey(output, "duration") {
+		t.Error("duration should be omitted when empty")
+	}
+	if containsKey(output, "links") {
+		t.Error("links should be omitted when nil")
+	}
+}
+
+func TestPrintError(t *testing.T) {
+	var buf bytes.Buffer
+	detail := &ErrorDetail{
+		Code:       "auth_required",
+		Message:    "Authentication failed",
+		Operation:  "get workflows",
+		StatusCode: 401,
+		RequestID:  "req-abc-123",
+		Suggestions: []string{
+			"Run 'dtctl auth login' to refresh your token",
+		},
+	}
+
+	if err := PrintError(&buf, detail); err != nil {
+		t.Fatalf("PrintError failed: %v", err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	if resp.OK {
+		t.Error("expected ok=false for error")
+	}
+	if resp.Result != nil {
+		t.Error("expected no result for error")
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error detail")
+	}
+	if resp.Error.Code != "auth_required" {
+		t.Errorf("expected code=auth_required, got %q", resp.Error.Code)
+	}
+	if resp.Error.StatusCode != 401 {
+		t.Errorf("expected status_code=401, got %d", resp.Error.StatusCode)
+	}
+	if len(resp.Error.Suggestions) != 1 {
+		t.Fatalf("expected 1 suggestion, got %d", len(resp.Error.Suggestions))
+	}
+}
+
+func TestClassifyHTTPError(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{400, "bad_request"},
+		{401, "auth_required"},
+		{403, "permission_denied"},
+		{404, "not_found"},
+		{409, "conflict"},
+		{429, "rate_limited"},
+		{500, "server_error"},
+		{502, "server_error"},
+		{503, "server_error"},
+		{504, "server_error"},
+		{418, "error"}, // Unknown 4xx
+		{200, "error"}, // Success codes (shouldn't be used but return generic)
+		{0, "error"},   // Zero
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := ClassifyHTTPError(tt.status)
+			if got != tt.want {
+				t.Errorf("ClassifyHTTPError(%d) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentPrinter_PrintList_WithoutSetTotal(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := &ResponseContext{Verb: "get", Resource: "workflow"}
+	p := NewAgentPrinter(&buf, ctx)
+
+	items := []map[string]string{
+		{"id": "1", "title": "WF 1"},
+		{"id": "2", "title": "WF 2"},
+	}
+
+	// Do NOT call SetTotal — total should be omitted from output
+	if err := p.PrintList(items); err != nil {
+		t.Fatalf("PrintList failed: %v", err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+
+	if !resp.OK {
+		t.Error("expected ok=true")
+	}
+	if resp.Context.Total != nil {
+		t.Errorf("expected total to be nil (omitted), got %d", *resp.Context.Total)
+	}
+}
+
+func TestAgentPrinter_Print_ResultAlwaysPresent(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewAgentPrinter(&buf, &ResponseContext{Verb: "get"})
+
+	// Print nil result — should still have "result" key in JSON (as null)
+	if err := p.Print(nil); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if _, exists := m["result"]; !exists {
+		t.Error("expected 'result' key to be present in output even when value is nil")
+	}
+}
+
+// containsKey checks if a JSON output contains a specific key.
+func containsKey(jsonOutput, key string) bool {
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonOutput), &m); err != nil {
+		return false
+	}
+	ctx, ok := m["context"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	_, exists := ctx[key]
+	return exists
+}


### PR DESCRIPTION
## Summary

- Add `--agent` / `-A` flag that wraps all CLI output in a structured JSON envelope (`ok`, `result`, `error`, `context`) for AI agents and automation consumers
- Auto-detect AI agent environments via existing `aidetect` package and enable agent mode automatically (opt out with `--no-agent`)
- Wire up agent-mode context (suggestions, pagination, warnings) for `get workflows`, `get workflow-executions`, `delete workflow`, and `apply` commands

## Implementation

**Core** (`pkg/output/agent.go`):
- `Response` envelope with `ok`/`result`/`error`/`context` fields
- `AgentPrinter` implementing the `Printer` interface with setter methods for context enrichment
- `PrintError()` for centralized error envelope output
- `ClassifyHTTPError()` mapping HTTP status codes to machine-readable error codes

**Integration** (`cmd/root.go`):
- `--agent`/`-A` and `--no-agent` persistent flags
- Auto-detection in `initConfig()` via `aidetect.Detect()`
- `enrichAgent()` helper for type-asserting `Printer` to `AgentPrinter`
- Agent mode implies `--plain` (no colors, no interactive prompts)

**Apply helpers** (`cmd/agent_helpers.go`):
- `extractApplyBase()` using type switch (not reflection) for safe field extraction from sealed `ApplyResult` interface
- `buildApplySuggestions()` returning action-aware follow-up hints

**Wired commands**:
- `get workflows` — suggestions, `has_more` pagination detection, total count
- `get workflow-executions` — suggestions, total count
- `delete workflow` — structured response with suggestions (replaces bare `fmt.Printf`)
- `apply` — action-aware suggestions (created/updated/unchanged), warning forwarding, resource type extraction

## Example output

```json
{
  "ok": true,
  "result": [ ... ],
  "context": {
    "total": 5,
    "has_more": true,
    "verb": "get",
    "resource": "workflow",
    "suggestions": [
      "Run 'dtctl describe workflow <id>' for details",
      "More results available. Use '--chunk-size 0' to retrieve all, or filter with DQL"
    ]
  }
}
```

## Testing

- 13 tests in `pkg/output/agent_test.go` — envelope structure, all setters, omitted fields, error output, HTTP classification, `result` key always present
- 11 tests in `cmd/agent_helpers_test.go` — `extractApplyBase` (pointer and value types), `buildApplySuggestions` (all actions + empty), `enrichAgent` (agent and non-agent printers)

## Spec

Implements `specs/agent-output-envelope.md` (with 7 improvements applied to spec prior to implementation).