### PR TITLE
fix(settings): don't send schemaIds/scopes with nextPageKey on pagination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,13 +195,16 @@ Never put customer names, employee names, usernames, or specific Dynatrace envir
 
 ❌ **Don't** send `page-size` together with `next-page-key`/`page-key` on paginated requests  
 ❌ **Don't** drop filter/search params on subsequent pages — page tokens do NOT always preserve them  
-✅ **Do** use the pagination pattern below: only `page-size` goes in the if/else; filters go outside
+❌ **Don't** send `schemaIds`/`scopes` with `nextPageKey` on Settings API — the page token embeds everything  
+✅ **Do** use the pagination pattern below: only `page-size` goes in the if/else; filters go outside (except Settings API)
 
 ## Pagination Pattern (CRITICAL)
 
 Dynatrace APIs **reject** requests that combine `page-size` with `next-page-key`/`page-key` (HTTP 400). However, **page tokens do NOT always preserve filter parameters** — the Document API is a confirmed example where the `filter` param is dropped on page 2+ if not resent. To be safe, **always resend filter/search params on every page request**, and only exclude `page-size` when a page key is present.
 
 **Exception — Document API**: The Document API (`/platform/document/v1/documents`) does **not** reject `page-size` + `page-key`. It also does **not** embed the page size in the page token (defaulting to 20/page if `page-size` is omitted). For Document API endpoints, send `page-size` on every request alongside `page-key`. See `pkg/resources/document/document.go` for the reference implementation.
+
+**Exception — Settings API**: The Settings API (`/platform/classic/environment-api/v2/settings/objects`) rejects ALL other query params when `nextPageKey` is present — not just `pageSize`, but also `schemaIds` and `scopes` (HTTP 400: "must not be used in combination with nextPageKey query parameter"). The page token embeds everything. For Settings API endpoints, send ONLY `nextPageKey` on page 2+. See `pkg/resources/settings/settings.go` for the reference implementation.
 
 ### Correct pattern (default — most APIs)
 
@@ -242,6 +245,33 @@ for {
     }
 
     resp, err := req.Get("/platform/document/v1/documents")
+    // ... handle response, break if no more pages
+}
+```
+
+### Correct pattern (Settings API — page token embeds ALL params)
+
+```go
+for {
+    req := h.client.HTTP().R().SetResult(&result)
+
+    // Settings API rejects ALL other params when nextPageKey is present
+    // (pageSize, schemaIds, scopes are all embedded in the page token).
+    if nextPageKey != "" {
+        req.SetQueryParam("nextPageKey", nextPageKey)
+    } else {
+        if chunkSize > 0 {
+            req.SetQueryParam("pageSize", fmt.Sprintf("%d", chunkSize))
+        }
+        if schemaID != "" {
+            req.SetQueryParam("schemaIds", schemaID)
+        }
+        if scope != "" {
+            req.SetQueryParam("scopes", scope)
+        }
+    }
+
+    resp, err := req.Get("/platform/classic/environment-api/v2/settings/objects")
     // ... handle response, break if no more pages
 }
 ```
@@ -302,7 +332,23 @@ if r.URL.Query().Get("page-size") != "" && r.URL.Query().Get("page-key") != "" {
 }
 ```
 
-**Reference implementations**: `pkg/resources/document/document.go` (Document API pattern), `pkg/resources/settings/settings.go`, `pkg/resources/extension/extension.go` (default pattern)
+For Settings API mocks, the guard must also reject `schemaIds` and `scopes` with `nextPageKey`:
+
+```go
+// Simulate Settings API constraint: pageSize, schemaIds, and scopes
+// must NOT be combined with nextPageKey (all are embedded in the page token).
+if r.URL.Query().Get("nextPageKey") != "" {
+    for _, param := range []string{"pageSize", "schemaIds", "scopes"} {
+        if r.URL.Query().Get(param) != "" {
+            w.WriteHeader(http.StatusBadRequest)
+            fmt.Fprintf(w, `{"error":{"code":400,"message":"Constraints violated."}}`)
+            return
+        }
+    }
+}
+```
+
+**Reference implementations**: `pkg/resources/document/document.go` (Document API pattern), `pkg/resources/settings/settings.go` (Settings API pattern), `pkg/resources/extension/extension.go` (default pattern)
 
 ## Code Examples
 

