### PR TITLE
Add PII redaction for DQL query results with RUM coverage and custom …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **PII redaction for DQL query results** — new `--pii` flag on `dtctl query` replaces detected PII (emails, names, IPs, credentials, etc.) with category placeholders (`[EMAIL]`, `[PERSON]`) in lite mode, or stable session-scoped pseudonyms (`<EMAIL_0>`, `<PERSON_1>`) in full mode (`--pii=full`); pseudonyms enable correlation across records while keeping data safe for AI agents; sessions are persisted to disk and can be resolved by a human operator via the separate `dtctl-pii-resolve` tool; supports RUM `usr.*` field detection, optional Presidio NER integration for free-text analysis, custom field rules via `.dtctl-pii.yaml` project files and config preferences, and `--no-pii` to override; configurable via flag, `DTCTL_PII` env var, or `preferences.pii.mode` in config; see [docs/PII_REDACTION.md](docs/PII_REDACTION.md) for the full guide
+
 ## [0.20.1] - 2026-03-25
 
 ### Added

--- a/cmd/pii-resolve/main.go
+++ b/cmd/pii-resolve/main.go
@@ -1,0 +1,217 @@
+// dtctl-pii-resolve is a standalone tool for resolving PII pseudonyms back to
+// their original values. It is deliberately a SEPARATE binary from dtctl so
+// that AI agents can use dtctl (which only produces pseudonyms) without ever
+// having access to the reverse mapping.
+//
+// This binary is intended for human operators only.
+//
+// Usage:
+//
+//	dtctl-pii-resolve resolve <session-id> <pseudonym>   Resolve a single pseudonym
+//	dtctl-pii-resolve resolve <session-id> --all         Show all mappings in a session
+//	dtctl-pii-resolve sessions                           List all PII sessions
+//	dtctl-pii-resolve purge [--max-age 72h]              Delete sessions older than max-age
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/dynatrace-oss/dtctl/pkg/pii"
+)
+
+const usage = `dtctl-pii-resolve — resolve PII pseudonyms from dtctl query sessions
+
+USAGE:
+  dtctl-pii-resolve resolve <session-id> <pseudonym>   Resolve a single pseudonym
+  dtctl-pii-resolve resolve <session-id> --all         Show all mappings in a session
+  dtctl-pii-resolve sessions [--json]                  List all PII sessions
+  dtctl-pii-resolve purge [--max-age <duration>]       Delete sessions older than max-age (default: 72h)
+  dtctl-pii-resolve help                               Show this help
+
+EXAMPLES:
+  dtctl-pii-resolve sessions
+  dtctl-pii-resolve resolve pii_20240315_143022_a1b2 "<EMAIL_0>"
+  dtctl-pii-resolve resolve pii_20240315_143022_a1b2 --all
+  dtctl-pii-resolve purge --max-age 168h
+
+The pseudonym session files are stored at:
+  $XDG_DATA_HOME/dtctl/pii/sessions/ (typically ~/.local/share/dtctl/pii/sessions/)
+`
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "resolve":
+		cmdResolve(os.Args[2:])
+	case "sessions":
+		cmdSessions(os.Args[2:])
+	case "purge":
+		cmdPurge(os.Args[2:])
+	case "help", "--help", "-h":
+		fmt.Print(usage)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", os.Args[1])
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(1)
+	}
+}
+
+func cmdResolve(args []string) {
+	if len(args) < 1 {
+		fatalf("Usage: dtctl-pii-resolve resolve <session-id> <pseudonym|--all>\n")
+	}
+
+	sessionID := args[0]
+	sf, err := pii.LoadSession(sessionID)
+	if err != nil {
+		fatalf("Failed to load session %q: %v\n", sessionID, err)
+	}
+
+	// --all: dump all mappings
+	if len(args) >= 2 && args[1] == "--all" {
+		printAllMappings(sf)
+		return
+	}
+
+	if len(args) < 2 {
+		fatalf("Usage: dtctl-pii-resolve resolve <session-id> <pseudonym|--all>\n")
+	}
+
+	pseudonym := args[1]
+	entry, category, found := sf.ResolveInSession(pseudonym)
+	if !found {
+		fatalf("Pseudonym %q not found in session %s\n", pseudonym, sessionID)
+	}
+
+	fmt.Printf("Pseudonym:  %s\n", entry.Pseudonym)
+	fmt.Printf("Category:   %s\n", category)
+	fmt.Printf("Original:   %s\n", entry.Original)
+}
+
+func printAllMappings(sf *pii.SessionFile) {
+	fmt.Printf("Session:    %s\n", sf.SessionID)
+	fmt.Printf("Context:    %s\n", sf.Context)
+	fmt.Printf("Created:    %s\n", sf.CreatedAt)
+	fmt.Printf("Mappings:   %d\n\n", sf.TotalMappings())
+
+	// Sort categories for stable output
+	categories := make([]string, 0, len(sf.Mappings))
+	for cat := range sf.Mappings {
+		categories = append(categories, cat)
+	}
+	sort.Strings(categories)
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintf(tw, "PSEUDONYM\tCATEGORY\tORIGINAL\n")
+
+	for _, cat := range categories {
+		entries := sf.Mappings[cat]
+		for _, e := range entries {
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", e.Pseudonym, cat, e.Original)
+		}
+	}
+	tw.Flush()
+}
+
+func cmdSessions(args []string) {
+	jsonOutput := false
+	for _, a := range args {
+		if a == "--json" {
+			jsonOutput = true
+		}
+	}
+
+	sessions, err := pii.ListSessions()
+	if err != nil {
+		fatalf("Failed to list sessions: %v\n", err)
+	}
+
+	if len(sessions) == 0 {
+		fmt.Println("No PII sessions found.")
+		return
+	}
+
+	if jsonOutput {
+		data, err := json.MarshalIndent(sessions, "", "  ")
+		if err != nil {
+			fatalf("Failed to marshal sessions: %v\n", err)
+		}
+		fmt.Println(string(data))
+		return
+	}
+
+	// Sort by CreatedAt descending (newest first)
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].CreatedAt > sessions[j].CreatedAt
+	})
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintf(tw, "SESSION ID\tCONTEXT\tCREATED\tMAPPINGS\n")
+
+	for _, s := range sessions {
+		// Format timestamp for display
+		created := s.CreatedAt
+		if t, err := time.Parse(time.RFC3339, s.CreatedAt); err == nil {
+			created = t.Local().Format("2006-01-02 15:04:05")
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\n",
+			s.SessionID,
+			s.Context,
+			created,
+			s.TotalMappings(),
+		)
+	}
+	tw.Flush()
+}
+
+func cmdPurge(args []string) {
+	maxAge := 72 * time.Hour
+
+	for i, a := range args {
+		if a == "--max-age" && i+1 < len(args) {
+			d, err := time.ParseDuration(args[i+1])
+			if err != nil {
+				fatalf("Invalid duration %q: %v\n", args[i+1], err)
+			}
+			maxAge = d
+		}
+	}
+
+	deleted, err := pii.PurgeSessions(maxAge)
+	if err != nil {
+		fatalf("Failed to purge sessions: %v\n", err)
+	}
+
+	if deleted == 0 {
+		fmt.Printf("No sessions older than %s found.\n", formatDuration(maxAge))
+	} else {
+		fmt.Printf("Purged %d session(s) older than %s.\n", deleted, formatDuration(maxAge))
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	if d >= 24*time.Hour {
+		days := int(d.Hours()) / 24
+		if days == 1 {
+			return "1 day"
+		}
+		return fmt.Sprintf("%d days", days)
+	}
+	return strings.TrimRight(strings.TrimRight(d.String(), "0"), ".")
+}
+
+func fatalf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, args...)
+	os.Exit(1)
+}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
+	"github.com/dynatrace-oss/dtctl/pkg/pii"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
 )
 
@@ -134,6 +135,15 @@ Examples:
 		}
 
 		executor := exec.NewDQLExecutor(c)
+
+		// Resolve PII mode from flag / env / config
+		piiFlag, _ := cmd.Flags().GetString("pii")
+		noPII, _ := cmd.Flags().GetBool("no-pii")
+		var configPIIMode string
+		if cfg.Preferences.PII != nil {
+			configPIIMode = cfg.Preferences.PII.Mode
+		}
+		piiMode := pii.ResolveMode(piiFlag, cmd.Flags().Changed("pii"), noPII, configPIIMode)
 
 		queryFile, _ := cmd.Flags().GetString("file")
 		setFlags, _ := cmd.Flags().GetStringArray("set")
@@ -261,6 +271,53 @@ Examples:
 			Locale:                       locale,
 			Timezone:                     timezone,
 			MetadataFields:               metadataFields,
+			PIIMode:                      piiMode,
+		}
+
+		// Resolve Presidio URL for full PII mode
+		if piiMode == pii.ModeFull && cfg.Preferences.PII != nil && cfg.Preferences.PII.PresidioURL != "" {
+			opts.PIIPresidioURL = cfg.Preferences.PII.PresidioURL
+		}
+		// Also check PRESIDIO_URL env var
+		if piiMode == pii.ModeFull && opts.PIIPresidioURL == "" {
+			if envURL := os.Getenv("PRESIDIO_URL"); envURL != "" {
+				opts.PIIPresidioURL = envURL
+			}
+		}
+		// Wire context name for session metadata
+		if piiMode != pii.ModeOff {
+			opts.PIIContext = cfg.CurrentContext
+
+			// Load custom PII field rules from project file + config
+			var projectRules, configRules []pii.CustomRule
+
+			// Search upward for .dtctl-pii.yaml project file
+			if cwd, err := os.Getwd(); err == nil {
+				if rulesPath := pii.FindCustomRulesFile(cwd); rulesPath != "" {
+					if rules, err := pii.LoadCustomRulesFile(rulesPath); err == nil {
+						projectRules = rules
+					} else {
+						fmt.Fprintf(os.Stderr, "Warning: failed to load %s: %v\n", rulesPath, err)
+					}
+				}
+			}
+
+			// Load custom fields from config preferences
+			if cfg.Preferences.PII != nil {
+				for _, cf := range cfg.Preferences.PII.CustomFields {
+					category := cf.Category
+					if category == "" && !cf.Skip {
+						category = "REDACTED"
+					}
+					configRules = append(configRules, pii.CustomRule{
+						Field:    cf.Field,
+						Category: category,
+						Skip:     cf.Skip,
+					})
+				}
+			}
+
+			opts.PIICustomRules = pii.MergeRules(projectRules, configRules)
 		}
 
 		// Handle live mode
@@ -376,6 +433,22 @@ analysisTimeframe,contributions`)
 bare --decode-snapshots simplifies variant wrappers to plain values;
 --decode-snapshots=full preserves the full decoded tree with type annotations`)
 	queryCmd.Flags().Lookup("decode-snapshots").NoOptDefVal = "simplified"
+
+	// PII redaction flags
+	queryCmd.Flags().String("pii", "", `redact PII from query results
+bare --pii uses lite mode (simple placeholders like [EMAIL]);
+--pii=full uses pseudonyms (<EMAIL_0>) with optional Presidio NER.
+Overrides DTCTL_PII env var and config preferences.pii.mode`)
+	queryCmd.Flags().Lookup("pii").NoOptDefVal = "lite"
+	queryCmd.Flags().Bool("no-pii", false, "disable PII redaction (overrides env and config)")
+
+	// Shell completion for --pii values
+	_ = queryCmd.RegisterFlagCompletionFunc("pii", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{
+			"lite\tSimple category placeholders ([EMAIL], [PERSON])",
+			"full\tStable pseudonyms (<EMAIL_0>) with optional Presidio NER",
+		}, cobra.ShellCompDirectiveNoFileComp
+	})
 
 	// Shell completion for --metadata field names (supports comma-separated values)
 	_ = queryCmd.RegisterFlagCompletionFunc("metadata", metadataFieldCompletion)

