### PR TITLE
improve auth login error message when keyring is unavailable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Get version info
         id: version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Check goimports formatting
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.26.1']
+        go: ['1.26.2']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -231,7 +231,18 @@ you'll need to use API token authentication instead (dtctl config set-credential
 
 		// Ensure keyring is available before starting OAuth flow
 		if !config.IsKeyringAvailable() {
-			return fmt.Errorf("OAuth login requires a working system keyring, but none is available; please configure a keyring (or disable keyring usage if supported) and try again, or use an alternative authentication method")
+			return &diagnostic.Error{
+				Operation: "auth login",
+				Message:   "OAuth login requires a system keyring, but none is available on this system",
+				Suggestions: []string{
+					"Use token-based authentication instead (recommended for headless/CI environments):",
+					fmt.Sprintf("  dtctl config set-context %s --environment %q --token-ref my-token", contextName, environment),
+					"  dtctl config set-credentials my-token --token <YOUR_PLATFORM_TOKEN>",
+					"Create a platform token at: Identity & Access Management > Access Tokens > Generate new token > Platform token",
+					"For required token scopes, see: dtctl help token-scopes (or docs/TOKEN_SCOPES.md)",
+					"On Linux, install a keyring backend (e.g., gnome-keyring, kwallet, or pass) if you prefer OAuth",
+				},
+			}
 		}
 
 		// Warn about potentially wrong environment URLs

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynatrace-oss/dtctl
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/adrg/xdg v0.5.3


### PR DESCRIPTION
## Summary

- Replaces the raw `fmt.Errorf` wall-of-text in `dtctl auth login` with a structured `diagnostic.Error` when the system keyring is unavailable
- The error now provides actionable, copy-pasteable commands for token-based authentication (pre-filled with the user's `--context` and `--environment` values)
- Includes guidance on where to create a platform token, what scopes to configure, and how to install a keyring backend as an alternative

## Context

A user on a headless Linux server hit the old error:

> Error: OAuth login requires a working system keyring, but none is available; please configure a keyring (or disable keyring usage if supported) and try again, or use an alternative authentication method

This is a dead end — it doesn't tell you what the "alternative authentication method" is or what commands to run. The user ended up asking Claude Code, which hallucinated a `--api-token` flag that doesn't exist.

## Before / After

**Before:** single run-on sentence, no actionable guidance

**After:**
```
Failed to auth login: OAuth login requires a system keyring, but none is available on this system

Troubleshooting suggestions:
  • Use token-based authentication instead (recommended for headless/CI environments):
  •   dtctl config set-context my-env --environment "https://abc12345.apps.dynatrace.com" --token-ref my-token
  •   dtctl config set-credentials my-token --token <YOUR_PLATFORM_TOKEN>
  • Create a platform token at: Identity & Access Management > Access Tokens > Generate new token > Platform token
  • For required token scopes, see: dtctl help token-scopes (or docs/TOKEN_SCOPES.md)
  • On Linux, install a keyring backend (e.g., gnome-keyring, kwallet, or pass) if you prefer OAuth
```