### PR TITLE
fix: enforce safety checks for settings objects in apply

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -1009,6 +1009,10 @@ func (a *Applier) applySettings(data []byte) (ApplyResult, error) {
 			return nil, fmt.Errorf("scope is required to create a settings object")
 		}
 
+		if err := a.checkSafety(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
+			return nil, err
+		}
+
 		req := settings.SettingsObjectCreate{
 			SchemaID: schemaID,
 			Scope:    scope,
@@ -1042,6 +1046,10 @@ func (a *Applier) applySettings(data []byte) (ApplyResult, error) {
 			return nil, fmt.Errorf("scope is required to create a settings object (objectId %q not found)", objectID)
 		}
 
+		if err := a.checkSafety(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
+			return nil, err
+		}
+
 		req := settings.SettingsObjectCreate{
 			SchemaID: schemaID,
 			Scope:    scope,
@@ -1065,6 +1073,10 @@ func (a *Applier) applySettings(data []byte) (ApplyResult, error) {
 	}
 
 	// Update existing settings object
+	if err := a.checkSafety(safety.OperationUpdate, safety.OwnershipUnknown); err != nil {
+		return nil, err
+	}
+
 	updated, err := handler.UpdateWithContext(objectID, value, schemaID, scope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update settings object: %w", err)


### PR DESCRIPTION
## Problem

`dtctl apply` with a settings object YAML bypasses the `readonly` safety level entirely. The `applySettings` function in `pkg/apply/applier.go` never calls `checkSafety`, so create and update operations proceed against the API even when the active context has `safety: readonly`.

All other resource handlers (workflows, dashboards, SLOs, buckets, etc.) correctly gate their mutating paths with `checkSafety`.

## Fix

Add `checkSafety` calls to all three mutating paths in `applySettings`:

1. **Create (no objectId)** — new settings object created from scratch
2. **Create (objectId not found)** — upsert path that falls through to create
3. **Update** — existing settings object updated

`OperationCreate` / `OperationUpdate` with `OwnershipUnknown` is used, consistent with other ownership-less resources (e.g. buckets).

## Testing

All existing unit tests pass (`make test`). No new tests were required as the safety checker logic is already thoroughly tested in `pkg/safety/checker_test.go`.