--- a/docs/PII_REDACTION.md
+++ b/docs/PII_REDACTION.md
@@ -1,0 +1,445 @@
+# PII Redaction: Query Freely, Leak Nothing
+
+dtctl includes built-in PII (Personally Identifiable Information) detection and redaction for DQL query results. This ensures AI agents and automated pipelines can work with real query data without exposing sensitive information like email addresses, names, IPs, or credentials.
+
+## Table of Contents
+
+1. [Why PII Masking Matters for LLMs](#why-pii-masking-matters-for-llms)
+2. [Trust Boundary Architecture](#trust-boundary-architecture)
+3. [Two-Tier Design](#two-tier-design)
+4. [Quick Start](#quick-start)
+5. [Configuration Reference](#configuration-reference)
+6. [Custom Field Rules](#custom-field-rules)
+7. [Detection Strategy](#detection-strategy)
+8. [RUM Data Coverage](#rum-data-coverage)
+9. [Testing Guide](#testing-guide)
+
+---
+
+## Why PII Masking Matters for LLMs
+
+When AI agents query observability data, every record they see becomes part of their context window. This creates several risks:
+
+**Training data leakage** — Model providers may use API interactions for training. Customer names, email addresses, and IPs in query results could end up in future model weights, making them potentially recoverable.
+
+**Prompt injection via data** — Malicious actors can embed instructions in log messages or user-agent strings. If an agent processes unredacted data containing `"user": "Ignore previous instructions and..."`, the attack surface is the entire dataset.
+
+**GDPR / CCPA compliance** — Regulations require data minimization. An AI agent diagnosing a performance issue does not need to know that `user_42` is `mario.rossi@example.invalid`. The category label `[PERSON]` is sufficient for pattern analysis.
+
+**Context windows as attack surface** — Every token of PII in a context window is a token that could be extracted via prompt injection, logged by middleware, or cached in an unencrypted session store. Redaction reduces the blast radius to zero.
+
+**Correlation without identification** — In full mode, pseudonyms like `<EMAIL_0>` and `<EMAIL_1>` preserve the ability to distinguish between different users without revealing who they are. The agent can still say "the same user triggered 47 errors" without knowing the user's name.
+
+---
+
+## Trust Boundary Architecture
+
+The PII system enforces a strict trust boundary:
+
+```
+┌──────────────────────────┐     ┌──────────────────────────┐
+│       dtctl (agent)      │     │   dtctl-pii-resolve      │
+│                          │     │   (human operator)       │
+│  Query → Redact → Output │     │                          │
+│                          │     │  Session file → Originals│
+│  Can NEVER reverse       │     │  CAN reverse pseudonyms  │
+│  pseudonyms              │     │                          │
+└──────────┬───────────────┘     └──────────┬───────────────┘
+           │                                │
+           │  writes session                │  reads session
+           ▼                                ▼
+     ~/.local/share/dtctl/pii/sessions/
+     └── pii_20260326_102611_3b3c73ad.json
+```
+
+**dtctl** (used by agents) can only write pseudonym sessions. It never reads them back. The reverse lookup (`pseudonym → original`) is in a **separate binary** (`dtctl-pii-resolve`) that only human operators should have access to.
+
+This means even if an agent is compromised, it cannot access the pseudonym database to reverse the redaction.
+
+---
+
+## Two-Tier Design
+
+### Lite Mode (`--pii` or `--pii=lite`)
+
+- Replaces PII with category placeholders: `[EMAIL]`, `[PERSON]`, `[IP_ADDRESS]`
+- No state, no files written, no external dependencies
+- All occurrences of the same value get the same placeholder (no correlation)
+- Best for: quick queries, CI pipelines, environments where you don't need correlation
+
+```bash
+dtctl query "fetch logs | limit 5" --pii
+```
+
+```
+email: [EMAIL]   firstName: [PERSON]   ip: [IP_ADDRESS]
+```
+
+### Full Mode (`--pii=full`)
+
+- Replaces PII with stable, session-scoped pseudonyms: `<EMAIL_0>`, `<PERSON_1>`
+- Same value → same pseudonym within a session (enables correlation)
+- Session persisted to `~/.local/share/dtctl/pii/sessions/`
+- Optionally integrates with [Microsoft Presidio](https://microsoft.github.io/presidio/) for NER-based detection of PII in free-text fields
+- Best for: investigation sessions, debugging where you need to track "the same user" across records
+
+```bash
+dtctl query "fetch logs | limit 5" --pii=full
+```
+
+```
+email: <EMAIL_0>   firstName: <PERSON_0>   ip: <IP_ADDRESS_0>
+email: <EMAIL_1>   firstName: <PERSON_0>   ip: <IP_ADDRESS_1>
+# ^ Same person, different email/IP — pseudonyms let you see the pattern
+```
+
+After the query, resolve pseudonyms (human operator only):
+
+```bash
+dtctl-pii-resolve resolve pii_20260326_102611_3b3c73ad --all
+```
+
+---
+
+## Quick Start
+
+```bash
+# Lite mode — simple placeholders, zero setup
+dtctl query "fetch logs | limit 10" --pii
+
+# Full mode — stable pseudonyms with session persistence
+dtctl query "fetch logs | limit 10" --pii=full
+
+# Disable PII even if enabled in config/env
+dtctl query "fetch logs | limit 10" --no-pii
+
+# List saved sessions
+dtctl-pii-resolve sessions
+
+# Resolve all pseudonyms in a session
+dtctl-pii-resolve resolve <session-id> --all
+
+# Purge sessions older than 7 days
+dtctl-pii-resolve purge --max-age 168h
+```
+
+---
+
+## Configuration Reference
+
+PII mode is resolved with layered precedence: **flag > environment variable > config file**.
+
+### Flag
+
+```bash
+dtctl query "..." --pii          # lite mode (default when bare --pii)
+dtctl query "..." --pii=lite     # explicit lite
+dtctl query "..." --pii=full     # full mode with pseudonyms
+dtctl query "..." --no-pii       # disable (overrides everything)
+```
+
+### Environment Variable
+
+```bash
+export DTCTL_PII=lite    # or "full"
+dtctl query "..."        # PII redaction active without --pii flag
+```
+
+### Config File (`~/.config/dtctl/config`)
+
+```yaml
+preferences:
+  pii:
+    mode: lite            # or "full"
+    presidio-url: http://localhost:5002   # optional, full mode only
+    custom-fields:        # optional per-field rules
+      - field: "data.customerRef"
+        category: PERSON
+      - field: "data.action"
+        skip: true
+```
+
+### Presidio Integration (Full Mode Only)
+
+If you have a [Microsoft Presidio Analyzer](https://microsoft.github.io/presidio/) instance running, dtctl can use it for NER-based detection of PII in free-text fields (log messages, descriptions, etc.) that regex patterns might miss.
+
+Configure via config or environment:
+
+```yaml
+# In ~/.config/dtctl/config
+preferences:
+  pii:
+    mode: full
+    presidio-url: http://localhost:5002
+```
+
+```bash
+# Or via environment variable
+export PRESIDIO_URL=http://localhost:5002
+```
+
+Presidio is **optional and non-fatal** — if it's unavailable, dtctl falls back to regex-only detection. The score threshold is 0.85 (high confidence).
+
+---
+
+## Custom Field Rules
+
+Custom rules let you extend or override built-in PII detection. They are useful for:
+
+- Redacting domain-specific fields that built-in patterns don't cover
+- Skipping fields that built-in patterns would incorrectly flag
+- Adding categories like `DEVICE_INFO` for fields you consider sensitive in your context
+
+### Rule Format
+
+```yaml
+version: v1
+rules:
+  - field: "data.customerRef"     # exact field path
+    category: PERSON
+  - field: "usr.*"                # glob suffix — matches usr.name, usr.id, etc.
+    category: PERSON
+  - field: "data.internalNote"    # category defaults to REDACTED
+  - field: "data.action"
+    skip: true                    # override built-in match — field is preserved
+```
+
+### Rule Behavior
+
+| Property | Description | Default |
+|----------|-------------|---------|
+| `field` | Field path. Exact match (`data.customerRef`) or glob suffix (`usr.*`). | Required |
+| `category` | PII category label for the replacement (`[CATEGORY]` or `<CATEGORY_N>`). | `REDACTED` |
+| `skip` | When `true`, excludes the field from all redaction (overrides built-in patterns). | `false` |
+
+**Matching precedence**: Custom rules are checked **before** built-in patterns. Exact matches take priority over glob matches.
+
+### Two Sources (Merged)
+
+1. **Project file `.dtctl-pii.yaml`** — committed to your repo, shared with team. Searched upward from the current working directory (same as `.dtctl.yaml`).
+
+2. **Config `preferences.pii.custom-fields`** — personal overrides in `~/.config/dtctl/config`.
+
+When both exist, config rules **override** project rules for the same field path. Config-only rules are appended.
+
+### Examples
+
+**Redact a custom business field:**
+
+```yaml
+# .dtctl-pii.yaml
+version: v1
+rules:
+  - field: "data.customerRef"
+    category: PERSON
+```
+
+**Skip a field that's incorrectly flagged:**
+
+```yaml
+version: v1
+rules:
+  - field: "workflow.name"
+    skip: true
+```
+
+**Add device fingerprinting fields (not redacted by default):**
+
+```yaml
+version: v1
+rules:
+  - field: "device"
+    category: DEVICE_INFO
+  - field: "browser"
+    category: DEVICE_INFO
+  - field: "os"
+    category: DEVICE_INFO
+  - field: "referrer"
+    category: URL
+```
+
+---
+
+## Detection Strategy
+
+PII detection works in three phases, applied to every field in every record:
+
+### Phase 0: Custom Rules (Highest Priority)
+
+User-defined rules from `.dtctl-pii.yaml` and config `preferences.pii.custom-fields`. Checked against the full dotted field path. `skip: true` rules stop all further detection for that field.
+
+### Phase 1: Field Name Heuristics
+
+The field name (last dot-segment for dotted keys, or the full key for prefix rules like `usr.*`) is matched against regex patterns. This catches fields like `email`, `firstName`, `password` regardless of their value.
+
+### Phase 2: Value Regex
+
+The string value is matched against anchored regex patterns for emails and IP addresses. This catches PII in generically-named fields like `"generic_field": "john@example.com"`.
+
+### Phase 3: Presidio NER (Full Mode Only)
+
+Free-text fields (long strings with spaces, not UUIDs or entity IDs) are sent to Presidio for Named Entity Recognition. This catches PII embedded in prose like `"message": "Login failed for user John Doe from 10.0.0.1"`.
+
+### Built-in Detection Coverage
+
+| Category | Field Name Patterns | Value Patterns | Examples |
+|----------|-------------------|----------------|----------|
+| `EMAIL` | `email`, `e-mail`, `recipients`, `sendToOthers`, `otherEmails` | `user@domain.tld` regex | `"email": "j.doe@example.com"` |
+| `PHONE` | `phone`, `mobile`, `telephone`, `fax` | — | `"phone": "+1-555-0123"` |
+| `PERSON` | `firstName`, `lastName`, `fullName`, `displayName`, `userName`, `customerName`, `personName`, `givenName`, `surname`, `familyName` | — | `"firstName": "Jane"` |
+| `PERSON` | `usr.*` (full-key prefix) | — | `"usr.name": "Jane"`, `"usr.id": "j42"` |
+| `CREDENTIAL` | `password`, `secret`, `apiKey`, `accessToken`, `refreshToken`, `authToken`, `bearer`, `jwt` | — | `"password": "s3cr3t"` |
+| `IP_ADDRESS` | `ip`, `ipAddress`, `ipv4`, `ipv6`, `remoteAddr`, `clientIp`, `sourceIp`, `destIp` | IPv4 and IPv6 regex | `"ip": "10.0.0.1"` |
+| `ADDRESS` | `street`, `postalCode`, `zipCode`, `city`, `state`, `country`, `region`, `mailingAddress`, `streetAddress` | — | `"city": "Vienna"` |
+| `ID_NUMBER` | `ssn`, `socialSecurity`, `taxId`, `nationalId`, `passport`, `license`, `creditCard`, `cardNumber`, `pan`, `cvv`, `cvc` | — | `"ssn": "123-45-6789"` |
+| `ORGANIZATION` | `accountName`, `companyName`, `orgName`, `organizationName` | — | `"companyName": "Acme"` |
+
+### Intentionally Excluded (Add via Custom Rules)
+
+These fields are **not** redacted by default. They are borderline PII (useful for debugging, low identification risk alone) but can be added via [custom field rules](#custom-field-rules) if your compliance requirements are stricter.
+
+| Field | Reason for Exclusion | Custom Rule to Add |
+|-------|---------------------|--------------------|
+| `device` | Device type ("iPhone 15") — low PII risk alone | `{field: "device", category: "DEVICE_INFO"}` |
+| `browser` | Browser name ("Chrome 120") — technical metadata | `{field: "browser", category: "DEVICE_INFO"}` |
+| `os` | OS name ("iOS 17") — technical metadata | `{field: "os", category: "DEVICE_INFO"}` |
+| `referrer` | Referrer URL — may contain PII in query params | `{field: "referrer", category: "URL"}` |
+
+---
+
+## RUM Data Coverage
+
+Real User Monitoring (RUM) data contains user-scoped fields under the `usr.*` prefix. These are automatically detected and redacted:
+
+| RUM Field | Category | Detection |
+|-----------|----------|-----------|
+| `usr.name` | `PERSON` | `usr.*` prefix match |
+| `usr.id` | `PERSON` | `usr.*` prefix match |
+| `usr.email` | `PERSON` | `usr.*` prefix match |
+| `usr.company` | `PERSON` | `usr.*` prefix match |
+| `usr.*` (any custom tag) | `PERSON` | `usr.*` prefix match |
+| `ip` | `IP_ADDRESS` | Field name regex |
+| `region` | `ADDRESS` | Field name regex |
+| `city` | `ADDRESS` | Field name regex |
+| `country` | `ADDRESS` | Field name regex |
+
+Note: RUM also includes `device`, `browser`, `os`, and `referrer` fields. These are not redacted by default — see [Intentionally Excluded](#intentionally-excluded-add-via-custom-rules) above.
+
+---
+
+## Testing Guide
+
+This section walks through testing PII redaction end-to-end using fictitious data.
+
+### Prerequisites
+
+```bash
+# Ensure dtctl is built
+go build -o dtctl .
+
+# Build the resolve tool
+go build -o dtctl-pii-resolve ./cmd/pii-resolve/
+```
+
+### Step 1: Verify Lite Mode
+
+Run a query with `--pii` against any environment with log data:
+
+```bash
+dtctl query "fetch logs
+| filter matchesPhrase(content, \"error\")
+| fields timestamp, content, dt.entity.host
+| limit 5" --pii
+```
+
+Expected: string fields that match PII patterns are replaced with `[CATEGORY]` placeholders. Non-PII fields (timestamp, technical IDs) are preserved.
+
+### Step 2: Verify Full Mode with Pseudonyms
+
+```bash
+dtctl query "fetch logs
+| fields timestamp, content
+| limit 10" --pii=full
+```
+
+Expected output on stderr:
+
+```
+PII session pii_20260326_143022_a1b2c3d4: redacted 12 fields across 10 records
+```
+
+Verify pseudonym stability — the same PII value in different records should get the same pseudonym (e.g., `<EMAIL_0>` appears in rows 1, 3, and 7 if it's the same email).
+
+### Step 3: Resolve Pseudonyms
+
+```bash
+# List sessions
+dtctl-pii-resolve sessions
+
+# Resolve all mappings from the session
+dtctl-pii-resolve resolve <session-id> --all
+```
+
+Expected output:
+
+```
+PSEUDONYM       ORIGINAL
+<EMAIL_0>       elena.martinez@example.invalid
+<EMAIL_1>       kai.tanaka@example.invalid
+<PERSON_0>      Elena Martinez
+<IP_ADDRESS_0>  192.168.1.42
+```
+
+### Step 4: Test Custom Rules
+
+Create a `.dtctl-pii.yaml` file in your working directory:
+
+```yaml
+version: v1
+rules:
+  - field: "device"
+    category: DEVICE_INFO
+  - field: "content"
+    skip: true
+```
+
+Run a query:
+
+```bash
+dtctl query "fetch logs | limit 5" --pii
+```
+
+Expected: `device` fields show `[DEVICE_INFO]`, `content` fields are preserved (even if they contain PII-like patterns).
+
+### Step 5: Verify No-PII Override
+
+```bash
+# Even with DTCTL_PII=full in env, --no-pii disables redaction
+DTCTL_PII=full dtctl query "fetch logs | limit 5" --no-pii
+```
+
+Expected: raw, unredacted output.
+
+### Step 6: Test Value-Based Detection
+
+Create a DQL query that returns email addresses in non-email-named fields:
+
+```bash
+dtctl query "fetch logs
+| filter isNotNull(content)
+| parse content, \"LD 'user=' LD:user_field ','\"
+| fields user_field
+| limit 5" --pii
+```
+
+If `user_field` contains values like `elena.martinez@example.invalid`, they should be detected by the email value regex and replaced with `[EMAIL]`.
+
+### Step 7: Run Unit Tests
+
+```bash
+# All PII tests
+go test ./pkg/pii/ -v
+
+# Full test suite (includes golden tests)
+go test ./...
+```

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean test test-unit test-integration test-all test-coverage test-update-golden install lint lint-strict fmt markdownlint markdownlint-fix security-scan check release release-snapshot
+.PHONY: all build build-pii-resolve clean test test-unit test-integration test-all test-coverage test-update-golden install lint lint-strict fmt markdownlint markdownlint-fix security-scan check release release-snapshot
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -18,6 +18,11 @@ all: build
 build:
 	@echo "Building dtctl..."
 	@go build $(LDFLAGS) -o bin/dtctl .
+
+# Build the PII resolve tool (separate trust boundary — human-only)
+build-pii-resolve:
+	@echo "Building dtctl-pii-resolve..."
+	@go build $(LDFLAGS) -o bin/dtctl-pii-resolve ./cmd/pii-resolve
 
 # Build for macOS (arm64)
 build-darwin-arm64:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,8 +94,32 @@ type NamedToken struct {
 
 // Preferences holds user preferences
 type Preferences struct {
-	Output string `yaml:"output,omitempty"`
-	Editor string `yaml:"editor,omitempty"`
+	Output string     `yaml:"output,omitempty"`
+	Editor string     `yaml:"editor,omitempty"`
+	PII    *PIIConfig `yaml:"pii,omitempty"`
+}
+
+// PIIConfig holds PII redaction preferences.
+type PIIConfig struct {
+	// Mode controls PII redaction: "" (disabled), "lite", or "full".
+	// Lite replaces PII with category placeholders ([EMAIL], [PERSON]).
+	// Full uses stable pseudonyms (<EMAIL_0>, <PERSON_1>) with optional Presidio NER.
+	Mode string `yaml:"mode,omitempty"`
+	// PresidioURL is the base URL of a Microsoft Presidio Analyzer API
+	// (e.g., "http://localhost:5002"). Only used in full mode.
+	PresidioURL string `yaml:"presidio-url,omitempty"`
+	// CustomFields defines per-field PII rules (redact, skip, custom category).
+	CustomFields []PIICustomField `yaml:"custom-fields,omitempty"`
+}
+
+// PIICustomField defines a custom PII field rule in the config file.
+type PIICustomField struct {
+	// Field is the field path to match. Exact ("data.customerRef") or glob suffix ("usr.*").
+	Field string `yaml:"field"`
+	// Category is the PII category label. Defaults to "REDACTED" if empty.
+	Category string `yaml:"category,omitempty"`
+	// Skip, when true, excludes the field from PII redaction.
+	Skip bool `yaml:"skip,omitempty"`
 }
 
 // DefaultConfigPath returns the default config file path following XDG Base Directory spec

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
+	"github.com/dynatrace-oss/dtctl/pkg/pii"
 )
 
 // DQLExecutor handles DQL query execution
@@ -66,6 +67,12 @@ type DQLExecuteOptions struct {
 
 	// Metadata options
 	MetadataFields []string // Metadata fields to include; nil/empty = disabled, ["all"] = all fields, specific names = filtered
+
+	// PII redaction options
+	PIIMode        pii.Mode         // PII redaction mode (off, lite, full)
+	PIIPresidioURL string           // Optional Presidio API URL for NER (full mode only)
+	PIIContext     string           // Dynatrace context name (for session metadata)
+	PIICustomRules []pii.CustomRule // User-defined PII field rules
 }
 
 // DQLVerifyOptions configures DQL query verification
@@ -437,6 +444,32 @@ func (e *DQLExecutor) printResults(result *DQLQueryResponse, opts DQLExecuteOpti
 		switch opts.OutputFormat {
 		case "", "table", "wide", "csv":
 			records = output.SummarizeSnapshotForTable(records)
+		}
+	}
+
+	// Apply PII redaction if enabled
+	if opts.PIIMode != pii.ModeOff && len(records) > 0 {
+		redactor, redactErr := pii.NewRedactor(pii.Config{
+			Mode:        opts.PIIMode,
+			PresidioURL: opts.PIIPresidioURL,
+			Context:     opts.PIIContext,
+			CustomRules: opts.PIICustomRules,
+		})
+		if redactErr != nil {
+			return fmt.Errorf("failed to initialize PII redactor: %w", redactErr)
+		}
+
+		records = redactor.RedactRecords(records)
+
+		// In full mode, persist the session and report session ID
+		if opts.PIIMode == pii.ModeFull {
+			if err := redactor.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to save PII session: %v\n", err)
+			} else if redactor.SessionID() != "" {
+				stats := redactor.Stats()
+				fmt.Fprintf(os.Stderr, "PII session %s: redacted %d fields across %d records\n",
+					redactor.SessionID(), stats.RedactedFields, stats.TotalRecords)
+			}
 		}
 	}
 

--- a/pkg/pii/custom.go
+++ b/pkg/pii/custom.go
@@ -1,0 +1,156 @@
+package pii
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// CustomRule defines a user-specified PII field rule.
+// Rules can target exact field paths ("data.customerRef") or use a glob
+// suffix ("usr.*") to match all fields under a prefix.
+type CustomRule struct {
+	// Field is the field path to match. Supports exact match ("data.customerRef")
+	// or glob suffix ("usr.*") where * matches any single segment.
+	Field string `yaml:"field"`
+
+	// Category is the PII category label (e.g., "PERSON", "EMAIL").
+	// Defaults to "REDACTED" if empty.
+	Category string `yaml:"category,omitempty"`
+
+	// Skip, when true, excludes the field from PII redaction even if
+	// built-in patterns would match it.
+	Skip bool `yaml:"skip,omitempty"`
+}
+
+// CustomRulesFile is the on-disk format for .dtctl-pii.yaml project files.
+type CustomRulesFile struct {
+	Version string       `yaml:"version"`
+	Rules   []CustomRule `yaml:"rules"`
+}
+
+// customRulesFileName is the name of the project-level custom rules file.
+const customRulesFileName = ".dtctl-pii.yaml"
+
+// LoadCustomRulesFile reads and parses a custom rules YAML file.
+func LoadCustomRulesFile(path string) ([]CustomRule, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading custom rules file: %w", err)
+	}
+
+	var file CustomRulesFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("parsing custom rules file %s: %w", path, err)
+	}
+
+	// Normalize: default category to "REDACTED"
+	for i := range file.Rules {
+		if file.Rules[i].Category == "" && !file.Rules[i].Skip {
+			file.Rules[i].Category = "REDACTED"
+		}
+	}
+
+	return file.Rules, nil
+}
+
+// FindCustomRulesFile searches upward from the given directory for a
+// .dtctl-pii.yaml file, returning its path or empty string if not found.
+// This mirrors how .dtctl.yaml is discovered.
+func FindCustomRulesFile(startDir string) string {
+	dir := startDir
+	for {
+		candidate := filepath.Join(dir, customRulesFileName)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached filesystem root
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// MergeRules combines project-level and config-level custom rules.
+// Config rules override project rules when they target the same field.
+// The returned slice has project rules first (possibly overridden), then
+// any config-only rules appended.
+func MergeRules(project, config []CustomRule) []CustomRule {
+	if len(project) == 0 {
+		return config
+	}
+	if len(config) == 0 {
+		return project
+	}
+
+	// Index config rules by field for quick lookup
+	configByField := make(map[string]CustomRule, len(config))
+	for _, r := range config {
+		configByField[r.Field] = r
+	}
+
+	// Start with project rules, overriding from config where applicable
+	merged := make([]CustomRule, 0, len(project)+len(config))
+	seen := make(map[string]bool, len(project))
+
+	for _, pr := range project {
+		if cr, ok := configByField[pr.Field]; ok {
+			// Config overrides project for this field
+			merged = append(merged, cr)
+		} else {
+			merged = append(merged, pr)
+		}
+		seen[pr.Field] = true
+	}
+
+	// Append config-only rules (not in project)
+	for _, cr := range config {
+		if !seen[cr.Field] {
+			merged = append(merged, cr)
+		}
+	}
+
+	return merged
+}
+
+// MatchCustomRule checks a field name against custom rules.
+// Returns the first matching rule, or nil if no match.
+// Matching order: exact match first, then glob suffix.
+func MatchCustomRule(rules []CustomRule, fieldName string) *CustomRule {
+	// First pass: exact match
+	for i := range rules {
+		if rules[i].Field == fieldName {
+			return &rules[i]
+		}
+	}
+
+	// Second pass: glob suffix match (e.g., "usr.*" matches "usr.name")
+	for i := range rules {
+		if matchGlob(rules[i].Field, fieldName) {
+			return &rules[i]
+		}
+	}
+
+	return nil
+}
+
+// matchGlob checks if a glob pattern matches a field name.
+// Only suffix glob is supported: "prefix.*" matches "prefix.anything".
+// The * matches exactly one dot-segment (not nested paths).
+func matchGlob(pattern, fieldName string) bool {
+	if !strings.HasSuffix(pattern, ".*") {
+		return false
+	}
+	prefix := pattern[:len(pattern)-1] // "usr.*" -> "usr."
+	if !strings.HasPrefix(fieldName, prefix) {
+		return false
+	}
+	// Ensure * matches exactly one segment (no dots in the remainder)
+	remainder := fieldName[len(prefix):]
+	return len(remainder) > 0 && !strings.Contains(remainder, ".")
+}

--- a/pkg/pii/custom_test.go
+++ b/pkg/pii/custom_test.go
@@ -1,0 +1,345 @@
+package pii
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- MatchCustomRule tests ---
+
+func TestMatchCustomRuleExact(t *testing.T) {
+	rules := []CustomRule{
+		{Field: "data.customerRef", Category: "PERSON"},
+		{Field: "data.action", Skip: true},
+	}
+
+	// Exact match
+	rule := MatchCustomRule(rules, "data.customerRef")
+	require.NotNil(t, rule)
+	assert.Equal(t, "PERSON", rule.Category)
+	assert.False(t, rule.Skip)
+
+	// Skip rule
+	rule = MatchCustomRule(rules, "data.action")
+	require.NotNil(t, rule)
+	assert.True(t, rule.Skip)
+
+	// No match
+	rule = MatchCustomRule(rules, "data.other")
+	assert.Nil(t, rule)
+}
+
+func TestMatchCustomRuleGlob(t *testing.T) {
+	rules := []CustomRule{
+		{Field: "usr.*", Category: "PERSON"},
+		{Field: "data.nested.*", Category: "REDACTED"},
+	}
+
+	// Glob match
+	rule := MatchCustomRule(rules, "usr.name")
+	require.NotNil(t, rule)
+	assert.Equal(t, "PERSON", rule.Category)
+
+	rule = MatchCustomRule(rules, "usr.email")
+	require.NotNil(t, rule)
+
+	rule = MatchCustomRule(rules, "data.nested.field1")
+	require.NotNil(t, rule)
+	assert.Equal(t, "REDACTED", rule.Category)
+
+	// Glob does NOT match nested paths beyond one segment
+	rule = MatchCustomRule(rules, "usr.deep.nested")
+	assert.Nil(t, rule)
+
+	// Glob does NOT match the prefix itself
+	rule = MatchCustomRule(rules, "usr.")
+	assert.Nil(t, rule)
+
+	// No match
+	rule = MatchCustomRule(rules, "other.field")
+	assert.Nil(t, rule)
+}
+
+func TestMatchCustomRuleExactPrecedence(t *testing.T) {
+	rules := []CustomRule{
+		{Field: "usr.email", Category: "EMAIL"}, // exact
+		{Field: "usr.*", Category: "PERSON"},    // glob
+	}
+
+	// Exact match takes precedence over glob
+	rule := MatchCustomRule(rules, "usr.email")
+	require.NotNil(t, rule)
+	assert.Equal(t, "EMAIL", rule.Category)
+
+	// Other usr.* fields fall through to glob
+	rule = MatchCustomRule(rules, "usr.name")
+	require.NotNil(t, rule)
+	assert.Equal(t, "PERSON", rule.Category)
+}
+
+func TestMatchCustomRuleEmpty(t *testing.T) {
+	rule := MatchCustomRule(nil, "anything")
+	assert.Nil(t, rule)
+
+	rule = MatchCustomRule([]CustomRule{}, "anything")
+	assert.Nil(t, rule)
+}
+
+// --- matchGlob tests ---
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		pattern   string
+		fieldName string
+		expected  bool
+	}{
+		{"usr.*", "usr.name", true},
+		{"usr.*", "usr.email", true},
+		{"usr.*", "usr.", false},            // empty remainder
+		{"usr.*", "usr.deep.nested", false}, // multi-segment
+		{"usr.*", "other.name", false},      // wrong prefix
+		{"usr.*", "usrname", false},         // no dot
+		{"data", "data", false},             // no glob suffix
+		{"data.*", "data.x", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.fieldName, func(t *testing.T) {
+			assert.Equal(t, tt.expected, matchGlob(tt.pattern, tt.fieldName))
+		})
+	}
+}
+
+// --- MergeRules tests ---
+
+func TestMergeRulesEmpty(t *testing.T) {
+	project := []CustomRule{{Field: "a", Category: "X"}}
+	config := []CustomRule{{Field: "b", Category: "Y"}}
+
+	// Both empty
+	assert.Nil(t, MergeRules(nil, nil))
+
+	// Only project
+	result := MergeRules(project, nil)
+	assert.Equal(t, project, result)
+
+	// Only config
+	result = MergeRules(nil, config)
+	assert.Equal(t, config, result)
+}
+
+func TestMergeRulesConfigOverridesProject(t *testing.T) {
+	project := []CustomRule{
+		{Field: "data.customerRef", Category: "PERSON"},
+		{Field: "data.action", Category: "REDACTED"},
+	}
+	config := []CustomRule{
+		{Field: "data.customerRef", Category: "ORGANIZATION"}, // override
+		{Field: "data.extra", Category: "EMAIL"},              // config-only
+	}
+
+	merged := MergeRules(project, config)
+
+	require.Len(t, merged, 3)
+	// data.customerRef: config overrides project
+	assert.Equal(t, "data.customerRef", merged[0].Field)
+	assert.Equal(t, "ORGANIZATION", merged[0].Category)
+	// data.action: project only
+	assert.Equal(t, "data.action", merged[1].Field)
+	assert.Equal(t, "REDACTED", merged[1].Category)
+	// data.extra: config only
+	assert.Equal(t, "data.extra", merged[2].Field)
+	assert.Equal(t, "EMAIL", merged[2].Category)
+}
+
+// --- LoadCustomRulesFile tests ---
+
+func TestLoadCustomRulesFile(t *testing.T) {
+	content := `version: v1
+rules:
+  - field: "data.customerRef"
+    category: PERSON
+  - field: "usr.*"
+    category: PERSON
+  - field: "data.internalNote"
+  - field: "data.action"
+    skip: true
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".dtctl-pii.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	rules, err := LoadCustomRulesFile(path)
+	require.NoError(t, err)
+	require.Len(t, rules, 4)
+
+	assert.Equal(t, "data.customerRef", rules[0].Field)
+	assert.Equal(t, "PERSON", rules[0].Category)
+
+	assert.Equal(t, "usr.*", rules[1].Field)
+	assert.Equal(t, "PERSON", rules[1].Category)
+
+	// Default category
+	assert.Equal(t, "data.internalNote", rules[2].Field)
+	assert.Equal(t, "REDACTED", rules[2].Category)
+
+	// Skip rule (no category needed)
+	assert.Equal(t, "data.action", rules[3].Field)
+	assert.True(t, rules[3].Skip)
+	assert.Equal(t, "", rules[3].Category) // skip rules don't get default
+}
+
+func TestLoadCustomRulesFileNotFound(t *testing.T) {
+	_, err := LoadCustomRulesFile("/nonexistent/.dtctl-pii.yaml")
+	assert.Error(t, err)
+}
+
+func TestLoadCustomRulesFileInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".dtctl-pii.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("{{invalid"), 0644))
+
+	_, err := LoadCustomRulesFile(path)
+	assert.Error(t, err)
+}
+
+// --- FindCustomRulesFile tests ---
+
+func TestFindCustomRulesFile(t *testing.T) {
+	// Create a temp dir tree: root/sub1/sub2
+	root := t.TempDir()
+	sub1 := filepath.Join(root, "sub1")
+	sub2 := filepath.Join(sub1, "sub2")
+	require.NoError(t, os.MkdirAll(sub2, 0755))
+
+	// Place rules file in root
+	rulesPath := filepath.Join(root, ".dtctl-pii.yaml")
+	require.NoError(t, os.WriteFile(rulesPath, []byte("version: v1\nrules: []\n"), 0644))
+
+	// Search from sub2 should find root's file
+	found := FindCustomRulesFile(sub2)
+	assert.Equal(t, rulesPath, found)
+
+	// Search from sub1 should also find it
+	found = FindCustomRulesFile(sub1)
+	assert.Equal(t, rulesPath, found)
+
+	// Search from root should find it
+	found = FindCustomRulesFile(root)
+	assert.Equal(t, rulesPath, found)
+}
+
+func TestFindCustomRulesFileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	found := FindCustomRulesFile(dir)
+	assert.Equal(t, "", found)
+}
+
+func TestFindCustomRulesFilePreferNearest(t *testing.T) {
+	// root has rules, root/sub also has rules -> sub's rules should win
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	require.NoError(t, os.MkdirAll(sub, 0755))
+
+	rootRules := filepath.Join(root, ".dtctl-pii.yaml")
+	subRules := filepath.Join(sub, ".dtctl-pii.yaml")
+	require.NoError(t, os.WriteFile(rootRules, []byte("version: v1\nrules: []\n"), 0644))
+	require.NoError(t, os.WriteFile(subRules, []byte("version: v1\nrules: []\n"), 0644))
+
+	found := FindCustomRulesFile(sub)
+	assert.Equal(t, subRules, found)
+}
+
+// --- Integration: custom rules + redaction ---
+
+func TestRedactRecordsWithCustomRules(t *testing.T) {
+	r, err := NewRedactor(Config{
+		Mode: ModeLite,
+		CustomRules: []CustomRule{
+			{Field: "data.customerRef", Category: "PERSON"},
+			{Field: "data.action", Skip: true},
+		},
+	})
+	require.NoError(t, err)
+
+	records := []map[string]interface{}{
+		{
+			"data.customerRef": "John Doe",      // custom rule -> PERSON
+			"data.action":      "login",         // custom skip -> preserved
+			"email":            "john@test.com", // built-in pattern -> EMAIL
+			"data.status":      "active",        // no match -> preserved
+		},
+	}
+
+	result := r.RedactRecords(records)
+
+	assert.Equal(t, "[PERSON]", result[0]["data.customerRef"])
+	assert.Equal(t, "login", result[0]["data.action"])
+	assert.Equal(t, "[EMAIL]", result[0]["email"])
+	assert.Equal(t, "active", result[0]["data.status"])
+}
+
+func TestRedactRecordsCustomSkipOverridesBuiltin(t *testing.T) {
+	r, err := NewRedactor(Config{
+		Mode: ModeLite,
+		CustomRules: []CustomRule{
+			{Field: "email", Skip: true}, // override built-in EMAIL pattern
+		},
+	})
+	require.NoError(t, err)
+
+	records := []map[string]interface{}{
+		{
+			"email": "john@test.com", // skip rule overrides built-in
+		},
+	}
+
+	result := r.RedactRecords(records)
+	assert.Equal(t, "john@test.com", result[0]["email"]) // preserved!
+}
+
+func TestRedactRecordsCustomGlobRule(t *testing.T) {
+	r, err := NewRedactor(Config{
+		Mode: ModeLite,
+		CustomRules: []CustomRule{
+			{Field: "custom.*", Category: "CUSTOM_PII"},
+		},
+	})
+	require.NoError(t, err)
+
+	// DQL returns flat dotted keys
+	records := []map[string]interface{}{
+		{
+			"custom.field1": "sensitive data",
+			"custom.field2": "more data",
+			"other.field":   "safe data",
+		},
+	}
+
+	result := r.RedactRecords(records)
+
+	assert.Equal(t, "[CUSTOM_PII]", result[0]["custom.field1"])
+	assert.Equal(t, "[CUSTOM_PII]", result[0]["custom.field2"])
+	assert.Equal(t, "safe data", result[0]["other.field"])
+}
+
+func TestRedactRecordsCustomDefaultCategory(t *testing.T) {
+	r, err := NewRedactor(Config{
+		Mode: ModeLite,
+		CustomRules: []CustomRule{
+			{Field: "data.secret", Category: "REDACTED"}, // default category
+		},
+	})
+	require.NoError(t, err)
+
+	records := []map[string]interface{}{
+		{"data.secret": "top secret"},
+	}
+
+	result := r.RedactRecords(records)
+	assert.Equal(t, "[REDACTED]", result[0]["data.secret"])
+}

--- a/pkg/pii/patterns.go
+++ b/pkg/pii/patterns.go
@@ -1,0 +1,176 @@
+package pii
+
+import "regexp"
+
+// PII category constants. These match the categories used by pii-client
+// for potential interoperability.
+const (
+	CategoryEmail      = "EMAIL"
+	CategoryPhone      = "PHONE"
+	CategoryPerson     = "PERSON"
+	CategoryAddress    = "ADDRESS"
+	CategoryIPAddress  = "IP_ADDRESS"
+	CategoryCredential = "CREDENTIAL"
+	CategoryIDNumber   = "ID_NUMBER"
+	CategoryOrg        = "ORGANIZATION"
+)
+
+// Pattern defines a PII detection rule. Patterns can match on field names
+// (key-name heuristic), field values (regex on the string value), or both.
+type Pattern struct {
+	Category  string         // PII category (e.g., "EMAIL", "PERSON")
+	FieldName *regexp.Regexp // Matches field names (nil = skip key-name check)
+	Value     *regexp.Regexp // Matches field values (nil = skip value check)
+}
+
+// DefaultPatterns returns the built-in PII detection patterns.
+// These are modeled after pii-client's 13 pattern categories, covering
+// the most common PII found in logs and API responses.
+func DefaultPatterns() []Pattern {
+	return []Pattern{
+		// Email: detect by field name or by value pattern
+		{
+			Category:  CategoryEmail,
+			FieldName: regexp.MustCompile(`(?i)^(e-?mail|sendToOthers|recipients|otherEmails)$`),
+		},
+		{
+			Category: CategoryEmail,
+			Value:    regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`),
+		},
+
+		// Phone
+		{
+			Category:  CategoryPhone,
+			FieldName: regexp.MustCompile(`(?i)(phone|mobile|telephone|fax)`),
+		},
+
+		// Person name (field-name heuristic)
+		{
+			Category:  CategoryPerson,
+			FieldName: regexp.MustCompile(`(?i)^(first.?name|last.?name|full.?name|given.?name|surname|family.?name|display.?name|user.?name|customer.?name|person.?name)$`),
+		},
+
+		// Credentials / tokens / secrets
+		{
+			Category:  CategoryCredential,
+			FieldName: regexp.MustCompile(`(?i)^(password|passwd|pwd|secret|api.?key|access.?token|refresh.?token|auth.?token|\bbearer\b|jwt|json.?web.?token)$`),
+		},
+
+		// IP address: detect by field name or by value pattern
+		{
+			Category:  CategoryIPAddress,
+			FieldName: regexp.MustCompile(`(?i)^(ip|ip.?address|ipv4|ipv6|remote.?addr|client.?ip|source.?ip|dest.?ip)$`),
+		},
+		{
+			Category: CategoryIPAddress,
+			Value:    regexp.MustCompile(`^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|([0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4})$`),
+		},
+
+		// Address (physical)
+		{
+			Category:  CategoryAddress,
+			FieldName: regexp.MustCompile(`(?i)^(street|postal.?code|zip.?code|city|state|country|region|mailing.?address|street.?address)$`),
+		},
+
+		// SSN, tax ID, passport, license
+		{
+			Category:  CategoryIDNumber,
+			FieldName: regexp.MustCompile(`(?i)^(ssn|social.?security|tax.?id|national.?id|passport|license|licence|credit.?card|card.?number|\bpan\b|cvv|cvc)$`),
+		},
+
+		// Organization / account name
+		{
+			Category:  CategoryOrg,
+			FieldName: regexp.MustCompile(`(?i)^(account.?name|company.?name|org.?name|organization.?name)$`),
+		},
+	}
+}
+
+// rumUserPrefix matches RUM user-scoped field keys (usr.*).
+// These contain end-user PII (name, id, email, etc.) and are always
+// redacted as PERSON. The prefix is checked against the full dotted key
+// before falling back to last-segment matching.
+const rumUserPrefix = "usr."
+
+// matchFieldName checks all patterns against a field name.
+// Returns the matching category, or empty string if no match.
+func matchFieldName(patterns []Pattern, fieldName string) string {
+	// Check full dotted key against known PII-parent prefixes first.
+	// RUM usr.* fields (usr.name, usr.id, usr.email, etc.) are always PERSON.
+	if len(fieldName) > len(rumUserPrefix) && fieldName[:len(rumUserPrefix)] == rumUserPrefix {
+		return CategoryPerson
+	}
+
+	// Check the last segment for dotted keys (e.g., "user.email" -> check "email")
+	name := fieldName
+	if idx := lastDotIndex(name); idx >= 0 {
+		name = name[idx+1:]
+	}
+
+	for _, p := range patterns {
+		if p.FieldName != nil && p.FieldName.MatchString(name) {
+			return p.Category
+		}
+	}
+	return ""
+}
+
+// matchValue checks all value-based patterns against a string value.
+// Returns the matching category, or empty string if no match.
+func matchValue(patterns []Pattern, value string) string {
+	// Skip very short values (unlikely to be PII, high false positive rate)
+	if len(value) < 3 {
+		return ""
+	}
+
+	for _, p := range patterns {
+		if p.Value != nil && p.Value.MatchString(value) {
+			return p.Category
+		}
+	}
+	return ""
+}
+
+// lastDotIndex returns the index of the last '.' in s, or -1 if not found.
+func lastDotIndex(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '.' {
+			return i
+		}
+	}
+	return -1
+}
+
+// isLikelyFreeText returns true if a string value looks like free-form text
+// that should be sent to Presidio NER for analysis. Short values, UUIDs,
+// Dynatrace entity IDs, and numeric strings are excluded.
+func isLikelyFreeText(s string) bool {
+	// Must be long enough to contain meaningful text
+	if len(s) < 10 {
+		return false
+	}
+
+	// Skip if it looks like a UUID
+	if uuidPattern.MatchString(s) {
+		return false
+	}
+
+	// Skip if it looks like a Dynatrace entity ID (HOST-xxx, SERVICE-xxx, etc.)
+	if dtEntityPattern.MatchString(s) {
+		return false
+	}
+
+	// Must contain at least one space (indicates prose/free text)
+	for _, c := range s {
+		if c == ' ' {
+			return true
+		}
+	}
+
+	return false
+}
+
+var (
+	uuidPattern     = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	dtEntityPattern = regexp.MustCompile(`^(HOST|SERVICE|PROCESS|APPLICATION|SYNTHETIC_TEST|DEVICE|KUBERNETES|CLOUD)-[A-Z0-9]+$`)
+)

--- a/pkg/pii/pii.go
+++ b/pkg/pii/pii.go
@@ -1,0 +1,192 @@
+// Package pii provides PII (Personally Identifiable Information) detection
+// and redaction for query results. It supports two modes:
+//
+//   - Lite mode: replaces detected PII with category placeholders like [EMAIL],
+//     [PERSON], [IP_ADDRESS]. No state, no external dependencies.
+//
+//   - Full mode: replaces PII with stable, session-scoped pseudonyms like
+//     <EMAIL_0>, <PERSON_1> that allow correlation across records within a
+//     query. Optionally integrates with Microsoft Presidio for NER-based
+//     detection of PII in free-text fields. Sessions are persisted to disk
+//     so a separate resolve tool can map pseudonyms back to originals.
+//
+// The package is designed to be modular: it has no coupling to the rest of
+// dtctl and can be used independently.
+package pii
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Mode controls the PII redaction behavior.
+type Mode string
+
+const (
+	// ModeOff disables PII redaction (default).
+	ModeOff Mode = ""
+	// ModeLite replaces PII with category placeholders: [EMAIL], [PERSON], etc.
+	ModeLite Mode = "lite"
+	// ModeFull replaces PII with stable pseudonyms: <EMAIL_0>, <PERSON_1>, etc.
+	// Sessions are persisted to disk for later resolution.
+	ModeFull Mode = "full"
+)
+
+// ParseMode parses a mode string, returning ModeOff for empty/unknown values.
+func ParseMode(s string) Mode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "lite":
+		return ModeLite
+	case "full":
+		return ModeFull
+	default:
+		return ModeOff
+	}
+}
+
+// Config holds PII redaction configuration.
+type Config struct {
+	Mode        Mode         // Redaction mode: lite or full
+	PresidioURL string       // Optional Presidio API URL for NER (full mode only)
+	Context     string       // Dynatrace context name (used in session metadata)
+	CustomRules []CustomRule // User-defined field rules (.dtctl-pii.yaml + config)
+}
+
+// Redactor orchestrates PII detection and replacement across query records.
+// It is the main entry point for the pii package.
+type Redactor struct {
+	mode        Mode
+	patterns    []Pattern
+	customRules []CustomRule    // user-defined field rules (checked before built-in patterns)
+	store       *PseudonymStore // nil in lite mode
+	presidio    *PresidioClient // nil if Presidio is not configured
+	stats       RedactionStats
+}
+
+// RedactionStats tracks what was redacted in a session.
+type RedactionStats struct {
+	TotalRecords   int            // Number of records processed
+	RedactedFields int            // Number of fields redacted
+	ByCategory     map[string]int // Redaction count per PII category
+}
+
+// NewRedactor creates a Redactor with the given configuration.
+// In full mode, it initializes a PseudonymStore and optionally a Presidio client.
+func NewRedactor(cfg Config) (*Redactor, error) {
+	if cfg.Mode == ModeOff {
+		return nil, fmt.Errorf("cannot create redactor with mode off")
+	}
+
+	r := &Redactor{
+		mode:        cfg.Mode,
+		patterns:    DefaultPatterns(),
+		customRules: cfg.CustomRules,
+		stats: RedactionStats{
+			ByCategory: make(map[string]int),
+		},
+	}
+
+	if cfg.Mode == ModeFull {
+		store, err := NewPseudonymStore(cfg.Context)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create pseudonym store: %w", err)
+		}
+		r.store = store
+
+		// Initialize Presidio client if URL is configured
+		if cfg.PresidioURL != "" {
+			r.presidio = NewPresidioClient(cfg.PresidioURL)
+		}
+	}
+
+	return r, nil
+}
+
+// RedactRecords applies PII redaction to a slice of query result records.
+// Each record is a map[string]interface{} as returned by DQL queries.
+// Returns the redacted records (modified in place).
+func (r *Redactor) RedactRecords(records []map[string]interface{}) []map[string]interface{} {
+	if r == nil || len(records) == 0 {
+		return records
+	}
+
+	// Phase 1+2: Walk records, detect PII by field name and value patterns
+	for i := range records {
+		r.stats.TotalRecords++
+		r.walkRecord(records[i])
+	}
+
+	// Phase 3 (full mode only): Presidio NER on collected free-text fields
+	if r.mode == ModeFull && r.presidio != nil {
+		r.applyPresidioNER(records)
+	}
+
+	return records
+}
+
+// Stats returns the redaction statistics for this session.
+func (r *Redactor) Stats() RedactionStats {
+	if r == nil {
+		return RedactionStats{ByCategory: make(map[string]int)}
+	}
+	return r.stats
+}
+
+// SessionID returns the session ID (full mode only, empty in lite mode).
+func (r *Redactor) SessionID() string {
+	if r.store != nil {
+		return r.store.SessionID()
+	}
+	return ""
+}
+
+// Close persists the pseudonym store to disk (full mode only).
+// Must be called after RedactRecords to save the session.
+func (r *Redactor) Close() error {
+	if r.store != nil {
+		return r.store.Save()
+	}
+	return nil
+}
+
+// replace returns the redacted replacement for a PII value.
+// In lite mode, returns a category placeholder like [EMAIL].
+// In full mode, returns a stable pseudonym like <EMAIL_0>.
+func (r *Redactor) replace(category, original string) string {
+	r.stats.RedactedFields++
+	r.stats.ByCategory[category]++
+
+	if r.mode == ModeFull && r.store != nil {
+		return r.store.GetOrCreate(category, original)
+	}
+
+	return "[" + category + "]"
+}
+
+// ResolveMode determines the PII mode from flag, env var, and config preference.
+// Precedence: flag > env > config.
+//
+//   - flagValue: the value from --pii flag ("" if not set, "lite" for bare --pii, "full" for --pii=full)
+//   - flagChanged: whether --pii was explicitly set on the command line
+//   - noPII: whether --no-pii was set (overrides everything)
+//   - configMode: the mode from config preferences
+func ResolveMode(flagValue string, flagChanged bool, noPII bool, configMode string) Mode {
+	// --no-pii overrides everything
+	if noPII {
+		return ModeOff
+	}
+
+	// Explicit --pii flag takes precedence
+	if flagChanged {
+		return ParseMode(flagValue)
+	}
+
+	// Environment variable
+	if envVal := os.Getenv("DTCTL_PII"); envVal != "" {
+		return ParseMode(envVal)
+	}
+
+	// Config preference
+	return ParseMode(configMode)
+}

--- a/pkg/pii/pii_test.go
+++ b/pkg/pii/pii_test.go
@@ -1,0 +1,466 @@
+package pii
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mode parsing tests ---
+
+func TestParseMode(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected Mode
+	}{
+		{"", ModeOff},
+		{"lite", ModeLite},
+		{"Lite", ModeLite},
+		{"LITE", ModeLite},
+		{"full", ModeFull},
+		{"Full", ModeFull},
+		{"FULL", ModeFull},
+		{"unknown", ModeOff},
+		{"  lite  ", ModeLite},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ParseMode(tt.input))
+		})
+	}
+}
+
+func TestResolveMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		flagValue   string
+		flagChanged bool
+		noPII       bool
+		configMode  string
+		expected    Mode
+	}{
+		{"no-pii overrides everything", "full", true, true, "full", ModeOff},
+		{"flag takes precedence", "full", true, false, "lite", ModeFull},
+		{"flag lite", "lite", true, false, "", ModeLite},
+		{"env var", "", false, false, "", ModeOff}, // env tested separately
+		{"config preference", "", false, false, "full", ModeFull},
+		{"all empty", "", false, false, "", ModeOff},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ResolveMode(tt.flagValue, tt.flagChanged, tt.noPII, tt.configMode))
+		})
+	}
+}
+
+func TestResolveModeEnvVar(t *testing.T) {
+	t.Setenv("DTCTL_PII", "full")
+	assert.Equal(t, ModeFull, ResolveMode("", false, false, ""))
+
+	t.Setenv("DTCTL_PII", "lite")
+	assert.Equal(t, ModeLite, ResolveMode("", false, false, ""))
+}
+
+// --- Pattern matching tests ---
+
+func TestMatchFieldName(t *testing.T) {
+	patterns := DefaultPatterns()
+
+	tests := []struct {
+		fieldName string
+		expected  string
+	}{
+		// Email fields
+		{"email", CategoryEmail},
+		{"Email", CategoryEmail},
+		{"e-mail", CategoryEmail},
+		{"recipients", CategoryEmail},
+		{"sendToOthers", CategoryEmail},
+
+		// Person name fields
+		{"firstName", CategoryPerson},
+		{"last_name", CategoryPerson},
+		{"fullName", CategoryPerson},
+		{"displayName", CategoryPerson},
+		{"userName", CategoryPerson},
+
+		// Phone fields
+		{"phone", CategoryPhone},
+		{"mobile", CategoryPhone},
+		{"telephone", CategoryPhone},
+
+		// Credential fields
+		{"password", CategoryCredential},
+		{"secret", CategoryCredential},
+		{"apiKey", CategoryCredential},
+		{"api_key", CategoryCredential},
+		{"accessToken", CategoryCredential},
+
+		// IP address fields
+		{"ipAddress", CategoryIPAddress},
+		{"ip_address", CategoryIPAddress},
+		{"clientIp", CategoryIPAddress},
+		{"sourceIp", CategoryIPAddress},
+		{"ip", CategoryIPAddress}, // bare "ip" (e.g., RUM client IP)
+
+		// Address fields
+		{"street", CategoryAddress},
+		{"postalCode", CategoryAddress},
+		{"zipCode", CategoryAddress},
+		{"region", CategoryAddress}, // RUM region field
+
+		// ID number fields
+		{"ssn", CategoryIDNumber},
+		{"passport", CategoryIDNumber},
+		{"creditCard", CategoryIDNumber},
+
+		// Organization fields
+		{"accountName", CategoryOrg},
+		{"companyName", CategoryOrg},
+		{"orgName", CategoryOrg},
+
+		// Non-PII fields (should not match)
+		{"id", ""},
+		{"timestamp", ""},
+		{"status", ""},
+		{"content", ""},
+		{"message", ""},
+		{"host.name", ""},
+		{"dt.entity.host", ""},
+		{"span_id", ""},
+		{"workflow.name", ""}, // "name" alone would match PERSON, but last-segment "name" is NOT in the pattern
+		{"device", ""},        // RUM device — intentionally excluded (add via custom rules)
+		{"browser", ""},       // RUM browser — intentionally excluded
+		{"os", ""},            // RUM os — intentionally excluded
+		{"referrer", ""},      // RUM referrer — intentionally excluded
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fieldName, func(t *testing.T) {
+			result := matchFieldName(patterns, tt.fieldName)
+			assert.Equal(t, tt.expected, result, "field: %s", tt.fieldName)
+		})
+	}
+}
+
+func TestMatchFieldNameDottedKeys(t *testing.T) {
+	patterns := DefaultPatterns()
+
+	// Dotted keys should match on the last segment
+	assert.Equal(t, CategoryEmail, matchFieldName(patterns, "user.email"))
+	assert.Equal(t, CategoryPerson, matchFieldName(patterns, "contact.firstName"))
+	assert.Equal(t, "", matchFieldName(patterns, "data.timestamp"))
+}
+
+func TestMatchFieldNameRUMUserPrefix(t *testing.T) {
+	patterns := DefaultPatterns()
+
+	// RUM usr.* fields should always match as PERSON
+	tests := []struct {
+		fieldName string
+		expected  string
+	}{
+		{"usr.name", CategoryPerson},
+		{"usr.id", CategoryPerson},
+		{"usr.email", CategoryPerson},
+		{"usr.company", CategoryPerson},
+		{"usr.customTag", CategoryPerson},
+
+		// Not usr.* prefix (should fall through to normal matching)
+		{"usrdata", ""},               // no dot, not a prefix match
+		{"user.email", CategoryEmail}, // "user." is not "usr.", but "email" matches
+		{"data.usr.name", ""},         // "usr." is not the prefix of the full key
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fieldName, func(t *testing.T) {
+			result := matchFieldName(patterns, tt.fieldName)
+			assert.Equal(t, tt.expected, result, "field: %s", tt.fieldName)
+		})
+	}
+}
+
+func TestMatchValue(t *testing.T) {
+	patterns := DefaultPatterns()
+
+	tests := []struct {
+		value    string
+		expected string
+	}{
+		// Emails
+		{"john.doe@example.com", CategoryEmail},
+		{"user@company.co.uk", CategoryEmail},
+		{"test+tag@gmail.com", CategoryEmail},
+
+		// IPv4
+		{"192.168.1.1", CategoryIPAddress},
+		{"10.0.0.255", CategoryIPAddress},
+		{"8.8.8.8", CategoryIPAddress},
+
+		// Non-PII values
+		{"hello world", ""},
+		{"12345", ""},
+		{"true", ""},
+		{"", ""},
+		{"ab", ""},            // too short
+		{"not-an-email@", ""}, // invalid email
+		{"@invalid.com", ""},  // invalid email
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			result := matchValue(patterns, tt.value)
+			assert.Equal(t, tt.expected, result, "value: %s", tt.value)
+		})
+	}
+}
+
+// --- Lite mode redaction tests ---
+
+func TestRedactRecordsLiteMode(t *testing.T) {
+	r, err := NewRedactor(Config{Mode: ModeLite})
+	require.NoError(t, err)
+
+	records := []map[string]interface{}{
+		{
+			"timestamp": "2024-01-01T00:00:00Z",
+			"content":   "Server started on port 8080",
+			"email":     "john@example.com",
+			"host.name": "web-server-01",
+			"firstName": "John",
+			"password":  "s3cr3t!",
+			"ipAddress": "192.168.1.100",
+		},
+	}
+
+	result := r.RedactRecords(records)
+
+	assert.Equal(t, "2024-01-01T00:00:00Z", result[0]["timestamp"])
+	assert.Equal(t, "Server started on port 8080", result[0]["content"])
+	assert.Equal(t, "[EMAIL]", result[0]["email"])
+	assert.Equal(t, "web-server-01", result[0]["host.name"])
+	assert.Equal(t, "[PERSON]", result[0]["firstName"])
+	assert.Equal(t, "[CREDENTIAL]", result[0]["password"])
+	assert.Equal(t, "[IP_ADDRESS]", result[0]["ipAddress"])
+
+	// Stats
+	stats := r.Stats()
+	assert.Equal(t, 1, stats.TotalRecords)
+	assert.Equal(t, 4, stats.RedactedFields) // email, firstName, password, ipAddress (all field-name matches)
+}
+
+func TestRedactRecordsLiteModeValueDetection(t *testing.T) {
+	r, err := NewRedactor(Config{Mode: ModeLite})
+	require.NoError(t, err)
+
+	records := []map[string]interface{}{
+		{
+			"log_line":      "Login by admin",
+			"generic_field": "user@company.com", // email in non-email field
+			"ip_field":      "10.20.30.40",      // value-based IP detection
+		},
+	}
+
+	result := r.RedactRecords(records)
+
+	assert.Equal(t, "Login by admin", result[0]["log_line"])
+	assert.Equal(t, "[EMAIL]", result[0]["generic_field"]) // Detected by value regex
+	assert.Equal(t, "[IP_ADDRESS]", result[0]["ip_field"]) // Detected by value regex
+}
+
+func TestRedactRecordsNestedObjects(t *testing.T) {
+	r, err := NewRedactor(Config{Mode: ModeLite})
+	require.NoError(t, err)
+
+	records := []map[string]interface{}{
+		{
+			"user": map[string]interface{}{
+				"email":     "jane@example.com",
+				"firstName": "Jane",
+				"age":       30,
+			},
+			"metadata": map[string]interface{}{
+				"requestId": "abc-123",
+			},
+		},
+	}
+
+	result := r.RedactRecords(records)
+
+	user := result[0]["user"].(map[string]interface{})
+	assert.Equal(t, "[EMAIL]", user["email"])
+	assert.Equal(t, "[PERSON]", user["firstName"])
+	assert.Equal(t, 30, user["age"])
+
+	meta := result[0]["metadata"].(map[string]interface{})
+	assert.Equal(t, "abc-123", meta["requestId"])
+}
+
+func TestRedactRecordsArrays(t *testing.T) {
+	r, err := NewRedactor(Config{Mode: ModeLite})
+	require.NoError(t, err)
+
+	records := []map[string]interface{}{
+		{
+			"recipients": []interface{}{
+				"alice@example.com",
+				"bob@example.com",
+			},
+			"tags": []interface{}{
+				"production",
+				"us-east-1",
+			},
+		},
+	}
+
+	result := r.RedactRecords(records)
+
+	// "recipients" field name matches EMAIL, so array items should be redacted
+	recipients := result[0]["recipients"].([]interface{})
+	assert.Equal(t, "[EMAIL]", recipients[0])
+	assert.Equal(t, "[EMAIL]", recipients[1])
+
+	// "tags" is not a PII field
+	tags := result[0]["tags"].([]interface{})
+	assert.Equal(t, "production", tags[0])
+	assert.Equal(t, "us-east-1", tags[1])
+}
+
+// --- Full mode redaction tests ---
+
+func TestRedactRecordsFullMode(t *testing.T) {
+	r, err := NewRedactor(Config{Mode: ModeFull, Context: "test"})
+	require.NoError(t, err)
+	defer r.Close()
+
+	records := []map[string]interface{}{
+		{
+			"email":     "john@example.com",
+			"firstName": "John",
+		},
+		{
+			"email":     "jane@example.com",
+			"firstName": "John", // Same value as above → same pseudonym
+		},
+	}
+
+	result := r.RedactRecords(records)
+
+	// Full mode: pseudonyms should be stable
+	assert.Equal(t, "<EMAIL_0>", result[0]["email"])
+	assert.Equal(t, "<PERSON_0>", result[0]["firstName"])
+
+	assert.Equal(t, "<EMAIL_1>", result[1]["email"])      // Different email → different pseudonym
+	assert.Equal(t, "<PERSON_0>", result[1]["firstName"]) // Same value → same pseudonym
+
+	assert.Equal(t, "pii_", r.SessionID()[:4]) // Has session ID
+}
+
+func TestRedactRecordsFullModeStability(t *testing.T) {
+	r, err := NewRedactor(Config{Mode: ModeFull, Context: "test"})
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Process first batch
+	records1 := []map[string]interface{}{
+		{"email": "alice@example.com"},
+	}
+	r.RedactRecords(records1)
+
+	// Process second batch (same session)
+	records2 := []map[string]interface{}{
+		{"email": "alice@example.com"}, // Same value
+		{"email": "bob@example.com"},   // New value
+	}
+	r.RedactRecords(records2)
+
+	// Same value should get same pseudonym across batches
+	assert.Equal(t, "<EMAIL_0>", records1[0]["email"])
+	assert.Equal(t, "<EMAIL_0>", records2[0]["email"])
+	assert.Equal(t, "<EMAIL_1>", records2[1]["email"])
+}
+
+// --- Free text detection tests ---
+
+func TestIsLikelyFreeText(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected bool
+	}{
+		{"short", false},                                     // Too short
+		{"abcdefghij", false},                                // No spaces
+		{"Login failed for user admin", true},                // Has spaces, long enough
+		{"550e8400-e29b-41d4-a716-446655440000", false},      // UUID
+		{"HOST-A1B2C3D4E5F6", false},                         // DT entity ID
+		{"Error: connection reset by peer", true},            // Free text
+		{"The server experienced an unexpected error", true}, // Free text
+		{"abc", false},                                       // Too short
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isLikelyFreeText(tt.value))
+		})
+	}
+}
+
+// --- isRedacted tests ---
+
+func TestIsRedacted(t *testing.T) {
+	assert.True(t, isRedacted("[EMAIL]"))
+	assert.True(t, isRedacted("[PERSON]"))
+	assert.True(t, isRedacted("<EMAIL_0>"))
+	assert.True(t, isRedacted("<PERSON_1>"))
+	assert.False(t, isRedacted("hello"))
+	assert.False(t, isRedacted(""))
+	assert.False(t, isRedacted("ab"))
+}
+
+// --- Empty/nil edge cases ---
+
+func TestRedactRecordsNil(t *testing.T) {
+	var r *Redactor
+	result := r.RedactRecords(nil)
+	assert.Nil(t, result)
+}
+
+func TestRedactRecordsEmpty(t *testing.T) {
+	r, err := NewRedactor(Config{Mode: ModeLite})
+	require.NoError(t, err)
+
+	result := r.RedactRecords([]map[string]interface{}{})
+	assert.Empty(t, result)
+}
+
+func TestNewRedactorModeOff(t *testing.T) {
+	_, err := NewRedactor(Config{Mode: ModeOff})
+	assert.Error(t, err)
+}
+
+// --- splitFieldPath tests ---
+
+func TestSplitFieldPath(t *testing.T) {
+	assert.Equal(t, []string{"user", "email"}, splitFieldPath("user.email"))
+	assert.Equal(t, []string{"a", "b", "c"}, splitFieldPath("a.b.c"))
+	assert.Equal(t, []string{"single"}, splitFieldPath("single"))
+	assert.Nil(t, splitFieldPath(""))
+}
+
+// --- setNestedField tests ---
+
+func TestSetNestedField(t *testing.T) {
+	record := map[string]interface{}{
+		"user": map[string]interface{}{
+			"email": "original@example.com",
+			"name":  "Test",
+		},
+	}
+
+	setNestedField(record, "user.email", "redacted")
+	user := record["user"].(map[string]interface{})
+	assert.Equal(t, "redacted", user["email"])
+	assert.Equal(t, "Test", user["name"])
+}

