### PR TITLE
fix: doctor token check fails for OAuth tokens

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/version"
 )
@@ -110,7 +111,7 @@ func runDoctorChecks() []checkResult {
 	})
 
 	// 4. Token retrieval
-	token, tokenErr := cfg.GetToken(ctx.TokenRef)
+	token, tokenErr := client.GetTokenWithOAuthSupport(cfg, ctx.TokenRef)
 	if tokenErr != nil || token == "" {
 		detail := "token not found"
 		if tokenErr != nil {


### PR DESCRIPTION
## Summary

- `dtctl doctor` was calling `cfg.GetToken()` directly for the token check, which cannot resolve OAuth tokens stored in compact keyring format (only a refresh token, no access token in the JSON blob)
- All real commands (`get`, `describe`, etc.) already use `client.GetTokenWithOAuthSupport()`, which goes through the full `auth.TokenManager` with auto-refresh — so the context was functional while doctor falsely reported `[FAIL]`
- Fix: replace `cfg.GetToken(ctx.TokenRef)` with `client.GetTokenWithOAuthSupport(cfg, ctx.TokenRef)` in `cmd/doctor.go`

## Reproduction

```
dtctl doctor   # [FAIL] Token: cannot retrieve token "...-oauth": token not found
dtctl get db   # works fine
```