### PR TITLE
test: add golden tests for wide format DQL query output

### DIFF
--- a/pkg/output/golden_test.go
+++ b/pkg/output/golden_test.go
@@ -577,6 +577,7 @@ func TestGolden_QueryDQL(t *testing.T) {
 
 	formats := map[string]string{
 		"table": "table",
+		"wide":  "wide",
 		"json":  "json",
 		"csv":   "csv",
 	}
@@ -722,6 +723,38 @@ func TestGolden_QueryDQL_Metadata_Table(t *testing.T) {
 		}
 		footer := FormatMetadataFooter(meta, fields)
 		assertGolden(t, "query/dql-metadata-filtered-table", buf.String()+footer)
+	})
+}
+
+func TestGolden_QueryDQL_Metadata_Wide(t *testing.T) {
+	records := dqlRecordsFixture()
+	meta := metadataFixture()
+
+	// Disable color for deterministic output
+	ResetColorCache()
+	SetPlainMode(true)
+	defer ResetColorCache()
+
+	t.Run("all", func(t *testing.T) {
+		var buf bytes.Buffer
+		printer := NewPrinterWithWriter("wide", &buf)
+		if err := printer.PrintList(records); err != nil {
+			t.Fatalf("PrintList failed: %v", err)
+		}
+		// Append metadata footer (same as printResults does for wide format)
+		footer := FormatMetadataFooter(meta, nil)
+		assertGolden(t, "query/dql-metadata-wide", buf.String()+footer)
+	})
+
+	t.Run("filtered", func(t *testing.T) {
+		fields := []string{"executionTimeMilliseconds", "scannedRecords", "queryId"}
+		var buf bytes.Buffer
+		printer := NewPrinterWithWriter("wide", &buf)
+		if err := printer.PrintList(records); err != nil {
+			t.Fatalf("PrintList failed: %v", err)
+		}
+		footer := FormatMetadataFooter(meta, fields)
+		assertGolden(t, "query/dql-metadata-filtered-wide", buf.String()+footer)
 	})
 }
 

--- a/pkg/output/testdata/golden/query/dql-metadata-filtered-wide.golden
+++ b/pkg/output/testdata/golden/query/dql-metadata-filtered-wide.golden
@@ -1,0 +1,9 @@
+CONTENT                          HOST NAME       STATUS   TIMESTAMP            
+Connection timeout to database   web-server-01   ERROR    2025-03-15T10:30:00Z   
+High memory usage detected       web-server-02   WARN     2025-03-15T10:29:55Z   
+Request processed successfully   api-gateway     INFO     2025-03-15T10:29:50Z   
+
+--- Query Metadata ---
+Execution time:     47ms
+Scanned records:    42,351
+Query ID:           27c4daf9-2619-4ba1-b1ad-9e276c75a351

--- a/pkg/output/testdata/golden/query/dql-metadata-wide.golden
+++ b/pkg/output/testdata/golden/query/dql-metadata-wide.golden
@@ -1,0 +1,21 @@
+CONTENT                          HOST NAME       STATUS   TIMESTAMP            
+Connection timeout to database   web-server-01   ERROR    2025-03-15T10:30:00Z   
+High memory usage detected       web-server-02   WARN     2025-03-15T10:29:55Z   
+Request processed successfully   api-gateway     INFO     2025-03-15T10:29:50Z   
+
+--- Query Metadata ---
+Execution time:     47ms
+Scanned records:    42,351
+Scanned bytes:      2.8 MB
+Scanned data pts:   0
+Analysis window:    2025-03-15T08:30:00.000000000Z → 2025-03-15T10:30:00.000000000Z
+Query ID:           27c4daf9-2619-4ba1-b1ad-9e276c75a351
+DQL version:        V1_0
+Canonical query:    fetch logs | limit 3 | fields timestamp, host.name, status, content
+Query:              fetch logs | limit 3 | fields timestamp, host.name, status, content
+Timezone:           Z
+Locale:             und
+Sampled:            no
+Contributions:
+  default_logs (logs)
+    scanned: 2.8 MB, matched: 100.0%

--- a/pkg/output/testdata/golden/query/dql-wide.golden
+++ b/pkg/output/testdata/golden/query/dql-wide.golden
@@ -1,0 +1,4 @@
+CONTENT                          HOST NAME       STATUS   TIMESTAMP            
+Connection timeout to database   web-server-01   ERROR    2025-03-15T10:30:00Z   
+High memory usage detected       web-server-02   WARN     2025-03-15T10:29:55Z   
+Request processed successfully   api-gateway     INFO     2025-03-15T10:29:50Z   


### PR DESCRIPTION
## Summary

- Add missing golden test coverage for the `wide` output format in DQL query results, which was omitted when the `printResults()` switch refactor landed in #74
- Add `wide` to `TestGolden_QueryDQL` (basic records without metadata)
- Add `TestGolden_QueryDQL_Metadata_Wide` with `all` and `filtered` sub-tests
- 3 new golden files confirm `wide == table` for DQL map results

Addresses review feedback from #74 (item 3: verify the wide format path didn't regress). Sanity-checked against live `fxz-readonly` context — wide and table produce identical output for DQL map results with and without `--metadata`.