### PR TITLE
feat: automatic keyring collection creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Automatic keyring collection creation** — on Linux/WSL, `dtctl auth login` now detects when a persistent Secret Service keyring collection is missing and offers to create one automatically, prompting for a password if needed; `dtctl doctor` reports keyring status and suggests running `auth login` to recover
+
 ## [0.22.0] - 2026-04-01
 
 ### Added

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -230,8 +231,31 @@ you'll need to use API token authentication instead (dtctl config set-credential
 		}
 
 		// Ensure keyring is available before starting OAuth flow
-		if !config.IsKeyringAvailable() {
-			return fmt.Errorf("OAuth login requires a working system keyring, but none is available; please configure a keyring (or disable keyring usage if supported) and try again, or use an alternative authentication method")
+		if keyringErr := config.CheckKeyring(); keyringErr != nil {
+			recovered := false
+			// On Linux/WSL the persistent keyring collection may not exist yet.
+			// Attempt to create it — this may trigger an OS password prompt.
+			if strings.Contains(keyringErr.Error(), "failed to unlock correct collection") {
+				output.PrintInfo("No keyring collection found — creating one (you may be prompted for a password)...")
+				if initErr := config.EnsureKeyringCollection(); initErr == nil {
+					if config.CheckKeyring() == nil {
+						output.PrintSuccess("Keyring collection created successfully")
+						recovered = true
+					}
+				}
+			}
+			if !recovered {
+				return &diagnostic.Error{
+					Operation: "auth login",
+					Message:   fmt.Sprintf("OAuth login requires a working system keyring: %v", keyringErr),
+					Suggestions: []string{
+						"Check that a D-Bus session bus is available (echo $DBUS_SESSION_BUS_ADDRESS)",
+						"Ensure a Secret Service provider is running (e.g. gnome-keyring-daemon --start --components=secrets)",
+						"Unset DTCTL_DISABLE_KEYRING if it was set unintentionally",
+						"Use API token authentication instead: dtctl config set-credentials",
+					},
+				}
+			}
 		}
 
 		// Warn about potentially wrong environment URLs

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -21,6 +21,14 @@ var (
 	refresh bool
 )
 
+// authCheckKeyringFunc and authEnsureKeyringFunc are the functions used to
+// probe and recover the keyring in auth login. They default to the real
+// implementations and can be overridden in tests.
+var (
+	authCheckKeyringFunc  = config.CheckKeyring
+	authEnsureKeyringFunc = func(ctx context.Context) error { return config.EnsureKeyringCollection(ctx) }
+)
+
 // authCmd represents the auth command
 var authCmd = &cobra.Command{
 	Use:   "auth",
@@ -231,14 +239,14 @@ you'll need to use API token authentication instead (dtctl config set-credential
 		}
 
 		// Ensure keyring is available before starting OAuth flow
-		if keyringErr := config.CheckKeyring(); keyringErr != nil {
+		if keyringErr := authCheckKeyringFunc(); keyringErr != nil {
 			recovered := false
 			// On Linux/WSL the persistent keyring collection may not exist yet.
 			// Attempt to create it — this may trigger an OS password prompt.
-			if strings.Contains(keyringErr.Error(), "failed to unlock correct collection") {
+			if strings.Contains(keyringErr.Error(), config.ErrMsgCollectionUnlock) {
 				output.PrintInfo("No keyring collection found — creating one (you may be prompted for a password)...")
-				if initErr := config.EnsureKeyringCollection(); initErr == nil {
-					if config.CheckKeyring() == nil {
+				if initErr := authEnsureKeyringFunc(cmd.Context()); initErr == nil {
+					if authCheckKeyringFunc() == nil {
 						output.PrintSuccess("Keyring collection created successfully")
 						recovered = true
 					}
@@ -247,14 +255,15 @@ you'll need to use API token authentication instead (dtctl config set-credential
 			if !recovered {
 				return &diagnostic.Error{
 					Operation: "auth login",
-					Message:   "OAuth login requires a system keyring, but none is available on this system",
+					Message:   fmt.Sprintf("OAuth login requires a working system keyring: %v", keyringErr),
 					Suggestions: []string{
 						"Use token-based authentication instead (recommended for headless/CI environments):",
 						fmt.Sprintf("  dtctl config set-context %s --environment %q --token-ref my-token", contextName, environment),
 						"  dtctl config set-credentials my-token --token <YOUR_PLATFORM_TOKEN>",
 						"Create a platform token at: Identity & Access Management > Access Tokens > Generate new token > Platform token",
 						"For required token scopes, see: dtctl help token-scopes (or docs/TOKEN_SCOPES.md)",
-						"On Linux, install a keyring backend (e.g., gnome-keyring, kwallet, or pass) if you prefer OAuth",
+						"On Linux, ensure a Secret Service provider is running (e.g. gnome-keyring-daemon --start --components=secrets)",
+						"Unset DTCTL_DISABLE_KEYRING if it was set unintentionally",
 					},
 				}
 			}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -26,7 +26,7 @@ var (
 // implementations and can be overridden in tests.
 var (
 	authCheckKeyringFunc  = config.CheckKeyring
-	authEnsureKeyringFunc = func(ctx context.Context) error { return config.EnsureKeyringCollection(ctx) }
+	authEnsureKeyringFunc = config.EnsureKeyringCollection
 )
 
 // authCmd represents the auth command

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -154,5 +156,107 @@ func TestAuthLogin_PartialFlags_EnvironmentFromContext(t *testing.T) {
 
 	if err != nil && strings.Contains(err.Error(), "--context and --environment are required") {
 		t.Errorf("expected environment to be filled from current context, but got: %v", err)
+	}
+}
+
+// TestAuthLogin_KeyringRecovery verifies that the auth login command
+// attempts to create a keyring collection when CheckKeyring returns an
+// error containing ErrMsgCollectionUnlock, and that a successful recovery
+// allows the flow to continue past the keyring gate.
+func TestAuthLogin_KeyringRecovery(t *testing.T) {
+	viper.Reset()
+
+	const (
+		ctxName = "recover-ctx"
+		envURL  = "https://abc12345.apps.dynatrace.com"
+	)
+
+	configPath := setupAuthTestConfig(t, ctxName, envURL, ctxName+"-oauth")
+	cfgFile = configPath
+	defer func() { cfgFile = "" }()
+
+	// Track whether EnsureKeyringCollection was called.
+	ensureCalled := false
+
+	// First call to CheckKeyring returns the unlock error; after recovery
+	// it returns nil (simulating a fixed keyring).
+	calls := 0
+	origCheck := authCheckKeyringFunc
+	origEnsure := authEnsureKeyringFunc
+	defer func() {
+		authCheckKeyringFunc = origCheck
+		authEnsureKeyringFunc = origEnsure
+	}()
+
+	authCheckKeyringFunc = func() error {
+		calls++
+		if calls == 1 {
+			return fmt.Errorf("keyring probe failed: %s", config.ErrMsgCollectionUnlock)
+		}
+		return nil // recovered
+	}
+	authEnsureKeyringFunc = func(_ context.Context) error {
+		ensureCalled = true
+		return nil
+	}
+
+	rootCmd.SetArgs([]string{"auth", "login", "--context", ctxName, "--environment", envURL})
+	err := rootCmd.Execute()
+
+	if !ensureCalled {
+		t.Fatal("expected EnsureKeyringCollection to be called during recovery")
+	}
+
+	// After recovery the command should proceed past the keyring gate.
+	// It will eventually fail further along (no real keyring for token
+	// storage, or OAuth infrastructure issues), but not with the initial
+	// keyring gate error about requiring a working keyring.
+	if err != nil && strings.Contains(err.Error(), "OAuth login requires a working system keyring") {
+		t.Errorf("expected recovery to succeed and proceed past keyring gate, got: %v", err)
+	}
+}
+
+// TestAuthLogin_KeyringRecoveryFailure verifies that when
+// EnsureKeyringCollection fails, the command returns an actionable
+// diagnostic error with suggestions.
+func TestAuthLogin_KeyringRecoveryFailure(t *testing.T) {
+	viper.Reset()
+
+	const (
+		ctxName = "fail-ctx"
+		envURL  = "https://abc12345.apps.dynatrace.com"
+	)
+
+	configPath := setupAuthTestConfig(t, ctxName, envURL, ctxName+"-oauth")
+	cfgFile = configPath
+	defer func() { cfgFile = "" }()
+
+	origCheck := authCheckKeyringFunc
+	origEnsure := authEnsureKeyringFunc
+	defer func() {
+		authCheckKeyringFunc = origCheck
+		authEnsureKeyringFunc = origEnsure
+	}()
+
+	// CheckKeyring always fails with the unlock error.
+	authCheckKeyringFunc = func() error {
+		return fmt.Errorf("keyring probe failed: %s", config.ErrMsgCollectionUnlock)
+	}
+	// EnsureKeyringCollection fails too.
+	authEnsureKeyringFunc = func(_ context.Context) error {
+		return fmt.Errorf("D-Bus connection refused")
+	}
+
+	rootCmd.SetArgs([]string{"auth", "login", "--context", ctxName, "--environment", envURL})
+	err := rootCmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error when keyring recovery fails")
+	}
+	if !strings.Contains(err.Error(), "keyring") {
+		t.Errorf("expected keyring-related error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "token-based authentication") {
+		t.Errorf("expected suggestion about token-based auth, got: %v", err)
 	}
 }

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -126,6 +126,12 @@ func TestAuthLogin_CurrentContextFallback(t *testing.T) {
 	if strings.Contains(err.Error(), "--context and --environment are required") {
 		t.Errorf("expected current-context fallback to work, but got flag validation error: %v", err)
 	}
+
+	// The error should include the underlying keyring probe reason
+	// (e.g. "disabled via DTCTL_DISABLE_KEYRING") instead of a generic message.
+	if strings.Contains(err.Error(), "keyring") && !strings.Contains(err.Error(), config.EnvDisableKeyring) {
+		t.Errorf("expected keyring error to include probe reason (%s env var), got: %v", config.EnvDisableKeyring, err)
+	}
 }
 
 // TestAuthLogin_PartialFlags verifies that supplying only --context (without

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -22,6 +22,10 @@ type checkResult struct {
 	Detail string
 }
 
+// checkKeyringFunc is the function used to probe keyring availability.
+// It defaults to config.CheckKeyring and can be overridden in tests.
+var checkKeyringFunc = config.CheckKeyring
+
 // doctorCmd runs health checks on the dtctl configuration and connectivity
 var doctorCmd = &cobra.Command{
 	Use:   "doctor",
@@ -141,9 +145,9 @@ func runDoctorChecksWithClient(httpClient *http.Client) []checkResult {
 	}
 
 	// 5. Keyring status
-	if keyringErr := config.CheckKeyring(); keyringErr != nil {
+	if keyringErr := checkKeyringFunc(); keyringErr != nil {
 		detail := fmt.Sprintf("%s: %v", config.KeyringBackend(), keyringErr)
-		if strings.Contains(keyringErr.Error(), "failed to unlock correct collection") {
+		if strings.Contains(keyringErr.Error(), config.ErrMsgCollectionUnlock) {
 			detail += " (run 'dtctl auth login' to create the collection automatically)"
 		}
 		results = append(results, checkResult{

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -33,9 +34,10 @@ Checks performed:
   2. Configuration file exists and is valid
   3. Current context is set
   4. Environment URL pattern is valid (detects common domain mistakes)
-  5. Token is retrievable (keyring or config)
-  6. Environment URL is reachable (HTTP connectivity)
-  7. API authentication works (user identity)`,
+  5. Keyring status (secure token storage)
+  6. Token is retrievable (keyring or config)
+  7. Environment URL is reachable (HTTP connectivity)
+  8. API authentication works (user identity)`,
 	Example: `  # Run all checks
   dtctl doctor
 
@@ -138,7 +140,26 @@ func runDoctorChecksWithClient(httpClient *http.Client) []checkResult {
 		})
 	}
 
-	// 5. Token retrieval
+	// 5. Keyring status
+	if keyringErr := config.CheckKeyring(); keyringErr != nil {
+		detail := fmt.Sprintf("%s: %v", config.KeyringBackend(), keyringErr)
+		if strings.Contains(keyringErr.Error(), "failed to unlock correct collection") {
+			detail += " (run 'dtctl auth login' to create the collection automatically)"
+		}
+		results = append(results, checkResult{
+			Name:   "Keyring",
+			Status: "warn",
+			Detail: detail,
+		})
+	} else {
+		results = append(results, checkResult{
+			Name:   "Keyring",
+			Status: "ok",
+			Detail: config.KeyringBackend(),
+		})
+	}
+
+	// 6. Token retrieval
 	token, tokenErr := client.GetTokenWithOAuthSupport(cfg, ctx.TokenRef)
 	if tokenErr != nil || token == "" {
 		detail := "token not found"

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -336,3 +336,45 @@ func TestDoctorURLValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestDoctorKeyringCheck(t *testing.T) {
+	t.Setenv("DTCTL_DISABLE_KEYRING", "1")
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config")
+
+	originalCfgFile := cfgFile
+	defer func() { cfgFile = originalCfgFile }()
+	cfgFile = configPath
+
+	cfg := config.NewConfig()
+	cfg.SetContext("test", "https://test.apps.dynatrace.com", "test-token")
+	if err := cfg.SetToken("test-token", "dt0c01.ST.test-token-value.test-secret"); err != nil {
+		t.Fatalf("failed to set token: %v", err)
+	}
+	cfg.CurrentContext = "test"
+	if err := cfg.SaveTo(configPath); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	results := runDoctorChecks()
+
+	found := false
+	for _, r := range results {
+		if r.Name == "Keyring" {
+			found = true
+			if r.Status != "warn" {
+				t.Errorf("expected keyring status 'warn' (disabled via env), got %q", r.Status)
+			}
+			if !strings.Contains(r.Detail, config.EnvDisableKeyring) {
+				t.Errorf("expected keyring detail to mention %s, got %q", config.EnvDisableKeyring, r.Detail)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected 'Keyring' check in results")
+		for _, r := range results {
+			t.Logf("  %s: %s: %s", r.Name, r.Status, r.Detail)
+		}
+	}
+}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -368,6 +369,57 @@ func TestDoctorKeyringCheck(t *testing.T) {
 			}
 			if !strings.Contains(r.Detail, config.EnvDisableKeyring) {
 				t.Errorf("expected keyring detail to mention %s, got %q", config.EnvDisableKeyring, r.Detail)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected 'Keyring' check in results")
+		for _, r := range results {
+			t.Logf("  %s: %s: %s", r.Name, r.Status, r.Detail)
+		}
+	}
+}
+
+// TestDoctorKeyringCollectionRecoverySuggestion verifies that when the keyring
+// error contains the collection-unlock message, the doctor output includes the
+// recovery suggestion telling the user to run 'dtctl auth login'.
+func TestDoctorKeyringCollectionRecoverySuggestion(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config")
+
+	originalCfgFile := cfgFile
+	defer func() { cfgFile = originalCfgFile }()
+	cfgFile = configPath
+
+	cfg := config.NewConfig()
+	cfg.SetContext("test", "https://test.apps.dynatrace.com", "test-token")
+	if err := cfg.SetToken("test-token", "dt0c01.ST.test-token-value.test-secret"); err != nil {
+		t.Fatalf("failed to set token: %v", err)
+	}
+	cfg.CurrentContext = "test"
+	if err := cfg.SaveTo(configPath); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	// Override checkKeyringFunc to return an error that contains the
+	// collection-unlock message.
+	origFunc := checkKeyringFunc
+	defer func() { checkKeyringFunc = origFunc }()
+	checkKeyringFunc = func() error {
+		return fmt.Errorf("keyring probe failed: %s", config.ErrMsgCollectionUnlock)
+	}
+
+	results := runDoctorChecks()
+
+	found := false
+	for _, r := range results {
+		if r.Name == "Keyring" {
+			found = true
+			if r.Status != "warn" {
+				t.Errorf("expected keyring status 'warn', got %q", r.Status)
+			}
+			if !strings.Contains(r.Detail, "dtctl auth login") {
+				t.Errorf("expected recovery suggestion mentioning 'dtctl auth login', got %q", r.Detail)
 			}
 		}
 	}

--- a/docs/OAUTH_IMPLEMENTATION.md
+++ b/docs/OAUTH_IMPLEMENTATION.md
@@ -73,6 +73,19 @@ The implementation uses OAuth 2.0 with PKCE for enhanced security:
 - Token expiration tracking for proactive refresh
 - Keyring payload size fallback: if a backend rejects a full token record (for example with `data passed to Set was too big`), dtctl stores a compact record (refresh token + metadata) and refreshes access token on demand
 
+### Automatic Keyring Collection Creation (Linux/WSL)
+
+On Linux and WSL, gnome-keyring may start with only a transient "session" collection and no persistent "login" collection. When `dtctl auth login` detects that the keyring is unreachable due to a missing collection (`failed to unlock correct collection`), it automatically attempts to create one:
+
+1. Connects to the D-Bus Secret Service
+2. Creates a persistent collection with the "default" alias
+3. Triggers an OS password prompt if required
+4. Polls for up to 2 minutes for the user to complete the prompt
+
+If automatic creation fails, the error message includes actionable suggestions (token-based auth, Secret Service provider setup).
+
+`dtctl doctor` also includes a dedicated Keyring check that reports backend status and suggests running `dtctl auth login` to create the collection if needed.
+
 ### Keyring Size-Limit Behavior
 
 Some keyring backends impose per-item size limits. With large OAuth responses (for example many scopes and/or large JWTs), saving the full serialized token set may fail.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -3582,7 +3582,7 @@ Before diving into manual troubleshooting, run the built-in health check:
 dtctl doctor
 ```
 
-This runs 6 sequential checks — version, config, context, token, connectivity, and authentication — and reports pass/fail with actionable suggestions for each.
+This runs 8 sequential checks — version, config, context, URL validation, keyring, token, connectivity, and authentication — and reports pass/fail with actionable suggestions for each.
 
 ### Understanding Error Messages
 
@@ -3644,6 +3644,21 @@ This is useful for:
 - Verifying request parameters
 - Checking response format
 - Troubleshooting performance issues
+
+### Keyring Issues on Linux/WSL
+
+If `dtctl doctor` shows a keyring warning or `dtctl auth login` fails with a keyring error, the persistent keyring collection may not exist yet. Run:
+
+```bash
+dtctl auth login --context my-env --environment "https://YOUR_ENV.apps.dynatrace.com"
+```
+
+dtctl will detect the missing collection and offer to create it automatically — you may be prompted for a password.
+
+If automatic creation fails:
+- Ensure a Secret Service provider is running: `gnome-keyring-daemon --start --components=secrets`
+- Or switch to token-based authentication (see Option 2 above)
+- To disable keyring entirely: `export DTCTL_DISABLE_KEYRING=1`
 
 ### "config file not found"
 

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -46,7 +46,7 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] `share/unshare` - Share dashboards and notebooks
 - [x] `alias` - Manage command aliases (set, list, delete, import, export)
 - [x] `ctx` - Quick context management (list, switch, describe, set, delete)
-- [x] `doctor` - Health check (config, context, token, connectivity, auth)
+- [x] `doctor` - Health check (config, context, URL validation, keyring, token, connectivity, auth)
 - [x] `commands` - Machine-readable command catalog (JSON/YAML, `--brief`, resource filter, `howto` subcommand)
 - [x] `skills` - AI agent skill file management (install, uninstall, status for Claude, Copilot, Cursor, Kiro, Junie, OpenCode, OpenClaw; cross-client via `--cross-client`)
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	github.com/adrg/xdg v0.5.3
 	github.com/go-resty/resty/v2 v2.11.0
+	github.com/godbus/dbus/v5 v5.1.0
 	github.com/guptarohit/asciigraph v0.7.3
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
@@ -26,7 +27,6 @@ require (
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/pkg/config/keyring.go
+++ b/pkg/config/keyring.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
 
-	dbus "github.com/godbus/dbus/v5"
 	"github.com/zalando/go-keyring"
-	ss "github.com/zalando/go-keyring/secret_service"
 )
 
 const (
@@ -17,6 +14,12 @@ const (
 
 	// EnvDisableKeyring can be set to disable keyring integration
 	EnvDisableKeyring = "DTCTL_DISABLE_KEYRING"
+
+	// ErrMsgCollectionUnlock is the error substring returned by the Secret Service
+	// backend when a persistent keyring collection does not exist or cannot be
+	// unlocked. Centralised here so callers match on a single constant instead
+	// of a fragile raw string.
+	ErrMsgCollectionUnlock = "failed to unlock correct collection"
 )
 
 // TokenStore provides secure token storage using the OS keyring
@@ -33,10 +36,16 @@ func NewTokenStore() *TokenStore {
 	}
 }
 
+// isKeyringDisabled reports whether the keyring has been intentionally
+// disabled via the DTCTL_DISABLE_KEYRING environment variable.
+func isKeyringDisabled() bool {
+	return os.Getenv(EnvDisableKeyring) != ""
+}
+
 // CheckKeyring probes the OS keyring and returns nil if it is usable,
 // or a descriptive error explaining why it is not.
 func CheckKeyring() error {
-	if os.Getenv(EnvDisableKeyring) != "" {
+	if isKeyringDisabled() {
 		return fmt.Errorf("keyring disabled via %s environment variable", EnvDisableKeyring)
 	}
 
@@ -50,74 +59,6 @@ func CheckKeyring() error {
 // IsKeyringAvailable checks if keyring storage is available on this system
 func IsKeyringAvailable() bool {
 	return CheckKeyring() == nil
-}
-
-// EnsureKeyringCollection checks whether a usable Secret Service collection
-// exists and, if not, creates a persistent "login" collection.
-// On Linux/WSL gnome-keyring may start with only a transient "session"
-// collection; this function creates the permanent one, which may trigger
-// an OS password prompt.
-func EnsureKeyringCollection() error {
-	svc, err := ss.NewSecretService()
-	if err != nil {
-		return fmt.Errorf("cannot connect to Secret Service: %w", err)
-	}
-
-	// If the "login" collection already exists, nothing to do.
-	loginPath := dbus.ObjectPath("/org/freedesktop/secrets/collection/login")
-	if svc.CheckCollectionPath(loginPath) == nil {
-		return nil
-	}
-
-	// Create a persistent collection via D-Bus with alias "default".
-	// gnome-keyring only accepts the "default" alias. Using this alias
-	// ensures GetLoginCollection() can discover the collection via its
-	// fallback to /org/freedesktop/secrets/aliases/default.
-	props := map[string]dbus.Variant{
-		"org.freedesktop.Secret.Collection.Label": dbus.MakeVariant("Login"),
-	}
-	var collectionPath, promptPath dbus.ObjectPath
-	obj := svc.Object("org.freedesktop.secrets", "/org/freedesktop/secrets")
-	err = obj.Call("org.freedesktop.Secret.Service.CreateCollection", 0, props, "default").
-		Store(&collectionPath, &promptPath)
-	if err != nil {
-		return fmt.Errorf("failed to create keyring collection: %w", err)
-	}
-
-	// If no prompt was returned, the collection was created immediately.
-	if promptPath == dbus.ObjectPath("/") {
-		return nil
-	}
-
-	// A prompt was returned — trigger it so the OS displays a password dialog.
-	promptObj := svc.Object("org.freedesktop.secrets", promptPath)
-	if err := promptObj.Call("org.freedesktop.Secret.Prompt.Prompt", 0, "").Err; err != nil {
-		return fmt.Errorf("failed to trigger keyring prompt: %w", err)
-	}
-
-	// Poll until the default alias points to a real collection, indicating
-	// the user completed the password prompt. D-Bus signal delivery is
-	// unreliable in some environments (notably WSL), so polling is more
-	// robust than waiting for the Prompt.Completed signal.
-	deadline := time.After(2 * time.Minute)
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-deadline:
-			return fmt.Errorf("timed out waiting for keyring password prompt to complete")
-		case <-ticker.C:
-			var alias dbus.ObjectPath
-			call := obj.Call("org.freedesktop.Secret.Service.ReadAlias", 0, "default")
-			if call.Err == nil {
-				_ = call.Store(&alias)
-				if alias != "/" && alias != "" {
-					return nil
-				}
-			}
-		}
-	}
 }
 
 // SetToken stores a token securely in the OS keyring

--- a/pkg/config/keyring.go
+++ b/pkg/config/keyring.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
+	dbus "github.com/godbus/dbus/v5"
 	"github.com/zalando/go-keyring"
+	ss "github.com/zalando/go-keyring/secret_service"
 )
 
 const (
@@ -30,44 +33,91 @@ func NewTokenStore() *TokenStore {
 	}
 }
 
-// IsKeyringAvailable checks if keyring storage is available on this system
-func IsKeyringAvailable() bool {
-	// Check if explicitly disabled
+// CheckKeyring probes the OS keyring and returns nil if it is usable,
+// or a descriptive error explaining why it is not.
+func CheckKeyring() error {
 	if os.Getenv(EnvDisableKeyring) != "" {
-		return false
+		return fmt.Errorf("keyring disabled via %s environment variable", EnvDisableKeyring)
 	}
 
-	// Test keyring availability by attempting a get operation
-	// This will fail gracefully if keyring is not available
 	_, err := keyring.Get(KeyringService, "__test__")
-	// If error is "not found", keyring is available but key doesn't exist
-	// If error is something else (like "keyring not available"), it's not available
-	if err == keyring.ErrNotFound {
-		return true
+	if err == nil || err == keyring.ErrNotFound {
+		return nil // keyring is reachable
 	}
-	// Try to detect if it's a "keyring unavailable" type error
-	if err != nil {
-		errStr := err.Error()
-		// Common error messages when keyring is unavailable
-		if contains(errStr, "secret service", "dbus", "keychain", "credential") {
-			return false
-		}
-	}
-	return err == nil
+	return fmt.Errorf("keyring probe failed: %w", err)
 }
 
-// contains checks if s contains any of the substrings
-func contains(s string, substrs ...string) bool {
-	for _, substr := range substrs {
-		if len(s) >= len(substr) {
-			for i := 0; i <= len(s)-len(substr); i++ {
-				if s[i:i+len(substr)] == substr {
-					return true
+// IsKeyringAvailable checks if keyring storage is available on this system
+func IsKeyringAvailable() bool {
+	return CheckKeyring() == nil
+}
+
+// EnsureKeyringCollection checks whether a usable Secret Service collection
+// exists and, if not, creates a persistent "login" collection.
+// On Linux/WSL gnome-keyring may start with only a transient "session"
+// collection; this function creates the permanent one, which may trigger
+// an OS password prompt.
+func EnsureKeyringCollection() error {
+	svc, err := ss.NewSecretService()
+	if err != nil {
+		return fmt.Errorf("cannot connect to Secret Service: %w", err)
+	}
+
+	// If the "login" collection already exists, nothing to do.
+	loginPath := dbus.ObjectPath("/org/freedesktop/secrets/collection/login")
+	if svc.CheckCollectionPath(loginPath) == nil {
+		return nil
+	}
+
+	// Create a persistent collection via D-Bus with alias "default".
+	// gnome-keyring only accepts the "default" alias. Using this alias
+	// ensures GetLoginCollection() can discover the collection via its
+	// fallback to /org/freedesktop/secrets/aliases/default.
+	props := map[string]dbus.Variant{
+		"org.freedesktop.Secret.Collection.Label": dbus.MakeVariant("Login"),
+	}
+	var collectionPath, promptPath dbus.ObjectPath
+	obj := svc.Object("org.freedesktop.secrets", "/org/freedesktop/secrets")
+	err = obj.Call("org.freedesktop.Secret.Service.CreateCollection", 0, props, "default").
+		Store(&collectionPath, &promptPath)
+	if err != nil {
+		return fmt.Errorf("failed to create keyring collection: %w", err)
+	}
+
+	// If no prompt was returned, the collection was created immediately.
+	if promptPath == dbus.ObjectPath("/") {
+		return nil
+	}
+
+	// A prompt was returned — trigger it so the OS displays a password dialog.
+	promptObj := svc.Object("org.freedesktop.secrets", promptPath)
+	if err := promptObj.Call("org.freedesktop.Secret.Prompt.Prompt", 0, "").Err; err != nil {
+		return fmt.Errorf("failed to trigger keyring prompt: %w", err)
+	}
+
+	// Poll until the default alias points to a real collection, indicating
+	// the user completed the password prompt. D-Bus signal delivery is
+	// unreliable in some environments (notably WSL), so polling is more
+	// robust than waiting for the Prompt.Completed signal.
+	deadline := time.After(2 * time.Minute)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			return fmt.Errorf("timed out waiting for keyring password prompt to complete")
+		case <-ticker.C:
+			var alias dbus.ObjectPath
+			call := obj.Call("org.freedesktop.Secret.Service.ReadAlias", 0, "default")
+			if call.Err == nil {
+				_ = call.Store(&alias)
+				if alias != "/" && alias != "" {
+					return nil
 				}
 			}
 		}
 	}
-	return false
 }
 
 // SetToken stores a token securely in the OS keyring

--- a/pkg/config/keyring_collection_linux.go
+++ b/pkg/config/keyring_collection_linux.go
@@ -25,7 +25,12 @@ func EnsureKeyringCollection(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("cannot connect to Secret Service: %w", err)
 	}
-	defer svc.Conn.Close()
+	// NOTE: Do NOT call svc.Conn.Close(). NewSecretService() uses
+	// dbus.SessionBus() which returns a shared, process-wide connection.
+	// The dbus docs explicitly warn: "This method must not be called on
+	// shared connections." Closing it could break go-keyring (called via
+	// CheckKeyring right after this function). The connection is cleaned
+	// up automatically when the process exits.
 
 	// If the "login" collection already exists, nothing to do.
 	loginPath := dbus.ObjectPath("/org/freedesktop/secrets/collection/login")

--- a/pkg/config/keyring_collection_linux.go
+++ b/pkg/config/keyring_collection_linux.go
@@ -1,0 +1,88 @@
+//go:build linux
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	dbus "github.com/godbus/dbus/v5"
+	ss "github.com/zalando/go-keyring/secret_service"
+)
+
+// EnsureKeyringCollection checks whether a usable Secret Service collection
+// exists and, if not, creates a persistent "login" collection.
+// On Linux/WSL gnome-keyring may start with only a transient "session"
+// collection; this function creates the permanent one, which may trigger
+// an OS password prompt.
+//
+// The provided context allows the caller to cancel the operation (e.g. via
+// Ctrl+C); without cancellation the function polls for up to 2 minutes
+// waiting for the user to complete the password prompt.
+func EnsureKeyringCollection(ctx context.Context) error {
+	svc, err := ss.NewSecretService()
+	if err != nil {
+		return fmt.Errorf("cannot connect to Secret Service: %w", err)
+	}
+	defer svc.Conn.Close()
+
+	// If the "login" collection already exists, nothing to do.
+	loginPath := dbus.ObjectPath("/org/freedesktop/secrets/collection/login")
+	if svc.CheckCollectionPath(loginPath) == nil {
+		return nil
+	}
+
+	// Create a persistent collection via D-Bus with alias "default".
+	// We use a raw D-Bus call instead of svc.CreateCollection(label) because
+	// the library method does not accept an alias parameter. The "default"
+	// alias is required so that gnome-keyring's GetLoginCollection() can
+	// discover the collection via /org/freedesktop/secrets/aliases/default.
+	props := map[string]dbus.Variant{
+		"org.freedesktop.Secret.Collection.Label": dbus.MakeVariant("Login"),
+	}
+	var collectionPath, promptPath dbus.ObjectPath
+	obj := svc.Object("org.freedesktop.secrets", "/org/freedesktop/secrets")
+	err = obj.Call("org.freedesktop.Secret.Service.CreateCollection", 0, props, "default").
+		Store(&collectionPath, &promptPath)
+	if err != nil {
+		return fmt.Errorf("failed to create keyring collection: %w", err)
+	}
+
+	// If no prompt was returned, the collection was created immediately.
+	if promptPath == dbus.ObjectPath("/") {
+		return nil
+	}
+
+	// A prompt was returned — trigger it so the OS displays a password dialog.
+	promptObj := svc.Object("org.freedesktop.secrets", promptPath)
+	if err := promptObj.Call("org.freedesktop.Secret.Prompt.Prompt", 0, "").Err; err != nil {
+		return fmt.Errorf("failed to trigger keyring prompt: %w", err)
+	}
+
+	// Poll until the default alias points to a real collection, indicating
+	// the user completed the password prompt. D-Bus signal delivery is
+	// unreliable in some environments (notably WSL), so polling is more
+	// robust than waiting for the Prompt.Completed signal.
+	deadline := time.After(2 * time.Minute)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("keyring collection creation cancelled: %w", ctx.Err())
+		case <-deadline:
+			return fmt.Errorf("timed out waiting for keyring password prompt to complete")
+		case <-ticker.C:
+			var alias dbus.ObjectPath
+			call := obj.Call("org.freedesktop.Secret.Service.ReadAlias", 0, "default")
+			if call.Err == nil {
+				_ = call.Store(&alias)
+				if alias != "/" && alias != "" {
+					return nil
+				}
+			}
+		}
+	}
+}

--- a/pkg/config/keyring_collection_other.go
+++ b/pkg/config/keyring_collection_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+)
+
+// EnsureKeyringCollection is only supported on Linux where D-Bus and
+// Secret Service are available.
+func EnsureKeyringCollection(_ context.Context) error {
+	return fmt.Errorf("automatic keyring collection creation is only supported on Linux (current OS: %s)", runtime.GOOS)
+}

--- a/pkg/config/keyring_test.go
+++ b/pkg/config/keyring_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"context"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -72,10 +74,40 @@ func TestEnsureKeyringCollection_Smoke(t *testing.T) {
 	// EnsureKeyringCollection requires D-Bus and Secret Service.
 	// In most test environments these are unavailable, so the function
 	// should return an error without panicking.
-	err := EnsureKeyringCollection()
-	if err != nil {
-		t.Logf("EnsureKeyringCollection() error (expected in CI): %v", err)
+	err := EnsureKeyringCollection(context.Background())
+	if err == nil {
+		return // D-Bus available (desktop environment) — nothing more to assert
 	}
+	t.Logf("EnsureKeyringCollection() error (expected in CI): %v", err)
+
+	if runtime.GOOS == "linux" {
+		// On Linux without D-Bus we expect a connection error.
+		if !strings.Contains(err.Error(), "cannot connect to Secret Service") {
+			t.Errorf("expected 'cannot connect to Secret Service' error, got: %v", err)
+		}
+	} else {
+		// On non-Linux platforms the stub should report the OS.
+		if !strings.Contains(err.Error(), "only supported on Linux") {
+			t.Errorf("expected 'only supported on Linux' error, got: %v", err)
+		}
+	}
+}
+
+func TestEnsureKeyringCollection_RespectsContext(t *testing.T) {
+	// Verify that a cancelled context is honoured (the function should
+	// return promptly rather than blocking).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err := EnsureKeyringCollection(ctx)
+	if err == nil {
+		// If D-Bus is available and the collection already exists the
+		// function returns nil before reaching the poll loop — acceptable.
+		return
+	}
+	// The error is either the context cancellation or the usual D-Bus
+	// / platform error — both are fine.
+	t.Logf("EnsureKeyringCollection(cancelled) error: %v", err)
 }
 
 func TestGetTokenWithFallback(t *testing.T) {

--- a/pkg/config/keyring_test.go
+++ b/pkg/config/keyring_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -38,51 +39,42 @@ func TestKeyringBackend(t *testing.T) {
 	}
 }
 
-func TestContains(t *testing.T) {
-	tests := []struct {
-		name    string
-		s       string
-		substrs []string
-		want    bool
-	}{
-		{
-			name:    "contains one",
-			s:       "hello world",
-			substrs: []string{"world"},
-			want:    true,
-		},
-		{
-			name:    "contains multiple check",
-			s:       "secret service error",
-			substrs: []string{"keychain", "secret service"},
-			want:    true,
-		},
-		{
-			name:    "contains none",
-			s:       "some error",
-			substrs: []string{"keychain", "dbus"},
-			want:    false,
-		},
-		{
-			name:    "empty string",
-			s:       "",
-			substrs: []string{"test"},
-			want:    false,
-		},
-		{
-			name:    "empty substrs",
-			s:       "hello",
-			substrs: []string{},
-			want:    false,
-		},
-	}
+func TestCheckKeyring_Disabled(t *testing.T) {
+	t.Setenv(EnvDisableKeyring, "1")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := contains(tt.s, tt.substrs...); got != tt.want {
-				t.Errorf("contains() = %v, want %v", got, tt.want)
-			}
-		})
+	err := CheckKeyring()
+	if err == nil {
+		t.Fatal("CheckKeyring() should return error when keyring is disabled")
+	}
+	if !strings.Contains(err.Error(), EnvDisableKeyring) {
+		t.Errorf("error should mention %s, got: %v", EnvDisableKeyring, err)
+	}
+}
+
+func TestCheckKeyring_ReturnsNilOrError(t *testing.T) {
+	// Smoke test: the function should not panic regardless of environment.
+	// In CI (no keyring) it returns an error; on a desktop it may return nil.
+	err := CheckKeyring()
+	if err != nil {
+		t.Logf("CheckKeyring() returned error (expected in CI): %v", err)
+	}
+}
+
+func TestIsKeyringAvailable_MatchesCheckKeyring(t *testing.T) {
+	available := IsKeyringAvailable()
+	err := CheckKeyring()
+	if available != (err == nil) {
+		t.Errorf("IsKeyringAvailable()=%v but CheckKeyring() returned %v", available, err)
+	}
+}
+
+func TestEnsureKeyringCollection_Smoke(t *testing.T) {
+	// EnsureKeyringCollection requires D-Bus and Secret Service.
+	// In most test environments these are unavailable, so the function
+	// should return an error without panicking.
+	err := EnsureKeyringCollection()
+	if err != nil {
+		t.Logf("EnsureKeyringCollection() error (expected in CI): %v", err)
 	}
 }
 


### PR DESCRIPTION
This is a quality-of-life improvement primarily for folks using WSL. The authentication mechanism relies on a keyring by default, which is amazing when configured properly. However, it wasn't set up on my system yet (despite having heavily used WSL for the past few years). The existing error message implied that I needed to install something, when in fact it simply needed to be enabled. This change will prompt the user to create a new keyring if it hasn't been configured.

## Description

Keyring diagnostics and recovery improvements:
* Replaces the old `IsKeyringAvailable` check with a new `CheckKeyring` function that returns descriptive errors explaining why the keyring is unavailable, including when it is disabled via environment variable (`DTCTL_DISABLE_KEYRING`). This enables more precise error handling and user guidance. (`pkg/config/keyring.go`, `cmd/auth.go`, `cmd/doctor.go`, `pkg/config/keyring_test.go`, [[1]](diffhunk://#diff-db5edcdd2697b4d8b970d407b32e5b641c34914e4c0f8181f96c09ce9d06734cL33-L70) [[2]](diffhunk://#diff-2a99768a3ac5c528aaefcdbcfc65b406d9913e150e08dab88cfbeacdd19793a8L233-R258) [[3]](diffhunk://#diff-cb3f7fd106d4cda9b5164e7037a1465c04fd5be73bac630571722a1ab386dd4bL141-R162) [[4]](diffhunk://#diff-b104828433077b471af16dab178ccbd511d651aa08edd4e3bfcfcb7217c6161cL41-R77)
* Adds `EnsureKeyringCollection`, which attempts to create a persistent keyring collection on Linux/WSL if one does not exist, helping users recover automatically from common keyring issues. This may prompt the user for a password if required. (`pkg/config/keyring.go`, [pkg/config/keyring.goL33-L70](diffhunk://#diff-db5edcdd2697b4d8b970d407b32e5b641c34914e4c0f8181f96c09ce9d06734cL33-L70))
* Updates the `auth login` command to attempt automatic keyring collection creation if the keyring is missing or locked, and provides actionable suggestions if recovery fails. (`cmd/auth.go`, [cmd/auth.goL233-R258](diffhunk://#diff-2a99768a3ac5c528aaefcdbcfc65b406d9913e150e08dab88cfbeacdd19793a8L233-R258))

CLI diagnostics and test coverage:
* Enhances the `doctor` command to include a dedicated "Keyring" check, reporting detailed backend status and guidance for recovery. The help text and check order are updated accordingly. (`cmd/doctor.go`, [[1]](diffhunk://#diff-cb3f7fd106d4cda9b5164e7037a1465c04fd5be73bac630571722a1ab386dd4bL36-R40) [[2]](diffhunk://#diff-cb3f7fd106d4cda9b5164e7037a1465c04fd5be73bac630571722a1ab386dd4bL141-R162)
* Adds new and updated tests for keyring error reporting, collection creation, and CLI diagnostics, ensuring that error reasons are surfaced and recovery paths are exercised. (`cmd/auth_test.go`, `cmd/doctor_test.go`, `pkg/config/keyring_test.go`, [[1]](diffhunk://#diff-367ecbc9a30d38b7723373ddad4380a18afd915f581c3df05c2944843e003e8fR129-R134) [[2]](diffhunk://#diff-32e640741fbef32eef0802f58a63d426b23671a2db268de1f0e791d8f42715a4R339-R380) [[3]](diffhunk://#diff-b104828433077b471af16dab178ccbd511d651aa08edd4e3bfcfcb7217c6161cL41-R77)

Dependency management:
* Promotes `github.com/godbus/dbus/v5` to a direct dependency to support D-Bus operations required for keyring management. (`go.mod`, [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R8) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L29)


## Testing

<!-- How did you test this? -->

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)

I also manually tested this in Ubuntu on WSL. It would be great if someone could manually test in macOS to ensure I didn't break anything.