### PR TITLE
fix: drop page-size param on paginated extension requests

### DIFF
--- a/pkg/resources/extension/extension.go
+++ b/pkg/resources/extension/extension.go
@@ -153,16 +153,15 @@ func (h *Handler) List(name string, chunkSize int64) (*ExtensionList, error) {
 		var result ExtensionList
 		req := h.client.HTTP().R().SetResult(&result)
 
-		if name != "" {
-			req.SetQueryParam("name", name)
-		}
-
-		if chunkSize > 0 {
-			req.SetQueryParam("page-size", fmt.Sprintf("%d", chunkSize))
-		}
-
 		if nextPageKey != "" {
 			req.SetQueryParam("next-page-key", nextPageKey)
+		} else {
+			if name != "" {
+				req.SetQueryParam("name", name)
+			}
+			if chunkSize > 0 {
+				req.SetQueryParam("page-size", fmt.Sprintf("%d", chunkSize))
+			}
 		}
 
 		resp, err := req.Get("/platform/extensions/v2/extensions")
@@ -316,16 +315,15 @@ func (h *Handler) ListMonitoringConfigurations(extensionName, version string, ch
 		var result MonitoringConfigurationList
 		req := h.client.HTTP().R().SetResult(&result)
 
-		if version != "" {
-			req.SetQueryParam("version", version)
-		}
-
-		if chunkSize > 0 {
-			req.SetQueryParam("page-size", fmt.Sprintf("%d", chunkSize))
-		}
-
 		if nextPageKey != "" {
 			req.SetQueryParam("next-page-key", nextPageKey)
+		} else {
+			if version != "" {
+				req.SetQueryParam("version", version)
+			}
+			if chunkSize > 0 {
+				req.SetQueryParam("page-size", fmt.Sprintf("%d", chunkSize))
+			}
 		}
 
 		resp, err := req.Get(fmt.Sprintf("/platform/extensions/v2/extensions/%s/monitoring-configurations", url.PathEscape(extensionName)))

--- a/pkg/resources/extension/extension_test.go
+++ b/pkg/resources/extension/extension_test.go
@@ -163,6 +163,13 @@ func TestList(t *testing.T) {
 					return
 				}
 
+				// Simulate API constraint: page-size must not be combined with next-page-key
+				if r.URL.Query().Get("page-size") != "" && r.URL.Query().Get("next-page-key") != "" {
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte(`{"error":{"code":400,"message":"Constraints violated.","constraintViolations":[{"path":"page-size","message":"must not be used in combination with next-page-key query parameter."}]}}`))
+					return
+				}
+
 				// Simulate API page-size limit (rejects > maxPageSize)
 				if ps := r.URL.Query().Get("page-size"); ps != "" {
 					pageSizeVal, _ := strconv.ParseInt(ps, 10, 64)


### PR DESCRIPTION
## Summary

- **Bug**: The Extensions v2 API rejects requests that combine `page-size` with `next-page-key` (returns 400). When listing >100 extensions, the second page request included both params, causing `dtctl get extensions` to fail.
- **Fix**: Use an `if/else` so that subsequent page requests only send `next-page-key`, dropping `page-size` and filter params. This matches the correct pattern already used in `pkg/resources/settings/settings.go`.
- **Test**: Added API constraint guard to the `List` mock server so the pagination test would catch this regression.

Applies to both `List()` and `ListMonitoringConfigurations()` in `pkg/resources/extension/extension.go`.