### PR TITLE
fix: handle document version field as string or int

### DIFF
--- a/pkg/resources/document/document.go
+++ b/pkg/resources/document/document.go
@@ -4,11 +4,34 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 )
+
+// parseFlexibleInt parses a JSON value that may be either a number or a
+// quoted-string number (e.g. 1 or "1"). Some API versions return version
+// fields as strings instead of integers.
+func parseFlexibleInt(raw json.RawMessage) (int, error) {
+	if len(raw) == 0 {
+		return 0, nil
+	}
+
+	// Try as int first (most common case)
+	var n int
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n, nil
+	}
+
+	// Fall back to quoted string
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return 0, fmt.Errorf("version field is neither a number nor a string: %s", string(raw))
+	}
+	return strconv.Atoi(s)
+}
 
 // Handler handles document resources (dashboards, notebooks, etc.)
 type Handler struct {
@@ -45,6 +68,28 @@ type DocumentMetadata struct {
 	IsPrivate        bool             `json:"isPrivate"`
 	ModificationInfo ModificationInfo `json:"modificationInfo"`
 	Access           []string         `json:"access,omitempty"`
+}
+
+// UnmarshalJSON custom unmarshaler for DocumentMetadata to handle version as string or int.
+func (m *DocumentMetadata) UnmarshalJSON(data []byte) error {
+	type Alias DocumentMetadata
+	aux := &struct {
+		Version json.RawMessage `json:"version"`
+		*Alias
+	}{
+		Alias: (*Alias)(m),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if len(aux.Version) > 0 {
+		v, err := parseFlexibleInt(aux.Version)
+		if err != nil {
+			return fmt.Errorf("invalid version: %w", err)
+		}
+		m.Version = v
+	}
+	return nil
 }
 
 // ModificationInfo contains creation and modification timestamps
@@ -797,11 +842,13 @@ func (d Document) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON custom unmarshaler for Document to handle nested modificationInfo
+// and version as string or int.
 func (d *Document) UnmarshalJSON(data []byte) error {
 	type Alias Document
 	aux := &struct {
 		ModificationInfo *ModificationInfo `json:"modificationInfo"`
 		Content          json.RawMessage   `json:"content"`
+		Version          json.RawMessage   `json:"version"`
 		*Alias
 	}{
 		Alias: (*Alias)(d),
@@ -809,6 +856,14 @@ func (d *Document) UnmarshalJSON(data []byte) error {
 
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
+	}
+
+	if len(aux.Version) > 0 {
+		v, err := parseFlexibleInt(aux.Version)
+		if err != nil {
+			return fmt.Errorf("invalid version: %w", err)
+		}
+		d.Version = v
 	}
 
 	if aux.ModificationInfo != nil {
@@ -850,15 +905,32 @@ type SnapshotModInfo struct {
 }
 
 // UnmarshalJSON custom unmarshaler for Snapshot to flatten modificationInfo
+// and handle version fields as string or int.
 func (s *Snapshot) UnmarshalJSON(data []byte) error {
 	type Alias Snapshot
 	aux := &struct {
+		SnapshotVersion json.RawMessage `json:"snapshotVersion"`
+		DocumentVersion json.RawMessage `json:"documentVersion"`
 		*Alias
 	}{
 		Alias: (*Alias)(s),
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
+	}
+	if len(aux.SnapshotVersion) > 0 {
+		v, err := parseFlexibleInt(aux.SnapshotVersion)
+		if err != nil {
+			return fmt.Errorf("invalid snapshotVersion: %w", err)
+		}
+		s.SnapshotVersion = v
+	}
+	if len(aux.DocumentVersion) > 0 {
+		v, err := parseFlexibleInt(aux.DocumentVersion)
+		if err != nil {
+			return fmt.Errorf("invalid documentVersion: %w", err)
+		}
+		s.DocumentVersion = v
 	}
 	// Flatten modificationInfo fields for table display
 	s.CreatedBy = s.ModificationInfo.CreatedBy

--- a/pkg/resources/document/multipart_test.go
+++ b/pkg/resources/document/multipart_test.go
@@ -242,3 +242,161 @@ func TestParseMultipartDocument_MissingMetadata(t *testing.T) {
 		t.Errorf("Error should mention 'metadata', got: %v", err)
 	}
 }
+
+// TestDocumentMetadata_VersionAsString tests that version can be unmarshaled from a string
+// (some API versions return version as "1" instead of 1).
+func TestDocumentMetadata_VersionAsString(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "version as int",
+			json: `{"id":"doc-1","name":"Test","type":"dashboard","version":3,"owner":"user-1","isPrivate":false,"modificationInfo":{"createdBy":"user-1","createdTime":"2025-01-01T00:00:00Z","lastModifiedBy":"user-1","lastModifiedTime":"2025-01-01T00:00:00Z"}}`,
+			want: 3,
+		},
+		{
+			name: "version as string",
+			json: `{"id":"doc-1","name":"Test","type":"dashboard","version":"5","owner":"user-1","isPrivate":false,"modificationInfo":{"createdBy":"user-1","createdTime":"2025-01-01T00:00:00Z","lastModifiedBy":"user-1","lastModifiedTime":"2025-01-01T00:00:00Z"}}`,
+			want: 5,
+		},
+		{
+			name: "version as zero",
+			json: `{"id":"doc-1","name":"Test","type":"dashboard","version":0,"owner":"user-1","isPrivate":false,"modificationInfo":{"createdBy":"user-1","createdTime":"2025-01-01T00:00:00Z","lastModifiedBy":"user-1","lastModifiedTime":"2025-01-01T00:00:00Z"}}`,
+			want: 0,
+		},
+		{
+			name: "version as string zero",
+			json: `{"id":"doc-1","name":"Test","type":"dashboard","version":"0","owner":"user-1","isPrivate":false,"modificationInfo":{"createdBy":"user-1","createdTime":"2025-01-01T00:00:00Z","lastModifiedBy":"user-1","lastModifiedTime":"2025-01-01T00:00:00Z"}}`,
+			want: 0,
+		},
+		{
+			name:    "version as non-numeric string",
+			json:    `{"id":"doc-1","name":"Test","type":"dashboard","version":"abc","owner":"user-1","isPrivate":false,"modificationInfo":{"createdBy":"user-1","createdTime":"2025-01-01T00:00:00Z","lastModifiedBy":"user-1","lastModifiedTime":"2025-01-01T00:00:00Z"}}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m DocumentMetadata
+			err := json.Unmarshal([]byte(tt.json), &m)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if m.Version != tt.want {
+				t.Errorf("Version = %d, want %d", m.Version, tt.want)
+			}
+		})
+	}
+}
+
+// TestDocument_VersionAsString tests that Document can unmarshal version from string.
+func TestDocument_VersionAsString(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want int
+	}{
+		{
+			name: "version as int",
+			json: `{"id":"doc-1","name":"Test","type":"dashboard","version":2,"owner":"user-1","isPrivate":false}`,
+			want: 2,
+		},
+		{
+			name: "version as string",
+			json: `{"id":"doc-1","name":"Test","type":"dashboard","version":"7","owner":"user-1","isPrivate":false}`,
+			want: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d Document
+			if err := json.Unmarshal([]byte(tt.json), &d); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if d.Version != tt.want {
+				t.Errorf("Version = %d, want %d", d.Version, tt.want)
+			}
+		})
+	}
+}
+
+// TestDocumentList_VersionAsString tests that a list response with string versions parses correctly.
+func TestDocumentList_VersionAsString(t *testing.T) {
+	listJSON := `{
+		"documents": [
+			{"id":"doc-1","name":"Dashboard 1","type":"dashboard","version":"3","owner":"user-1","isPrivate":false,"modificationInfo":{"createdBy":"user-1","createdTime":"2025-01-01T00:00:00Z","lastModifiedBy":"user-1","lastModifiedTime":"2025-01-01T00:00:00Z"}},
+			{"id":"doc-2","name":"Notebook 1","type":"notebook","version":5,"owner":"user-2","isPrivate":true,"modificationInfo":{"createdBy":"user-2","createdTime":"2025-02-01T00:00:00Z","lastModifiedBy":"user-2","lastModifiedTime":"2025-02-01T00:00:00Z"}}
+		],
+		"totalCount": 2
+	}`
+
+	var list DocumentList
+	if err := json.Unmarshal([]byte(listJSON), &list); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(list.Documents) != 2 {
+		t.Fatalf("expected 2 documents, got %d", len(list.Documents))
+	}
+	if list.Documents[0].Version != 3 {
+		t.Errorf("Documents[0].Version = %d, want 3", list.Documents[0].Version)
+	}
+	if list.Documents[1].Version != 5 {
+		t.Errorf("Documents[1].Version = %d, want 5", list.Documents[1].Version)
+	}
+}
+
+// TestSnapshot_VersionAsString tests that Snapshot can unmarshal version fields from strings.
+func TestSnapshot_VersionAsString(t *testing.T) {
+	tests := []struct {
+		name           string
+		json           string
+		wantSnapshot   int
+		wantDocVersion int
+	}{
+		{
+			name:           "versions as ints",
+			json:           `{"snapshotVersion":1,"documentVersion":2,"modificationInfo":{"createdBy":"user-1","createdTime":"2025-01-01T00:00:00Z"}}`,
+			wantSnapshot:   1,
+			wantDocVersion: 2,
+		},
+		{
+			name:           "versions as strings",
+			json:           `{"snapshotVersion":"3","documentVersion":"4","modificationInfo":{"createdBy":"user-1","createdTime":"2025-01-01T00:00:00Z"}}`,
+			wantSnapshot:   3,
+			wantDocVersion: 4,
+		},
+		{
+			name:           "mixed versions",
+			json:           `{"snapshotVersion":5,"documentVersion":"6","modificationInfo":{"createdBy":"user-1","createdTime":"2025-01-01T00:00:00Z"}}`,
+			wantSnapshot:   5,
+			wantDocVersion: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var s Snapshot
+			if err := json.Unmarshal([]byte(tt.json), &s); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if s.SnapshotVersion != tt.wantSnapshot {
+				t.Errorf("SnapshotVersion = %d, want %d", s.SnapshotVersion, tt.wantSnapshot)
+			}
+			if s.DocumentVersion != tt.wantDocVersion {
+				t.Errorf("DocumentVersion = %d, want %d", s.DocumentVersion, tt.wantDocVersion)
+			}
+		})
+	}
+}

--- a/pkg/resources/document/trash.go
+++ b/pkg/resources/document/trash.go
@@ -1,6 +1,7 @@
 package document
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -20,6 +21,28 @@ type TrashedDocument struct {
 	// Computed fields for display
 	DeletedBy string    `json:"-" yaml:"-" table:"DELETED BY"`
 	DeletedAt time.Time `json:"-" yaml:"-" table:"DELETED AT"`
+}
+
+// UnmarshalJSON custom unmarshaler for TrashedDocument to handle version as string or int.
+func (t *TrashedDocument) UnmarshalJSON(data []byte) error {
+	type Alias TrashedDocument
+	aux := &struct {
+		Version json.RawMessage `json:"version"`
+		*Alias
+	}{
+		Alias: (*Alias)(t),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if len(aux.Version) > 0 {
+		v, err := parseFlexibleInt(aux.Version)
+		if err != nil {
+			return fmt.Errorf("invalid version: %w", err)
+		}
+		t.Version = v
+	}
+	return nil
 }
 
 // TrashDocumentListEntry represents a document in the trash list (from GET /trash/documents)


### PR DESCRIPTION
## Summary

- Some API environments return the document `version` field as a JSON string (`"1"`) instead of an integer (`1`), causing `json: cannot unmarshal string into Go struct field DocumentMetadata.documents.version of type int` errors with retry exhaustion on all document commands (`get notebooks`, `get dashboards`, etc.)
- Adds a `parseFlexibleInt` helper and custom `UnmarshalJSON` methods to `Document`, `DocumentMetadata`, `TrashedDocument`, and `Snapshot` structs to accept both string and integer version formats
- Includes comprehensive test coverage for int versions, string versions, zero values, mixed formats, list responses, and error cases