### PR TITLE
fix: revert --chunk-size default from 0 back to 500

### DIFF
--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -21,7 +21,7 @@ func TestGlobalFlags(t *testing.T) {
 		{"verbose", "0"},
 		{"dry-run", "false"},
 		{"plain", "false"},
-		{"chunk-size", "0"},
+		{"chunk-size", "500"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -480,7 +480,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&plainMode, "plain", false, "plain output for machine processing (no colors, no interactive prompts)")
 	rootCmd.PersistentFlags().BoolVarP(&agentMode, "agent", "A", false, "agent output mode: wrap output in a structured JSON envelope with metadata")
 	rootCmd.PersistentFlags().BoolVar(&noAgent, "no-agent", false, "disable auto-detected agent mode")
-	rootCmd.PersistentFlags().Int64Var(&chunkSize, "chunk-size", 0, "Paginate through all results in chunks of this size. 0 (default) returns only the first page.")
+	rootCmd.PersistentFlags().Int64Var(&chunkSize, "chunk-size", 500, "Paginate through all results in chunks of this size. 0 returns only the first page.")
 
 	// Bind flags to viper
 	_ = viper.BindPFlag("context", rootCmd.PersistentFlags().Lookup("context"))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -312,8 +312,8 @@ func TestGlobalFlags_ChunkSize(t *testing.T) {
 	}{
 		{
 			name:      "default chunk size",
-			chunkSize: 0,
-			want:      0,
+			chunkSize: 500,
+			want:      500,
 		},
 		{
 			name:      "custom chunk size",
@@ -321,7 +321,7 @@ func TestGlobalFlags_ChunkSize(t *testing.T) {
 			want:      1000,
 		},
 		{
-			name:      "disabled chunking",
+			name:      "first page only",
 			chunkSize: 0,
 			want:      0,
 		},


### PR DESCRIPTION
## Summary

- Reverts the `--chunk-size` default from `0` (first page only) back to `500` (fetch all in chunks), matching kubectl behavior
- The change to `0` in #98 silently truncated results for **all** resources — `dtctl get dashboards` showed only 20 items instead of the full list, with no warning

## Context

The default was changed to `0` to work around the Document API ignoring the `page-size` parameter on some environments (PS-41914). However, this broke the UX for every resource type.

**Validation on gmg80500:**
- Sent `page-size=500` → API returned 20 documents with `totalCount=1294`. Bug confirmed (environment-specific; works on dev2 per Thomas Franz).
- Full pagination (1294 dashboards, 20/page) completed in 4m14s. Slow but correct — the API-side bug should not be worked around by truncating results globally.

## Changes

| File | Change |
|------|--------|
| `cmd/root.go` | Default `--chunk-size` from `0` → `500` |
| `cmd/flags_test.go` | Update expected default |
| `cmd/root_test.go` | Update test cases |