### PR TITLE
fix: add troubleshooting hints to auth login error messages

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -165,16 +165,31 @@ you'll need to use API token authentication instead (dtctl config set-credential
 
 		// If --context or --environment are not provided, fall back to the current context
 		if contextName == "" || environment == "" {
+			contextHint := "Use 'dtctl ctx' to list available context names, then pass --context <name> --environment <url>"
 			cfg, err := LoadConfig()
 			if err != nil {
-				return fmt.Errorf("--context and --environment are required (no existing config found: %w)", err)
+				return &diagnostic.Error{
+					Operation:   "auth login",
+					Message:     "--context and --environment are required (no existing config found)",
+					Suggestions: []string{contextHint},
+					Err:         err,
+				}
 			}
 			if cfg.CurrentContext == "" {
-				return fmt.Errorf("--context and --environment are required when no current context is set")
+				return &diagnostic.Error{
+					Operation:   "auth login",
+					Message:     "--context and --environment are required when no current context is set",
+					Suggestions: []string{contextHint, "Set a current context with 'dtctl ctx use-context <name>'"},
+				}
 			}
 			ctx, err := cfg.CurrentContextObj()
 			if err != nil {
-				return fmt.Errorf("--context and --environment are required (failed to load current context: %w)", err)
+				return &diagnostic.Error{
+					Operation:   "auth login",
+					Message:     "--context and --environment are required (failed to load current context)",
+					Suggestions: []string{contextHint},
+					Err:         err,
+				}
 			}
 			if contextName == "" {
 				contextName = cfg.CurrentContext

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -35,18 +35,21 @@ func TestAuthLogin_FlagValidation(t *testing.T) {
 		args        []string
 		setupConfig bool // whether to write a config with a current context
 		wantErrSub  string
+		wantHint    string
 	}{
 		{
 			name:        "no flags no config errors helpfully",
 			args:        []string{"auth", "login"},
 			setupConfig: false,
 			wantErrSub:  "--context and --environment are required",
+			wantHint:    "dtctl ctx",
 		},
 		{
 			name:        "no flags empty current context errors helpfully",
 			args:        []string{"auth", "login"},
 			setupConfig: true, // config exists but CurrentContext is empty (handled below)
 			wantErrSub:  "--context and --environment are required when no current context is set",
+			wantHint:    "dtctl ctx",
 		},
 	}
 
@@ -78,6 +81,9 @@ func TestAuthLogin_FlagValidation(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tt.wantErrSub) {
 				t.Errorf("expected error containing %q, got: %v", tt.wantErrSub, err)
+			}
+			if !strings.Contains(err.Error(), tt.wantHint) {
+				t.Errorf("expected error to contain hint %q, got: %v", tt.wantHint, err)
 			}
 
 			// Reset


### PR DESCRIPTION
## Summary

- When `dtctl auth login` fails because `--context`/`--environment` are missing and no current context is available, the error now includes actionable troubleshooting suggestions pointing users to `dtctl ctx` for listing context names
- Uses `diagnostic.Error` instead of plain `fmt.Errorf`, so hints work in both human and agent (`--agent`) output modes
- Adds an extra hint ("Set a current context with `dtctl ctx use-context <name>`") when config exists but no current context is set

## Before

```
$ dtctl auth login
Error: --context and --environment are required (no existing config found: ...)
```

## After

```
$ dtctl auth login
Failed to auth login: --context and --environment are required (no existing config found)

Troubleshooting suggestions:
  • Use 'dtctl ctx' to list available context names, then pass --context <name> --environment <url>
```

## Motivation

User feedback: the `NAME` column in `dtctl ctx` output wasn't immediately obvious as the value to pass to `--context` in `auth login`. Rather than renaming the column (which would break kubectl convention), we add a hint that guides users to the right command.