### PR TITLE
feat(dql): auto-refresh OAuth token on 401 during long-running query …

### DIFF
--- a/cmd/exec_dql.go
+++ b/cmd/exec_dql.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 )
 
@@ -43,7 +42,7 @@ Examples:
 			return err
 		}
 
-		executor := exec.NewDQLExecutor(c)
+		executor := NewDQLExecutorFromConfig(cfg, c)
 
 		queryFile, _ := cmd.Flags().GetString("file")
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -153,7 +153,7 @@ Examples:
 			return err
 		}
 
-		executor := exec.NewDQLExecutor(c)
+		executor := NewDQLExecutorFromConfig(cfg, c)
 
 		queryFile, _ := cmd.Flags().GetString("file")
 		setFlags, _ := cmd.Flags().GetStringArray("set")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
+	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/suggest"
@@ -473,6 +474,24 @@ func NewClientFromConfig(cfg *config.Config) (*client.Client, error) {
 		c.SetVerbosity(verbosity)
 	}
 	return c, nil
+}
+
+// NewDQLExecutorFromConfig creates a DQL executor from a config and client, with OAuth
+// token refresh support. When the OAuth token expires during a long-running query poll
+// (which can exceed the 5-minute token lifetime), the executor automatically fetches a
+// fresh token and retries without aborting the query.
+func NewDQLExecutorFromConfig(cfg *config.Config, c *client.Client) *exec.DQLExecutor {
+	executor := exec.NewDQLExecutor(c)
+	if config.IsKeyringAvailable() {
+		ctx, err := cfg.CurrentContextObj()
+		if err == nil && ctx.TokenRef != "" {
+			tokenRef := ctx.TokenRef
+			executor = executor.WithTokenRefresher(func() (string, error) {
+				return client.GetTokenWithOAuthSupport(cfg, tokenRef)
+			})
+		}
+	}
+	return executor
 }
 
 func init() {

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -203,7 +203,7 @@ Examples:
 		}
 
 		// Create executor and waiter
-		executor := exec.NewDQLExecutor(c)
+		executor := NewDQLExecutorFromConfig(cfg, c)
 		waiter := wait.NewQueryWaiter(executor, waitConfig)
 
 		// Execute wait

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -114,6 +114,13 @@ func (c *Client) HTTP() *resty.Client {
 	return c.http
 }
 