--- a/pkg/pii/presidio.go
+++ b/pkg/pii/presidio.go
@@ -1,0 +1,158 @@
+package pii
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// PresidioClient is an HTTP client for the Microsoft Presidio Analyzer API.
+// It sends text to Presidio for Named Entity Recognition (NER) and returns
+// detected PII entities with their positions and types.
+//
+// Presidio can be run standalone via Docker:
+//
+//	docker run -p 5002:5001 mcr.microsoft.com/presidio-analyzer:latest
+//
+// Or via the pii-client's Python sidecar (presidio_sidecar/).
+type PresidioClient struct {
+	baseURL        string
+	httpClient     *http.Client
+	scoreThreshold float64
+}
+
+// PresidioEntity represents a PII entity detected by Presidio.
+type PresidioEntity struct {
+	EntityType string  `json:"entity_type"`
+	Start      int     `json:"start"`
+	End        int     `json:"end"`
+	Score      float64 `json:"score"`
+}
+
+// presidioRequest is the request body for the Presidio /analyze endpoint.
+type presidioRequest struct {
+	Text           string   `json:"text"`
+	Language       string   `json:"language"`
+	Entities       []string `json:"entities,omitempty"`
+	ScoreThreshold float64  `json:"score_threshold,omitempty"`
+}
+
+// presidioResponse is the response from the /analyze endpoint (array of entities).
+// The response is directly []PresidioEntity.
+
+// presidioHealthResponse is the response from the /health endpoint.
+type presidioHealthResponse struct {
+	Status string `json:"status"`
+}
+
+// NewPresidioClient creates a new client for the given Presidio API URL.
+// The URL should be the base URL without a trailing slash (e.g., "http://localhost:5002").
+func NewPresidioClient(baseURL string) *PresidioClient {
+	return &PresidioClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		scoreThreshold: 0.85,
+	}
+}
+
+// SetScoreThreshold sets the minimum confidence score for entity detection.
+// Default is 0.85. Range: 0.0 to 1.0.
+func (c *PresidioClient) SetScoreThreshold(threshold float64) {
+	c.scoreThreshold = threshold
+}
+
+// activeEntityTypes are the Presidio entity types we care about for PII detection.
+// We use a focused set to reduce false positives.
+var activeEntityTypes = []string{
+	"PERSON",
+	"EMAIL_ADDRESS",
+	"PHONE_NUMBER",
+	"ORGANIZATION",
+	"IP_ADDRESS",
+}
+
+// presidioToCategory maps Presidio entity types to our PII categories.
+var presidioToCategory = map[string]string{
+	"PERSON":        CategoryPerson,
+	"EMAIL_ADDRESS": CategoryEmail,
+	"PHONE_NUMBER":  CategoryPhone,
+	"ORGANIZATION":  CategoryOrg,
+	"IP_ADDRESS":    CategoryIPAddress,
+}
+
+// Analyze sends a single text to Presidio for NER analysis.
+func (c *PresidioClient) Analyze(text string) ([]PresidioEntity, error) {
+	req := presidioRequest{
+		Text:           text,
+		Language:       "en",
+		Entities:       activeEntityTypes,
+		ScoreThreshold: c.scoreThreshold,
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Presidio request: %w", err)
+	}
+
+	resp, err := c.httpClient.Post(c.baseURL+"/analyze", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("Presidio request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Presidio returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var entities []PresidioEntity
+	if err := json.NewDecoder(resp.Body).Decode(&entities); err != nil {
+		return nil, fmt.Errorf("failed to decode Presidio response: %w", err)
+	}
+
+	// Map Presidio entity types to our categories
+	for i := range entities {
+		if cat, ok := presidioToCategory[entities[i].EntityType]; ok {
+			entities[i].EntityType = cat
+		}
+	}
+
+	return entities, nil
+}
+
+// AnalyzeBatch sends multiple texts to Presidio for NER analysis.
+// Returns a slice of entity slices, one per input text.
+// If Presidio doesn't support batch analysis, falls back to sequential calls.
+func (c *PresidioClient) AnalyzeBatch(texts []string) ([][]PresidioEntity, error) {
+	// Presidio's standard API doesn't have a batch endpoint.
+	// The pii-client's sidecar adds /analyze-batch, but the standard
+	// Presidio image only has /analyze. We fall back to sequential calls.
+	results := make([][]PresidioEntity, len(texts))
+
+	for i, text := range texts {
+		entities, err := c.Analyze(text)
+		if err != nil {
+			// Non-fatal: skip this text and continue with others
+			continue
+		}
+		results[i] = entities
+	}
+
+	return results, nil
+}
+
+// IsHealthy checks if the Presidio service is reachable and healthy.
+func (c *PresidioClient) IsHealthy() bool {
+	resp, err := c.httpClient.Get(c.baseURL + "/health")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}

--- a/pkg/pii/store.go
+++ b/pkg/pii/store.go
@@ -1,0 +1,298 @@
+package pii
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+)
+
+// PseudonymStore manages session-scoped pseudonym mappings.
+// It maps (category, original_value) → stable pseudonym within a session.
+// Sessions are persisted to disk as JSON files so a separate resolve tool
+// can map pseudonyms back to originals.
+type PseudonymStore struct {
+	mu        sync.Mutex
+	sessionID string
+	context   string
+	createdAt time.Time
+
+	// forward maps "CATEGORY:original" → "<CATEGORY_N>"
+	forward map[string]string
+
+	// reverse maps "<CATEGORY_N>" → Mapping
+	reverse map[string]Mapping
+
+	// counters tracks the next index per category
+	counters map[string]int
+}
+
+// Mapping represents a single pseudonym mapping.
+type Mapping struct {
+	Category  string `json:"category"`
+	Original  string `json:"original"`
+	Pseudonym string `json:"pseudonym"`
+}
+
+// SessionFile represents the on-disk format of a pseudonym session.
+type SessionFile struct {
+	SessionID string             `json:"session_id"`
+	Context   string             `json:"context"`
+	CreatedAt string             `json:"created_at"`
+	Mappings  map[string][]Entry `json:"mappings"` // category → entries
+}
+
+// Entry is a single mapping entry in the session file.
+type Entry struct {
+	Original  string `json:"original"`
+	Pseudonym string `json:"pseudonym"`
+}
+
+// NewPseudonymStore creates a new store for the given context.
+func NewPseudonymStore(context string) (*PseudonymStore, error) {
+	id, err := generateSessionID()
+	if err != nil {
+		return nil, err
+	}
+
+	return &PseudonymStore{
+		sessionID: id,
+		context:   context,
+		createdAt: time.Now().UTC(),
+		forward:   make(map[string]string),
+		reverse:   make(map[string]Mapping),
+		counters:  make(map[string]int),
+	}, nil
+}
+
+// SessionID returns the session identifier.
+func (s *PseudonymStore) SessionID() string {
+	return s.sessionID
+}
+
+// GetOrCreate returns the pseudonym for the given (category, original) pair.
+// If a pseudonym already exists for this pair, it is returned (stable).
+// Otherwise, a new pseudonym is created with the next available index.
+func (s *PseudonymStore) GetOrCreate(category, original string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := category + ":" + original
+	if pseudonym, ok := s.forward[key]; ok {
+		return pseudonym
+	}
+
+	// Create new pseudonym: <CATEGORY_N>
+	idx := s.counters[category]
+	s.counters[category] = idx + 1
+	pseudonym := fmt.Sprintf("<%s_%d>", category, idx)
+
+	s.forward[key] = pseudonym
+	s.reverse[pseudonym] = Mapping{
+		Category:  category,
+		Original:  original,
+		Pseudonym: pseudonym,
+	}
+
+	return pseudonym
+}
+
+// Resolve returns the original value for a pseudonym.
+// Returns empty Mapping and false if not found.
+func (s *PseudonymStore) Resolve(pseudonym string) (Mapping, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	m, ok := s.reverse[pseudonym]
+	return m, ok
+}
+
+// AllMappings returns all mappings in the store.
+func (s *PseudonymStore) AllMappings() []Mapping {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := make([]Mapping, 0, len(s.reverse))
+	for _, m := range s.reverse {
+		result = append(result, m)
+	}
+	return result
+}
+
+// Save persists the session to disk as a JSON file.
+// Files are stored at: XDG_DATA_HOME/dtctl/pii/sessions/<session-id>.json
+func (s *PseudonymStore) Save() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.forward) == 0 {
+		return nil // Nothing to save
+	}
+
+	dir := SessionDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create PII session directory: %w", err)
+	}
+
+	// Build session file
+	sf := SessionFile{
+		SessionID: s.sessionID,
+		Context:   s.context,
+		CreatedAt: s.createdAt.Format(time.RFC3339),
+		Mappings:  make(map[string][]Entry),
+	}
+
+	for _, m := range s.reverse {
+		sf.Mappings[m.Category] = append(sf.Mappings[m.Category], Entry{
+			Original:  m.Original,
+			Pseudonym: m.Pseudonym,
+		})
+	}
+
+	data, err := json.MarshalIndent(sf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal session: %w", err)
+	}
+
+	path := filepath.Join(dir, s.sessionID+".json")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write session file: %w", err)
+	}
+
+	return nil
+}
+
+// SessionDir returns the directory where PII sessions are stored.
+// It is a variable so tests can override it.
+var SessionDir = func() string {
+	return filepath.Join(config.DataDir(), "pii", "sessions")
+}
+
+// LoadSession loads a session file from disk.
+func LoadSession(sessionID string) (*SessionFile, error) {
+	path := filepath.Join(SessionDir(), sessionID+".json")
+	return LoadSessionFrom(path)
+}
+
+// LoadSessionFrom loads a session file from a specific path.
+func LoadSessionFrom(path string) (*SessionFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read session file: %w", err)
+	}
+
+	var sf SessionFile
+	if err := json.Unmarshal(data, &sf); err != nil {
+		return nil, fmt.Errorf("failed to parse session file: %w", err)
+	}
+
+	return &sf, nil
+}
+
+// ListSessions returns all session files in the session directory.
+func ListSessions() ([]SessionFile, error) {
+	dir := SessionDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read session directory: %w", err)
+	}
+
+	var sessions []SessionFile
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		sf, err := LoadSessionFrom(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue // Skip malformed files
+		}
+		sessions = append(sessions, *sf)
+	}
+
+	return sessions, nil
+}
+
+// PurgeSessions deletes sessions older than the given duration.
+// Returns the number of sessions deleted.
+func PurgeSessions(maxAge time.Duration) (int, error) {
+	dir := SessionDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to read session directory: %w", err)
+	}
+
+	cutoff := time.Now().Add(-maxAge)
+	deleted := 0
+
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+
+		path := filepath.Join(dir, e.Name())
+		sf, err := LoadSessionFrom(path)
+		if err != nil {
+			continue
+		}
+
+		created, err := time.Parse(time.RFC3339, sf.CreatedAt)
+		if err != nil {
+			continue
+		}
+
+		if created.Before(cutoff) {
+			if err := os.Remove(path); err == nil {
+				deleted++
+			}
+		}
+	}
+
+	return deleted, nil
+}
+
+// generateSessionID creates a unique session identifier.
+// Format: pii_YYYYMMDD_HHMMSS_<random>
+func generateSessionID() (string, error) {
+	now := time.Now().UTC()
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("pii_%s_%s",
+		now.Format("20060102_150405"),
+		hex.EncodeToString(b),
+	), nil
+}
+
+// ResolveInSession resolves a pseudonym from a loaded session file.
+func (sf *SessionFile) ResolveInSession(pseudonym string) (Entry, string, bool) {
+	for category, entries := range sf.Mappings {
+		for _, e := range entries {
+			if e.Pseudonym == pseudonym {
+				return e, category, true
+			}
+		}
+	}
+	return Entry{}, "", false
+}
+
+// TotalMappings returns the total number of mappings in the session.
+func (sf *SessionFile) TotalMappings() int {
+	total := 0
+	for _, entries := range sf.Mappings {
+		total += len(entries)
+	}
+	return total
+}

