### PR TITLE
fix: reduce skills install output to SKILL.md only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.4] - 2026-03-10
+
+### Changed
+- **`dtctl skills install` minimal output** — installed skill files now contain only `SKILL.md` (~283 lines / ~10 KB) instead of inlining all reference documents (~1,100 lines / ~35 KB); reference docs remain embedded in the binary but are no longer concatenated into the installed file
+
 ## [0.14.3] - 2026-03-10
 
 ### Fixed

--- a/pkg/skills/installer.go
+++ b/pkg/skills/installer.go
@@ -1,7 +1,6 @@
 // Package skills provides installation and management of AI coding assistant
-// skill files for dtctl. It embeds the full skill content from skills/dtctl/
-// (SKILL.md and all reference files) and concatenates them into a single
-// document at install time, with agent-specific wrappers.
+// skill files for dtctl. It embeds SKILL.md from skills/dtctl/ and writes it
+// to the appropriate agent-specific location with agent-specific wrappers.
 package skills
 
 import (
@@ -17,27 +16,7 @@ import (
 	dtctlskill "github.com/dynatrace-oss/dtctl/skills/dtctl"
 )
 
-// referenceFile defines a reference document to append after SKILL.md.
-// The order here determines the order in the concatenated output.
-type referenceFile struct {
-	// Path within the embedded FS.
-	Path string
-	// SectionTitle is the heading used when inlining this file.
-	// If empty, the file's first H1 heading is used.
-	SectionTitle string
-}
-
-// referenceFiles lists all reference documents to concatenate after SKILL.md,
-// in the order they should appear in the output.
-var referenceFiles = []referenceFile{
-	{Path: "references/DQL-reference.md"},
-	{Path: "references/troubleshooting.md"},
-	{Path: "references/config-management.md"},
-	{Path: "references/resources/dashboards.md"},
-	{Path: "references/resources/notebooks.md"},
-}
-
-// skillContent holds the concatenated skill document, built once at init time.
+// skillContent holds the skill document, built once at init time.
 var skillContent string
 
 func init() {
@@ -48,48 +27,16 @@ func init() {
 	skillContent = content
 }
 
-// buildSkillContent reads the embedded SKILL.md and all reference files,
-// strips YAML frontmatter, resolves relative markdown links, and
-// concatenates everything into a single document.
+// buildSkillContent reads the embedded SKILL.md, strips YAML frontmatter,
+// and resolves relative markdown links.
 func buildSkillContent() (string, error) {
-	// Read main SKILL.md
-	mainBytes, err := fs.ReadFile(dtctlskill.Content, "SKILL.md")
+	data, err := fs.ReadFile(dtctlskill.Content, "SKILL.md")
 	if err != nil {
 		return "", fmt.Errorf("reading SKILL.md: %w", err)
 	}
-	main := stripYAMLFrontmatter(string(mainBytes))
-
-	// Read all reference files
-	var refs []string
-	for _, ref := range referenceFiles {
-		data, err := fs.ReadFile(dtctlskill.Content, ref.Path)
-		if err != nil {
-			return "", fmt.Errorf("reading %s: %w", ref.Path, err)
-		}
-		content := string(data)
-		// Strip any YAML frontmatter from reference files too
-		content = stripYAMLFrontmatter(content)
-		refs = append(refs, content)
-	}
-
-	// Resolve relative markdown links in main — since reference content
-	// will be appended inline, links like [text](references/foo.md) become
-	// just the link text.
-	main = resolveRelativeLinks(main)
-
-	// Build the concatenated document
-	var sb strings.Builder
-	sb.WriteString(main)
-
-	for i, ref := range refs {
-		sb.WriteString("\n\n---\n\n")
-		// Resolve any cross-references between reference files
-		ref = resolveRelativeLinks(ref)
-		_ = i // index available for future use
-		sb.WriteString(ref)
-	}
-
-	return sb.String(), nil
+	content := stripYAMLFrontmatter(string(data))
+	content = resolveRelativeLinks(content)
+	return content, nil
 }
 
 // yamlFrontmatterRE matches YAML frontmatter at the start of a document:

--- a/pkg/skills/installer_test.go
+++ b/pkg/skills/installer_test.go
@@ -566,27 +566,6 @@ func TestSkillContent_ContainsMainSections(t *testing.T) {
 	}
 }
 
-func TestSkillContent_ContainsReferenceContent(t *testing.T) {
-	content := SkillContent()
-
-	// Must contain content from each reference file
-	referenceMarkers := []struct {
-		file   string
-		marker string
-	}{
-		{"DQL-reference.md", "DQL Syntax Guide"},
-		{"troubleshooting.md", "dtctl Troubleshooting"},
-		{"config-management.md", "Configuration Management"},
-		{"dashboards.md", "Dashboards Resource"},
-		{"notebooks.md", "Notebooks Resource"},
-	}
-	for _, rm := range referenceMarkers {
-		if !strings.Contains(content, rm.marker) {
-			t.Errorf("SkillContent() should contain %q from %s", rm.marker, rm.file)
-		}
-	}
-}
-
 func TestSkillContent_NoYAMLFrontmatter(t *testing.T) {
 	content := SkillContent()
 
@@ -612,26 +591,14 @@ func TestSkillContent_NoRelativeLinks(t *testing.T) {
 	}
 }
 
-func TestSkillContent_HasSeparators(t *testing.T) {
-	content := SkillContent()
-
-	// Reference sections should be separated by horizontal rules
-	separatorCount := strings.Count(content, "\n\n---\n\n")
-	if separatorCount < len(referenceFiles) {
-		t.Errorf("expected at least %d section separators, got %d",
-			len(referenceFiles), separatorCount)
-	}
-}
-
 func TestSkillContent_SubstantialSize(t *testing.T) {
 	content := SkillContent()
 
-	// The concatenated content should be much larger than the old templates.
-	// The source files total ~1,115 lines. With separators, we expect at
-	// least 800 lines (some frontmatter is stripped).
+	// SKILL.md is ~287 lines; after stripping the 4-line YAML frontmatter
+	// the output should be at least 200 lines.
 	lines := strings.Count(content, "\n")
-	if lines < 800 {
-		t.Errorf("SkillContent() has only %d lines, expected 800+ (comprehensive skill content)", lines)
+	if lines < 200 {
+		t.Errorf("SkillContent() has only %d lines, expected 200+", lines)
 	}
 }
 
@@ -727,7 +694,7 @@ func TestResolveRelativeLinks(t *testing.T) {
 }
 
 func TestInstalledFileContent(t *testing.T) {
-	// Verify that installed files contain the full comprehensive content
+	// Verify that installed files contain the core skill content.
 	for _, agent := range AllAgents() {
 		t.Run(agent.Name, func(t *testing.T) {
 			tmpDir := t.TempDir()
@@ -743,14 +710,11 @@ func TestInstalledFileContent(t *testing.T) {
 
 			content := string(data)
 
-			// Must contain comprehensive content, not just stubs
+			// Must contain SKILL.md core content
 			mustContain := []string{
 				"Dynatrace Control with dtctl",
-				"DQL Syntax Guide",
-				"dtctl Troubleshooting",
-				"Configuration Management",
-				"Dashboards Resource",
-				"Notebooks Resource",
+				"Available Resources",
+				"Command Verbs",
 			}
 			for _, s := range mustContain {
 				if !strings.Contains(content, s) {
@@ -758,10 +722,10 @@ func TestInstalledFileContent(t *testing.T) {
 				}
 			}
 
-			// Installed files should be substantial (800+ lines)
+			// Installed files should be at least 200 lines
 			lines := strings.Count(content, "\n")
-			if lines < 800 {
-				t.Errorf("installed %s file has only %d lines, expected 800+", agent.Name, lines)
+			if lines < 200 {
+				t.Errorf("installed %s file has only %d lines, expected 200+", agent.Name, lines)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Installed skill files were ~1,100 lines / ~35 KB because `SKILL.md` was concatenated with 5 reference documents at install time
- Installed file is now **SKILL.md only** (~283 lines / ~10 KB) — a ~70% reduction
- Reference docs remain embedded in the binary but are no longer inlined into the installed file

## Changes

- `pkg/skills/installer.go` — removed `referenceFile` type, `referenceFiles` registry, and the concatenation loop from `buildSkillContent()`
- `pkg/skills/installer_test.go` — removed tests asserting reference content is present; updated size threshold from ≥800 → ≥200 lines
- `CHANGELOG.md` — added v0.14.4 entry