+// SetToken updates the bearer token used for all subsequent HTTP requests.
+// This is used to inject a freshly refreshed OAuth token without recreating the client.
+func (c *Client) SetToken(token string) {
+	c.token = token
+	c.http.SetAuthToken(token)
+}
+
 // sensitiveHeaders lists headers that should always be redacted in debug output
 var sensitiveHeaders = []string{"authorization", "x-api-key", "cookie", "set-cookie"}
 

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -14,12 +14,22 @@ import (
 
 // DQLExecutor handles DQL query execution
 type DQLExecutor struct {
-	client *client.Client
+	client         *client.Client
+	tokenRefresher func() (string, error)
 }
 
 // NewDQLExecutor creates a new DQL executor
 func NewDQLExecutor(c *client.Client) *DQLExecutor {
 	return &DQLExecutor{client: c}
+}
+
+// WithTokenRefresher sets an optional callback that is invoked when a poll request
+// receives a 401 Unauthorized response (e.g. because the OAuth token expired during
+// a long-running query). The callback must return a fresh access token. The executor
+// updates the underlying HTTP client with the new token and retries the poll.
+func (e *DQLExecutor) WithTokenRefresher(refresher func() (string, error)) *DQLExecutor {
+	e.tokenRefresher = refresher
+	return e
 }
 
 // DecodeMode controls snapshot payload decoding behavior.
@@ -651,8 +661,12 @@ func (e *DQLExecutor) pollForResults(requestToken string) (DQLQueryResponse, err
 // pollForResultsWithOptions polls the query:poll endpoint until the query completes with options
 func (e *DQLExecutor) pollForResultsWithOptions(requestToken string, opts DQLExecuteOptions) (DQLQueryResponse, error) {
 	var result DQLQueryResponse
+	// tokenJustRefreshed prevents an infinite refresh loop: if we get a 401 immediately
+	// after a successful token refresh the credentials are fundamentally broken, so we abort.
+	tokenJustRefreshed := false
 
 	for {
+		result = DQLQueryResponse{}
 		httpReq := e.client.HTTP().R().
 			SetQueryParam("request-token", requestToken).
 			SetQueryParam("request-timeout-milliseconds", "60000").
@@ -664,9 +678,24 @@ func (e *DQLExecutor) pollForResultsWithOptions(requestToken string, opts DQLExe
 			return result, fmt.Errorf("failed to poll query: %w", err)
 		}
 
+		// On 401 (e.g. "jwt expired") try to refresh the OAuth token once per
+		// consecutive failure. A successful poll in between resets the guard so that a
+		// second expiry later in the same long-running query can also be recovered.
+		if resp.StatusCode() == 401 && e.tokenRefresher != nil && !tokenJustRefreshed {
+			newToken, refreshErr := e.tokenRefresher()
+			if refreshErr != nil {
+				return result, fmt.Errorf("poll request returned 401 and token refresh failed: %w", refreshErr)
+			}
+			e.client.SetToken(newToken)
+			tokenJustRefreshed = true
+			continue
+		}
+
 		if resp.IsError() {
 			return result, fmt.Errorf("poll failed with status %d: %s", resp.StatusCode(), resp.String())
 		}
+
+		tokenJustRefreshed = false // reset after any successful response
 
 		if result.State == "SUCCEEDED" || result.State == "FAILED" {
 			break

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -1775,3 +1775,126 @@ func TestEnhanceQueryError(t *testing.T) {
 		})
 	}
 }
+
+// TestDQLExecutor_PollTokenRefresh verifies that a 401 during polling triggers a token refresh and retries.
+func TestDQLExecutor_PollTokenRefresh(t *testing.T) {
+pollCallCount := 0
+refreshCallCount := 0
+
+server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+if r.URL.Path == "/platform/storage/query/v1/query:execute" {
+resp := DQLQueryResponse{State: "RUNNING", RequestToken: "tok-abc"}
+w.Header().Set("Content-Type", "application/json")
+w.WriteHeader(http.StatusAccepted)
+_ = json.NewEncoder(w).Encode(resp)
+return
+}
+
+if r.URL.Path == "/platform/storage/query/v1/query:poll" {
+pollCallCount++
+if pollCallCount == 1 {
+// First poll: simulate expired JWT
+w.WriteHeader(http.StatusUnauthorized)
+_, _ = w.Write([]byte(`{"error":{"message":"jwt expired"}}`))
+return
+}
+// Second poll (after refresh): succeed
+resp := DQLQueryResponse{
+State:  "SUCCEEDED",
+Result: &DQLResult{Records: []map[string]interface{}{{"key": "value"}}},
+}
+w.Header().Set("Content-Type", "application/json")
+_ = json.NewEncoder(w).Encode(resp)
+}
+}))
+defer server.Close()
+
+c, err := client.NewForTesting(server.URL, "old-token")
+if err != nil {
+t.Fatalf("failed to create client: %v", err)
+}
+
+executor := NewDQLExecutor(c).WithTokenRefresher(func() (string, error) {
+refreshCallCount++
+return "new-token", nil
+})
+
+result, err := executor.ExecuteQueryWithOptions("fetch logs", DQLExecuteOptions{})
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if result.State != "SUCCEEDED" {
+t.Errorf("expected state SUCCEEDED, got %s", result.State)
+}
+if refreshCallCount != 1 {
+t.Errorf("expected token refresh to be called once, got %d", refreshCallCount)
+}
+if pollCallCount != 2 {
+t.Errorf("expected 2 poll calls (1 expired + 1 success), got %d", pollCallCount)
+}
+}
+
+// TestDQLExecutor_PollTokenRefresh_FailsWhenRefresherErrors verifies that a refresh error aborts polling.
+func TestDQLExecutor_PollTokenRefresh_FailsWhenRefresherErrors(t *testing.T) {
+server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+if r.URL.Path == "/platform/storage/query/v1/query:execute" {
+resp := DQLQueryResponse{State: "RUNNING", RequestToken: "tok-abc"}
+w.Header().Set("Content-Type", "application/json")
+w.WriteHeader(http.StatusAccepted)
+_ = json.NewEncoder(w).Encode(resp)
+return
+}
+// Always return 401
+w.WriteHeader(http.StatusUnauthorized)
+_, _ = w.Write([]byte(`{"error":{"message":"jwt expired"}}`))
+}))
+defer server.Close()
+
+c, err := client.NewForTesting(server.URL, "old-token")
+if err != nil {
+t.Fatalf("failed to create client: %v", err)
+}
+
+executor := NewDQLExecutor(c).WithTokenRefresher(func() (string, error) {
+return "", fmt.Errorf("refresh service unavailable")
+})
+
+_, err = executor.ExecuteQueryWithOptions("fetch logs", DQLExecuteOptions{})
+if err == nil {
+t.Fatal("expected error, got nil")
+}
+if !strings.Contains(err.Error(), "token refresh failed") {
+t.Errorf("expected error to mention token refresh failure, got: %v", err)
+}
+}
+
+// TestDQLExecutor_PollTokenRefresh_NoRefresherReturnsError verifies that without a refresher a 401 is a hard error.
+func TestDQLExecutor_PollTokenRefresh_NoRefresherReturnsError(t *testing.T) {
+server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+if r.URL.Path == "/platform/storage/query/v1/query:execute" {
+resp := DQLQueryResponse{State: "RUNNING", RequestToken: "tok-abc"}
+w.Header().Set("Content-Type", "application/json")
+w.WriteHeader(http.StatusAccepted)
+_ = json.NewEncoder(w).Encode(resp)
+return
+}
+w.WriteHeader(http.StatusUnauthorized)
+_, _ = w.Write([]byte(`{"error":{"message":"jwt expired"}}`))
+}))
+defer server.Close()
+
+c, err := client.NewForTesting(server.URL, "old-token")
+if err != nil {
+t.Fatalf("failed to create client: %v", err)
+}
+
+executor := NewDQLExecutor(c) // no token refresher
+
+_, err = executor.ExecuteQueryWithOptions("fetch logs", DQLExecuteOptions{})
+if err == nil {
+t.Fatal("expected error, got nil")
+}
+if !strings.Contains(err.Error(), "401") {
+t.Errorf("expected error to contain status 401, got: %v", err)
+}
+}


### PR DESCRIPTION
…poll

When a DQL query runs longer than the OAuth token lifetime (5 minutes), poll requests receive a 401 Unauthorized (jwt expired) response and the query was aborted. This change adds transparent token refresh so the query continues uninterrupted.

Changes:
- pkg/client: add SetToken() to update bearer token on the resty client
- pkg/exec: add WithTokenRefresher() to DQLExecutor; on 401 during polling the refresher is called, the client token is updated, and the request is retried. A guard flag prevents an infinite loop if the refresh itself is broken.
- cmd: add NewDQLExecutorFromConfig() helper that wires the OAuth refresher automatically (when keyring is available); update query, exec dql, and wait commands to use it.
- pkg/exec: add three unit tests covering successful refresh, refresh error, and the no-refresher fallback.

## Description

Implement OAuth token refresh for long running queries.

## Testing

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
