### PR TITLE
feat: structured JSON error output in agent/plain mode

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/aidetect"
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/suggest"
@@ -84,8 +86,14 @@ func Execute() {
 			err = enhanceFlagError(rootCmd, err)
 		}
 
+		if agentMode || plainMode {
+			detail := errorToDetail(err)
+			_ = output.PrintError(os.Stderr, detail)
+			os.Exit(exitCodeForError(err))
+		}
+
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		os.Exit(1)
+		os.Exit(exitCodeForError(err))
 	}
 }
 
@@ -157,6 +165,132 @@ func setupErrorHandlers(cmd *cobra.Command) {
 	for _, sub := range cmd.Commands() {
 		setupErrorHandlers(sub)
 	}
+}
+
+// errorToDetail converts any error into a structured ErrorDetail for agent/plain mode output.
+// It uses errors.As to extract rich context from typed errors when available.
+func errorToDetail(err error) *output.ErrorDetail {
+	// diagnostic.Error — wraps API errors with operation context and suggestions
+	var diagErr *diagnostic.Error
+	if errors.As(err, &diagErr) {
+		code := output.ClassifyHTTPError(diagErr.StatusCode)
+		if diagErr.StatusCode == 0 {
+			code = "error"
+		}
+		return &output.ErrorDetail{
+			Code:        code,
+			Message:     diagErr.Message,
+			Operation:   diagErr.Operation,
+			StatusCode:  diagErr.StatusCode,
+			RequestID:   diagErr.RequestID,
+			Suggestions: diagErr.Suggestions,
+		}
+	}
+
+	// client.APIError — raw API error without diagnostic wrapping
+	var apiErr *client.APIError
+	if errors.As(err, &apiErr) {
+		msg := apiErr.Message
+		if apiErr.Details != "" {
+			msg += " - " + apiErr.Details
+		}
+		return &output.ErrorDetail{
+			Code:       output.ClassifyHTTPError(apiErr.StatusCode),
+			Message:    msg,
+			StatusCode: apiErr.StatusCode,
+		}
+	}
+
+	// safety.SafetyError — operation blocked by safety level
+	var safetyErr *safety.SafetyError
+	if errors.As(err, &safetyErr) {
+		return &output.ErrorDetail{
+			Code:        "safety_blocked",
+			Message:     safetyErr.Reason,
+			Suggestions: safetyErr.Suggestions,
+		}
+	}
+
+	// suggest.CommandError — unknown command with "did you mean?" suggestions
+	var cmdErr *suggest.CommandError
+	if errors.As(err, &cmdErr) {
+		detail := &output.ErrorDetail{
+			Code:    "unknown_command",
+			Message: cmdErr.Message,
+		}
+		if cmdErr.Suggestion != nil {
+			detail.Suggestions = []string{
+				fmt.Sprintf("did you mean %q?", cmdErr.Suggestion.Value),
+			}
+		}
+		return detail
+	}
+
+	// suggest.FlagError — unknown flag with "did you mean?" suggestion
+	var flagErr *suggest.FlagError
+	if errors.As(err, &flagErr) {
+		detail := &output.ErrorDetail{
+			Code:    "unknown_command",
+			Message: flagErr.Message,
+		}
+		if flagErr.Suggestion != nil {
+			detail.Suggestions = []string{
+				fmt.Sprintf("did you mean --%s?", flagErr.Suggestion.Value),
+			}
+		}
+		return detail
+	}
+
+	// Fallback — generic error with no structured context
+	return &output.ErrorDetail{
+		Code:    classifyGenericError(err),
+		Message: err.Error(),
+	}
+}
+
+// classifyGenericError attempts to classify an error by inspecting its message
+// when no typed error is available.
+func classifyGenericError(err error) string {
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "no active context") || strings.Contains(msg, "no context"):
+		return "context_error"
+	case strings.Contains(msg, "config") || strings.Contains(msg, "configuration"):
+		return "config_error"
+	case strings.Contains(msg, "timed out") || strings.Contains(msg, "timeout"):
+		return "timeout"
+	case strings.Contains(msg, "validation") || strings.Contains(msg, "invalid"):
+		return "validation_error"
+	default:
+		return "error"
+	}
+}
+
+// exitCodeForError returns the appropriate process exit code for an error.
+// Uses typed exit codes from client.APIError and diagnostic.Error when available,
+// falling back to ExitUsageError for command/flag errors and ExitError for everything else.
+func exitCodeForError(err error) int {
+	var diagErr *diagnostic.Error
+	if errors.As(err, &diagErr) {
+		return diagErr.ExitCode()
+	}
+
+	var apiErr *client.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ExitCode()
+	}
+
+	var cmdErr *suggest.CommandError
+	if errors.As(err, &cmdErr) {
+		return client.ExitUsageError
+	}
+
+	var flagErr *suggest.FlagError
+	if errors.As(err, &flagErr) {
+		return client.ExitUsageError
+	}
+
+	return client.ExitError
 }
 
 // requireSubcommand returns an error with suggestions when a subcommand is required but not provided or invalid

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,7 +10,11 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
+	"github.com/dynatrace-oss/dtctl/pkg/suggest"
 )
 
 // TestGlobalFlags_Config tests the --config flag