--- a/pkg/pii/store_test.go
+++ b/pkg/pii/store_test.go
@@ -1,0 +1,202 @@
+package pii
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPseudonymStoreGetOrCreate(t *testing.T) {
+	store, err := NewPseudonymStore("test")
+	require.NoError(t, err)
+
+	// First call creates a new pseudonym
+	p1 := store.GetOrCreate(CategoryEmail, "alice@example.com")
+	assert.Equal(t, "<EMAIL_0>", p1)
+
+	// Same value returns the same pseudonym (stable)
+	p2 := store.GetOrCreate(CategoryEmail, "alice@example.com")
+	assert.Equal(t, "<EMAIL_0>", p2)
+
+	// Different value gets a new index
+	p3 := store.GetOrCreate(CategoryEmail, "bob@example.com")
+	assert.Equal(t, "<EMAIL_1>", p3)
+
+	// Different category starts at 0
+	p4 := store.GetOrCreate(CategoryPerson, "Alice Smith")
+	assert.Equal(t, "<PERSON_0>", p4)
+}
+
+func TestPseudonymStoreResolve(t *testing.T) {
+	store, err := NewPseudonymStore("test")
+	require.NoError(t, err)
+
+	store.GetOrCreate(CategoryEmail, "alice@example.com")
+	store.GetOrCreate(CategoryPerson, "Alice Smith")
+
+	// Resolve known pseudonyms
+	m, ok := store.Resolve("<EMAIL_0>")
+	assert.True(t, ok)
+	assert.Equal(t, CategoryEmail, m.Category)
+	assert.Equal(t, "alice@example.com", m.Original)
+
+	m, ok = store.Resolve("<PERSON_0>")
+	assert.True(t, ok)
+	assert.Equal(t, "Alice Smith", m.Original)
+
+	// Resolve unknown pseudonym
+	_, ok = store.Resolve("<EMAIL_99>")
+	assert.False(t, ok)
+}
+
+func TestPseudonymStoreAllMappings(t *testing.T) {
+	store, err := NewPseudonymStore("test")
+	require.NoError(t, err)
+
+	store.GetOrCreate(CategoryEmail, "a@example.com")
+	store.GetOrCreate(CategoryEmail, "b@example.com")
+	store.GetOrCreate(CategoryPerson, "Alice")
+
+	mappings := store.AllMappings()
+	assert.Len(t, mappings, 3)
+}
+
+func TestPseudonymStoreSaveAndLoad(t *testing.T) {
+	// Use a temp directory for session files
+	tmpDir := t.TempDir()
+	origSessionDir := SessionDir
+	SessionDir = func() string { return tmpDir }
+	defer func() { SessionDir = origSessionDir }()
+
+	store, err := NewPseudonymStore("test-ctx")
+	require.NoError(t, err)
+
+	store.GetOrCreate(CategoryEmail, "alice@example.com")
+	store.GetOrCreate(CategoryPerson, "Alice Smith")
+
+	err = store.Save()
+	require.NoError(t, err)
+
+	// Verify file exists
+	files, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	// Load the session
+	sf, err := LoadSessionFrom(filepath.Join(tmpDir, files[0].Name()))
+	require.NoError(t, err)
+
+	assert.Equal(t, store.SessionID(), sf.SessionID)
+	assert.Equal(t, "test-ctx", sf.Context)
+	assert.NotEmpty(t, sf.CreatedAt)
+	assert.Equal(t, 2, sf.TotalMappings())
+
+	// Resolve from loaded session
+	entry, cat, ok := sf.ResolveInSession("<EMAIL_0>")
+	assert.True(t, ok)
+	assert.Equal(t, CategoryEmail, cat)
+	assert.Equal(t, "alice@example.com", entry.Original)
+
+	// Unknown pseudonym
+	_, _, ok = sf.ResolveInSession("<PHONE_99>")
+	assert.False(t, ok)
+}
+
+func TestPseudonymStoreSaveEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	origSessionDir := SessionDir
+	SessionDir = func() string { return tmpDir }
+	defer func() { SessionDir = origSessionDir }()
+
+	store, err := NewPseudonymStore("test")
+	require.NoError(t, err)
+
+	// Save with no mappings should be a no-op
+	err = store.Save()
+	require.NoError(t, err)
+
+	files, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+func TestListSessions(t *testing.T) {
+	tmpDir := t.TempDir()
+	origSessionDir := SessionDir
+	SessionDir = func() string { return tmpDir }
+	defer func() { SessionDir = origSessionDir }()
+
+	// Create two sessions
+	s1, _ := NewPseudonymStore("ctx1")
+	s1.GetOrCreate(CategoryEmail, "a@test.com")
+	require.NoError(t, s1.Save())
+
+	s2, _ := NewPseudonymStore("ctx2")
+	s2.GetOrCreate(CategoryPerson, "Bob")
+	require.NoError(t, s2.Save())
+
+	sessions, err := ListSessions()
+	require.NoError(t, err)
+	assert.Len(t, sessions, 2)
+}
+
+func TestListSessionsEmptyDir(t *testing.T) {
+	origSessionDir := SessionDir
+	SessionDir = func() string { return "/nonexistent/path/that/does/not/exist" }
+	defer func() { SessionDir = origSessionDir }()
+
+	sessions, err := ListSessions()
+	require.NoError(t, err)
+	assert.Nil(t, sessions)
+}
+
+func TestPurgeSessions(t *testing.T) {
+	tmpDir := t.TempDir()
+	origSessionDir := SessionDir
+	SessionDir = func() string { return tmpDir }
+	defer func() { SessionDir = origSessionDir }()
+
+	// Create a session
+	s, _ := NewPseudonymStore("test")
+	s.GetOrCreate(CategoryEmail, "test@test.com")
+	require.NoError(t, s.Save())
+
+	// Purge with 0 duration should delete everything (all sessions are older than "now")
+	deleted, err := PurgeSessions(0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+
+	// Verify empty
+	files, _ := os.ReadDir(tmpDir)
+	assert.Empty(t, files)
+}
+
+func TestPurgeSessionsKeepsRecent(t *testing.T) {
+	tmpDir := t.TempDir()
+	origSessionDir := SessionDir
+	SessionDir = func() string { return tmpDir }
+	defer func() { SessionDir = origSessionDir }()
+
+	// Create a session
+	s, _ := NewPseudonymStore("test")
+	s.GetOrCreate(CategoryEmail, "test@test.com")
+	require.NoError(t, s.Save())
+
+	// Purge with large max age — session is recent, should be kept
+	deleted, err := PurgeSessions(24 * time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+
+	files, _ := os.ReadDir(tmpDir)
+	assert.Len(t, files, 1)
+}
+
+func TestSessionIDFormat(t *testing.T) {
+	id, err := generateSessionID()
+	require.NoError(t, err)
+	assert.Regexp(t, `^pii_\d{8}_\d{6}_[0-9a-f]{8}$`, id)
+}

--- a/pkg/pii/walker.go
+++ b/pkg/pii/walker.go
@@ -1,0 +1,250 @@
+package pii
+
+import (
+	"fmt"
+	"os"
+)
+
+// walkRecord recursively walks a record map, detecting and replacing PII values.
+// It modifies the map in place. Top-level keys in DQL results are flat dotted
+// strings (e.g., "usr.name"), so the key itself is the full path.
+func (r *Redactor) walkRecord(record map[string]interface{}) {
+	for key, val := range record {
+		record[key] = r.walkValue(key, key, val)
+	}
+}
+
+// walkValue processes a single value, returning the (possibly redacted) replacement.
+// fullPath is the dot-separated path from the record root (for custom rule + pattern matching).
+// fieldName is the immediate key name (used for array recursion context).
+func (r *Redactor) walkValue(fullPath, fieldName string, val interface{}) interface{} {
+	switch v := val.(type) {
+	case string:
+		return r.redactString(fullPath, v)
+
+	case map[string]interface{}:
+		// Recurse into nested objects, extending the full path
+		for k, nested := range v {
+			childPath := fullPath + "." + k
+			v[k] = r.walkValue(childPath, k, nested)
+		}
+		return v
+
+	case []interface{}:
+		// Recurse into arrays
+		for i, elem := range v {
+			v[i] = r.walkValue(fullPath, fieldName, elem)
+		}
+		return v
+
+	default:
+		// Non-string primitives (numbers, bools, nil) are never PII
+		return val
+	}
+}
+
+// redactString checks a string value against custom rules, built-in patterns,
+// and returns the redacted replacement if PII is detected, or the original value.
+// fullPath is the dot-separated path from the record root (e.g., "data.customerRef").
+func (r *Redactor) redactString(fullPath, value string) string {
+	// Phase 0: Check custom rules (highest priority — checked on full path)
+	if rule := MatchCustomRule(r.customRules, fullPath); rule != nil {
+		if rule.Skip {
+			return value // explicitly excluded from redaction
+		}
+		return r.replace(rule.Category, value)
+	}
+
+	// Phase 1: Check field name against built-in key-name patterns.
+	// matchFieldName checks usr.* prefix on the full path, then extracts
+	// the last dot-segment for regex matching.
+	if category := matchFieldName(r.patterns, fullPath); category != "" {
+		return r.replace(category, value)
+	}
+
+	// Phase 2: Check value against value-based patterns (email regex, IP regex)
+	if category := matchValue(r.patterns, value); category != "" {
+		return r.replace(category, value)
+	}
+
+	// Phase 3 candidate collection: if in full mode with Presidio,
+	// collect free-text values for NER analysis (handled separately in applyPresidioNER)
+	// We don't collect here — Presidio analysis is done in a second pass.
+
+	return value
+}
+
+// freeTextField represents a free-text field location for Presidio NER analysis.
+type freeTextField struct {
+	recordIdx int
+	fieldPath string // dot-separated path to the field
+	value     string
+}
+
+// applyPresidioNER runs Presidio NER analysis on free-text fields in the records.
+// It modifies the records in place, replacing detected entities with pseudonyms.
+func (r *Redactor) applyPresidioNER(records []map[string]interface{}) {
+	if r.presidio == nil {
+		return
+	}
+
+	// Collect free-text fields from all records
+	var fields []freeTextField
+	for i, record := range records {
+		collectFreeTextFields(record, "", i, &fields)
+	}
+
+	if len(fields) == 0 {
+		return
+	}
+
+	// Extract text values for batch analysis
+	texts := make([]string, len(fields))
+	for i, f := range fields {
+		texts[i] = f.value
+	}
+
+	// Call Presidio for NER analysis
+	results, err := r.presidio.AnalyzeBatch(texts)
+	if err != nil {
+		// Presidio failure is non-fatal — we already did regex-based detection
+		warnf("Warning: Presidio NER analysis failed: %v\n", err)
+		return
+	}
+
+	// Apply NER results: replace detected entities in the original records
+	for i, entities := range results {
+		if len(entities) == 0 {
+			continue
+		}
+		field := fields[i]
+		redacted := applyEntities(field.value, entities, r)
+		setNestedField(records[field.recordIdx], field.fieldPath, redacted)
+	}
+}
+
+// applyEntities replaces detected entity spans in a text value.
+// Processes entities right-to-left to preserve offset positions.
+func applyEntities(text string, entities []PresidioEntity, r *Redactor) string {
+	// Sort entities by start position descending (right-to-left replacement)
+	sortEntitiesDesc(entities)
+
+	result := text
+	for _, e := range entities {
+		if e.Start < 0 || e.End > len(result) || e.Start >= e.End {
+			continue
+		}
+		original := result[e.Start:e.End]
+		replacement := r.replace(e.EntityType, original)
+		result = result[:e.Start] + replacement + result[e.End:]
+	}
+	return result
+}
+
+// sortEntitiesDesc sorts entities by Start position in descending order.
+func sortEntitiesDesc(entities []PresidioEntity) {
+	// Simple insertion sort (typically very few entities per text)
+	for i := 1; i < len(entities); i++ {
+		for j := i; j > 0 && entities[j].Start > entities[j-1].Start; j-- {
+			entities[j], entities[j-1] = entities[j-1], entities[j]
+		}
+	}
+}
+
+// collectFreeTextFields recursively collects string values that look like free text.
+func collectFreeTextFields(obj map[string]interface{}, pathPrefix string, recordIdx int, out *[]freeTextField) {
+	for key, val := range obj {
+		path := key
+		if pathPrefix != "" {
+			path = pathPrefix + "." + key
+		}
+
+		switch v := val.(type) {
+		case string:
+			// Only collect if it wasn't already redacted by pattern matching
+			// and looks like free text
+			if isLikelyFreeText(v) && !isRedacted(v) {
+				*out = append(*out, freeTextField{
+					recordIdx: recordIdx,
+					fieldPath: path,
+					value:     v,
+				})
+			}
+		case map[string]interface{}:
+			collectFreeTextFields(v, path, recordIdx, out)
+		case []interface{}:
+			for i, elem := range v {
+				if m, ok := elem.(map[string]interface{}); ok {
+					elemPath := fmt.Sprintf("%s[%d]", path, i)
+					collectFreeTextFields(m, elemPath, recordIdx, out)
+				}
+			}
+		}
+	}
+}
+
+// setNestedField sets a value at a dot-separated path in a nested map.
+func setNestedField(record map[string]interface{}, path string, value interface{}) {
+	parts := splitFieldPath(path)
+	if len(parts) == 0 {
+		return
+	}
+
+	current := record
+	for i := 0; i < len(parts)-1; i++ {
+		next, ok := current[parts[i]]
+		if !ok {
+			return
+		}
+		m, ok := next.(map[string]interface{})
+		if !ok {
+			return
+		}
+		current = m
+	}
+	current[parts[len(parts)-1]] = value
+}
+
+// splitFieldPath splits a dot-separated field path into components.
+// Array indices like "items[0]" are treated as single components.
+func splitFieldPath(path string) []string {
+	if path == "" {
+		return nil
+	}
+
+	var parts []string
+	start := 0
+	for i := 0; i < len(path); i++ {
+		if path[i] == '.' {
+			if i > start {
+				parts = append(parts, path[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(path) {
+		parts = append(parts, path[start:])
+	}
+	return parts
+}
+
+// isRedacted checks if a string value has already been redacted.
+func isRedacted(s string) bool {
+	if len(s) < 3 {
+		return false
+	}
+	// Lite mode: [CATEGORY]
+	if s[0] == '[' && s[len(s)-1] == ']' {
+		return true
+	}
+	// Full mode: <CATEGORY_N>
+	if s[0] == '<' && s[len(s)-1] == '>' {
+		return true
+	}
+	return false
+}
+
+// warnf prints a warning message to stderr. It can be overridden in tests.
+var warnf = func(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, args...)
+}


### PR DESCRIPTION
…field rules

Implement two-tier PII detection (lite placeholders / full pseudonyms) for dtctl query output, with a separate dtctl-pii-resolve binary for the reverse lookup trust boundary. Extend built-in patterns with RUM usr.* prefix matching, bare ip, and region fields. Add custom field rules engine (.dtctl-pii.yaml project files + config preferences) with exact/glob matching and skip overrides. Include comprehensive docs and 51 tests.

## Description

<!-- What does this PR do? -->

## Related Issues

Closes #

## Testing

<!-- How did you test this? -->

- [ ] Tests pass (`make test`)
- [ ] Linting passes (`make lint`)
