### PR TITLE
docs: document agent output envelope (--agent / -A flag)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,23 @@ pkg/
   ├── client/    # HTTP client (auth, retry, rate limiting, pagination)
   ├── config/    # Multi-context config (~/.config/dtctl/config, keyring tokens)
   ├── resources/ # Resource handlers (one per API)
-  ├── output/    # Formatters (table, JSON, YAML, charts)
+  ├── output/    # Formatters (table, JSON, YAML, charts, agent envelope)
   └── exec/      # DQL query execution
 ```
+
+## Agent Output Mode
+
+dtctl supports `--agent` / `-A` to wrap all output in a structured JSON envelope for AI agents:
+
+```json
+{"ok": true, "result": [...], "context": {"verb": "get", "resource": "workflow", "suggestions": [...]}}
+```
+
+- **Auto-detected** in AI agent environments (opt out with `--no-agent`)
+- Implies `--plain` (no colors, no interactive prompts)
+- Errors are also structured: `{"ok": false, "error": {"code": "not_found", "message": "..."}}`
+- Implementation: `pkg/output/agent.go` (`AgentPrinter`, `Response`, `PrintError`)
+- Per-command context enrichment via `enrichAgent()` helper in `cmd/root.go`
 
 ## Adding a Resource
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Agent output envelope (`--agent` / `-A`)** — Wrap all CLI output in a structured JSON envelope (`ok`, `result`, `error`, `context`) for AI agents and automation consumers
+  - Auto-detects AI agent environments and enables agent mode automatically (opt out with `--no-agent`)
+  - Enriched context (suggestions, pagination, warnings) for `get workflows`, `get workflow-executions`, `delete workflow`, and `apply` commands
+  - Structured error output with machine-readable error codes and suggestions
 - **`dtctl ctx` command** — Top-level context management shortcut (like kubectx)
   - `dtctl ctx` lists all contexts, `dtctl ctx <name>` switches context
   - Subcommands: `current`, `describe`, `set`, `delete`/`rm`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ dtctl exec copilot nl2dql "error logs from last hour"
 
 ## Why dtctl?
 
-- **Built for AI agents** — Predictable verb-noun commands, structured output (`--plain`, `-o json`), and YAML-based editing make dtctl a natural tool for LLM-driven automation
+- **Built for AI agents** — Predictable verb-noun commands, structured output (`--plain`, `-o json`, `--agent`), and YAML-based editing make dtctl a natural tool for LLM-driven automation
+- **Agent output envelope** — `--agent` flag (auto-detected in AI environments) wraps all output in a structured JSON envelope with `ok`/`result`/`error`/`context` fields, follow-up suggestions, and pagination metadata
 - **Agent Skill included** — Ships with an [Agent Skill](https://agentskills.io) that teaches AI assistants how to operate your Dynatrace environment
 - **Familiar CLI conventions** — `get`, `describe`, `edit`, `apply`, `delete` — if you (or your AI) know `kubectl`, you already know dtctl
 - **Watch mode** — Real-time monitoring with `--watch` flag for all resources

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -3111,6 +3111,47 @@ No colors, no interactive prompts (for scripts):
 dtctl get workflows --plain
 ```
 
+### Agent Mode (`--agent` / `-A`)
+
+Wraps all output in a structured JSON envelope designed for AI agents and automation:
+
+```bash
+dtctl get workflows --agent
+
+# Output:
+# {
+#   "ok": true,
+#   "result": [...],
+#   "context": {
+#     "total": 5,
+#     "has_more": false,
+#     "verb": "get",
+#     "resource": "workflow",
+#     "suggestions": [
+#       "Run 'dtctl describe workflow <id>' for details",
+#       "Run 'dtctl exec workflow <id>' to trigger a workflow"
+#     ]
+#   }
+# }
+```
+
+Agent mode is auto-detected when running inside an AI agent environment (e.g., GitHub Copilot, Claude Code). To opt out, pass `--no-agent`. Agent mode implies `--plain`.
+
+```bash
+# Force agent mode off in an auto-detected environment
+dtctl get workflows --no-agent
+
+# Errors are also structured
+# {
+#   "ok": false,
+#   "error": {
+#     "code": "auth_required",
+#     "message": "Authentication failed",
+#     "suggestions": ["Run 'dtctl auth login' to refresh your token"]
+#   }
+# }
+```
+
 ### Pagination (--chunk-size)
 
 Like kubectl, dtctl automatically paginates through large result sets:

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -194,10 +194,43 @@ dtctl query "fetch logs | limit 10"
 --debug               # Enable debug mode (full HTTP logging, equivalent to -vv)
 --dry-run             # Print what would be done without doing it
 --field-selector string # Filter by fields (e.g., owner=me,type=notebook)