@@ -561,5 +567,332 @@ func TestEnvironmentVariableBinding(t *testing.T) {
 				t.Errorf("viper.GetString(%s) = %v, want %v", tt.flagKey, got, tt.envVal)
 			}
 		})
+	}
+}
+
+// --- errorToDetail tests ---
+
+func TestErrorToDetail_DiagnosticError(t *testing.T) {
+	err := &diagnostic.Error{
+		Operation:  "get workflows",
+		StatusCode: 401,
+		Message:    "authentication failed",
+		RequestID:  "req-abc-123",
+		Suggestions: []string{
+			"Run 'dtctl auth login' to refresh your token",
+		},
+	}
+
+	detail := errorToDetail(err)
+
+	if detail.Code != "auth_required" {
+		t.Errorf("Code = %q, want %q", detail.Code, "auth_required")
+	}
+	if detail.Message != "authentication failed" {
+		t.Errorf("Message = %q, want %q", detail.Message, "authentication failed")
+	}
+	if detail.Operation != "get workflows" {
+		t.Errorf("Operation = %q, want %q", detail.Operation, "get workflows")
+	}
+	if detail.StatusCode != 401 {
+		t.Errorf("StatusCode = %d, want %d", detail.StatusCode, 401)
+	}
+	if detail.RequestID != "req-abc-123" {
+		t.Errorf("RequestID = %q, want %q", detail.RequestID, "req-abc-123")
+	}
+	if len(detail.Suggestions) != 1 {
+		t.Fatalf("Suggestions count = %d, want 1", len(detail.Suggestions))
+	}
+}
+
+func TestErrorToDetail_DiagnosticErrorStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantCode   string
+	}{
+		{"400 bad request", 400, "bad_request"},
+		{"401 unauthorized", 401, "auth_required"},
+		{"403 forbidden", 403, "permission_denied"},
+		{"404 not found", 404, "not_found"},
+		{"409 conflict", 409, "conflict"},
+		{"429 rate limited", 429, "rate_limited"},
+		{"500 server error", 500, "server_error"},
+		{"502 bad gateway", 502, "server_error"},
+		{"0 no status code", 0, "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &diagnostic.Error{
+				Operation:  "test",
+				StatusCode: tt.statusCode,
+				Message:    "test error",
+			}
+			detail := errorToDetail(err)
+			if detail.Code != tt.wantCode {
+				t.Errorf("Code = %q, want %q", detail.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestErrorToDetail_APIError(t *testing.T) {
+	err := &client.APIError{
+		StatusCode: 404,
+		Message:    "not found",
+		Details:    "workflow does not exist",
+	}
+
+	detail := errorToDetail(err)
+
+	if detail.Code != "not_found" {
+		t.Errorf("Code = %q, want %q", detail.Code, "not_found")
+	}
+	if detail.Message != "not found - workflow does not exist" {
+		t.Errorf("Message = %q, want %q", detail.Message, "not found - workflow does not exist")
+	}
+	if detail.StatusCode != 404 {
+		t.Errorf("StatusCode = %d, want %d", detail.StatusCode, 404)
+	}
+}
+
+func TestErrorToDetail_APIErrorWithoutDetails(t *testing.T) {
+	err := &client.APIError{
+		StatusCode: 500,
+		Message:    "internal server error",
+	}
+
+	detail := errorToDetail(err)
+
+	if detail.Code != "server_error" {
+		t.Errorf("Code = %q, want %q", detail.Code, "server_error")
+	}
+	if detail.Message != "internal server error" {
+		t.Errorf("Message = %q, want %q", detail.Message, "internal server error")
+	}
+}
+
+func TestErrorToDetail_SafetyError(t *testing.T) {
+	err := &safety.SafetyError{
+		ContextName: "production",
+		SafetyLevel: config.SafetyLevelReadOnly,
+		Operation:   safety.OperationDelete,
+		Reason:      "Context 'production' (readonly) does not allow delete operations",
+		Suggestions: []string{
+			"Switch to a context with write permissions",
+		},
+	}
+
+	detail := errorToDetail(err)
+
+	if detail.Code != "safety_blocked" {
+		t.Errorf("Code = %q, want %q", detail.Code, "safety_blocked")
+	}
+	if detail.Message != "Context 'production' (readonly) does not allow delete operations" {
+		t.Errorf("Message = %q, want expected reason", detail.Message)
+	}
+	if len(detail.Suggestions) != 1 {
+		t.Fatalf("Suggestions count = %d, want 1", len(detail.Suggestions))
+	}
+}
+
+func TestErrorToDetail_CommandError(t *testing.T) {
+	err := &suggest.CommandError{
+		Command: "geet",
+		Message: `unknown command "geet"`,
+		Suggestion: &suggest.Suggestion{
+			Value:    "get",
+			Distance: 1,
+		},
+	}
+
+	detail := errorToDetail(err)
+
+	if detail.Code != "unknown_command" {
+		t.Errorf("Code = %q, want %q", detail.Code, "unknown_command")
+	}
+	if detail.Message != `unknown command "geet"` {
+		t.Errorf("Message = %q, want expected message", detail.Message)
+	}
+	if len(detail.Suggestions) != 1 {
+		t.Fatalf("Suggestions count = %d, want 1", len(detail.Suggestions))
+	}
+	if detail.Suggestions[0] != `did you mean "get"?` {
+		t.Errorf("Suggestion = %q, want %q", detail.Suggestions[0], `did you mean "get"?`)
+	}
+}
+
+func TestErrorToDetail_CommandErrorNoSuggestion(t *testing.T) {
+	err := &suggest.CommandError{
+		Command: "xyzzy",
+		Message: `unknown command "xyzzy"`,
+	}
+
+	detail := errorToDetail(err)
+
+	if detail.Code != "unknown_command" {
+		t.Errorf("Code = %q, want %q", detail.Code, "unknown_command")
+	}
+	if detail.Suggestions != nil {
+		t.Errorf("Suggestions should be nil, got %v", detail.Suggestions)
+	}
+}
+
+func TestErrorToDetail_FlagError(t *testing.T) {
+	err := &suggest.FlagError{
+		Flag:    "outpt",
+		Message: "unknown flag --outpt",
+		Suggestion: &suggest.Suggestion{
+			Value:    "output",
+			Distance: 1,
+		},
+	}
+
+	detail := errorToDetail(err)
+
+	if detail.Code != "unknown_command" {
+		t.Errorf("Code = %q, want %q", detail.Code, "unknown_command")
+	}
+	if len(detail.Suggestions) != 1 {
+		t.Fatalf("Suggestions count = %d, want 1", len(detail.Suggestions))
+	}
+	if detail.Suggestions[0] != "did you mean --output?" {
+		t.Errorf("Suggestion = %q, want %q", detail.Suggestions[0], "did you mean --output?")
+	}
+}
+
+func TestErrorToDetail_GenericError(t *testing.T) {
+	err := fmt.Errorf("something unexpected happened")
+
+	detail := errorToDetail(err)
+
+	if detail.Code != "error" {
+		t.Errorf("Code = %q, want %q", detail.Code, "error")
+	}
+	if detail.Message != "something unexpected happened" {
+		t.Errorf("Message = %q, want %q", detail.Message, "something unexpected happened")
+	}
+}
+
+func TestErrorToDetail_WrappedDiagnosticError(t *testing.T) {
+	inner := &diagnostic.Error{
+		Operation:  "apply dashboard",
+		StatusCode: 403,
+		Message:    "insufficient permissions",
+	}
+	wrapped := fmt.Errorf("command failed: %w", inner)
+
+	detail := errorToDetail(wrapped)
+
+	if detail.Code != "permission_denied" {
+		t.Errorf("Code = %q, want %q (should unwrap diagnostic.Error)", detail.Code, "permission_denied")
+	}
+	if detail.Operation != "apply dashboard" {
+		t.Errorf("Operation = %q, want %q", detail.Operation, "apply dashboard")
+	}
+}
+
+func TestErrorToDetail_DiagnosticPrecedesAPIError(t *testing.T) {
+	// diagnostic.Error wraps a client.APIError — diagnostic should take precedence
+	apiErr := &client.APIError{StatusCode: 404, Message: "not found"}
+	diagErr := diagnostic.Wrap(apiErr, "get workflows")
+
+	detail := errorToDetail(diagErr)
+
+	// Should use diagnostic.Error classification, not raw APIError
+	if detail.Code != "not_found" {
+		t.Errorf("Code = %q, want %q", detail.Code, "not_found")
+	}
+	if detail.Operation != "get workflows" {
+		t.Errorf("Operation = %q, want %q", detail.Operation, "get workflows")
+	}
+}
+
+// --- classifyGenericError tests ---
+
+func TestClassifyGenericError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode string
+	}{
+		{"context error", errors.New("no active context configured"), "context_error"},
+		{"no context", errors.New("no context set"), "context_error"},
+		{"config error", errors.New("failed to load config"), "config_error"},
+		{"configuration error", errors.New("invalid configuration"), "config_error"},
+		{"timeout error", errors.New("operation timed out"), "timeout"},
+		{"timeout variant", errors.New("request timeout after 30s"), "timeout"},
+		{"validation error", errors.New("validation failed for field name"), "validation_error"},
+		{"invalid input", errors.New("invalid resource definition"), "validation_error"},
+		{"generic error", errors.New("something went wrong"), "error"},
+		{"empty error", errors.New(""), "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyGenericError(tt.err)
+			if got != tt.wantCode {
+				t.Errorf("classifyGenericError(%q) = %q, want %q", tt.err, got, tt.wantCode)
+			}
+		})
+	}
+}
+
+// --- exitCodeForError tests ---
+
+func TestExitCodeForError_DiagnosticError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantCode   int
+	}{
+		{"401 auth error", 401, client.ExitAuthError},
+		{"403 permission error", 403, client.ExitPermissionError},
+		{"404 not found", 404, client.ExitNotFoundError},
+		{"500 server error", 500, client.ExitError},
+		{"0 generic error", 0, client.ExitError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &diagnostic.Error{StatusCode: tt.statusCode}
+			got := exitCodeForError(err)
+			if got != tt.wantCode {
+				t.Errorf("exitCodeForError() = %d, want %d", got, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestExitCodeForError_APIError(t *testing.T) {
+	err := &client.APIError{StatusCode: 404, Message: "not found"}
+	got := exitCodeForError(err)
+	if got != client.ExitNotFoundError {
+		t.Errorf("exitCodeForError() = %d, want %d", got, client.ExitNotFoundError)
+	}
+}
+
+func TestExitCodeForError_CommandError(t *testing.T) {
+	err := &suggest.CommandError{Command: "geet", Message: "unknown command"}
+	got := exitCodeForError(err)
+	if got != client.ExitUsageError {
+		t.Errorf("exitCodeForError() = %d, want %d", got, client.ExitUsageError)
+	}
+}
+
+func TestExitCodeForError_FlagError(t *testing.T) {
+	err := &suggest.FlagError{Flag: "outpt", Message: "unknown flag"}
+	got := exitCodeForError(err)
+	if got != client.ExitUsageError {
+		t.Errorf("exitCodeForError() = %d, want %d", got, client.ExitUsageError)
+	}
+}
+
+func TestExitCodeForError_GenericError(t *testing.T) {
+	err := errors.New("generic error")
+	got := exitCodeForError(err)
+	if got != client.ExitError {
+		t.Errorf("exitCodeForError() = %d, want %d", got, client.ExitError)
 	}
 }

--- a/pkg/output/golden_test.go
+++ b/pkg/output/golden_test.go
@@ -647,6 +647,74 @@ func TestGolden_ErrorPermission(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Golden tests: agent mode error output (JSON envelope with ok: false)
+// ---------------------------------------------------------------------------
+
+func TestGolden_AgentErrorAuth(t *testing.T) {
+	var buf bytes.Buffer
+	detail := &ErrorDetail{
+		Code:       "auth_required",
+		Message:    "authentication failed",
+		Operation:  "get workflows",
+		StatusCode: 401,
+		RequestID:  "req-abc-123",
+		Suggestions: []string{
+			"Run 'dtctl auth login' to refresh your token",
+			"Verify your token is correct in the current context configuration",
+		},
+	}
+	if err := PrintError(&buf, detail); err != nil {
+		t.Fatalf("PrintError failed: %v", err)
+	}
+	assertGolden(t, "errors/auth-error-agent", buf.String())
+}
+
+func TestGolden_AgentErrorNotFound(t *testing.T) {
+	var buf bytes.Buffer
+	detail := &ErrorDetail{
+		Code:       "not_found",
+		Message:    "workflow not found",
+		Operation:  "get workflows",
+		StatusCode: 404,
+		Suggestions: []string{
+			"Verify the resource name or ID is correct",
+			"List available resources: 'dtctl get workflows'",
+		},
+	}
+	if err := PrintError(&buf, detail); err != nil {
+		t.Fatalf("PrintError failed: %v", err)
+	}
+	assertGolden(t, "errors/not-found-agent", buf.String())
+}
+
+func TestGolden_AgentErrorSafetyBlocked(t *testing.T) {
+	var buf bytes.Buffer
+	detail := &ErrorDetail{
+		Code:    "safety_blocked",
+		Message: "Context 'production' (readonly) does not allow delete operations",
+		Suggestions: []string{
+			"Switch to a context with write permissions",
+		},
+	}
+	if err := PrintError(&buf, detail); err != nil {
+		t.Fatalf("PrintError failed: %v", err)
+	}
+	assertGolden(t, "errors/safety-blocked-agent", buf.String())
+}
+
+func TestGolden_AgentErrorGeneric(t *testing.T) {
+	var buf bytes.Buffer
+	detail := &ErrorDetail{
+		Code:    "error",
+		Message: "something unexpected happened",
+	}
+	if err := PrintError(&buf, detail); err != nil {
+		t.Fatalf("PrintError failed: %v", err)
+	}
+	assertGolden(t, "errors/generic-error-agent", buf.String())
+}
+
+// ---------------------------------------------------------------------------
 // Golden tests: agent mode output
 // ---------------------------------------------------------------------------
 

--- a/pkg/output/testdata/golden/errors/auth-error-agent.golden
+++ b/pkg/output/testdata/golden/errors/auth-error-agent.golden
@@ -1,0 +1,15 @@
+{
+  "ok": false,
+  "result": null,
+  "error": {
+    "code": "auth_required",
+    "message": "authentication failed",
+    "operation": "get workflows",
+    "status_code": 401,
+    "request_id": "req-abc-123",
+    "suggestions": [
+      "Run 'dtctl auth login' to refresh your token",
+      "Verify your token is correct in the current context configuration"
+    ]
+  }
+}

--- a/pkg/output/testdata/golden/errors/generic-error-agent.golden
+++ b/pkg/output/testdata/golden/errors/generic-error-agent.golden
@@ -1,0 +1,8 @@
+{
+  "ok": false,
+  "result": null,
+  "error": {
+    "code": "error",
+    "message": "something unexpected happened"
+  }
+}

--- a/pkg/output/testdata/golden/errors/not-found-agent.golden
+++ b/pkg/output/testdata/golden/errors/not-found-agent.golden
@@ -1,0 +1,14 @@
+{
+  "ok": false,
+  "result": null,
+  "error": {
+    "code": "not_found",
+    "message": "workflow not found",
+    "operation": "get workflows",
+    "status_code": 404,
+    "suggestions": [
+      "Verify the resource name or ID is correct",
+      "List available resources: 'dtctl get workflows'"
+    ]
+  }
+}

--- a/pkg/output/testdata/golden/errors/safety-blocked-agent.golden
+++ b/pkg/output/testdata/golden/errors/safety-blocked-agent.golden
@@ -1,0 +1,11 @@
+{
+  "ok": false,
+  "result": null,
+  "error": {
+    "code": "safety_blocked",
+    "message": "Context 'production' (readonly) does not allow delete operations",
+    "suggestions": [
+      "Switch to a context with write permissions"
+    ]
+  }
+}

--- a/pkg/safety/checker.go
+++ b/pkg/safety/checker.go
@@ -171,11 +171,17 @@ func (c *Checker) FormatError(result CheckResult) string {
 	return b.String()
 }
 
-// CheckError performs a safety check and returns an error if not allowed
+// CheckError performs a safety check and returns a *SafetyError if not allowed.
 func (c *Checker) CheckError(op Operation, ownership ResourceOwnership) error {
 	result := c.Check(op, ownership)
 	if !result.Allowed {
-		return fmt.Errorf("%s", c.FormatError(result))
+		return &SafetyError{
+			ContextName: c.contextName,
+			SafetyLevel: c.safetyLevel,
+			Operation:   op,
+			Reason:      result.Reason,
+			Suggestions: result.Suggestions,
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Wire up the existing but unused error handling infrastructure (`output.PrintError`, `output.ClassifyHTTPError`, `diagnostic.Error`, `client.APIError`, `safety.SafetyError`) so that errors are rendered as structured JSON in agent/plain mode
- Use typed exit codes (auth=3, not_found=4, permission=5, usage=2) instead of hardcoding `os.Exit(1)` for all failures
- Fix `safety.CheckError()` to return `*SafetyError` instead of `fmt.Errorf`, enabling `errors.As` detection

## Details

The codebase had all the building blocks for structured error output — `ErrorDetail`, `PrintError()`, `ClassifyHTTPError()`, `diagnostic.Error`, typed exit codes — but none of them were actually called from the command dispatch path. All errors went through `fmt.Fprintf(os.Stderr, "Error: %s\n", err)` + `os.Exit(1)`.

This PR adds an `errorToDetail()` function in `cmd/root.go` that converts any error to `*output.ErrorDetail` using `errors.As` to check for all known error types (`*diagnostic.Error`, `*client.APIError`, `*safety.SafetyError`, `*suggest.CommandError`, `*suggest.FlagError`), with a heuristic fallback (`classifyGenericError`) for config/context/timeout/validation errors.

In agent or plain mode, `Execute()` now calls `output.PrintError()` for JSON output. In normal (human) mode, the existing human-readable message is preserved but exit codes are now typed.

## Test coverage

- 17 unit tests in `cmd/root_test.go` covering `errorToDetail()`, `classifyGenericError()`, and `exitCodeForError()` for all error types
- 4 golden tests in `pkg/output/golden_test.go` for agent-mode JSON error output (auth, not-found, safety-blocked, generic)

Implements: `specs/structured-error-output.md`