--- a/pkg/resources/settings/handler_test.go
+++ b/pkg/resources/settings/handler_test.go
@@ -164,7 +164,18 @@ func TestListObjects_Pagination(t *testing.T) {
 	mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		w.Header().Set("Content-Type", "application/json")
+
+		// Simulate Settings API constraint: pageSize, schemaIds, and scopes
+		// must NOT be combined with nextPageKey (all are embedded in the page token).
 		if r.URL.Query().Get("nextPageKey") != "" {
+			for _, param := range []string{"pageSize", "schemaIds", "scopes"} {
+				if r.URL.Query().Get(param) != "" {
+					t.Errorf("%s must not be sent with nextPageKey", param)
+					w.WriteHeader(http.StatusBadRequest)
+					fmt.Fprintf(w, `{"error":{"code":400,"message":"Constraints violated.","constraintViolations":[{"path":"%s","message":"must not be used in combination with nextPageKey query parameter."}]}}`, param)
+					return
+				}
+			}
 			// Second page: no more pages
 			json.NewEncoder(w).Encode(SettingsObjectsList{
 				Items:      []SettingsObject{{ObjectID: "obj2", Summary: "Second"}},
@@ -183,6 +194,59 @@ func TestListObjects_Pagination(t *testing.T) {
 	defer cleanup()
 
 	result, err := h.ListObjects("", "", 10) // chunkSize>0 enables pagination
+	if err != nil {
+		t.Fatalf("ListObjects() error = %v", err)
+	}
+	if len(result.Items) != 2 {
+		t.Errorf("expected 2 items across pages, got %d", len(result.Items))
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls, got %d", callCount)
+	}
+}
+
+func TestListObjects_PaginationWithFilters(t *testing.T) {
+	callCount := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		// Simulate Settings API constraint: pageSize, schemaIds, and scopes
+		// must NOT be combined with nextPageKey.
+		if r.URL.Query().Get("nextPageKey") != "" {
+			for _, param := range []string{"pageSize", "schemaIds", "scopes"} {
+				if r.URL.Query().Get(param) != "" {
+					t.Errorf("%s must not be sent with nextPageKey", param)
+					w.WriteHeader(http.StatusBadRequest)
+					fmt.Fprintf(w, `{"error":{"code":400,"message":"Constraints violated."}}`)
+					return
+				}
+			}
+			// Second page
+			json.NewEncoder(w).Encode(SettingsObjectsList{
+				Items:      []SettingsObject{{ObjectID: "obj2", SchemaID: "builtin:alerting.profile", Scope: "environment", Summary: "Second"}},
+				TotalCount: 2,
+			})
+		} else {
+			// First page: verify filter params are sent
+			if r.URL.Query().Get("schemaIds") != "builtin:alerting.profile" {
+				t.Errorf("expected schemaIds on first request, got %q", r.URL.Query().Get("schemaIds"))
+			}
+			if r.URL.Query().Get("scopes") != "environment" {
+				t.Errorf("expected scopes on first request, got %q", r.URL.Query().Get("scopes"))
+			}
+			json.NewEncoder(w).Encode(SettingsObjectsList{
+				Items:       []SettingsObject{{ObjectID: "obj1", SchemaID: "builtin:alerting.profile", Scope: "environment", Summary: "First"}},
+				TotalCount:  2,
+				NextPageKey: "page2token",
+			})
+		}
+	})
+	h, cleanup := newTestHandler(t, mux)
+	defer cleanup()
+
+	result, err := h.ListObjects("builtin:alerting.profile", "environment", 10)
 	if err != nil {
 		t.Fatalf("ListObjects() error = %v", err)
 	}

--- a/pkg/resources/settings/settings.go
+++ b/pkg/resources/settings/settings.go
@@ -183,18 +183,20 @@ func (h *Handler) ListObjects(schemaID, scope string, chunkSize int64) (*Setting
 	for {
 		req := h.client.HTTP().R()
 
-		// The API rejects requests that combine pageSize with nextPageKey,
-		// but filter params must be sent on every request (page tokens may not preserve them).
+		// The Settings API rejects ALL other params when nextPageKey is used
+		// (schemaIds, scopes, pageSize are all embedded in the page token).
 		if nextPageKey != "" {
 			req.SetQueryParam("nextPageKey", nextPageKey)
-		} else if chunkSize > 0 {
-			req.SetQueryParam("pageSize", fmt.Sprintf("%d", chunkSize))
-		}
-		if schemaID != "" {
-			req.SetQueryParam("schemaIds", schemaID)
-		}
-		if scope != "" {
-			req.SetQueryParam("scopes", scope)
+		} else {
+			if chunkSize > 0 {
+				req.SetQueryParam("pageSize", fmt.Sprintf("%d", chunkSize))
+			}
+			if schemaID != "" {
+				req.SetQueryParam("schemaIds", schemaID)
+			}
+			if scope != "" {
+				req.SetQueryParam("scopes", scope)
+			}
 		}
 
 		resp, err := req.Get("/platform/classic/environment-api/v2/settings/objects")
@@ -327,18 +329,18 @@ func (h *Handler) getByUID(uid, schemaID, scope string) (*SettingsObject, error)
 	for {
 		req := h.client.HTTP().R()
 
-		// The API rejects requests that combine pageSize with nextPageKey,
-		// but filter params must be sent on every request (page tokens may not preserve them).
+		// The Settings API rejects ALL other params when nextPageKey is used
+		// (schemaIds, scopes, pageSize are all embedded in the page token).
 		if nextPageKey != "" {
 			req.SetQueryParam("nextPageKey", nextPageKey)
 		} else {
 			req.SetQueryParam("pageSize", fmt.Sprintf("%d", pageSize))
-		}
-		if schemaID != "" {
-			req.SetQueryParam("schemaIds", schemaID)
-		}
-		if searchScope != "" {
-			req.SetQueryParam("scopes", searchScope)
+			if schemaID != "" {
+				req.SetQueryParam("schemaIds", schemaID)
+			}
+			if searchScope != "" {
+				req.SetQueryParam("scopes", searchScope)
+			}
 		}
 
 		resp, err := req.Get("/platform/classic/environment-api/v2/settings/objects")


### PR DESCRIPTION
## Summary

- **Bug fix**: The Settings API rejects ALL query params (not just `pageSize`) when `nextPageKey` is present. The previous code sent `schemaIds` and `scopes` on every page request, causing HTTP 400 errors on page 2+ when filters were active.
- **Test coverage**: Added constraint guard to existing pagination test mock and a new `TestListObjects_PaginationWithFilters` test that exercises pagination with schema/scope filters.
- **Documentation**: Updated `AGENTS.md` with the Settings API pagination exception pattern and mock guard examples.