+-A, --agent           # Agent output mode: wrap all output in a structured JSON envelope
+--no-agent            # Disable auto-detected agent mode
 
 # (not implemented yet)
 # -w, --watch           # Watch for changes
 ```
+
+### Agent Mode (`--agent` / `-A`)
+
+When `--agent` (or `-A`) is passed, all CLI output is wrapped in a structured JSON envelope designed for AI agents and automation consumers:
+
+```json
+{
+  "ok": true,
+  "result": [ ... ],
+  "context": {
+    "total": 5,
+    "has_more": true,
+    "verb": "get",
+    "resource": "workflow",
+    "suggestions": [
+      "Run 'dtctl describe workflow <id>' for details",
+      "More results available. Use '--chunk-size 0' to retrieve all, or filter with DQL"
+    ]
+  }
+}
+```
+
+**Envelope fields:**
+- `ok` (bool) — `true` for success, `false` for errors. Always present.
+- `result` — The command output data. Always present (may be `null`).
+- `error` (object, optional) — Structured error with `code`, `message`, `operation`, `status_code`, `request_id`, `suggestions`.
+- `context` (object, optional) — Operational metadata: `total`, `has_more`, `verb`, `resource`, `suggestions`, `warnings`, `duration`, `links`.
+
+**Auto-detection:** Agent mode is automatically enabled when dtctl detects it is running inside an AI agent environment (via the `aidetect` package). Use `--no-agent` to opt out. Auto-detection is skipped if an explicit `--output` format is set.
+
+**Behavior:** Agent mode implies `--plain` (no colors, no interactive prompts).
 
 ### Debug Mode
 

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -16,7 +16,7 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] Context safety levels (readonly, readwrite-mine, readwrite-all, dangerously-unrestricted)
 - [x] HTTP client with retry, rate limiting, error handling
 - [x] Output formatters: JSON, YAML, table, wide, CSV, chart, sparkline, barchart
-- [x] Global flags: `--context`, `--output`, `--verbose`, `--debug`, `--dry-run`, `--chunk-size`, `--show-diff`
+- [x] Global flags: `--context`, `--output`, `--verbose`, `--debug`, `--dry-run`, `--chunk-size`, `--show-diff`, `--agent`, `--no-agent`
 - [x] Shell completion (bash, zsh, fish)
 - [x] Automatic pagination with `--chunk-size` (default 500)
 - [x] User identity: `dtctl auth whoami` (via metadata API with JWT fallback)

--- a/skills/dtctl/SKILL.md
+++ b/skills/dtctl/SKILL.md
@@ -96,6 +96,10 @@ Use IDs whenever possible instead of names to avoid ambiguity.
 ### Output Modes
 
 ```bash
+# Agent envelope mode (auto-detected in AI environments)
+-A, --agent      # Structured JSON envelope with ok/result/error/context
+--no-agent       # Opt out of auto-detected agent mode
+
 # Machine-readable formats (use these for AI agents)
 -o json          # JSON output
 -o yaml          # YAML output
@@ -108,11 +112,25 @@ Use IDs whenever possible instead of names to avoid ambiguity.
 -o table         # Table format (default)
 -o wide          # Wide table with more columns
 
-# Always use --plain flag for AI consumption
+# Always use --plain flag for AI consumption (implied by --agent)
 --plain          # Strips colors and prompts, best for parsing
 ```
 
-**For AI agents, always use:** `dtctl <command> -o json --plain`
+**For AI agents, prefer:** `dtctl <command> --agent` (auto-detected) or `dtctl <command> -o json --plain`
+
+The `--agent` envelope provides structured metadata alongside results:
+
+```json
+{
+  "ok": true,
+  "result": [ ... ],
+  "context": {
+    "verb": "get", "resource": "workflow",
+    "total": 5, "has_more": false,
+    "suggestions": ["Run 'dtctl describe workflow <id>' for details"]
+  }
+}
+```
 
 ### Template Variables
 


### PR DESCRIPTION
## Summary

Adds missing documentation for the agent output envelope feature introduced in #60.

- **docs/dev/API_DESIGN.md** — Added `--agent/-A` and `--no-agent` to Global Flags section, with full envelope schema description, auto-detection behavior, and example output
- **docs/dev/IMPLEMENTATION_STATUS.md** — Added `--agent` and `--no-agent` to the implemented global flags list
- **CHANGELOG.md** — Added entry under `[Unreleased]` for the agent output envelope feature
- **docs/QUICK_START.md** — Added "Agent Mode" section after "Plain Output" with usage examples and structured error example
- **README.md** — Added agent output envelope to the "Why dtctl?" feature list
- **AGENTS.md** — Added "Agent Output Mode" section with envelope format, auto-detection, and implementation pointers
- **skills/dtctl/SKILL.md** — Updated Output Modes section with `--agent`/`--no-agent` flags and envelope example