### PR TITLE
feat: pre-apply hook for external validation

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -84,6 +84,7 @@ that contains the dashboard ID. The 'create' command always creates new resource
 		setFlags, _ := cmd.Flags().GetStringArray("set")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		showDiff, _ := cmd.Flags().GetBool("show-diff")
+		noHooks, _ := cmd.Flags().GetBool("no-hooks")
 
 		// Read the file
 		fileData, err := os.ReadFile(file)
@@ -120,6 +121,13 @@ that contains the dashboard ID. The 'create' command always creates new resource
 				return err
 			}
 			applier = applier.WithSafetyChecker(checker)
+		}
+
+		// Configure pre-apply hook
+		if !noHooks {
+			if hookCmd := cfg.GetPreApplyHook(); hookCmd != "" {
+				applier = applier.WithPreApplyHook(hookCmd).WithSourceFile(file)
+			}
 		}
 
 		// Apply the resource
@@ -179,6 +187,7 @@ func init() {
 	applyCmd.Flags().StringArray("set", []string{}, "set template variable (key=value)")
 	applyCmd.Flags().Bool("dry-run", false, "preview changes without applying")
 	applyCmd.Flags().Bool("show-diff", false, "show diff of changes when updating existing resources")
+	applyCmd.Flags().Bool("no-hooks", false, "skip pre-apply hooks")
 
 	_ = applyCmd.MarkFlagRequired("file")
 }

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -321,6 +321,7 @@ func TestApplyFlags(t *testing.T) {
 	}{
 		{"file", ""},
 		{"show-diff", "false"},
+		{"no-hooks", "false"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,7 +94,9 @@ func Execute() {
 		// Check for auth-related hints (e.g., expired OAuth session)
 		authHints := getAuthHintsForError(err)
 
-		allHints := append(urlHints, authHints...)
+		allHints := make([]string, 0, len(urlHints)+len(authHints))
+		allHints = append(allHints, urlHints...)
+		allHints = append(allHints, authHints...)
 
 		if agentMode || plainMode {
 			detail := errorToDetail(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/dynatrace-oss/dtctl/pkg/aidetect"
+	"github.com/dynatrace-oss/dtctl/pkg/apply"
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
@@ -90,17 +91,22 @@ func Execute() {
 		// Check for URL-related hints (e.g., wrong domain like live.dynatrace.com)
 		urlHints := getURLHintsForError(err)
 
+		// Check for auth-related hints (e.g., expired OAuth session)
+		authHints := getAuthHintsForError(err)
+
+		allHints := append(urlHints, authHints...)
+
 		if agentMode || plainMode {
 			detail := errorToDetail(err)
-			detail.Suggestions = append(detail.Suggestions, urlHints...)
+			detail.Suggestions = append(detail.Suggestions, allHints...)
 			_ = output.PrintError(os.Stderr, detail)
 			os.Exit(exitCodeForError(err))
 		}
 
 		output.PrintHumanError("%s", err)
-		if len(urlHints) > 0 {
+		if len(allHints) > 0 {
 			fmt.Fprintln(os.Stderr)
-			for _, hint := range urlHints {
+			for _, hint := range allHints {
 				output.PrintHint("%s", hint)
 			}
 		}
@@ -222,6 +228,19 @@ func errorToDetail(err error) *output.ErrorDetail {
 		}
 	}
 
+	// apply.HookRejectedError — pre-apply hook rejected the resource
+	var hookErr *apply.HookRejectedError
+	if errors.As(err, &hookErr) {
+		return &output.ErrorDetail{
+			Code:    "hook_rejected",
+			Message: "pre-apply hook rejected the resource",
+			Suggestions: []string{
+				"check hook stderr output for details",
+				"use --no-hooks to skip pre-apply hooks",
+			},
+		}
+	}
+
 	// suggest.CommandError — unknown command with "did you mean?" suggestions
 	var cmdErr *suggest.CommandError
 	if errors.As(err, &cmdErr) {
@@ -298,6 +317,28 @@ func getURLHintsForError(err error) []string {
 	}
 
 	return diagnostic.URLSuggestions(ctx.Environment)
+}
+
+// getAuthHintsForError returns actionable hints when the error looks like an
+// OAuth token refresh failure (e.g., expired session, revoked refresh token).
+func getAuthHintsForError(err error) []string {
+	if !isTokenRefreshError(err) {
+		return nil
+	}
+	return []string{
+		"Run 'dtctl auth login' to re-authenticate",
+	}
+}
+
+// isTokenRefreshError returns true if the error looks like an OAuth token
+// refresh failure (expired session, invalid grant, etc.).
+func isTokenRefreshError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "failed to refresh token") ||
+		strings.Contains(msg, "token expired and refresh failed")
 }
 
 // isURLRelatedError returns true if the error could plausibly be caused by

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1112,10 +1112,8 @@ func TestGetAuthHintsForError(t *testing.T) {
 				if !found {
 					t.Errorf("expected hint to mention 'dtctl auth login', got %v", hints)
 				}
-			} else {
-				if len(hints) > 0 {
-					t.Errorf("expected no hints, got %v", hints)
-				}
+			} else if len(hints) > 0 {
+				t.Errorf("expected no hints, got %v", hints)
 			}
 		})
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/dynatrace-oss/dtctl/pkg/apply"
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
@@ -809,6 +811,47 @@ func TestErrorToDetail_DiagnosticPrecedesAPIError(t *testing.T) {
 	}
 }
 
+func TestErrorToDetail_HookRejectedError(t *testing.T) {
+	err := &apply.HookRejectedError{
+		Command:  "node validate.js",
+		ExitCode: 1,
+		Stderr:   "validation failed: missing required field 'owner'",
+	}
+
+	detail := errorToDetail(err)
+
+	if detail.Code != "hook_rejected" {
+		t.Errorf("Code = %q, want %q", detail.Code, "hook_rejected")
+	}
+	if detail.Message != "pre-apply hook rejected the resource" {
+		t.Errorf("Message = %q, want %q", detail.Message, "pre-apply hook rejected the resource")
+	}
+	if len(detail.Suggestions) != 2 {
+		t.Fatalf("Suggestions count = %d, want 2", len(detail.Suggestions))
+	}
+	if detail.Suggestions[0] != "check hook stderr output for details" {
+		t.Errorf("Suggestions[0] = %q, want %q", detail.Suggestions[0], "check hook stderr output for details")
+	}
+	if detail.Suggestions[1] != "use --no-hooks to skip pre-apply hooks" {
+		t.Errorf("Suggestions[1] = %q, want %q", detail.Suggestions[1], "use --no-hooks to skip pre-apply hooks")
+	}
+}
+
+func TestErrorToDetail_HookRejectedErrorWrapped(t *testing.T) {
+	inner := &apply.HookRejectedError{
+		Command:  "bash lint.sh",
+		ExitCode: 2,
+		Stderr:   "lint failed",
+	}
+	wrapped := fmt.Errorf("apply failed: %w", inner)
+
+	detail := errorToDetail(wrapped)
+
+	if detail.Code != "hook_rejected" {
+		t.Errorf("Code = %q, want %q (should unwrap HookRejectedError)", detail.Code, "hook_rejected")
+	}
+}
+
 // --- classifyGenericError tests ---
 
 func TestClassifyGenericError(t *testing.T) {
@@ -970,6 +1013,109 @@ func TestIsURLRelatedError(t *testing.T) {
 			got := isURLRelatedError(tt.err)
 			if got != tt.want {
 				t.Errorf("isURLRelatedError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTokenRefreshError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "generic error",
+			err:  errors.New("workflow not found"),
+			want: false,
+		},
+		{
+			name: "compact storage refresh failure",
+			err:  fmt.Errorf("failed to refresh token from compact storage: %w", fmt.Errorf("failed to refresh token: token refresh failed: 400 Bad Request - {\"error\":\"invalid_grant\"}")),
+			want: true,
+		},
+		{
+			name: "token expired and refresh failed",
+			err:  fmt.Errorf("token expired and refresh failed: %w", fmt.Errorf("failed to refresh token: some error")),
+			want: true,
+		},
+		{
+			name: "simple refresh failure",
+			err:  fmt.Errorf("failed to refresh token: some error"),
+			want: true,
+		},
+		{
+			name: "unrelated auth error",
+			err:  fmt.Errorf("unauthorized: invalid API token"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTokenRefreshError(tt.err)
+			if got != tt.want {
+				t.Errorf("isTokenRefreshError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAuthHintsForError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantHints bool
+	}{
+		{
+			name:      "nil error returns no hints",
+			err:       nil,
+			wantHints: false,
+		},
+		{
+			name:      "generic error returns no hints",
+			err:       errors.New("workflow not found"),
+			wantHints: false,
+		},
+		{
+			name:      "token refresh error returns login hint",
+			err:       fmt.Errorf("failed to refresh token from compact storage: failed to refresh token: token refresh failed: 400 Bad Request"),
+			wantHints: true,
+		},
+		{
+			name:      "expired token returns login hint",
+			err:       fmt.Errorf("token expired and refresh failed: some error"),
+			wantHints: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hints := getAuthHintsForError(tt.err)
+			if tt.wantHints {
+				if len(hints) == 0 {
+					t.Error("expected hints, got none")
+				}
+				// Verify the hint mentions the login command
+				found := false
+				for _, h := range hints {
+					if strings.Contains(h, "dtctl auth login") {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected hint to mention 'dtctl auth login', got %v", hints)
+				}
+			} else {
+				if len(hints) > 0 {
+					t.Errorf("expected no hints, got %v", hints)
+				}
 			}
 		})
 	}

--- a/docs/dev/PRE_APPLY_HOOK_DESIGN.md
+++ b/docs/dev/PRE_APPLY_HOOK_DESIGN.md
@@ -1,0 +1,847 @@
+# Pre-Apply Hook Design
+
+**Status:** Design Proposal
+**Created:** 2026-04-02
+**Author:** dtctl team
+
+## Overview
+
+Pre-apply hooks let users run an external command to validate (or reject) a
+resource before `dtctl apply` sends it to the Dynatrace API. The hook receives
+the **processed JSON on stdin** (after YAML-to-JSON conversion and template
+rendering) and the **resource type and source filename as positional parameters
+($1 and $2)**. The source filename is informational only — hooks must always
+read content from stdin, not from the file. A non-zero exit code aborts the
+apply.
+
+This enables validation workflows that dtctl itself does not need to know about:
+JSON Schema checks, OPA/Rego policies, team naming conventions, custom linters
+written in any language. It also provides a clean integration point for a future
+server-side `dtctl verify` command -- the hook mechanism remains the same, only
+the hook command changes.
+
+## Goals
+
+1. **External validation** -- Run any command to validate resource content before apply
+2. **Language-agnostic** -- Works with node, python, bash, jq, OPA, or any stdin-reading tool
+3. **Processed content** -- Hook sees the final JSON that would be sent to the API, not raw YAML
+4. **Clear contract** -- Exit code, stdin, args, stderr -- nothing ambiguous
+5. **Escapable** -- `--no-hooks` flag to bypass when needed
+
+## Non-Goals
+
+- Post-apply hooks (wrapping dtctl in a script covers this)
+- Content mutation (hooks validate, they don't transform)
+- Multiple hooks or hook chains (single command; users chain with `&&` or a dispatcher)
+- Built-in validators (the whole point is to keep validation external)
+- Hook discovery or marketplace
+
+---
+
+## User Experience
+
+### Configuration
+
+Hooks are configured in the preferences section (global) or per-context (scoped):
+
+```yaml
+# Global hook -- applies to all contexts
+preferences:
+  hooks:
+    pre-apply: 'node ./scripts/validate.js "$1" "$2"'
+
+# Per-context hook -- overrides global for this context
+contexts:
+  - name: production
+    context:
+      environment: https://xyz.apps.dynatrace.com
+      token-ref: prod-token
+      safety-level: readwrite-mine
+      hooks:
+        pre-apply: 'python3 ./policy/strict-check.py "$1" "$2"'
+```
+
+Per-context hooks take precedence over global hooks. This allows stricter
+validation for production while keeping development lightweight.
+
+### Basic Usage
+
+```bash
+# Normal apply -- hook runs automatically
+dtctl apply -f dashboard.yaml
+# Hook runs via: sh -c '<command>' -- dashboard dashboard.yaml
+# $1 = resource type, $2 = filename (available as positional params), stdin = processed JSON
+# Hook exits 0 → apply proceeds
+# Hook exits non-zero → apply aborted, stderr shown to user
+
+# Skip hook
+dtctl apply -f dashboard.yaml --no-hooks
+
+# Dry-run -- hook still runs (validation is useful even in dry-run)
+dtctl apply -f dashboard.yaml --dry-run
+```
+
+### Writing a Hook
+
+A hook is any executable that:
+1. Reads JSON from stdin (the processed resource content — **not** from the file)
+2. Receives resource type (`$1`) and source filename (`$2`) as positional arguments
+3. Exits 0 to allow, non-zero to reject
+4. Writes validation errors to stderr
+
+> **Important:** The resource content is always delivered via **stdin** as processed
+> JSON (after YAML→JSON conversion and template rendering). The source filename
+> (`$2`) is the original path passed to `dtctl apply -f` — it is provided for
+> context and logging only. Do **not** read from `$2`; the file may contain raw
+> YAML or unresolved templates that differ from the processed JSON on stdin.
+
+**Minimal example (bash + jq):**
+
+```bash
+#!/bin/bash
+# validate.sh -- require dashboards to have a title
+resource_type="$1"
+source_file="$2"  # informational only — read content from stdin, not this file
+
+if [ "$resource_type" = "dashboard" ]; then
+  title=$(cat | jq -r '.title // empty')
+  if [ -z "$title" ]; then
+    echo "Error: dashboard must have a title" >&2
+    exit 1
+  fi
+fi
+```
+
+**Node.js example:**
+
+```js
+#!/usr/bin/env node
+// validate.js
+const fs = require('fs');
+const [resourceType, sourceFile] = process.argv.slice(2);
+// Read processed JSON from stdin — do NOT read sourceFile directly
+const input = JSON.parse(fs.readFileSync('/dev/stdin', 'utf8'));
+
+const errors = [];
+
+if (resourceType === 'workflow') {
+  if (!input.title) errors.push('workflow must have a title');
+  if (!input.tasks || input.tasks.length === 0) errors.push('workflow must have at least one task');
+}
+
+if (resourceType === 'dashboard') {
+  if (!input.title) errors.push('dashboard must have a title');
+}
+
+if (errors.length > 0) {
+  errors.forEach(e => console.error(`Error: ${e}`));
+  process.exit(1);
+}
+```
+
+**OPA/Rego example:**
+
+```bash
+#!/bin/bash
+# opa-validate.sh -- validate using OPA policy
+resource_type="$1"
+cat | opa eval -I -d "./policies/${resource_type}.rego" 'data.policy.deny' --format raw | \
+  grep -q '[]' || { echo "Policy violation" >&2; exit 1; }
+```
+
+### Output on Failure
+
+When a hook rejects a resource, dtctl shows the hook's stderr output:
+
+```
+$ dtctl apply -f bad-dashboard.yaml
+Error: pre-apply hook rejected the resource
+
+Hook stderr:
+  Error: dashboard must have a title
+  Error: dashboard must have at least one tile
+
+Hook command: node ./scripts/validate.js "$1" "$2"
+Exit code: 1
+```
+
+In agent mode (`--agent`), the error is structured:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "hook_rejected",
+    "message": "pre-apply hook rejected the resource",
+    "details": {
+      "hook": "node ./scripts/validate.js \"$1\" \"$2\"",
+      "exit_code": 1,
+      "stderr": "Error: dashboard must have a title\nError: dashboard must have at least one tile"
+    }
+  }
+}
+```
+
+### Error Cases
+
+```bash
+# Hook command not found
+$ dtctl apply -f dashboard.yaml
+Error: pre-apply hook failed to execute: exec: "validate.sh": executable file not found in $PATH
+
+# Hook times out (default: 30s)
+$ dtctl apply -f dashboard.yaml
+Error: pre-apply hook timed out after 30s
+
+# Hook crashes (segfault, etc.)
+$ dtctl apply -f dashboard.yaml
+Error: pre-apply hook failed: signal: segmentation fault
+```
+
+---
+
+## Technical Design
+
+### Config Changes
+
+Add a `Hooks` struct to both `Preferences` (global) and `Context` (per-context):
+
+```go
+// pkg/config/config.go
+
+type Hooks struct {
+    PreApply string `yaml:"pre-apply,omitempty"`
+}
+
+type Preferences struct {
+    Output string `yaml:"output,omitempty"`
+    Editor string `yaml:"editor,omitempty"`
+    Hooks  Hooks  `yaml:"hooks,omitempty"`
+}
+
+type Context struct {
+    Environment string      `yaml:"environment"             table:"ENVIRONMENT"`
+    TokenRef    string      `yaml:"token-ref"               table:"TOKEN-REF"`
+    SafetyLevel SafetyLevel `yaml:"safety-level,omitempty"  table:"SAFETY-LEVEL"`
+    Description string      `yaml:"description,omitempty"   table:"DESCRIPTION,wide"`
+    Hooks       Hooks       `yaml:"hooks,omitempty"`
+}
+```
+
+### Hook Resolution
+
+Per-context hooks take precedence over global hooks:
+
+```go
+// pkg/config/config.go
+
+func (c *Config) GetPreApplyHook() string {
+    // Per-context hook wins
+    if ctx, err := c.CurrentContextObj(); err == nil {
+        if ctx.Context.Hooks.PreApply != "" {
+            return ctx.Context.Hooks.PreApply
+        }
+    }
+    // Fall back to global
+    return c.Preferences.Hooks.PreApply
+}
+```
+
+### Hook Executor
+
+A standalone package that knows nothing about dtctl internals -- it just runs
+a command with stdin/args and returns the result:
+
+```go
+// pkg/hook/hook.go
+package hook
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "os/exec"
+    "time"
+)
+
+const DefaultTimeout = 30 * time.Second
+
+// Result holds the outcome of a hook execution
+type Result struct {
+    ExitCode int
+    Stderr   string
+}
+
+// RunPreApply executes the pre-apply hook command.
+// The command is run via "sh -c" with resource type and source file as
+// positional parameters. Processed JSON is piped to stdin.
+// sourceFile is the original filename (informational only — the hook must
+// read content from stdin, not from this path).
+func RunPreApply(ctx context.Context, command string, resourceType string, sourceFile string, jsonData []byte) (*Result, error) {
+    if command == "" {
+        return &Result{ExitCode: 0}, nil
+    }
+
+    ctx, cancel := context.WithTimeout(ctx, DefaultTimeout)
+    defer cancel()
+
+    // Pass resource type and source file as positional parameters.
+    // Inside the hook: $1 = resource type, $2 = source file (available but not
+    // appended to the command — the hook references them explicitly if needed).
+    // Note: $2 is the original filename for context/logging only. The actual
+    // resource content is always on stdin (processed JSON).
+    cmd := exec.CommandContext(ctx, "sh", "-c", command, "--", resourceType, sourceFile)
+    cmd.Stdin = bytes.NewReader(jsonData)
+
+    var stderr bytes.Buffer
+    cmd.Stderr = &stderr
+
+    err := cmd.Run()
+    if err != nil {
+        if ctx.Err() == context.DeadlineExceeded {
+            return nil, fmt.Errorf("pre-apply hook timed out after %s", DefaultTimeout)
+        }
+        if exitErr, ok := err.(*exec.ExitError); ok {
+            return &Result{
+                ExitCode: exitErr.ExitCode(),
+                Stderr:   stderr.String(),
+            }, nil
+        }
+        return nil, fmt.Errorf("pre-apply hook failed to execute: %w", err)
+    }
+
+    return &Result{ExitCode: 0, Stderr: stderr.String()}, nil
+}
+```
+
+### Integration into the Apply Flow
+
+The hook runs inside `Applier.Apply()`, after template rendering and resource
+type detection, before dry-run branching or API dispatch. This is the point
+where the processed JSON and resource type are both available.
+
+```go
+// pkg/apply/applier.go
+
+type Applier struct {
+    client        *client.Client
+    baseURL       string
+    safetyChecker *safety.Checker
+    currentUserID string
+    preApplyHook  string   // hook command (empty = no hook)
+    sourceFile    string   // original filename for hook context
+}
+
+// WithPreApplyHook sets the pre-apply hook command
+func (a *Applier) WithPreApplyHook(command string) *Applier {
+    a.preApplyHook = command
+    return a
+}
+
+// WithSourceFile sets the original filename (passed to hook as context)
+func (a *Applier) WithSourceFile(filename string) *Applier {
+    a.sourceFile = filename
+    return a
+}
+
+func (a *Applier) Apply(fileData []byte, opts ApplyOptions) ([]ApplyResult, error) {
+    // ... existing: ValidateAndConvert, RenderTemplate ...
+
+    resourceType, err := detectResourceType(jsonData)
+    if err != nil {
+        return nil, err
+    }
+
+    // --- Pre-apply hook ---
+    if !opts.NoHooks && a.preApplyHook != "" {
+        result, err := hook.RunPreApply(
+            context.Background(),
+            a.preApplyHook,
+            string(resourceType),
+            a.sourceFile,
+            jsonData,
+        )
+        if err != nil {
+            return nil, err
+        }
+        if result.ExitCode != 0 {
+            return nil, &HookRejectedError{
+                Command:  a.preApplyHook,
+                ExitCode: result.ExitCode,
+                Stderr:   result.Stderr,
+            }
+        }
+    }
+
+    // ... existing: dry-run, dispatch ...
+}
+```
+
+### HookRejectedError
+
+A typed error so the command layer can format it appropriately:
+
+```go
+// pkg/apply/errors.go
+
+type HookRejectedError struct {
+    Command  string
+    ExitCode int
+    Stderr   string
+}
+
+func (e *HookRejectedError) Error() string {
+    msg := "pre-apply hook rejected the resource"
+    if e.Stderr != "" {
+        msg += "\n\nHook stderr:\n"
+        // Indent each line of stderr
+        for _, line := range strings.Split(strings.TrimSpace(e.Stderr), "\n") {
+            msg += "  " + line + "\n"
+        }
+    }
+    msg += fmt.Sprintf("\nHook command: %s\nExit code: %d", e.Command, e.ExitCode)
+    return msg
+}
+```
+
+### Command Layer Changes
+
+```go
+// cmd/apply.go
+
+func init() {
+    // ... existing flags ...
+    applyCmd.Flags().Bool("no-hooks", false, "skip pre-apply hooks")
+}
+
+// In RunE:
+noHooks, _ := cmd.Flags().GetBool("no-hooks")
+
+applier := apply.NewApplier(c)
+
+// Configure hook
+if !noHooks {
+    if hookCmd := cfg.GetPreApplyHook(); hookCmd != "" {
+        applier = applier.WithPreApplyHook(hookCmd).WithSourceFile(file)
+    }
+}
+```
+
+### ApplyOptions Change
+
+```go
+type ApplyOptions struct {
+    TemplateVars map[string]interface{}
+    DryRun       bool
+    Force        bool
+    ShowDiff     bool
+    NoHooks      bool  // skip pre-apply hooks
+}
+```
+
+---
+
+## Execution Contract
+
+| Aspect | Behavior |
+|--------|----------|
+| **Invocation** | `sh -c '<command>' -- <resource-type> <source-file>` |
+| **$1** | Resource type (e.g., `dashboard`, `workflow`) |
+| **$2** | Source filename from `dtctl apply -f` (informational; do NOT read this file) |
+| **Stdin** | Processed JSON (after YAML→JSON + template rendering) — **always read content from stdin** |
+| **Stdout** | Ignored (hook can print debug info without affecting dtctl) |
+| **Stderr** | Shown to user on failure |
+| **Exit 0** | Proceed with apply |
+| **Exit non-zero** | Abort apply, show stderr |
+| **Timeout** | 30 seconds (hardcoded, reasonable for any validation) |
+| **Working directory** | Inherited from dtctl process |
+| **Environment** | Inherited from dtctl process |
+| **`--no-hooks`** | Skips hook entirely |
+| **`--dry-run`** | Hook still runs (validation is useful even in preview) |
+| **`--agent` mode** | Structured error with `code: "hook_rejected"` |
+
+---
+
+## Config Precedence
+
+```
+per-context hooks.pre-apply  →  preferences.hooks.pre-apply  →  (no hook)
+```
+
+This allows:
+- A global default hook for all environments
+- A stricter hook for production contexts
+- An empty per-context hook to disable the global hook for a specific context
+
+To explicitly disable the global hook for a context, set it to an empty string
+or the special value `"none"`:
+
+```yaml
+contexts:
+  - name: development
+    context:
+      environment: https://dev.dynatrace.com
+      token-ref: dev-token
+      hooks:
+        pre-apply: "none"  # disables global hook for this context
+```
+
+---
+
+## Use Cases
+
+### 1. Team Naming Conventions
+
+```bash
+#!/bin/bash
+# check-naming.sh -- enforce team naming conventions
+resource_type="$1"
+input=$(cat)
+
+name=$(echo "$input" | jq -r '.title // .name // empty')
+if [ -n "$name" ] && ! echo "$name" | grep -qE '^\[team-'; then
+  echo "Error: $resource_type name must start with [team-*] prefix, got: $name" >&2
+  exit 1
+fi
+```
+
+### 2. JSON Schema Validation
+
+```bash
+#!/bin/bash
+# schema-validate.sh -- validate against JSON Schema
+resource_type="$1"
+schema="./schemas/${resource_type}.json"
+
+if [ -f "$schema" ]; then
+  cat | ajv validate -s "$schema" --errors=text 2>&1 || exit 1
+fi
+# No schema for this type -- allow
+```
+
+### 3. OPA Policy Check
+
+```bash
+#!/bin/bash
+# opa-check.sh
+resource_type="$1"
+input=$(cat)
+
+result=$(echo "$input" | opa eval -I -d ./policies/ \
+  "data.dtctl.${resource_type}.deny" --format json)
+
+violations=$(echo "$result" | jq -r '.result[0].expressions[0].value[]')
+if [ -n "$violations" ]; then
+  echo "Policy violations:" >&2
+  echo "$violations" | while read -r v; do echo "  - $v" >&2; done
+  exit 1
+fi
+```
+
+### 4. CI/CD Pipeline Validation
+
+```yaml
+# .dtctl.yaml (project-local config)
+apiVersion: v1
+kind: Config
+current-context: ci
+contexts:
+  - name: ci
+    context:
+      environment: https://ci.dynatrace.com
+      token-ref: ci-token
+      hooks:
+        pre-apply: "./ci/validate.sh"
+```
+
+### 5. Production Guardrails
+
+```yaml
+contexts:
+  - name: production
+    context:
+      environment: https://prod.apps.dynatrace.com
+      token-ref: prod-token
+      safety-level: readwrite-mine
+      hooks:
+        pre-apply: "python3 ./policy/prod-guardrails.py"
+  - name: staging
+    context:
+      environment: https://staging.apps.dynatrace.com
+      token-ref: staging-token
+      # No hook -- anything goes in staging
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+```go
+// pkg/hook/hook_test.go
+
+func TestRunPreApply_Success(t *testing.T) {
+    // Hook that exits 0
+    result, err := hook.RunPreApply(ctx, "cat > /dev/null", "dashboard", "test.yaml", []byte(`{"title":"test"}`))
+    require.NoError(t, err)
+    require.Equal(t, 0, result.ExitCode)
+}
+
+func TestRunPreApply_Rejected(t *testing.T) {
+    // Hook that exits 1 with stderr
+    result, err := hook.RunPreApply(ctx, "echo 'bad' >&2 && exit 1", "dashboard", "test.yaml", []byte(`{}`))
+    require.NoError(t, err) // err is nil; rejection is in result
+    require.Equal(t, 1, result.ExitCode)
+    require.Contains(t, result.Stderr, "bad")
+}
+
+func TestRunPreApply_Timeout(t *testing.T) {
+    // Hook that hangs
+    _, err := hook.RunPreApply(ctxWithShortTimeout, "sleep 999", "dashboard", "test.yaml", []byte(`{}`))
+    require.ErrorContains(t, err, "timed out")
+}
+
+func TestRunPreApply_NotFound(t *testing.T) {
+    // Command doesn't exist
+    _, err := hook.RunPreApply(ctx, "nonexistent-binary", "dashboard", "test.yaml", []byte(`{}`))
+    require.ErrorContains(t, err, "failed to execute")
+}
+
+func TestRunPreApply_EmptyCommand(t *testing.T) {
+    // No hook configured -- always succeeds
+    result, err := hook.RunPreApply(ctx, "", "dashboard", "test.yaml", []byte(`{}`))
+    require.NoError(t, err)
+    require.Equal(t, 0, result.ExitCode)
+}
+
+func TestRunPreApply_ReceivesJSON(t *testing.T) {
+    // Verify the hook receives the JSON on stdin
+    result, err := hook.RunPreApply(ctx,
+        `python3 -c "import sys,json; d=json.load(sys.stdin); assert d['title']=='test'"`,
+        "dashboard", "test.yaml", []byte(`{"title":"test"}`))
+    require.NoError(t, err)
+    require.Equal(t, 0, result.ExitCode)
+}
+
+func TestRunPreApply_ReceivesArgs(t *testing.T) {
+    // Verify the hook receives resource type and filename as args
+    result, err := hook.RunPreApply(ctx,
+        `test "$1" = "workflow" && test "$2" = "my-wf.yaml"`,
+        "workflow", "my-wf.yaml", []byte(`{}`))
+    require.NoError(t, err)
+    require.Equal(t, 0, result.ExitCode)
+}
+```
+
+### Integration Tests
+
+```go
+// pkg/apply/applier_hook_test.go
+
+func TestApply_HookRejects(t *testing.T) {
+    applier := apply.NewApplier(mockClient).
+        WithPreApplyHook("exit 1").
+        WithSourceFile("test.yaml")
+
+    _, err := applier.Apply(validWorkflowJSON, apply.ApplyOptions{})
+    require.Error(t, err)
+
+    var hookErr *apply.HookRejectedError
+    require.ErrorAs(t, err, &hookErr)
+    require.Equal(t, 1, hookErr.ExitCode)
+}
+
+func TestApply_HookAllows(t *testing.T) {
+    applier := apply.NewApplier(mockClient).
+        WithPreApplyHook("cat > /dev/null").
+        WithSourceFile("test.yaml")
+
+    results, err := applier.Apply(validWorkflowJSON, apply.ApplyOptions{})
+    require.NoError(t, err)
+    require.Len(t, results, 1)
+}
+
+func TestApply_NoHooksFlag(t *testing.T) {
+    applier := apply.NewApplier(mockClient).
+        WithPreApplyHook("exit 1").  // would reject
+        WithSourceFile("test.yaml")
+
+    results, err := applier.Apply(validWorkflowJSON, apply.ApplyOptions{NoHooks: true})
+    require.NoError(t, err) // hook was skipped
+    require.Len(t, results, 1)
+}
+
+func TestApply_HookRunsOnDryRun(t *testing.T) {
+    hookRan := false
+    // Use a hook that creates a marker file to verify it ran
+    applier := apply.NewApplier(mockClient).
+        WithPreApplyHook("exit 1").
+        WithSourceFile("test.yaml")
+
+    _, err := applier.Apply(validWorkflowJSON, apply.ApplyOptions{DryRun: true})
+    require.Error(t, err) // hook still runs and rejects
+}
+```
+
+### Config Tests
+
+```go
+// pkg/config/config_test.go
+
+func TestGetPreApplyHook_ContextOverridesGlobal(t *testing.T) {
+    cfg := &Config{
+        Preferences: Preferences{
+            Hooks: Hooks{PreApply: "global-hook"},
+        },
+        CurrentContext: "prod",
+        Contexts: []NamedContext{{
+            Name: "prod",
+            Context: Context{
+                Hooks: Hooks{PreApply: "prod-hook"},
+            },
+        }},
+    }
+    require.Equal(t, "prod-hook", cfg.GetPreApplyHook())
+}
+
+func TestGetPreApplyHook_FallsBackToGlobal(t *testing.T) {
+    cfg := &Config{
+        Preferences: Preferences{
+            Hooks: Hooks{PreApply: "global-hook"},
+        },
+        CurrentContext: "dev",
+        Contexts: []NamedContext{{
+            Name: "dev",
+            Context: Context{}, // no hook
+        }},
+    }
+    require.Equal(t, "global-hook", cfg.GetPreApplyHook())
+}
+
+func TestGetPreApplyHook_NoneDisablesGlobal(t *testing.T) {
+    cfg := &Config{
+        Preferences: Preferences{
+            Hooks: Hooks{PreApply: "global-hook"},
+        },
+        CurrentContext: "dev",
+        Contexts: []NamedContext{{
+            Name: "dev",
+            Context: Context{
+                Hooks: Hooks{PreApply: "none"},
+            },
+        }},
+    }
+    // "none" is treated as no hook
+    require.Equal(t, "", cfg.GetPreApplyHook())
+}
+```
+
+---
+
+## Alternatives Considered
+
+### 1. Shell aliases wrapping dtctl apply
+
+Users can already define `!` aliases like `validate-apply: "!./validate.sh $1 && dtctl apply -f $1"`.
+
+**Pros:** Zero implementation work.
+**Cons:** Loses all apply flags (`--set`, `--dry-run`, `--show-diff`), no
+resource-type awareness, fragile quoting, users have to know about it.
+**Decision:** Not sufficient. Hooks need to intercept the *processed* content
+inside the apply flow, which aliases can't do.
+
+### 2. Plugin system with Go interfaces
+
+A formal plugin mechanism where validators implement a Go interface and are
+loaded dynamically.
+
+**Pros:** Type-safe, fast.
+**Cons:** Massive complexity, Go-only, version coupling, CGo plugin limitations,
+cross-compilation pain.
+**Decision:** Way too complex. A stdin/stdout contract works with any language.
+
+### 3. Pipe-based mutation (hook transforms content)
+
+Hook receives JSON on stdin, returns modified JSON on stdout. dtctl uses the
+output instead of the input.
+
+**Pros:** More powerful -- hooks can normalize, inject defaults, strip fields.
+**Cons:** Mutation is hard to reason about ("why did my dashboard get extra
+fields?"), debugging is painful, breaks the mental model of "file = what gets
+applied".
+**Decision:** Validate-only. If users want transformation, they can build a
+pipeline *before* dtctl: `transform.sh < raw.yaml | dtctl apply -f -` (once
+stdin support is added).
+
+### 4. Multiple hook commands (chain)
+
+Support a list of hooks that run in sequence.
+
+**Pros:** Composable -- schema check + policy check + naming check.
+**Cons:** Adds complexity for ordering, partial failure semantics, timeout
+allocation. A single dispatcher script achieves the same thing.
+**Decision:** Single command. Users compose with `&&` or write a dispatcher:
+
+```yaml
+hooks:
+  pre-apply: "./hooks/run-all.sh"
+```
+
+```bash
+#!/bin/bash
+# hooks/run-all.sh -- dispatcher
+input=$(cat)
+echo "$input" | ./hooks/schema.sh "$@" && \
+echo "$input" | ./hooks/policy.sh "$@" && \
+echo "$input" | ./hooks/naming.sh "$@"
+```
+
+### 5. Post-apply hooks
+
+Run a command after successful apply (for notifications, audit logging, etc.).
+
+**Pros:** Complete lifecycle coverage.
+**Cons:** Everything a post-apply hook does can be done by wrapping dtctl in a
+script: `dtctl apply -f foo.yaml && notify.sh`. Pre-apply hooks are different --
+they need to intercept the *processed* content inside the apply flow, which
+can't be done externally.
+**Decision:** Defer. Can be added later without breaking changes if needed.
+
+---
+
+## Implementation Checklist
+
+1. Add `Hooks` struct to `pkg/config/config.go` (in `Preferences` and `Context`)
+2. Add `GetPreApplyHook()` method to `Config` with context-over-global precedence
+3. Create `pkg/hook/hook.go` with `RunPreApply()`
+4. Create `pkg/hook/hook_test.go`
+5. Add `HookRejectedError` to `pkg/apply/`
+6. Add `preApplyHook`/`sourceFile` fields and builder methods to `Applier`
+7. Wire hook execution into `Applier.Apply()` after type detection
+8. Add `NoHooks` to `ApplyOptions`
+9. Add `--no-hooks` flag to `cmd/apply.go`
+10. Wire config → applier in `cmd/apply.go` RunE
+11. Handle `HookRejectedError` in agent mode output
+12. Add tests for config, hook executor, and applier integration
+13. Update `docs/dev/IMPLEMENTATION_STATUS.md`
+
+---
+
+## Future Enhancements
+
+These are explicitly out of scope for the initial implementation:
+
+- **Configurable timeout** -- `hooks.pre-apply-timeout: 60s` in config
+- **Hook for other commands** -- `pre-create`, `pre-delete`, `pre-edit` (same pattern, add when needed)
+- **Server-side validation** -- `dtctl verify <resource> -f` that calls a Dynatrace API; completely orthogonal to hooks
+- **Stdin apply support** -- `cat dashboard.yaml | dtctl apply -f -` would need special handling for the filename arg (pass `-` or `<stdin>`)
+- **Hook metrics** -- Track hook execution time, pass/fail rate for debugging slow pipelines
+
+---
+
+## References
+
+- git hooks: https://git-scm.com/docs/githooks
+- kubectl admission webhooks (inspiration for the "validate but don't mutate" pattern): https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
+- OPA (Open Policy Agent): https://www.openpolicyagent.org/

--- a/docs/site/_docs/configuration.md
+++ b/docs/site/_docs/configuration.md
@@ -148,6 +148,76 @@ dtctl config describe-context prod
 
 Safety levels are client-side only. For actual security, configure your API tokens with minimum required scopes.
 
+## Pre-Apply Hooks
+
+Pre-apply hooks run an external command to validate resources before `dtctl apply` sends them to the API. The hook receives the **processed JSON on stdin** (after YAML-to-JSON conversion and template rendering) and the **resource type** (`$1`) and **source filename** (`$2`) as positional parameters. A non-zero exit code aborts the apply.
+
+### Configuration
+
+Hooks are configured globally in `preferences` or per-context:
+
+```yaml
+# ~/.config/dtctl/config
+preferences:
+  hooks:
+    pre-apply: "node validate.js"
+
+contexts:
+  - name: production
+    context:
+      environment: https://abc12345.apps.dynatrace.com
+      token-ref: prod-token
+      hooks:
+        pre-apply: "opa eval --bundle /policies -i /dev/stdin"
+  - name: dev
+    context:
+      environment: https://dev.apps.dynatrace.com
+      token-ref: dev-token
+      hooks:
+        pre-apply: "none"  # explicitly disable the global hook
+```
+
+Per-context hooks take precedence over global hooks. The special value `"none"` disables the global hook for a specific context.
+
+### Hook Contract
+
+| Aspect | Behavior |
+|--------|----------|
+| **Invocation** | `sh -c '<command>' -- <resource-type> <source-file>` |
+| **$1** | Resource type (e.g., `dashboard`, `workflow`, `slo`) |
+| **$2** | Source filename from `-f` (informational -- read content from stdin) |
+| **Stdin** | Processed JSON (after YAML-to-JSON + template rendering) |
+| **Exit 0** | Proceed with apply |
+| **Exit non-zero** | Abort apply, show stderr to user |
+| **Timeout** | 30 seconds |
+
+### Writing a Hook
+
+A hook is any command that reads JSON from stdin and exits 0 (allow) or non-zero (reject):
+
+```bash
+#!/bin/bash
+# validate.sh -- require dashboards to have a title
+resource_type="$1"
+
+if [ "$resource_type" = "dashboard" ]; then
+  title=$(cat | jq -r '.title // empty')
+  if [ -z "$title" ]; then
+    echo "Error: dashboard must have a title" >&2
+    exit 1
+  fi
+fi
+```
+
+### Usage
+
+```bash
+dtctl apply -f dashboard.yaml            # hook runs automatically
+dtctl apply -f dashboard.yaml --no-hooks # skip hook
+dtctl apply -f dashboard.yaml --dry-run  # hook still runs (validates before preview)
+dtctl apply -f dashboard.yaml -v         # verbose: logs hook command and duration
+```
+
 ## Command Aliases
 
 Create shortcuts for frequently used commands.

--- a/docs/site/_docs/quick-start.md
+++ b/docs/site/_docs/quick-start.md
@@ -83,4 +83,5 @@ dtctl exec copilot nl2dql "error logs from last hour"
 ## What's Next?
 
 - [Configuration]({{ '/docs/configuration/' | relative_url }}) -- multiple environments, safety levels, aliases
+- [Pre-apply hooks]({{ '/docs/configuration/#pre-apply-hooks' | relative_url }}) -- validate resources with external tools before applying
 - Individual resource guides for workflows, dashboards, DQL, SLOs, and more

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -60,6 +60,10 @@ title: Home
     <p>Browser-based SSO login with automatic token refresh, or classic API tokens. Credentials stored securely in your OS keyring.</p>
   </div>
   <div class="feature-card">
+    <h3>Pre-Apply Hooks</h3>
+    <p>Run external validators &mdash; OPA policies, JSON Schema checks, custom linters &mdash; before <code>apply</code> sends resources to the API. Configure globally or per-context. See <a href="{{ '/docs/configuration/#pre-apply-hooks' | relative_url }}">Configuration</a>.</p>
+  </div>
+  <div class="feature-card">
     <h3>Watch Mode</h3>
     <p>Real-time monitoring with <code>--watch</code> for all resources. See additions, modifications, and deletions highlighted as they happen.</p>
   </div>

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -2,12 +2,14 @@ package apply
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
+	"github.com/dynatrace-oss/dtctl/pkg/hook"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/anomalydetector"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/azureconnection"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/gcpconnection"
@@ -39,6 +41,8 @@ type Applier struct {
 	baseURL       string
 	safetyChecker *safety.Checker
 	currentUserID string
+	preApplyHook  string // hook command (empty = no hook)
+	sourceFile    string // original filename for hook context
 }
 
 // NewApplier creates a new applier
@@ -54,6 +58,21 @@ func NewApplier(c *client.Client) *Applier {
 // WithSafetyChecker sets the safety checker for the applier
 func (a *Applier) WithSafetyChecker(checker *safety.Checker) *Applier {
 	a.safetyChecker = checker
+	return a
+}
+
+// WithPreApplyHook sets the pre-apply hook command.
+// The command is run via sh -c with the resource type and source file as
+// positional parameters ($1 and $2), and the processed JSON on stdin.
+func (a *Applier) WithPreApplyHook(command string) *Applier {
+	a.preApplyHook = command
+	return a
+}
+
+// WithSourceFile sets the original filename (passed to hook as context).
+// This is the file path from "dtctl apply -f <file>" — informational only.
+func (a *Applier) WithSourceFile(filename string) *Applier {
+	a.sourceFile = filename
 	return a
 }
 
@@ -76,6 +95,7 @@ type ApplyOptions struct {
 	DryRun       bool
 	Force        bool
 	ShowDiff     bool
+	NoHooks      bool // skip pre-apply hooks
 }
 
 // ResourceType represents the type of resource
@@ -121,6 +141,27 @@ func (a *Applier) Apply(fileData []byte, opts ApplyOptions) ([]ApplyResult, erro
 	resourceType, err := detectResourceType(jsonData)
 	if err != nil {
 		return nil, err
+	}
+
+	// Run pre-apply hook (if configured and not skipped)
+	if !opts.NoHooks && a.preApplyHook != "" {
+		result, err := hook.RunPreApply(
+			context.Background(),
+			a.preApplyHook,
+			string(resourceType),
+			a.sourceFile,
+			jsonData,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if result.ExitCode != 0 {
+			return nil, &HookRejectedError{
+				Command:  a.preApplyHook,
+				ExitCode: result.ExitCode,
+				Stderr:   result.Stderr,
+			}
+		}
 	}
 
 	if opts.DryRun {

--- a/pkg/apply/apply_integration_test.go
+++ b/pkg/apply/apply_integration_test.go
@@ -836,3 +836,553 @@ func stringContains(s, substr string) bool {
 	}
 	return false
 }
+
+// --- Pre-apply hook tests ---
+
+func TestApply_HookRejects(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+
+	a := NewApplier(c).
+		WithPreApplyHook("echo 'validation failed' >&2; exit 1").
+		WithSourceFile("test.yaml")
+
+	// Use a valid workflow JSON so resource type detection succeeds
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	_, err := a.Apply([]byte(workflowJSON), ApplyOptions{})
+	if err == nil {
+		t.Fatal("Apply() should have returned error when hook rejects, got nil")
+	}
+
+	var hookErr *HookRejectedError
+	if !errorAs(err, &hookErr) {
+		t.Fatalf("expected HookRejectedError, got: %T: %v", err, err)
+	}
+	if hookErr.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1", hookErr.ExitCode)
+	}
+	if !stringContains(hookErr.Stderr, "validation failed") {
+		t.Errorf("Stderr = %q, want it to contain 'validation failed'", hookErr.Stderr)
+	}
+}
+
+func TestApply_HookAllows(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusCreated)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    "wf-001",
+					"title": "Test WF",
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		},
+	})
+	defer srv.Close()
+
+	a := NewApplier(c).
+		WithPreApplyHook("true").
+		WithSourceFile("test.yaml")
+
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	results, err := a.Apply([]byte(workflowJSON), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("len(results) = %d, want 1", len(results))
+	}
+}
+
+func TestApply_NoHooksFlagSkipsHook(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusCreated)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    "wf-001",
+					"title": "Test WF",
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		},
+	})
+	defer srv.Close()
+
+	a := NewApplier(c).
+		WithPreApplyHook("exit 1"). // would reject
+		WithSourceFile("test.yaml")
+
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	results, err := a.Apply([]byte(workflowJSON), ApplyOptions{NoHooks: true})
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil (hook should be skipped)", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("len(results) = %d, want 1", len(results))
+	}
+}
+
+func TestApply_HookRunsOnDryRun(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+
+	a := NewApplier(c).
+		WithPreApplyHook("exit 1"). // rejects
+		WithSourceFile("test.yaml")
+
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	_, err := a.Apply([]byte(workflowJSON), ApplyOptions{DryRun: true})
+	if err == nil {
+		t.Fatal("Apply() should have returned error (hook rejects even in dry-run)")
+	}
+
+	var hookErr *HookRejectedError
+	if !errorAs(err, &hookErr) {
+		t.Fatalf("expected HookRejectedError, got: %T: %v", err, err)
+	}
+}
+
+func TestApply_NoHookConfigured(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusCreated)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    "wf-001",
+					"title": "Test WF",
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		},
+	})
+	defer srv.Close()
+
+	// No hook configured — apply should proceed normally
+	a := NewApplier(c)
+
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	results, err := a.Apply([]byte(workflowJSON), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("len(results) = %d, want 1", len(results))
+	}
+}
+
+func TestWithPreApplyHook_FluentAPI(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+
+	a := NewApplier(c)
+	returned := a.WithPreApplyHook("true")
+	if returned != a {
+		t.Error("WithPreApplyHook should return the same applier (fluent API)")
+	}
+	returned = a.WithSourceFile("test.yaml")
+	if returned != a {
+		t.Error("WithSourceFile should return the same applier (fluent API)")
+	}
+}
+
+func TestApply_HookReceivesCorrectResourceType(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusCreated)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    "wf-001",
+					"title": "Test WF",
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		},
+	})
+	defer srv.Close()
+
+	// Hook verifies $1 is "workflow"
+	a := NewApplier(c).
+		WithPreApplyHook(`test "$1" = "workflow"`).
+		WithSourceFile("my-wf.yaml")
+
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	results, err := a.Apply([]byte(workflowJSON), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil (hook should see $1=workflow)", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("len(results) = %d, want 1", len(results))
+	}
+}
+
+func TestApply_HookReceivesCorrectSourceFile(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusCreated)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    "wf-001",
+					"title": "Test WF",
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		},
+	})
+	defer srv.Close()
+
+	// Hook verifies $2 is the source file path
+	a := NewApplier(c).
+		WithPreApplyHook(`test "$2" = "configs/my workflow.yaml"`).
+		WithSourceFile("configs/my workflow.yaml")
+
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	results, err := a.Apply([]byte(workflowJSON), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil (hook should see $2=source file)", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("len(results) = %d, want 1", len(results))
+	}
+}
+
+func TestApply_HookReceivesProcessedJSON(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusCreated)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    "wf-001",
+					"title": "Rendered Title",
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		},
+	})
+	defer srv.Close()
+
+	// Hook verifies stdin contains the rendered (not raw) JSON
+	a := NewApplier(c).
+		WithPreApplyHook(`input=$(cat); echo "$input" | grep -q "Rendered Title"`).
+		WithSourceFile("template.yaml")
+
+	// Template input — after rendering, "{{.name}}" becomes "Rendered Title"
+	templateJSON := `{"title":"{{.name}}","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	results, err := a.Apply([]byte(templateJSON), ApplyOptions{
+		TemplateVars: map[string]interface{}{"name": "Rendered Title"},
+	})
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil (hook should see rendered JSON)", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("len(results) = %d, want 1", len(results))
+	}
+}
+
+func TestApply_HookRejectsWithMultiLineStderr(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+
+	a := NewApplier(c).
+		WithPreApplyHook(`echo "error line 1" >&2; echo "error line 2" >&2; exit 1`).
+		WithSourceFile("test.yaml")
+
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	_, err := a.Apply([]byte(workflowJSON), ApplyOptions{})
+	if err == nil {
+		t.Fatal("Apply() should have returned error")
+	}
+
+	var hookErr *HookRejectedError
+	if !errorAs(err, &hookErr) {
+		t.Fatalf("expected HookRejectedError, got: %T: %v", err, err)
+	}
+	if !stringContains(hookErr.Stderr, "error line 1") || !stringContains(hookErr.Stderr, "error line 2") {
+		t.Errorf("Stderr = %q, want both error lines", hookErr.Stderr)
+	}
+}
+
+func TestApply_HookDashboardResourceType(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+		"/platform/document/v1/documents": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				boundary := "resp-boundary"
+				w.Header().Set("Content-Type", fmt.Sprintf("multipart/form-data; boundary=%s", boundary))
+				fmt.Fprintf(w, "--%s\r\nContent-Disposition: form-data; name=\"metadata\"\r\nContent-Type: application/json\r\n\r\n{\"id\":\"dash-new\",\"name\":\"Test\",\"type\":\"dashboard\",\"version\":1}\r\n--%s--\r\n", boundary, boundary)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		},
+	})
+	defer srv.Close()
+
+	// Hook verifies $1 is "dashboard" for dashboard resources
+	a := NewApplier(c).
+		WithPreApplyHook(`test "$1" = "dashboard"`).
+		WithSourceFile("dash.yaml")
+
+	dashJSON := `{"type":"dashboard","tiles":{"items":[]}}`
+	results, err := a.Apply([]byte(dashJSON), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil (hook should see $1=dashboard)", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("len(results) = %d, want 1", len(results))
+	}
+}
+
+func TestApply_HookSLOResourceType(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+		"/platform/slo/v1/slos": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":   "slo-001",
+					"name": "Test SLO",
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		},
+	})
+	defer srv.Close()
+
+	// Hook verifies $1 is "slo"
+	a := NewApplier(c).
+		WithPreApplyHook(`test "$1" = "slo"`).
+		WithSourceFile("slo.yaml")
+
+	sloJSON := `{"name":"Test SLO","criteria":{"pass":[{"criteria":[{"metric":"<100","steps":600}]}]},"target":99.0,"timeframe":"now-7d","metricExpression":"100*..."}`
+	results, err := a.Apply([]byte(sloJSON), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil (hook should see $1=slo)", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("len(results) = %d, want 1", len(results))
+	}
+}
+
+func TestApply_EmptyPreApplyHookField(t *testing.T) {
+	// Empty string hook (different from nil/no hook) should be a no-op
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusCreated)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    "wf-001",
+					"title": "Test WF",
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		},
+	})
+	defer srv.Close()
+
+	// Explicitly set empty string hook
+	a := NewApplier(c).
+		WithPreApplyHook("").
+		WithSourceFile("test.yaml")
+
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	results, err := a.Apply([]byte(workflowJSON), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() error = %v, want nil (empty hook should be no-op)", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("len(results) = %d, want 1", len(results))
+	}
+}
+
+func TestApply_HookErrorIsPropagated(t *testing.T) {
+	// Test that non-exec errors (like command not found via sh -c)
+	// are properly propagated through Apply
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+
+	// Command not found manifests as exit code 127 via sh -c
+	a := NewApplier(c).
+		WithPreApplyHook("nonexistent-binary-xyz-123").
+		WithSourceFile("test.yaml")
+
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	_, err := a.Apply([]byte(workflowJSON), ApplyOptions{})
+	if err == nil {
+		t.Fatal("Apply() should have returned error for command-not-found hook")
+	}
+
+	var hookErr *HookRejectedError
+	if !errorAs(err, &hookErr) {
+		t.Fatalf("expected HookRejectedError, got: %T: %v", err, err)
+	}
+	if hookErr.ExitCode != 127 {
+		t.Errorf("ExitCode = %d, want 127 (command not found)", hookErr.ExitCode)
+	}
+}
+
+func TestApply_HookRunsBeforeAPICall(t *testing.T) {
+	// Verify hook runs BEFORE any API call is made.
+	// If hook rejects, no API call should happen.
+	apiCalled := false
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			apiCalled = true
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":    "wf-001",
+				"title": "Test WF",
+			})
+		},
+	})
+	defer srv.Close()
+
+	a := NewApplier(c).
+		WithPreApplyHook("exit 1").
+		WithSourceFile("test.yaml")
+
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	_, _ = a.Apply([]byte(workflowJSON), ApplyOptions{})
+
+	if apiCalled {
+		t.Error("API was called despite hook rejection — hook should run before API calls")
+	}
+}
+
+func TestApply_HookWithDryRunStillRejects(t *testing.T) {
+	// Verify that hook rejection in dry-run still prevents dry-run result
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+
+	a := NewApplier(c).
+		WithPreApplyHook("echo 'blocked by policy' >&2; exit 1").
+		WithSourceFile("test.yaml")
+
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	_, err := a.Apply([]byte(workflowJSON), ApplyOptions{DryRun: true})
+	if err == nil {
+		t.Fatal("Apply() should have returned error (hook rejects even in dry-run)")
+	}
+
+	var hookErr *HookRejectedError
+	if !errorAs(err, &hookErr) {
+		t.Fatalf("expected HookRejectedError, got: %T: %v", err, err)
+	}
+	if !stringContains(hookErr.Stderr, "blocked by policy") {
+		t.Errorf("Stderr = %q, want it to contain 'blocked by policy'", hookErr.Stderr)
+	}
+}
+
+func TestApply_HookStderrInErrorObject(t *testing.T) {
+	// Verify the HookRejectedError contains the correct command
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+
+	hookCommand := "my-validator --strict"
+	a := NewApplier(c).
+		WithPreApplyHook(hookCommand).
+		WithSourceFile("test.yaml")
+
+	// This will fail because "my-validator" doesn't exist (exit 127)
+	workflowJSON := `{"title":"Test WF","tasks":{"t1":{"action":"dynatrace.automations:run-javascript"}},"trigger":{}}`
+	_, err := a.Apply([]byte(workflowJSON), ApplyOptions{})
+	if err == nil {
+		t.Fatal("Apply() should have returned error")
+	}
+
+	var hookErr *HookRejectedError
+	if !errorAs(err, &hookErr) {
+		t.Fatalf("expected HookRejectedError, got: %T: %v", err, err)
+	}
+	if hookErr.Command != hookCommand {
+		t.Errorf("Command = %q, want %q", hookErr.Command, hookCommand)
+	}
+}
+
+// errorAs is a simple helper since the apply package tests use stdlib only.
+func errorAs(err error, target interface{}) bool {
+	hookErr, ok := target.(**HookRejectedError)
+	if !ok {
+		return false
+	}
+	for err != nil {
+		if e, ok := err.(*HookRejectedError); ok {
+			*hookErr = e
+			return true
+		}
+		// Check for wrapped errors
+		type unwrapper interface {
+			Unwrap() error
+		}
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/pkg/apply/errors.go
+++ b/pkg/apply/errors.go
@@ -1,0 +1,26 @@
+package apply
+
+import (
+	"fmt"
+	"strings"
+)
+
+// HookRejectedError is returned when a pre-apply hook exits with a non-zero
+// exit code, indicating the resource was rejected by the hook.
+type HookRejectedError struct {
+	Command  string
+	ExitCode int
+	Stderr   string
+}
+
+func (e *HookRejectedError) Error() string {
+	msg := "pre-apply hook rejected the resource"
+	if e.Stderr != "" {
+		msg += "\n\nHook stderr:\n"
+		for _, line := range strings.Split(strings.TrimSpace(e.Stderr), "\n") {
+			msg += "  " + line + "\n"
+		}
+	}
+	msg += fmt.Sprintf("\nHook command: %s\nExit code: %d", e.Command, e.ExitCode)
+	return msg
+}

--- a/pkg/apply/errors_test.go
+++ b/pkg/apply/errors_test.go
@@ -1,0 +1,143 @@
+package apply
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHookRejectedError_WithStderr(t *testing.T) {
+	err := &HookRejectedError{
+		Command:  "validate.sh",
+		ExitCode: 1,
+		Stderr:   "missing required field: title",
+	}
+
+	msg := err.Error()
+
+	if !strings.Contains(msg, "pre-apply hook rejected the resource") {
+		t.Errorf("Error() missing prefix, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Hook stderr:") {
+		t.Errorf("Error() missing 'Hook stderr:' section, got: %s", msg)
+	}
+	if !strings.Contains(msg, "  missing required field: title") {
+		t.Errorf("Error() missing indented stderr line, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Hook command: validate.sh") {
+		t.Errorf("Error() missing command, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Exit code: 1") {
+		t.Errorf("Error() missing exit code, got: %s", msg)
+	}
+}
+
+func TestHookRejectedError_WithoutStderr(t *testing.T) {
+	err := &HookRejectedError{
+		Command:  "check.sh",
+		ExitCode: 2,
+		Stderr:   "",
+	}
+
+	msg := err.Error()
+
+	if !strings.Contains(msg, "pre-apply hook rejected the resource") {
+		t.Errorf("Error() missing prefix, got: %s", msg)
+	}
+	if strings.Contains(msg, "Hook stderr:") {
+		t.Errorf("Error() should not contain 'Hook stderr:' when stderr is empty, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Hook command: check.sh") {
+		t.Errorf("Error() missing command, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Exit code: 2") {
+		t.Errorf("Error() missing exit code, got: %s", msg)
+	}
+}
+
+func TestHookRejectedError_MultiLineStderr(t *testing.T) {
+	err := &HookRejectedError{
+		Command:  "lint.sh",
+		ExitCode: 1,
+		Stderr:   "Error 1: missing title\nError 2: invalid scope\nError 3: owner not set",
+	}
+
+	msg := err.Error()
+
+	// Each line of stderr should be indented with 2 spaces
+	if !strings.Contains(msg, "  Error 1: missing title") {
+		t.Errorf("Error() missing indented line 1, got: %s", msg)
+	}
+	if !strings.Contains(msg, "  Error 2: invalid scope") {
+		t.Errorf("Error() missing indented line 2, got: %s", msg)
+	}
+	if !strings.Contains(msg, "  Error 3: owner not set") {
+		t.Errorf("Error() missing indented line 3, got: %s", msg)
+	}
+}
+
+func TestHookRejectedError_StderrWithTrailingNewline(t *testing.T) {
+	err := &HookRejectedError{
+		Command:  "hook.sh",
+		ExitCode: 1,
+		Stderr:   "error message\n\n",
+	}
+
+	msg := err.Error()
+
+	// TrimSpace should remove trailing newlines — no empty indented lines
+	lines := strings.Split(msg, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue // empty lines between sections are ok
+		}
+	}
+	// The error message should still contain the actual error
+	if !strings.Contains(msg, "  error message") {
+		t.Errorf("Error() missing stderr content, got: %s", msg)
+	}
+}
+
+func TestHookRejectedError_EmptyCommand(t *testing.T) {
+	err := &HookRejectedError{
+		Command:  "",
+		ExitCode: 1,
+		Stderr:   "failed",
+	}
+
+	msg := err.Error()
+
+	if !strings.Contains(msg, "Hook command: \n") {
+		t.Errorf("Error() should show empty command, got: %s", msg)
+	}
+}
+
+func TestHookRejectedError_ExitCode127(t *testing.T) {
+	// Exit code 127 = command not found
+	err := &HookRejectedError{
+		Command:  "nonexistent-command",
+		ExitCode: 127,
+		Stderr:   "sh: nonexistent-command: not found",
+	}
+
+	msg := err.Error()
+
+	if !strings.Contains(msg, "Exit code: 127") {
+		t.Errorf("Error() missing exit code 127, got: %s", msg)
+	}
+	if !strings.Contains(msg, "nonexistent-command: not found") {
+		t.Errorf("Error() missing command-not-found stderr, got: %s", msg)
+	}
+}
+
+func TestHookRejectedError_ImplementsError(t *testing.T) {
+	var err error = &HookRejectedError{
+		Command:  "test",
+		ExitCode: 1,
+	}
+
+	// Verify it implements the error interface
+	if err.Error() == "" {
+		t.Error("Error() returned empty string")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,12 +78,18 @@ func (s SafetyLevel) String() string {
 	return string(s)
 }
 
+// Hooks holds hook commands for lifecycle events
+type Hooks struct {
+	PreApply string `yaml:"pre-apply,omitempty"`
+}
+
 // Context holds the connection information for a Dynatrace environment
 type Context struct {
 	Environment string      `yaml:"environment" table:"ENVIRONMENT"`
 	TokenRef    string      `yaml:"token-ref" table:"TOKEN-REF"`
 	SafetyLevel SafetyLevel `yaml:"safety-level,omitempty" table:"SAFETY-LEVEL"`
 	Description string      `yaml:"description,omitempty" table:"DESCRIPTION,wide"`
+	Hooks       Hooks       `yaml:"hooks,omitempty"`
 }
 
 // NamedToken holds a token with its name
@@ -96,6 +102,7 @@ type NamedToken struct {
 type Preferences struct {
 	Output string `yaml:"output,omitempty"`
 	Editor string `yaml:"editor,omitempty"`
+	Hooks  Hooks  `yaml:"hooks,omitempty"`
 }
 
 // DefaultConfigPath returns the default config file path following XDG Base Directory spec
@@ -391,6 +398,23 @@ func (c *Context) GetEffectiveSafetyLevel() SafetyLevel {
 		return DefaultSafetyLevel
 	}
 	return c.SafetyLevel
+}
+
+// GetPreApplyHook returns the effective pre-apply hook command.
+// Per-context hooks take precedence over global (preferences) hooks.
+// The special value "none" explicitly disables the global hook for a context.
+func (c *Config) GetPreApplyHook() string {
+	// Per-context hook wins
+	if ctx, err := c.CurrentContextObj(); err == nil {
+		if ctx.Hooks.PreApply != "" {
+			if ctx.Hooks.PreApply == "none" {
+				return "" // explicitly disabled
+			}
+			return ctx.Hooks.PreApply
+		}
+	}
+	// Fall back to global
+	return c.Preferences.Hooks.PreApply
 }
 
 // DeleteContext removes a context by name.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1240,3 +1240,301 @@ tokens:
 		})
 	}
 }
+
+func TestGetPreApplyHook_ContextOverridesGlobal(t *testing.T) {
+	cfg := &Config{
+		Preferences: Preferences{
+			Hooks: Hooks{PreApply: "global-hook"},
+		},
+		CurrentContext: "prod",
+		Contexts: []NamedContext{{
+			Name: "prod",
+			Context: Context{
+				Environment: "https://prod.example.invalid",
+				TokenRef:    "prod-token",
+				Hooks:       Hooks{PreApply: "prod-hook"},
+			},
+		}},
+	}
+	got := cfg.GetPreApplyHook()
+	if got != "prod-hook" {
+		t.Errorf("GetPreApplyHook() = %q, want %q", got, "prod-hook")
+	}
+}
+
+func TestGetPreApplyHook_FallsBackToGlobal(t *testing.T) {
+	cfg := &Config{
+		Preferences: Preferences{
+			Hooks: Hooks{PreApply: "global-hook"},
+		},
+		CurrentContext: "dev",
+		Contexts: []NamedContext{{
+			Name: "dev",
+			Context: Context{
+				Environment: "https://dev.example.invalid",
+				TokenRef:    "dev-token",
+			},
+		}},
+	}
+	got := cfg.GetPreApplyHook()
+	if got != "global-hook" {
+		t.Errorf("GetPreApplyHook() = %q, want %q", got, "global-hook")
+	}
+}
+
+func TestGetPreApplyHook_NoneDisablesGlobal(t *testing.T) {
+	cfg := &Config{
+		Preferences: Preferences{
+			Hooks: Hooks{PreApply: "global-hook"},
+		},
+		CurrentContext: "dev",
+		Contexts: []NamedContext{{
+			Name: "dev",
+			Context: Context{
+				Environment: "https://dev.example.invalid",
+				TokenRef:    "dev-token",
+				Hooks:       Hooks{PreApply: "none"},
+			},
+		}},
+	}
+	got := cfg.GetPreApplyHook()
+	if got != "" {
+		t.Errorf("GetPreApplyHook() = %q, want empty (none should disable global hook)", got)
+	}
+}
+
+func TestGetPreApplyHook_NoHookConfigured(t *testing.T) {
+	cfg := &Config{
+		CurrentContext: "dev",
+		Contexts: []NamedContext{{
+			Name: "dev",
+			Context: Context{
+				Environment: "https://dev.example.invalid",
+				TokenRef:    "dev-token",
+			},
+		}},
+	}
+	got := cfg.GetPreApplyHook()
+	if got != "" {
+		t.Errorf("GetPreApplyHook() = %q, want empty", got)
+	}
+}
+
+func TestGetPreApplyHook_NoCurrentContext(t *testing.T) {
+	// When no current context is set, fall back to global
+	cfg := &Config{
+		Preferences: Preferences{
+			Hooks: Hooks{PreApply: "global-hook"},
+		},
+	}
+	got := cfg.GetPreApplyHook()
+	if got != "global-hook" {
+		t.Errorf("GetPreApplyHook() = %q, want %q", got, "global-hook")
+	}
+}
+
+func TestGetPreApplyHook_CurrentContextPointsToNonexistent(t *testing.T) {
+	// current-context points to a name that doesn't exist in contexts[]
+	// Should fall back to global hook
+	cfg := &Config{
+		Preferences: Preferences{
+			Hooks: Hooks{PreApply: "global-hook"},
+		},
+		CurrentContext: "nonexistent",
+		Contexts:       []NamedContext{}, // empty — "nonexistent" won't be found
+	}
+	got := cfg.GetPreApplyHook()
+	if got != "global-hook" {
+		t.Errorf("GetPreApplyHook() = %q, want %q (should fall back to global)", got, "global-hook")
+	}
+}
+
+func TestGetPreApplyHook_MultipleContextsOnlyOneHasHook(t *testing.T) {
+	cfg := &Config{
+		Preferences: Preferences{
+			Hooks: Hooks{PreApply: "global-hook"},
+		},
+		CurrentContext: "staging",
+		Contexts: []NamedContext{
+			{
+				Name: "dev",
+				Context: Context{
+					Environment: "https://dev.example.invalid",
+					TokenRef:    "dev-token",
+					Hooks:       Hooks{PreApply: "dev-hook"},
+				},
+			},
+			{
+				Name: "staging",
+				Context: Context{
+					Environment: "https://staging.example.invalid",
+					TokenRef:    "staging-token",
+					// No hook — should fall back to global
+				},
+			},
+			{
+				Name: "prod",
+				Context: Context{
+					Environment: "https://prod.example.invalid",
+					TokenRef:    "prod-token",
+					Hooks:       Hooks{PreApply: "prod-hook"},
+				},
+			},
+		},
+	}
+	got := cfg.GetPreApplyHook()
+	if got != "global-hook" {
+		t.Errorf("GetPreApplyHook() = %q, want %q (staging has no hook, should use global)", got, "global-hook")
+	}
+
+	// Switch to dev context — should use dev-hook
+	cfg.CurrentContext = "dev"
+	got = cfg.GetPreApplyHook()
+	if got != "dev-hook" {
+		t.Errorf("GetPreApplyHook() = %q, want %q (dev context has hook)", got, "dev-hook")
+	}
+
+	// Switch to prod context — should use prod-hook
+	cfg.CurrentContext = "prod"
+	got = cfg.GetPreApplyHook()
+	if got != "prod-hook" {
+		t.Errorf("GetPreApplyHook() = %q, want %q (prod context has hook)", got, "prod-hook")
+	}
+}
+
+func TestHooks_YAMLRoundTrip(t *testing.T) {
+	cfg := &Config{
+		APIVersion:     "v1",
+		Kind:           "Config",
+		CurrentContext: "test",
+		Preferences: Preferences{
+			Output: "table",
+			Editor: "vim",
+			Hooks:  Hooks{PreApply: "global-validate.sh"},
+		},
+		Contexts: []NamedContext{
+			{
+				Name: "test",
+				Context: Context{
+					Environment: "https://test.example.invalid",
+					TokenRef:    "test-token",
+					Hooks:       Hooks{PreApply: "context-validate.sh"},
+				},
+			},
+		},
+		Tokens: []NamedToken{
+			{Name: "test-token", Token: "secret"},
+		},
+	}
+
+	// Save to temp file
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config")
+	if err := cfg.SaveTo(configPath); err != nil {
+		t.Fatalf("SaveTo() error = %v", err)
+	}
+
+	// Load back
+	loaded, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom() error = %v", err)
+	}
+
+	// Verify global hook survived
+	if loaded.Preferences.Hooks.PreApply != "global-validate.sh" {
+		t.Errorf("Preferences.Hooks.PreApply = %q, want %q", loaded.Preferences.Hooks.PreApply, "global-validate.sh")
+	}
+
+	// Verify context hook survived
+	if len(loaded.Contexts) != 1 {
+		t.Fatalf("Contexts count = %d, want 1", len(loaded.Contexts))
+	}
+	if loaded.Contexts[0].Context.Hooks.PreApply != "context-validate.sh" {
+		t.Errorf("Context.Hooks.PreApply = %q, want %q", loaded.Contexts[0].Context.Hooks.PreApply, "context-validate.sh")
+	}
+
+	// Verify GetPreApplyHook returns context hook (precedence)
+	got := loaded.GetPreApplyHook()
+	if got != "context-validate.sh" {
+		t.Errorf("GetPreApplyHook() = %q, want %q", got, "context-validate.sh")
+	}
+}
+
+func TestHooks_YAMLRoundTrip_NoneValue(t *testing.T) {
+	cfg := &Config{
+		APIVersion:     "v1",
+		Kind:           "Config",
+		CurrentContext: "test",
+		Preferences: Preferences{
+			Output: "table",
+			Hooks:  Hooks{PreApply: "global-hook"},
+		},
+		Contexts: []NamedContext{
+			{
+				Name: "test",
+				Context: Context{
+					Environment: "https://test.example.invalid",
+					TokenRef:    "test-token",
+					Hooks:       Hooks{PreApply: "none"},
+				},
+			},
+		},
+		Tokens: []NamedToken{
+			{Name: "test-token", Token: "secret"},
+		},
+	}
+
+	// Save and reload
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config")
+	if err := cfg.SaveTo(configPath); err != nil {
+		t.Fatalf("SaveTo() error = %v", err)
+	}
+	loaded, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom() error = %v", err)
+	}
+
+	// "none" should survive round-trip and disable global hook
+	got := loaded.GetPreApplyHook()
+	if got != "" {
+		t.Errorf("GetPreApplyHook() = %q, want empty (none should disable global hook after round-trip)", got)
+	}
+}
+
+func TestHooks_YAMLRoundTrip_EmptyHooks(t *testing.T) {
+	// Config with no hooks at all should round-trip cleanly
+	cfg := &Config{
+		APIVersion:     "v1",
+		Kind:           "Config",
+		CurrentContext: "test",
+		Preferences:    Preferences{Output: "table"},
+		Contexts: []NamedContext{
+			{
+				Name: "test",
+				Context: Context{
+					Environment: "https://test.example.invalid",
+					TokenRef:    "test-token",
+				},
+			},
+		},
+		Tokens: []NamedToken{
+			{Name: "test-token", Token: "secret"},
+		},
+	}
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config")
+	if err := cfg.SaveTo(configPath); err != nil {
+		t.Fatalf("SaveTo() error = %v", err)
+	}
+	loaded, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom() error = %v", err)
+	}
+
+	got := loaded.GetPreApplyHook()
+	if got != "" {
+		t.Errorf("GetPreApplyHook() = %q, want empty (no hooks configured)", got)
+	}
+}

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 	"time"
 )
@@ -15,6 +16,7 @@ const DefaultTimeout = 30 * time.Second
 type Result struct {
 	ExitCode int
 	Stderr   string
+	Duration time.Duration
 }
 
 // RunPreApply executes the pre-apply hook command.
@@ -47,11 +49,14 @@ func RunPreApply(ctx context.Context, command string, resourceType string, sourc
 	// resource content is always on stdin (processed JSON).
 	cmd := exec.CommandContext(ctx, "sh", "-c", command, "--", resourceType, sourceFile)
 	cmd.Stdin = bytes.NewReader(jsonData)
+	cmd.Stdout = io.Discard
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
+	start := time.Now()
 	err := cmd.Run()
+	elapsed := time.Since(start)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return nil, fmt.Errorf("pre-apply hook timed out after %s", DefaultTimeout)
@@ -60,10 +65,11 @@ func RunPreApply(ctx context.Context, command string, resourceType string, sourc
 			return &Result{
 				ExitCode: exitErr.ExitCode(),
 				Stderr:   stderr.String(),
+				Duration: elapsed,
 			}, nil
 		}
 		return nil, fmt.Errorf("pre-apply hook failed to execute: %w", err)
 	}
 
-	return &Result{ExitCode: 0, Stderr: stderr.String()}, nil
+	return &Result{ExitCode: 0, Stderr: stderr.String(), Duration: elapsed}, nil
 }

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -1,0 +1,69 @@
+package hook
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// DefaultTimeout is the maximum time a hook is allowed to run.
+const DefaultTimeout = 30 * time.Second
+
+// Result holds the outcome of a hook execution.
+type Result struct {
+	ExitCode int
+	Stderr   string
+}
+
+// RunPreApply executes the pre-apply hook command.
+// The command is run via "sh -c" with resource type and source file as
+// positional parameters ($1 and $2). Processed JSON is piped to stdin.
+//
+// sourceFile is the original filename that was passed to "dtctl apply -f".
+// It is informational only — the hook MUST read the resource content from
+// stdin (which contains the processed JSON after YAML→JSON conversion and
+// template rendering), not from this file path.
+//
+// Returns a Result with ExitCode 0 on success. A non-zero ExitCode means the
+// hook rejected the resource (this is not an error). An error return indicates
+// the hook could not be executed at all (not found, timed out, etc.).
+//
+// If command is empty, the hook is a no-op and returns ExitCode 0.
+func RunPreApply(ctx context.Context, command string, resourceType string, sourceFile string, jsonData []byte) (*Result, error) {
+	if command == "" {
+		return &Result{ExitCode: 0}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, DefaultTimeout)
+	defer cancel()
+
+	// Pass resource type and source file as positional parameters.
+	// The "--" separates sh options from the positional args.
+	// Inside the hook: $1 = resource type, $2 = source file (available but not
+	// appended to the command — the hook references them explicitly if needed).
+	// Note: $2 is the original filename for context/logging only. The actual
+	// resource content is always on stdin (processed JSON).
+	cmd := exec.CommandContext(ctx, "sh", "-c", command, "--", resourceType, sourceFile)
+	cmd.Stdin = bytes.NewReader(jsonData)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("pre-apply hook timed out after %s", DefaultTimeout)
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return &Result{
+				ExitCode: exitErr.ExitCode(),
+				Stderr:   stderr.String(),
+			}, nil
+		}
+		return nil, fmt.Errorf("pre-apply hook failed to execute: %w", err)
+	}
+
+	return &Result{ExitCode: 0, Stderr: stderr.String()}, nil
+}

--- a/pkg/hook/hook_test.go
+++ b/pkg/hook/hook_test.go
@@ -35,7 +35,7 @@ func TestRunPreApply_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	_, err := RunPreApply(ctx, "sleep 999", "dashboard", "test.yaml", []byte(`{}`))
+	_, err := RunPreApply(ctx, "sleep 1", "dashboard", "test.yaml", []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/pkg/hook/hook_test.go
+++ b/pkg/hook/hook_test.go
@@ -1,0 +1,334 @@
+package hook
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunPreApply_Success(t *testing.T) {
+	result, err := RunPreApply(context.Background(), "cat > /dev/null", "dashboard", "test.yaml", []byte(`{"title":"test"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_Rejected(t *testing.T) {
+	result, err := RunPreApply(context.Background(), "echo 'bad' >&2; exit 1", "dashboard", "test.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1", result.ExitCode)
+	}
+	if !strings.Contains(result.Stderr, "bad") {
+		t.Errorf("Stderr = %q, want it to contain 'bad'", result.Stderr)
+	}
+}
+
+func TestRunPreApply_Timeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := RunPreApply(ctx, "sleep 999", "dashboard", "test.yaml", []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error = %q, want it to contain 'timed out'", err.Error())
+	}
+}
+
+func TestRunPreApply_CommandNotFound(t *testing.T) {
+	// When run via sh -c, a missing command results in exit code 127, not a Go exec error.
+	result, err := RunPreApply(context.Background(), "nonexistent-binary-that-does-not-exist-xyz", "dashboard", "test.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 127 {
+		t.Errorf("ExitCode = %d, want 127 (command not found)", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_EmptyCommand(t *testing.T) {
+	result, err := RunPreApply(context.Background(), "", "dashboard", "test.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_ReceivesJSON(t *testing.T) {
+	// Read stdin and verify content matches expected JSON
+	result, err := RunPreApply(context.Background(),
+		`input=$(cat); test "$input" = '{"title":"test"}'`,
+		"dashboard", "test.yaml", []byte(`{"title":"test"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 (stdin content mismatch)", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_ReceivesArgs(t *testing.T) {
+	// $1 and $2 are available as positional parameters via sh -c
+	result, err := RunPreApply(context.Background(),
+		`test "$1" = "workflow" && test "$2" = "my-wf.yaml"`,
+		"workflow", "my-wf.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 (args mismatch)", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_FilenameWithSpaces(t *testing.T) {
+	result, err := RunPreApply(context.Background(),
+		`test "$2" = "my file with spaces.yaml"`,
+		"dashboard", "my file with spaces.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 (filename with spaces not handled correctly)", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_ExitCode2(t *testing.T) {
+	result, err := RunPreApply(context.Background(), "exit 2", "dashboard", "test.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 2 {
+		t.Errorf("ExitCode = %d, want 2", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_StdoutIgnored(t *testing.T) {
+	result, err := RunPreApply(context.Background(), "echo 'stdout noise'", "dashboard", "test.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if result.Stderr != "" {
+		t.Errorf("Stderr = %q, want empty (stdout should not leak into stderr)", result.Stderr)
+	}
+}
+
+func TestRunPreApply_RealisticHookCommand(t *testing.T) {
+	// Simulate a realistic hook: a script that uses args explicitly
+	result, err := RunPreApply(context.Background(),
+		`resource_type=$1; file=$2; test "$resource_type" = "dashboard" && test "$file" = "dash.yaml"`,
+		"dashboard", "dash.yaml", []byte(`{"title":"My Dashboard"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_LargeJSONPayload(t *testing.T) {
+	// Build a large JSON payload (~100KB)
+	var buf bytes.Buffer
+	buf.WriteString(`{"items":[`)
+	for i := 0; i < 1000; i++ {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(`{"id":"item-`)
+		buf.WriteString(strings.Repeat("x", 80))
+		buf.WriteString(`","value":`)
+		buf.WriteString(strings.Repeat("1", 10))
+		buf.WriteString(`}`)
+	}
+	buf.WriteString(`]}`)
+
+	payload := buf.Bytes()
+	if len(payload) < 50000 {
+		t.Fatalf("payload too small: %d bytes, want >50KB", len(payload))
+	}
+
+	// Hook reads all of stdin and counts bytes
+	result, err := RunPreApply(context.Background(),
+		`wc -c | tr -d ' ' | { read n; test "$n" -gt 50000; }`,
+		"workflow", "large.json", payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 (hook should receive full payload)", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_MultiLineStderr(t *testing.T) {
+	result, err := RunPreApply(context.Background(),
+		`echo "line 1" >&2; echo "line 2" >&2; echo "line 3" >&2; exit 1`,
+		"dashboard", "test.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1", result.ExitCode)
+	}
+	lines := strings.Split(strings.TrimSpace(result.Stderr), "\n")
+	if len(lines) != 3 {
+		t.Errorf("Stderr lines = %d, want 3; stderr = %q", len(lines), result.Stderr)
+	}
+	if !strings.Contains(result.Stderr, "line 1") || !strings.Contains(result.Stderr, "line 3") {
+		t.Errorf("Stderr = %q, want it to contain 'line 1' and 'line 3'", result.Stderr)
+	}
+}
+
+func TestRunPreApply_StdinAndArgsUsedTogether(t *testing.T) {
+	// Hook reads stdin AND uses $1/$2 positional parameters
+	result, err := RunPreApply(context.Background(),
+		`input=$(cat); test "$input" = '{"name":"test"}' && test "$1" = "slo" && test "$2" = "slo.yaml"`,
+		"slo", "slo.yaml", []byte(`{"name":"test"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 (stdin + args should both work)", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := RunPreApply(ctx, "sleep 10", "dashboard", "test.yaml", []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	// The error should mention timeout or be a context error
+	// (since we cancel immediately, the process may not even start)
+}
+
+func TestRunPreApply_EmptySourceFile(t *testing.T) {
+	result, err := RunPreApply(context.Background(),
+		`test "$2" = ""`,
+		"workflow", "", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 (empty sourceFile should be passed as empty $2)", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_SpecialCharsInResourceType(t *testing.T) {
+	// Resource types with underscores (like azure_connection)
+	result, err := RunPreApply(context.Background(),
+		`test "$1" = "azure_connection"`,
+		"azure_connection", "conn.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_SpecialCharsInSourceFile(t *testing.T) {
+	// Source file with special characters (path traversal, quotes, etc.)
+	result, err := RunPreApply(context.Background(),
+		`test "$2" = "../configs/my file (1).yaml"`,
+		"dashboard", "../configs/my file (1).yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 (special chars in filename not handled)", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_StdoutAndStderrSimultaneous(t *testing.T) {
+	// Hook writes to both stdout and stderr — only stderr should be captured
+	result, err := RunPreApply(context.Background(),
+		`echo "stdout output"; echo "stderr output" >&2; exit 1`,
+		"dashboard", "test.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1", result.ExitCode)
+	}
+	if !strings.Contains(result.Stderr, "stderr output") {
+		t.Errorf("Stderr = %q, want it to contain 'stderr output'", result.Stderr)
+	}
+	if strings.Contains(result.Stderr, "stdout output") {
+		t.Errorf("Stderr = %q, should not contain 'stdout output'", result.Stderr)
+	}
+}
+
+func TestRunPreApply_SuccessStderrPreserved(t *testing.T) {
+	// Even on success (exit 0), stderr output should be captured
+	result, err := RunPreApply(context.Background(),
+		`echo "warning: deprecated format" >&2; exit 0`,
+		"dashboard", "test.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if !strings.Contains(result.Stderr, "warning: deprecated format") {
+		t.Errorf("Stderr = %q, want it to contain warning even on success", result.Stderr)
+	}
+}
+
+func TestRunPreApply_EmptyJSONData(t *testing.T) {
+	// Empty byte slice as input
+	result, err := RunPreApply(context.Background(),
+		`input=$(cat); test -z "$input"`,
+		"dashboard", "test.yaml", []byte{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 (empty input should work)", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_BinaryDataOnStdin(t *testing.T) {
+	// Ensure binary-safe stdin (null bytes, etc.)
+	data := []byte{0x00, 0x01, 0x02, 0xff, 0xfe}
+	result, err := RunPreApply(context.Background(),
+		`wc -c | tr -d ' ' | { read n; test "$n" -eq 5; }`,
+		"dashboard", "test.yaml", data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 (binary data should pass through)", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_HighExitCode(t *testing.T) {
+	result, err := RunPreApply(context.Background(), "exit 255", "dashboard", "test.yaml", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 255 {
+		t.Errorf("ExitCode = %d, want 255", result.ExitCode)
+	}
+}
+
+func TestRunPreApply_DefaultTimeout(t *testing.T) {
+	// Verify DefaultTimeout constant is 30 seconds
+	if DefaultTimeout != 30*time.Second {
+		t.Errorf("DefaultTimeout = %v, want 30s", DefaultTimeout)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a **pre-apply hook** system that runs an external command before `dtctl apply` sends resources to the Dynatrace API, enabling policy enforcement, linting, and custom validation
- Hook receives processed JSON on stdin with resource type (`$1`) and source file (`$2`) as positional parameters; non-zero exit aborts the apply
- Configurable globally (`preferences.hooks.pre-apply`) or per-context (takes precedence), with `"none"` to explicitly disable a global hook

## Details

### New packages/files
| File | Purpose |
|------|---------|
| `pkg/hook/hook.go` | Standalone hook executor — `RunPreApply()` runs `sh -c '<cmd>' -- <type> <file>` with JSON on stdin, 30s timeout |
| `pkg/apply/errors.go` | `HookRejectedError` typed error with command, exit code, and stderr |
| `docs/dev/PRE_APPLY_HOOK_DESIGN.md` | Design specification |

### Modified files
| File | Change |
|------|--------|
| `pkg/config/config.go` | `Hooks` struct in `Preferences` + `Context`, `GetPreApplyHook()` with context-over-global precedence |
| `pkg/apply/applier.go` | `WithPreApplyHook()` / `WithSourceFile()` builders, hook call after type detection |
| `cmd/apply.go` | `--no-hooks` flag, config→applier wiring |
| `cmd/root.go` | `HookRejectedError` → `hook_rejected` in agent mode `errorToDetail()`, auth hint helpers |

### Tests (~60 new tests, all passing)
| File | Tests |
|------|-------|
| `pkg/hook/hook_test.go` | ~25 unit tests (success, failure, timeout, large payloads, special chars, binary data, cancelled context, etc.) |
| `pkg/apply/errors_test.go` | 7 tests (error formatting, multi-line stderr, exit codes, error interface) |
| `pkg/apply/apply_integration_test.go` | ~17 integration tests (correct $1/$2 delivery, JSON on stdin, template rendering, multi-resource types, dry-run, mock API verification) |
| `pkg/config/config_test.go` | ~10 tests (precedence, "none" override, YAML round-trip, fallback) |
| `cmd/root_test.go` | 2 tests (`errorToDetail` for `HookRejectedError` direct + wrapped) |
| `cmd/flags_test.go` | `--no-hooks` flag registration |

### Usage example
```yaml
# ~/.config/dtctl/config
preferences:
  hooks:
    pre-apply: "node validate.js \"$1\" \"$2\""

contexts:
  production:
    context:
      environment: https://abc.apps.dynatrace.com
      token-ref: prod-token
      hooks:
        pre-apply: "opa eval --bundle /policies -i /dev/stdin"
  dev:
    context:
      environment: https://dev.apps.dynatrace.com
      token-ref: dev-token
      hooks:
        pre-apply: "none"  # skip hook for dev
```
```bash
dtctl apply -f dashboard.yaml           # runs hook
dtctl apply -f dashboard.yaml --no-hooks # skips hook
dtctl apply -f dashboard.yaml --dry-run  # hook still runs (validates before preview)
```