### PR TITLE
fix: segment review fixes — PUT→PATCH, field order preservation, test hardening

### DIFF
--- a/docs/dev/FILTER_AST_PLAN.md
+++ b/docs/dev/FILTER_AST_PLAN.md
@@ -1,0 +1,316 @@
+# Filter AST Conversion — Implementation Plan
+
+**Issue**: [#132](https://github.com/dynatrace-oss/dtctl/issues/132) — Segment filter field requires JSON AST, not DQL strings  
+**Date**: 2026-04-09
+
+---
+
+## Problem
+
+The Dynatrace Filter Segments API (`/platform/storage/filter-segments/v1/filter-segments`) requires the `filter` field in segment includes to be a **stringified JSON AST** — not a plain DQL filter string.
+
+What dtctl currently sends (causes HTTP 400):
+```json
+{"filter": "k8s.cluster.name = \"alpha\""}
+```
+
+What the API actually expects:
+```json
+{"filter": "{\"type\":\"Group\",\"logicalOperator\":\"AND\",\"explicit\":false,\"range\":{\"from\":0,\"to\":25},\"children\":[{\"type\":\"Statement\",\"range\":{\"from\":0,\"to\":25},\"key\":{\"type\":\"Key\",\"textValue\":\"k8s.cluster.name\",\"value\":\"k8s.cluster.name\",\"range\":{\"from\":0,\"to\":16}},\"operator\":{\"type\":\"ComparisonOperator\",\"textValue\":\"=\",\"value\":\"=\",\"range\":{\"from\":17,\"to\":18}},\"value\":{\"type\":\"String\",\"textValue\":\"\\\"alpha\\\"\",\"value\":\"alpha\",\"range\":{\"from\":19,\"to\":26},\"isEscaped\":true}}]}"}
+```
+
+The API also returns filters as JSON AST in GET responses, so `describe` / `edit` currently display opaque AST blobs to users.
+
+---
+
+## Background: The AST Format
+
+The JSON AST is the **FilterField syntax tree** — the same format used by Dynatrace's own React UI component (`@dynatrace/strato-components/filters`). The UI provides `convertStringToFilterFieldTree` and `convertFilterFieldTreeToString` as client-side utilities. There is **no server-side parse endpoint** for this format.
+
+### Node Types
+
+```
+Group
+├── type: "Group"
+├── logicalOperator: "AND" | "OR"
+├── explicit: boolean           (false = implicit root/AND, true = explicit grouping)
+├── range: {from, to}           (character positions in the DQL string)
+└── children: []                (Statement | Group | LogicalOperator nodes)
+
+Statement
+├── type: "Statement"
+├── range: {from, to}
+├── key: Key
+├── operator: ComparisonOperator
+└── value: String | Number | Variable | ...
+
+Key
+├── type: "Key"
+├── textValue: string           (raw text, may include backtick escapes)
+├── value: string               (parsed value)
+└── range: {from, to}
+
+ComparisonOperator
+├── type: "ComparisonOperator"
+├── textValue: string           ("=", "!=", "<", "<=", ">", ">=", "in", "not in")
+├── value: string               (same as textValue)
+└── range: {from, to}
+
+String (value node)
+├── type: "String"
+├── textValue: string           (raw text including surrounding quotes if any)
+├── value: string               (unquoted/unescaped value)
+├── range: {from, to}
+└── isEscaped: boolean          (true when textValue has wrapping quotes or backslash escapes)
+```
+
+### Operator Constraints
+
+- Only `=` is valid for equality (the API rejects `==` with HTTP 400).
+- Full operator set from Strato docs: `=`, `!=`, `<`, `<=`, `>`, `>=`, `in`, `not in`, `exists` (`= *`), `not-exists` (`!= *`).
+- Field names with special characters must be backtick-escaped.
+
+### Key Observations
+
+- `range` values map to exact character positions in the *canonical* DQL string.
+- `textValue` is the raw text, `value` is the parsed/unescaped form.
+- Dynatrace's own docs warn that string→tree→string round-trips may not reproduce identical text (due to escape character variations).
+- `maxLength` for the serialized filter string: **18,000 characters**.
+- Max **20 includes** per segment.
+
+---
+
+## Design
+
+### Approach: Build a Go FilterField parser + renderer
+
+The FilterField syntax is a small, well-defined grammar (not full DQL):
+
+```
+filter     = expression
+expression = term (("OR") term)*
+term       = factor (("AND" | implicit-AND) factor)*
+factor     = "(" expression ")" | statement
+statement  = key operator value
+key        = identifier | backtick-escaped-identifier
+operator   = "=" | "!=" | "<" | "<=" | ">" | ">=" | "in" | "not in"
+value      = quoted-string | unquoted-token | number | boolean
+```
+
+This is feasible because:
+1. Dynatrace themselves parse it client-side (in their React FilterField component).
+2. The grammar is documented and small — it's NOT full DQL.
+3. The format is stable (it's a core UI component in the Strato Design System).
+4. The `range` fields are mechanical (character positions derived from parsing).
+
+### Conversion Points
+
+```
+User writes YAML           dtctl sends to API          API returns JSON
+─────────────────          ──────────────────          ────────────────
+filter: 'status = "ERROR"' → filter: "{JSON AST...}"   filter: "{JSON AST...}"
+                              (DQL → AST on create/    (AST → DQL on get/
+                               update/apply/edit)        describe/edit/getRaw)
+```
+
+**Inbound (user → API)**: Before sending to the API, detect if filter is plain DQL or already AST. If DQL, convert to AST. If already AST (starts with `{`), pass through.
+
+**Outbound (API → user)**: After receiving from the API, convert AST back to human-readable DQL for display in `describe`, `edit`, and `get -o yaml/json`.
+
+### Auto-Detection
+
+```go
+func isFilterAST(filter string) bool {
+    return len(filter) > 0 && filter[0] == '{'
+}
+```
+
+Plain DQL filter expressions never start with `{` (they start with a key name or parenthesis). This is a safe discriminator.
+
+---
+
+## Implementation Plan
+
+### Step 1: FilterField parser and renderer (`pkg/resources/segment/filterast.go`)
+
+New file with these public functions:
+
+```go
+// FilterToAST converts a DQL filter expression to a JSON AST string.
+// If the input is already a JSON AST (starts with '{'), it is returned as-is.
+func FilterToAST(dql string) (string, error)
+
+// FilterFromAST converts a JSON AST string back to a DQL filter expression.
+// If the input is not a JSON AST (doesn't start with '{'), it is returned as-is.
+func FilterFromAST(ast string) (string, error)
+```
+
+Internal implementation:
+- **Parser** (DQL → AST): Tokenize the filter string into tokens (keys, operators, values, parens, AND, OR). Then build the tree with correct `range` positions. Serialize to JSON.
+- **Renderer** (AST → DQL): Parse JSON into Go structs. Walk the tree and emit DQL text. Handle: groups with explicit OR, parenthesized sub-groups, statement key/operator/value.
+
+Supported grammar for initial implementation:
+- Statements: `key = "value"`, `key != value`, `key < 42`, `key >= 3.14`, etc.
+- Logical operators: `AND` (explicit or implicit via whitespace), `OR`
+- Parenthesized groups: `(a = 1 OR b = 2) c = 3`
+- Quoted string values (double-quoted, with backslash escapes)
+- Unquoted values (alphanumeric, dots, hyphens, underscores)
+- Backtick-escaped key names: `` `field.with.dots` ``
+- Operators: `=`, `!=`, `<`, `<=`, `>`, `>=`, `in`, `not in`
+
+Explicitly **out of scope** for v1 (error with clear message):
+- `exists` / `not-exists` operators (`= *`, `!= *`)
+- Wildcard patterns (`*value`, `value*`, `*value*`)
+- Matches-phrase (`~`, `!~`)
+- Search operator (`* ~`)
+- Variable references (`$var`)
+- `in (val1, val2)` list syntax
+
+These can be added later if needed. The error message should say: `unsupported filter syntax "..."; provide the filter as a JSON AST string instead`.
+
+### Step 2: Unit tests (`pkg/resources/segment/filterast_test.go`)
+
+Test cases:
+
+**DQL → AST (FilterToAST)**:
+- Simple: `status = "ERROR"` → correct AST with range positions
+- Unquoted value: `count = 42` → Number-like still treated as unquoted string/token
+- Dotted key: `k8s.cluster.name = "alpha"` → key value preserves dots
+- Backtick-escaped key: `` `my field` = "value" ``
+- Multiple AND (implicit): `a = "1" b = "2"` → Group with AND, two Statement children
+- Multiple AND (explicit): `a = "1" AND b = "2"` → same structure
+- OR: `a = "1" OR b = "2"` → Group with OR
+- Mixed AND/OR precedence: `a = "1" OR b = "2" c = "3"` → OR-group containing two sub-groups
+- Parentheses: `(a = "1" OR b = "2") AND c = "3"`
+- All comparison operators: `!=`, `<`, `<=`, `>`, `>=`
+- `not in` operator: `status not in ("a", "b")`  *(if implemented)*
+- Empty string → error
+- Invalid syntax → clear error
+
+**AST → DQL (FilterFromAST)**:
+- Single statement AST → `key = "value"`
+- Multi-statement AND → `key1 = "value1" key2 = "value2"`
+- OR group → `key1 = "value1" OR key2 = "value2"`
+- Nested groups → parenthesized output
+- Already-DQL passthrough (non-`{` input returns as-is)
+
+**Round-trip**:
+- Parse DQL → AST → DQL and verify the DQL is semantically equivalent
+- Parse the API spec examples and verify they render back to the expected DQL
+
+**Auto-detection**:
+- `isFilterAST("{...}")` → true
+- `isFilterAST("status = \"ERROR\"")` → false
+- Already-AST passthrough in both directions
+
+### Step 3: Wire into segment handler (`pkg/resources/segment/segment.go`)
+
+Add two helper functions:
+
+```go
+// convertIncludesForAPI converts include filters from DQL to AST (for create/update).
+func convertIncludesForAPI(data []byte) ([]byte, error)
+
+// convertIncludesForDisplay converts include filters from AST to DQL (for get/describe/edit).
+func convertIncludesForDisplay(seg *FilterSegment)
+```
+
+**Outbound (API responses)**: Call `convertIncludesForDisplay` in:
+- `Get()` — after unmarshaling the response
+- `List()` — after unmarshaling the response (for each segment)
+- `GetRaw()` — after `Get()` (already covered)
+
+**Inbound (API requests)**: Call `convertIncludesForAPI` in:
+- `Create(data)` — before sending the request body
+- `Update(uid, version, data)` — before sending the request body
+
+This keeps conversion centralized in the handler. No changes needed in `cmd/` files, `pkg/apply/`, or any other callers — they continue to work with human-readable DQL strings.
+
+### Step 4: Update existing tests
+
+**`pkg/resources/segment/segment_test.go`**:
+- Update test fixtures to use DQL strings (human-readable) as input.
+- Update mock server handlers to **validate** that the request body contains JSON AST (not plain DQL) in the `filter` field. This ensures the conversion is actually happening.
+- Update response fixtures to return JSON AST (simulating real API behavior), and verify that the handler returns DQL strings to callers.
+
+**`test/integration/fixtures.go`**:
+- Fix `SegmentFixture()`: change `status == "ERROR"` to `status = "ERROR"` (fix `==` → `=`).
+- Fix `SegmentFixtureModified()`: same fix.
+- Fix `SegmentFixtureMultiInclude()`: change `loglevel == "ERROR" OR loglevel == "WARN"` to `loglevel = "ERROR" OR loglevel = "WARN"`.
+- These fixtures are used by integration tests (behind build tag). The handler will auto-convert them to AST, so the DQL strings are correct input.
+
+### Step 5: Update golden tests
+
+**`pkg/output/golden_test.go`**:
+- The `segmentFixtures()` function currently uses DQL strings in `Include.Filter`. These represent what the handler returns after AST→DQL conversion, so they should **stay as DQL strings**. No changes needed to the fixtures themselves.
+- If the golden test output changes (e.g., because `describe` output now shows converted DQL differently), regenerate with `make test-update-golden` and review diffs.
+
+### Step 6: Update documentation
+
+**`docs/dev/SEGMENTS_DESIGN.md`**:
+- Add a new section "Filter Format Conversion" explaining the DQL ↔ AST auto-conversion.
+- Note that users always write DQL, dtctl handles conversion transparently.
+
+**`docs/site/_docs/segments.md`**:
+- No changes needed to YAML examples (they already show DQL, which is correct).
+- Add a brief note under the `filter` field description: "dtctl automatically converts DQL filter expressions to the API's internal format."
+
+### Step 7: Run tests and validate
+
+```bash
+go test ./pkg/resources/segment/ -v          # New + updated unit tests
+go test ./pkg/output/ -run TestGolden        # Golden tests
+make test                                     # Full suite
+```
+
+---
+
+## Files Changed
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `pkg/resources/segment/filterast.go` | DQL ↔ AST parser and renderer |
+| `pkg/resources/segment/filterast_test.go` | Comprehensive unit tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `pkg/resources/segment/segment.go` | Add `convertIncludesForAPI`, `convertIncludesForDisplay`; call from Get/List/Create/Update |
+| `pkg/resources/segment/segment_test.go` | Update mock servers to validate AST in requests and return AST in responses |
+| `test/integration/fixtures.go` | Fix `==` → `=` in three segment fixtures |
+| `docs/dev/SEGMENTS_DESIGN.md` | Add filter format conversion section |
+| `docs/site/_docs/segments.md` | Add note about auto-conversion |
+
+### NOT Changed (by design)
+
+| File | Why |
+|------|-----|
+| `cmd/create_segments.go` | Handler does conversion — callers don't need changes |
+| `cmd/edit_segments.go` | Same — handler converts on Get (display) and Update (send) |
+| `cmd/describe_segments.go` | Same — handler converts on Get |
+| `pkg/apply/apply_segment.go` | Same — handler converts on Create and Update |
+| `pkg/output/golden_test.go` | Fixtures already use DQL strings (correct after conversion) |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Parser doesn't handle some real-world filter syntax | Auto-detect: if filter is already AST (`{...}`), pass through. Users can always provide raw AST as an escape hatch. Clear error message for unsupported syntax. |
+| `range` positions are wrong | Ranges are computed mechanically during parsing. Extensive test coverage with known-good examples from the API spec. |
+| API returns unexpected AST node types in GET responses | `FilterFromAST` handles unknown types gracefully — falls back to returning the raw AST string with a warning, rather than erroring. |
+| Round-trip fidelity (DQL → AST → DQL) | Dynatrace's own docs warn about this. We normalize on canonical forms (e.g., always quote string values). Editing flow: Get returns DQL, user edits DQL, Update converts back to AST. The AST may differ from the original but is semantically equivalent. |
+| Grammar changes in future Strato versions | The core grammar (key/op/value with AND/OR) is stable. Advanced operators are out-of-scope with clear error + AST passthrough escape hatch. |
+
+---
+
+## Out of Scope
+
+- Advanced FilterField features (wildcards, matches-phrase, exists, variables, search)
+- Server-side validation of the AST before sending (the API validates it)
+- Caching or memoization of parsed ASTs
+- Changes to the query command (`--segment` flag) — that uses segment UIDs, not filter expressions

--- a/docs/dev/SEGMENTS_DESIGN.md
+++ b/docs/dev/SEGMENTS_DESIGN.md
@@ -371,7 +371,7 @@ The Dynatrace Filter Segments API requires the `filter` field in segment include
 - **Auto-detection**: A filter starting with `{` is treated as AST; plain DQL never starts with `{`.
 
 **Supported DQL syntax** (for the FilterField grammar):
-- Comparison operators: `=`, `!=`, `<`, `<=`, `>`, `>=`, `not in`
+- Comparison operators: `=`, `!=`, `<`, `<=`, `>`, `>=`, `in`, `not in`
 - Logical operators: `AND` (explicit or implicit via whitespace), `OR`
 - Parenthesized groups: `(a = "1" OR b = "2") AND c = "3"`
 - Quoted and unquoted values, backtick-escaped keys

--- a/docs/dev/SEGMENTS_DESIGN.md
+++ b/docs/dev/SEGMENTS_DESIGN.md
@@ -360,6 +360,33 @@ When segments are used, the agent output envelope's `context` should reflect the
 
 ---
 
+## Filter Format Conversion (DQL ↔ AST)
+
+The Dynatrace Filter Segments API requires the `filter` field in segment includes to be a **stringified JSON AST** (the FilterField syntax tree), not a plain DQL string. dtctl transparently converts between the two formats so users always work with human-readable DQL.
+
+**How it works:**
+
+- **Inbound (create/update/apply/edit)**: Before sending to the API, dtctl detects whether each include filter is plain DQL or already JSON AST. Plain DQL is converted to AST; existing AST is passed through unchanged.
+- **Outbound (get/describe/edit)**: After receiving from the API, dtctl converts AST filters back to human-readable DQL for display. If conversion fails (e.g., unknown AST node types), the raw AST is left as-is.
+- **Auto-detection**: A filter starting with `{` is treated as AST; plain DQL never starts with `{`.
+
+**Supported DQL syntax** (for the FilterField grammar):
+- Comparison operators: `=`, `!=`, `<`, `<=`, `>`, `>=`, `not in`
+- Logical operators: `AND` (explicit or implicit via whitespace), `OR`
+- Parenthesized groups: `(a = "1" OR b = "2") AND c = "3"`
+- Quoted and unquoted values, backtick-escaped keys
+
+**Unsupported syntax** (error with clear message suggesting JSON AST escape hatch):
+- `exists` / `not-exists`, wildcards, `matches-phrase`, variable references, `in (val1, val2)` list syntax
+
+**Escape hatch**: Users can always provide the raw JSON AST directly as the filter value — it will be passed through unchanged.
+
+Implementation: `pkg/resources/segment/filterast.go` (parser + renderer), wired in `segment.go` via `convertIncludesForAPI()` and `convertIncludesForDisplay()`.
+
+Design document: [FILTER_AST_PLAN.md](FILTER_AST_PLAN.md)
+
+---
+
 ## Implementation Phases
 
 ### Phase 1: Resource Handler + Read Commands

--- a/docs/site/_docs/segments.md
+++ b/docs/site/_docs/segments.md
@@ -88,7 +88,7 @@ variables:
 | `isPublic`    | `true` for environment-wide visibility, `false` for owner-only (default)    |
 | `includes`    | Array of filter rules. Each specifies a `dataObject` and a `filter` expression. Includes are OR-combined within a segment. |
 | `dataObject`  | Data type to filter: `logs`, `spans`, `events`, `metrics`, `entities`, or `_all_data_object` for all |
-| `filter`      | DQL filter expression applied to the data object                            |
+| `filter`      | DQL filter expression applied to the data object. dtctl automatically converts DQL to the API's internal JSON AST format on create/update, and converts back to DQL on get/describe. You can also provide a raw JSON AST string (starting with `{`) which will be passed through unchanged. |
 | `variables`   | Optional variable definition with `type` and `value` fields                 |
 
 ## Editing a Segment

--- a/pkg/apply/apply_integration_test.go
+++ b/pkg/apply/apply_integration_test.go
@@ -704,7 +704,7 @@ func TestApply_SegmentCreate_NoUID(t *testing.T) {
 	defer srv.Close()
 	a := NewApplier(c)
 
-	segJSON := `{"name":"Test Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status == \"ERROR\""}]}`
+	segJSON := `{"name":"Test Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status = \\\"ERROR\\\""}]}`
 	results, err := a.Apply([]byte(segJSON), ApplyOptions{})
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)
@@ -751,7 +751,7 @@ func TestApply_SegmentUpdate_Exists(t *testing.T) {
 	defer srv.Close()
 	a := NewApplier(c)
 
-	segJSON := `{"uid":"seg-uid-001","name":"Updated Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status == \"ERROR\""}]}`
+	segJSON := `{"uid":"seg-uid-001","name":"Updated Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status = \\\"ERROR\\\""}]}`
 	results, err := a.Apply([]byte(segJSON), ApplyOptions{})
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)
@@ -786,7 +786,7 @@ func TestApply_SegmentCreate_IDNotFound(t *testing.T) {
 	defer srv.Close()
 	a := NewApplier(c)
 
-	segJSON := `{"uid":"seg-missing","name":"New Segment","isPublic":false,"includes":[{"dataObject":"logs","filter":"status == \"ERROR\""}]}`
+	segJSON := `{"uid":"seg-missing","name":"New Segment","isPublic":false,"includes":[{"dataObject":"logs","filter":"status = \\\"ERROR\\\""}]}`
 	results, err := a.Apply([]byte(segJSON), ApplyOptions{})
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)
@@ -816,7 +816,7 @@ func TestApply_Segment_GetServerError_NoFallthrough(t *testing.T) {
 	defer srv.Close()
 	a := NewApplier(c)
 
-	segJSON := `{"uid":"seg-uid-001","name":"Test Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status == \"ERROR\""}]}`
+	segJSON := `{"uid":"seg-uid-001","name":"Test Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status = \\\"ERROR\\\""}]}`
 	_, err := a.Apply([]byte(segJSON), ApplyOptions{})
 	if err == nil {
 		t.Fatal("Apply() should have returned an error for server error, got nil")

--- a/pkg/apply/apply_integration_test.go
+++ b/pkg/apply/apply_integration_test.go
@@ -3,12 +3,41 @@ package apply
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 )
+
+// requireSegmentFiltersAST reads the request body and validates that all
+// include filters are JSON AST (start with '{'). Returns true if the request
+// should continue, false if an error was written to the response.
+func requireSegmentFiltersAST(t *testing.T, r *http.Request, w http.ResponseWriter) bool {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return true // can't read body — let normal handler run
+	}
+	var reqBody struct {
+		Includes []struct {
+			Filter string `json:"filter"`
+		} `json:"includes"`
+	}
+	if err := json.Unmarshal(body, &reqBody); err != nil {
+		return true // not valid JSON or no includes — let normal handler run
+	}
+	for i, inc := range reqBody.Includes {
+		if inc.Filter != "" && (len(inc.Filter) == 0 || inc.Filter[0] != '{') {
+			t.Errorf("include[%d] filter should be AST in API request, got DQL: %s", i, inc.Filter)
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"filter must be AST, got DQL"}`))
+			return false
+		}
+	}
+	return true
+}
 
 // newApplyTestServer creates a multiplexed test server that handles multiple resource endpoints.
 func newApplyTestServer(t *testing.T, handlers map[string]http.HandlerFunc) (*httptest.Server, *client.Client) {
@@ -691,6 +720,9 @@ func TestApply_SegmentCreate_NoUID(t *testing.T) {
 			if r.Method != http.MethodPost {
 				t.Errorf("expected POST, got %s", r.Method)
 			}
+			if !requireSegmentFiltersAST(t, r, w) {
+				return
+			}
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"uid":  "seg-new-001",
@@ -704,7 +736,7 @@ func TestApply_SegmentCreate_NoUID(t *testing.T) {
 	defer srv.Close()
 	a := NewApplier(c)
 
-	segJSON := `{"name":"Test Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status = \\\"ERROR\\\""}]}`
+	segJSON := `{"name":"Test Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status = \"ERROR\""}]}`
 	results, err := a.Apply([]byte(segJSON), ApplyOptions{})
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)
@@ -734,7 +766,10 @@ func TestApply_SegmentUpdate_Exists(t *testing.T) {
 					"version": 3,
 					"owner":   "user@example.invalid",
 				})
-			case http.MethodPut:
+			case http.MethodPatch:
+				if !requireSegmentFiltersAST(t, r, w) {
+					return
+				}
 				lockVer := r.URL.Query().Get("optimistic-locking-version")
 				if lockVer != "3" {
 					t.Errorf("expected optimistic-locking-version=3, got %q", lockVer)
@@ -751,7 +786,7 @@ func TestApply_SegmentUpdate_Exists(t *testing.T) {
 	defer srv.Close()
 	a := NewApplier(c)
 
-	segJSON := `{"uid":"seg-uid-001","name":"Updated Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status = \\\"ERROR\\\""}]}`
+	segJSON := `{"uid":"seg-uid-001","name":"Updated Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status = \"ERROR\""}]}`
 	results, err := a.Apply([]byte(segJSON), ApplyOptions{})
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)
@@ -773,6 +808,9 @@ func TestApply_SegmentCreate_IDNotFound(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		},
 		"/platform/storage/filter-segments/v1/filter-segments": func(w http.ResponseWriter, r *http.Request) {
+			if !requireSegmentFiltersAST(t, r, w) {
+				return
+			}
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"uid":  "seg-missing",
@@ -786,7 +824,7 @@ func TestApply_SegmentCreate_IDNotFound(t *testing.T) {
 	defer srv.Close()
 	a := NewApplier(c)
 
-	segJSON := `{"uid":"seg-missing","name":"New Segment","isPublic":false,"includes":[{"dataObject":"logs","filter":"status = \\\"ERROR\\\""}]}`
+	segJSON := `{"uid":"seg-missing","name":"New Segment","isPublic":false,"includes":[{"dataObject":"logs","filter":"status = \"ERROR\""}]}`
 	results, err := a.Apply([]byte(segJSON), ApplyOptions{})
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)
@@ -816,7 +854,7 @@ func TestApply_Segment_GetServerError_NoFallthrough(t *testing.T) {
 	defer srv.Close()
 	a := NewApplier(c)
 
-	segJSON := `{"uid":"seg-uid-001","name":"Test Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status = \\\"ERROR\\\""}]}`
+	segJSON := `{"uid":"seg-uid-001","name":"Test Segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status = \"ERROR\""}]}`
 	_, err := a.Apply([]byte(segJSON), ApplyOptions{})
 	if err == nil {
 		t.Fatal("Apply() should have returned an error for server error, got nil")

--- a/pkg/resources/segment/filterast.go
+++ b/pkg/resources/segment/filterast.go
@@ -490,10 +490,10 @@ func (p *parser) parseOperator() (*leafNode, error) {
 	remaining := p.input[p.pos:]
 
 	// Check operators from longest to shortest to avoid prefix conflicts
-	for _, op := range []string{"not in", "!=", "<=", ">=", "<", ">", "="} {
+	for _, op := range []string{"not in", "!=", "<=", ">=", "<", ">", "=", "in"} {
 		if strings.HasPrefix(remaining, op) {
-			// "not in" requires whitespace or end after it
-			if op == "not in" {
+			// "not in" and "in" require whitespace or end after them
+			if op == "not in" || op == "in" {
 				afterOp := p.pos + len(op)
 				if afterOp < len(p.input) && !isSpace(p.input[afterOp]) {
 					continue

--- a/pkg/resources/segment/filterast.go
+++ b/pkg/resources/segment/filterast.go
@@ -1,0 +1,825 @@
+package segment
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// FilterToAST converts a DQL filter expression to a JSON AST string.
+// If the input is already a JSON AST (starts with '{'), it is returned as-is.
+func FilterToAST(dql string) (string, error) {
+	dql = strings.TrimSpace(dql)
+	if dql == "" {
+		return "", fmt.Errorf("empty filter expression")
+	}
+	if isFilterAST(dql) {
+		return dql, nil
+	}
+
+	p := newParser(dql)
+	node, err := p.parseExpression()
+	if err != nil {
+		return "", fmt.Errorf("failed to parse filter expression: %w", err)
+	}
+	if p.pos < len(p.input) {
+		return "", fmt.Errorf("unexpected input at position %d: %q", p.pos, p.input[p.pos:])
+	}
+
+	// Wrap in an implicit root group.
+	root := ensureRootGroup(node, len(dql))
+
+	data, err := json.Marshal(root)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize filter AST: %w", err)
+	}
+	return string(data), nil
+}
+
+// FilterFromAST converts a JSON AST string back to a DQL filter expression.
+// If the input is not a JSON AST (doesn't start with '{'), it is returned as-is.
+func FilterFromAST(ast string) (string, error) {
+	ast = strings.TrimSpace(ast)
+	if ast == "" {
+		return "", fmt.Errorf("empty filter AST")
+	}
+	if !isFilterAST(ast) {
+		return ast, nil
+	}
+
+	result, err := renderFromRaw([]byte(ast))
+	if err != nil {
+		return "", fmt.Errorf("failed to render filter AST: %w", err)
+	}
+	return result, nil
+}
+
+// isFilterAST returns true if the filter string is a JSON AST (starts with '{').
+// Plain DQL filter expressions never start with '{'.
+func isFilterAST(filter string) bool {
+	return len(filter) > 0 && filter[0] == '{'
+}
+
+// ---------------------------------------------------------------------------
+// JSON structures for the AST format (the Dynatrace FilterField syntax tree)
+// ---------------------------------------------------------------------------
+
+// astGroupJSON is the JSON shape for Group nodes.
+type astGroupJSON struct {
+	Type            string            `json:"type"`
+	LogicalOperator string            `json:"logicalOperator"`
+	Explicit        bool              `json:"explicit"`
+	Range           *astRange         `json:"range,omitempty"`
+	Children        []json.RawMessage `json:"children"`
+}
+
+// astStatementJSON is the JSON shape for Statement nodes.
+type astStatementJSON struct {
+	Type     string          `json:"type"`
+	Range    *astRange       `json:"range,omitempty"`
+	Key      json.RawMessage `json:"key"`
+	Operator json.RawMessage `json:"operator"`
+	Value    json.RawMessage `json:"value"`
+}
+
+// astLeafJSON is the JSON shape for leaf nodes (Key, ComparisonOperator, String).
+type astLeafJSON struct {
+	Type      string    `json:"type"`
+	TextValue string    `json:"textValue"`
+	Value     string    `json:"value"`
+	Range     *astRange `json:"range,omitempty"`
+	IsEscaped *bool     `json:"isEscaped,omitempty"`
+}
+
+// astLogicalOperatorJSON is the JSON shape for LogicalOperator separator nodes.
+type astLogicalOperatorJSON struct {
+	Type      string    `json:"type"`
+	TextValue string    `json:"textValue"`
+	Value     string    `json:"value"`
+	Range     *astRange `json:"range,omitempty"`
+}
+
+type astRange struct {
+	From int `json:"from"`
+	To   int `json:"to"`
+}
+
+// ---------------------------------------------------------------------------
+// Internal representation used during parsing
+// ---------------------------------------------------------------------------
+
+// filterNode is the internal representation used during parsing.
+type filterNode struct {
+	nodeType        string // "Group", "Statement", "LogicalOperator"
+	logicalOperator string // "AND", "OR" (for Group)
+	explicit        bool   // true = explicit parenthesized group
+	rangeFrom       int
+	rangeTo         int
+	children        []*filterNode
+	// Statement fields
+	key      *leafNode
+	operator *leafNode
+	value    *leafNode
+	// LogicalOperator separator
+	textValue string
+}
+
+type leafNode struct {
+	leafType  string // "Key", "ComparisonOperator", "String"
+	textValue string
+	value     string
+	rangeFrom int
+	rangeTo   int
+	isEscaped *bool
+}
+
+func (n *filterNode) rangeStart() int { return n.rangeFrom }
+func (n *filterNode) rangeEnd() int   { return n.rangeTo }
+
+func (n *filterNode) logicalOperatorOrDefault() string {
+	if n.logicalOperator != "" {
+		return n.logicalOperator
+	}
+	return "AND"
+}
+
+// ensureRootGroup wraps the parsed node in a root group if needed.
+func ensureRootGroup(node *filterNode, inputLen int) *filterNode {
+	if node.nodeType == "Group" {
+		node.explicit = false
+		node.rangeFrom = 0
+		node.rangeTo = inputLen
+		return node
+	}
+	return &filterNode{
+		nodeType:        "Group",
+		logicalOperator: "AND",
+		explicit:        false,
+		rangeFrom:       0,
+		rangeTo:         inputLen,
+		children:        []*filterNode{node},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON marshaling: filterNode → API JSON
+// ---------------------------------------------------------------------------
+
+// MarshalJSON implements json.Marshaler for filterNode.
+func (n *filterNode) MarshalJSON() ([]byte, error) {
+	switch n.nodeType {
+	case "Group":
+		g := astGroupJSON{
+			Type:            "Group",
+			LogicalOperator: n.logicalOperator,
+			Explicit:        n.explicit,
+			Range:           &astRange{From: n.rangeFrom, To: n.rangeTo},
+		}
+		children := make([]json.RawMessage, 0, len(n.children))
+		for _, child := range n.children {
+			data, err := json.Marshal(child)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, data)
+		}
+		g.Children = children
+		return json.Marshal(g)
+
+	case "Statement":
+		keyData, err := marshalLeaf(n.key)
+		if err != nil {
+			return nil, err
+		}
+		opData, err := marshalLeaf(n.operator)
+		if err != nil {
+			return nil, err
+		}
+		valData, err := marshalLeaf(n.value)
+		if err != nil {
+			return nil, err
+		}
+		s := astStatementJSON{
+			Type:     "Statement",
+			Range:    &astRange{From: n.rangeFrom, To: n.rangeTo},
+			Key:      keyData,
+			Operator: opData,
+			Value:    valData,
+		}
+		return json.Marshal(s)
+
+	case "LogicalOperator":
+		lo := astLogicalOperatorJSON{
+			Type:      "LogicalOperator",
+			TextValue: n.textValue,
+			Value:     n.textValue,
+			Range:     &astRange{From: n.rangeFrom, To: n.rangeTo},
+		}
+		return json.Marshal(lo)
+
+	default:
+		return nil, fmt.Errorf("unknown node type: %s", n.nodeType)
+	}
+}
+
+func marshalLeaf(l *leafNode) (json.RawMessage, error) {
+	leaf := astLeafJSON{
+		Type:      l.leafType,
+		TextValue: l.textValue,
+		Value:     l.value,
+		Range:     &astRange{From: l.rangeFrom, To: l.rangeTo},
+		IsEscaped: l.isEscaped,
+	}
+	return json.Marshal(leaf)
+}
+
+// ---------------------------------------------------------------------------
+// Parser: DQL filter string → filterNode tree
+// ---------------------------------------------------------------------------
+
+type parser struct {
+	input string
+	pos   int
+}
+
+func newParser(input string) *parser {
+	return &parser{input: input, pos: 0}
+}
+
+func (p *parser) parseExpression() (*filterNode, error) {
+	return p.parseOr()
+}
+
+// parseOr: term (OR term)*
+func (p *parser) parseOr() (*filterNode, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+
+	type orTerm struct {
+		sepPos int
+		node   *filterNode
+	}
+	var extra []orTerm
+
+	for {
+		p.skipSpaces()
+		orPos := p.pos
+		if !p.matchKeyword("OR") {
+			break
+		}
+		p.skipSpaces()
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		extra = append(extra, orTerm{sepPos: orPos, node: right})
+	}
+
+	if len(extra) == 0 {
+		return left, nil
+	}
+
+	children := make([]*filterNode, 0, 1+len(extra)*2)
+	children = append(children, left)
+	for _, t := range extra {
+		children = append(children, &filterNode{
+			nodeType:  "LogicalOperator",
+			textValue: "OR",
+			rangeFrom: t.sepPos,
+			rangeTo:   t.sepPos + 2,
+		})
+		children = append(children, t.node)
+	}
+
+	return &filterNode{
+		nodeType:        "Group",
+		logicalOperator: "OR",
+		explicit:        false,
+		rangeFrom:       children[0].rangeStart(),
+		rangeTo:         children[len(children)-1].rangeEnd(),
+		children:        children,
+	}, nil
+}
+
+// parseAnd: factor ((AND | implicit-AND) factor)*
+func (p *parser) parseAnd() (*filterNode, error) {
+	left, err := p.parseFactor()
+	if err != nil {
+		return nil, err
+	}
+
+	type andTerm struct {
+		sep  *filterNode // nil for implicit AND
+		node *filterNode
+	}
+	var extra []andTerm
+
+	for {
+		p.skipSpaces()
+		if p.pos >= len(p.input) || p.peek() == ')' || p.peekKeyword("OR") {
+			break
+		}
+
+		andPos := p.pos
+		if p.matchKeyword("AND") {
+			p.skipSpaces()
+			right, err := p.parseFactor()
+			if err != nil {
+				return nil, err
+			}
+			extra = append(extra, andTerm{
+				sep: &filterNode{
+					nodeType:  "LogicalOperator",
+					textValue: "AND",
+					rangeFrom: andPos,
+					rangeTo:   andPos + 3,
+				},
+				node: right,
+			})
+			continue
+		}
+
+		// implicit AND
+		right, err := p.parseFactor()
+		if err != nil {
+			break
+		}
+		extra = append(extra, andTerm{sep: nil, node: right})
+	}
+
+	if len(extra) == 0 {
+		return left, nil
+	}
+
+	children := make([]*filterNode, 0)
+	children = append(children, left)
+	for _, t := range extra {
+		if t.sep != nil {
+			children = append(children, t.sep)
+		}
+		children = append(children, t.node)
+	}
+
+	return &filterNode{
+		nodeType:        "Group",
+		logicalOperator: "AND",
+		explicit:        false,
+		rangeFrom:       children[0].rangeStart(),
+		rangeTo:         children[len(children)-1].rangeEnd(),
+		children:        children,
+	}, nil
+}
+
+// parseFactor: "(" expression ")" | statement
+func (p *parser) parseFactor() (*filterNode, error) {
+	p.skipSpaces()
+	if p.pos < len(p.input) && p.input[p.pos] == '(' {
+		openPos := p.pos
+		p.pos++ // consume '('
+		p.skipSpaces()
+		expr, err := p.parseExpression()
+		if err != nil {
+			return nil, err
+		}
+		p.skipSpaces()
+		if p.pos >= len(p.input) || p.input[p.pos] != ')' {
+			return nil, fmt.Errorf("expected ')' at position %d", p.pos)
+		}
+		p.pos++ // consume ')'
+
+		group := &filterNode{
+			nodeType:        "Group",
+			logicalOperator: expr.logicalOperatorOrDefault(),
+			explicit:        true,
+			rangeFrom:       openPos,
+			rangeTo:         p.pos,
+		}
+		if expr.nodeType == "Group" {
+			group.children = expr.children
+			group.logicalOperator = expr.logicalOperator
+		} else {
+			group.children = []*filterNode{expr}
+		}
+		return group, nil
+	}
+	return p.parseStatement()
+}
+
+// parseStatement: key operator value
+func (p *parser) parseStatement() (*filterNode, error) {
+	p.skipSpaces()
+	startPos := p.pos
+
+	key, err := p.parseKey()
+	if err != nil {
+		return nil, fmt.Errorf("expected key at position %d: %w", p.pos, err)
+	}
+
+	p.skipSpaces()
+	op, err := p.parseOperator()
+	if err != nil {
+		return nil, fmt.Errorf("expected operator at position %d: %w", p.pos, err)
+	}
+
+	p.skipSpaces()
+	val, err := p.parseValue()
+	if err != nil {
+		return nil, fmt.Errorf("expected value at position %d: %w", p.pos, err)
+	}
+
+	return &filterNode{
+		nodeType:  "Statement",
+		rangeFrom: startPos,
+		rangeTo:   val.rangeTo,
+		key:       key,
+		operator:  op,
+		value:     val,
+	}, nil
+}
+
+func (p *parser) parseKey() (*leafNode, error) {
+	p.skipSpaces()
+	start := p.pos
+
+	if p.pos < len(p.input) && p.input[p.pos] == '`' {
+		// Backtick-escaped key
+		p.pos++ // consume opening backtick
+		end := strings.IndexByte(p.input[p.pos:], '`')
+		if end == -1 {
+			return nil, fmt.Errorf("unterminated backtick-escaped key")
+		}
+		keyValue := p.input[p.pos : p.pos+end]
+		p.pos += end + 1 // consume content + closing backtick
+		return &leafNode{
+			leafType:  "Key",
+			textValue: p.input[start:p.pos],
+			value:     keyValue,
+			rangeFrom: start,
+			rangeTo:   p.pos,
+		}, nil
+	}
+
+	// Unquoted key: alphanumeric, dots, hyphens, underscores
+	for p.pos < len(p.input) && isKeyChar(p.input[p.pos]) {
+		p.pos++
+	}
+
+	if p.pos == start {
+		if p.pos < len(p.input) {
+			return nil, fmt.Errorf("unexpected character %q", p.input[p.pos])
+		}
+		return nil, fmt.Errorf("unexpected end of input")
+	}
+
+	text := p.input[start:p.pos]
+	return &leafNode{
+		leafType:  "Key",
+		textValue: text,
+		value:     text,
+		rangeFrom: start,
+		rangeTo:   p.pos,
+	}, nil
+}
+
+func (p *parser) parseOperator() (*leafNode, error) {
+	p.skipSpaces()
+	start := p.pos
+	remaining := p.input[p.pos:]
+
+	// Check operators from longest to shortest to avoid prefix conflicts
+	for _, op := range []string{"not in", "!=", "<=", ">=", "<", ">", "="} {
+		if strings.HasPrefix(remaining, op) {
+			// "not in" requires whitespace or end after it
+			if op == "not in" {
+				afterOp := p.pos + len(op)
+				if afterOp < len(p.input) && !isSpace(p.input[afterOp]) {
+					continue
+				}
+			}
+			// Reject "==" — single "=" must not be followed by another "="
+			if op == "=" && p.pos+1 < len(p.input) && p.input[p.pos+1] == '=' {
+				return nil, fmt.Errorf("unsupported filter syntax %q; the Segments API uses single '=' for equality. Provide the filter as a JSON AST string if you need advanced syntax", "==")
+			}
+			p.pos += len(op)
+			return &leafNode{
+				leafType:  "ComparisonOperator",
+				textValue: op,
+				value:     op,
+				rangeFrom: start,
+				rangeTo:   p.pos,
+			}, nil
+		}
+	}
+
+	// Check unsupported operators for better error messages
+	for _, unsupported := range []string{"~", "!~"} {
+		if strings.HasPrefix(remaining, unsupported) {
+			return nil, fmt.Errorf("unsupported filter syntax %q; provide the filter as a JSON AST string instead", unsupported)
+		}
+	}
+
+	maxLen := len(remaining)
+	if maxLen > 10 {
+		maxLen = 10
+	}
+	return nil, fmt.Errorf("unknown operator at %q", remaining[:maxLen])
+}
+
+func (p *parser) parseValue() (*leafNode, error) {
+	p.skipSpaces()
+	start := p.pos
+
+	if p.pos >= len(p.input) {
+		return nil, fmt.Errorf("unexpected end of input")
+	}
+
+	ch := p.input[p.pos]
+
+	// Check for unsupported features
+	if ch == '*' {
+		return nil, fmt.Errorf("unsupported filter syntax \"*\" (wildcard/exists); provide the filter as a JSON AST string instead")
+	}
+	if ch == '$' {
+		return nil, fmt.Errorf("unsupported filter syntax \"$\" (variable reference); provide the filter as a JSON AST string instead")
+	}
+	if ch == '(' {
+		return nil, fmt.Errorf("unsupported filter syntax \"(\" in value position (list syntax); provide the filter as a JSON AST string instead")
+	}
+
+	if ch == '"' {
+		return p.parseQuotedString()
+	}
+	return p.parseUnquotedValue(start)
+}
+
+func (p *parser) parseQuotedString() (*leafNode, error) {
+	start := p.pos
+	p.pos++ // consume opening quote
+
+	var sb strings.Builder
+	for p.pos < len(p.input) {
+		ch := p.input[p.pos]
+		if ch == '\\' && p.pos+1 < len(p.input) {
+			next := p.input[p.pos+1]
+			switch next {
+			case '"', '\\':
+				sb.WriteByte(next)
+				p.pos += 2
+			default:
+				sb.WriteByte(ch)
+				p.pos++
+			}
+			continue
+		}
+		if ch == '"' {
+			p.pos++ // consume closing quote
+			escaped := true
+			return &leafNode{
+				leafType:  "String",
+				textValue: p.input[start:p.pos],
+				value:     sb.String(),
+				rangeFrom: start,
+				rangeTo:   p.pos,
+				isEscaped: &escaped,
+			}, nil
+		}
+		sb.WriteByte(ch)
+		p.pos++
+	}
+	return nil, fmt.Errorf("unterminated quoted string starting at position %d", start)
+}
+
+func (p *parser) parseUnquotedValue(start int) (*leafNode, error) {
+	for p.pos < len(p.input) {
+		ch := p.input[p.pos]
+		if isSpace(ch) || ch == ')' {
+			break
+		}
+		p.pos++
+	}
+
+	if p.pos == start {
+		return nil, fmt.Errorf("empty value")
+	}
+
+	text := p.input[start:p.pos]
+	escaped := false
+	return &leafNode{
+		leafType:  "String",
+		textValue: text,
+		value:     text,
+		rangeFrom: start,
+		rangeTo:   p.pos,
+		isEscaped: &escaped,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Parser helpers
+// ---------------------------------------------------------------------------
+
+func (p *parser) skipSpaces() {
+	for p.pos < len(p.input) && isSpace(p.input[p.pos]) {
+		p.pos++
+	}
+}
+
+func (p *parser) peek() byte {
+	if p.pos >= len(p.input) {
+		return 0
+	}
+	return p.input[p.pos]
+}
+
+// matchKeyword matches a keyword followed by non-key-char or EOF, consuming it.
+func (p *parser) matchKeyword(kw string) bool {
+	if p.pos+len(kw) > len(p.input) {
+		return false
+	}
+	if p.input[p.pos:p.pos+len(kw)] != kw {
+		return false
+	}
+	afterPos := p.pos + len(kw)
+	if afterPos < len(p.input) && isKeyChar(p.input[afterPos]) {
+		return false
+	}
+	p.pos += len(kw)
+	return true
+}
+
+// peekKeyword checks if the next token is a keyword without consuming it.
+func (p *parser) peekKeyword(kw string) bool {
+	if p.pos+len(kw) > len(p.input) {
+		return false
+	}
+	if p.input[p.pos:p.pos+len(kw)] != kw {
+		return false
+	}
+	afterPos := p.pos + len(kw)
+	if afterPos < len(p.input) && isKeyChar(p.input[afterPos]) {
+		return false
+	}
+	return true
+}
+
+func isKeyChar(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') ||
+		(ch >= 'A' && ch <= 'Z') ||
+		(ch >= '0' && ch <= '9') ||
+		ch == '.' || ch == '-' || ch == '_'
+}
+
+func isSpace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
+}
+
+// ---------------------------------------------------------------------------
+// Renderer: JSON AST → DQL filter string
+// ---------------------------------------------------------------------------
+
+// renderFromRaw renders a raw JSON AST back to a DQL filter string.
+func renderFromRaw(data []byte) (string, error) {
+	var peek struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return "", fmt.Errorf("failed to peek AST node type: %w", err)
+	}
+
+	switch peek.Type {
+	case "Group":
+		return renderGroup(data)
+	case "Statement":
+		return renderStatement(data)
+	default:
+		return "", fmt.Errorf("unknown AST node type: %q", peek.Type)
+	}
+}
+
+func renderGroup(data []byte) (string, error) {
+	var g astGroupJSON
+	if err := json.Unmarshal(data, &g); err != nil {
+		return "", fmt.Errorf("failed to unmarshal Group: %w", err)
+	}
+
+	var parts []string
+	for _, childRaw := range g.Children {
+		var peek struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(childRaw, &peek); err != nil {
+			return "", err
+		}
+
+		switch peek.Type {
+		case "LogicalOperator":
+			var lo astLogicalOperatorJSON
+			if err := json.Unmarshal(childRaw, &lo); err != nil {
+				return "", err
+			}
+			parts = append(parts, lo.Value)
+		case "Group":
+			sub, err := renderGroup(childRaw)
+			if err != nil {
+				return "", err
+			}
+			var subGroup astGroupJSON
+			if err := json.Unmarshal(childRaw, &subGroup); err != nil {
+				return "", err
+			}
+			if subGroup.Explicit {
+				sub = "(" + sub + ")"
+			}
+			parts = append(parts, sub)
+		case "Statement":
+			s, err := renderStatement(childRaw)
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, s)
+		default:
+			return "", fmt.Errorf("unknown child node type in group: %q", peek.Type)
+		}
+	}
+
+	return strings.Join(parts, " "), nil
+}
+
+func renderStatement(data []byte) (string, error) {
+	var s astStatementJSON
+	if err := json.Unmarshal(data, &s); err != nil {
+		return "", fmt.Errorf("failed to unmarshal Statement: %w", err)
+	}
+
+	var key astLeafJSON
+	if err := json.Unmarshal(s.Key, &key); err != nil {
+		return "", fmt.Errorf("failed to unmarshal key: %w", err)
+	}
+
+	var op astLeafJSON
+	if err := json.Unmarshal(s.Operator, &op); err != nil {
+		return "", fmt.Errorf("failed to unmarshal operator: %w", err)
+	}
+
+	var val astLeafJSON
+	if err := json.Unmarshal(s.Value, &val); err != nil {
+		return "", fmt.Errorf("failed to unmarshal value: %w", err)
+	}
+
+	keyText := renderKeyText(key)
+	valText := renderValueText(val)
+
+	return fmt.Sprintf("%s %s %s", keyText, op.Value, valText), nil
+}
+
+func renderKeyText(key astLeafJSON) string {
+	if len(key.TextValue) > 0 && key.TextValue[0] == '`' {
+		return key.TextValue
+	}
+	if needsBacktickEscape(key.Value) {
+		return "`" + key.Value + "`"
+	}
+	return key.Value
+}
+
+func renderValueText(val astLeafJSON) string {
+	if val.Type == "String" {
+		if val.IsEscaped != nil && *val.IsEscaped {
+			return `"` + escapeStringValue(val.Value) + `"`
+		}
+		if isNumericString(val.Value) {
+			return val.Value
+		}
+		return `"` + escapeStringValue(val.Value) + `"`
+	}
+	return val.Value
+}
+
+func escapeStringValue(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}
+
+func needsBacktickEscape(key string) bool {
+	if key == "" {
+		return true
+	}
+	for i := 0; i < len(key); i++ {
+		if !isKeyChar(key[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isNumericString(s string) bool {
+	if s == "" {
+		return false
+	}
+	_, err := strconv.ParseFloat(s, 64)
+	return err == nil
+}

--- a/pkg/resources/segment/filterast_test.go
+++ b/pkg/resources/segment/filterast_test.go
@@ -294,7 +294,7 @@ func TestFilterToAST_Parentheses(t *testing.T) {
 }
 
 func TestFilterToAST_AllOperators(t *testing.T) {
-	operators := []string{"=", "!=", "<", "<=", ">", ">="}
+	operators := []string{"=", "!=", "<", "<=", ">", ">=", "in"}
 	for _, op := range operators {
 		t.Run(op, func(t *testing.T) {
 			input := "key " + op + ` "value"`
@@ -331,6 +331,32 @@ func TestFilterToAST_NotInOperator(t *testing.T) {
 	json.Unmarshal(stmt.Operator, &op)
 	if op.Value != "not in" {
 		t.Errorf("expected operator 'not in', got %q", op.Value)
+	}
+}
+
+func TestFilterToAST_InOperator(t *testing.T) {
+	ast, err := FilterToAST(`status in "active"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root astGroupJSON
+	json.Unmarshal([]byte(ast), &root)
+	var stmt astStatementJSON
+	json.Unmarshal(root.Children[0], &stmt)
+	var op astLeafJSON
+	json.Unmarshal(stmt.Operator, &op)
+	if op.Value != "in" {
+		t.Errorf("expected operator 'in', got %q", op.Value)
+	}
+
+	// Verify round-trip: AST → DQL should produce original DQL
+	dql, err := FilterFromAST(ast)
+	if err != nil {
+		t.Fatalf("FilterFromAST error: %v", err)
+	}
+	if dql != `status in "active"` {
+		t.Errorf("round-trip failed, got %q", dql)
 	}
 }
 

--- a/pkg/resources/segment/filterast_test.go
+++ b/pkg/resources/segment/filterast_test.go
@@ -1,0 +1,867 @@
+package segment
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// DQL → AST (FilterToAST)
+// ---------------------------------------------------------------------------
+
+func TestFilterToAST_Simple(t *testing.T) {
+	ast, err := FilterToAST(`status = "ERROR"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isFilterAST(ast) {
+		t.Fatalf("expected JSON AST, got: %s", ast)
+	}
+
+	// Verify the root group structure
+	var root astGroupJSON
+	if err := json.Unmarshal([]byte(ast), &root); err != nil {
+		t.Fatalf("failed to unmarshal AST: %v", err)
+	}
+	if root.Type != "Group" {
+		t.Errorf("expected root type 'Group', got %q", root.Type)
+	}
+	if root.LogicalOperator != "AND" {
+		t.Errorf("expected logical operator 'AND', got %q", root.LogicalOperator)
+	}
+	if root.Explicit {
+		t.Error("expected root to be non-explicit")
+	}
+	if len(root.Children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(root.Children))
+	}
+
+	// Verify the statement
+	var stmt astStatementJSON
+	if err := json.Unmarshal(root.Children[0], &stmt); err != nil {
+		t.Fatalf("failed to unmarshal statement: %v", err)
+	}
+	if stmt.Type != "Statement" {
+		t.Errorf("expected statement type 'Statement', got %q", stmt.Type)
+	}
+
+	// Verify key
+	var key astLeafJSON
+	if err := json.Unmarshal(stmt.Key, &key); err != nil {
+		t.Fatalf("failed to unmarshal key: %v", err)
+	}
+	if key.Value != "status" {
+		t.Errorf("expected key value 'status', got %q", key.Value)
+	}
+	if key.TextValue != "status" {
+		t.Errorf("expected key textValue 'status', got %q", key.TextValue)
+	}
+
+	// Verify operator
+	var op astLeafJSON
+	if err := json.Unmarshal(stmt.Operator, &op); err != nil {
+		t.Fatalf("failed to unmarshal operator: %v", err)
+	}
+	if op.Value != "=" {
+		t.Errorf("expected operator '=', got %q", op.Value)
+	}
+
+	// Verify value
+	var val astLeafJSON
+	if err := json.Unmarshal(stmt.Value, &val); err != nil {
+		t.Fatalf("failed to unmarshal value: %v", err)
+	}
+	if val.Value != "ERROR" {
+		t.Errorf("expected value 'ERROR', got %q", val.Value)
+	}
+	if val.TextValue != `"ERROR"` {
+		t.Errorf("expected textValue '\"ERROR\"', got %q", val.TextValue)
+	}
+	if val.IsEscaped == nil || !*val.IsEscaped {
+		t.Error("expected isEscaped to be true")
+	}
+}
+
+func TestFilterToAST_UnquotedValue(t *testing.T) {
+	ast, err := FilterToAST(`count = 42`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root astGroupJSON
+	if err := json.Unmarshal([]byte(ast), &root); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	var stmt astStatementJSON
+	if err := json.Unmarshal(root.Children[0], &stmt); err != nil {
+		t.Fatalf("failed to unmarshal statement: %v", err)
+	}
+
+	var val astLeafJSON
+	if err := json.Unmarshal(stmt.Value, &val); err != nil {
+		t.Fatalf("failed to unmarshal value: %v", err)
+	}
+	if val.Value != "42" {
+		t.Errorf("expected value '42', got %q", val.Value)
+	}
+	if val.TextValue != "42" {
+		t.Errorf("expected textValue '42', got %q", val.TextValue)
+	}
+	if val.IsEscaped == nil || *val.IsEscaped {
+		t.Error("expected isEscaped to be false for unquoted value")
+	}
+}
+
+func TestFilterToAST_DottedKey(t *testing.T) {
+	ast, err := FilterToAST(`k8s.cluster.name = "alpha"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root astGroupJSON
+	if err := json.Unmarshal([]byte(ast), &root); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	var stmt astStatementJSON
+	if err := json.Unmarshal(root.Children[0], &stmt); err != nil {
+		t.Fatalf("failed to unmarshal statement: %v", err)
+	}
+	var key astLeafJSON
+	if err := json.Unmarshal(stmt.Key, &key); err != nil {
+		t.Fatalf("failed to unmarshal key: %v", err)
+	}
+	if key.Value != "k8s.cluster.name" {
+		t.Errorf("expected key 'k8s.cluster.name', got %q", key.Value)
+	}
+}
+
+func TestFilterToAST_BacktickKey(t *testing.T) {
+	ast, err := FilterToAST("`my field` = \"value\"")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root astGroupJSON
+	if err := json.Unmarshal([]byte(ast), &root); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	var stmt astStatementJSON
+	if err := json.Unmarshal(root.Children[0], &stmt); err != nil {
+		t.Fatalf("failed to unmarshal statement: %v", err)
+	}
+	var key astLeafJSON
+	if err := json.Unmarshal(stmt.Key, &key); err != nil {
+		t.Fatalf("failed to unmarshal key: %v", err)
+	}
+	if key.Value != "my field" {
+		t.Errorf("expected key 'my field', got %q", key.Value)
+	}
+	if key.TextValue != "`my field`" {
+		t.Errorf("expected textValue '`my field`', got %q", key.TextValue)
+	}
+}
+
+func TestFilterToAST_ImplicitAND(t *testing.T) {
+	ast, err := FilterToAST(`a = "1" b = "2"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root astGroupJSON
+	if err := json.Unmarshal([]byte(ast), &root); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if root.LogicalOperator != "AND" {
+		t.Errorf("expected AND, got %q", root.LogicalOperator)
+	}
+	// Should have 2 Statement children (no separator for implicit AND)
+	stmtCount := 0
+	for _, child := range root.Children {
+		var peek struct {
+			Type string `json:"type"`
+		}
+		json.Unmarshal(child, &peek)
+		if peek.Type == "Statement" {
+			stmtCount++
+		}
+	}
+	if stmtCount != 2 {
+		t.Errorf("expected 2 statements, got %d", stmtCount)
+	}
+}
+
+func TestFilterToAST_ExplicitAND(t *testing.T) {
+	ast, err := FilterToAST(`a = "1" AND b = "2"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root astGroupJSON
+	if err := json.Unmarshal([]byte(ast), &root); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if root.LogicalOperator != "AND" {
+		t.Errorf("expected AND, got %q", root.LogicalOperator)
+	}
+	// Should have 3 children: Statement, LogicalOperator("AND"), Statement
+	if len(root.Children) != 3 {
+		t.Fatalf("expected 3 children, got %d", len(root.Children))
+	}
+	var lo astLogicalOperatorJSON
+	if err := json.Unmarshal(root.Children[1], &lo); err != nil {
+		t.Fatalf("failed to unmarshal logical operator: %v", err)
+	}
+	if lo.Value != "AND" {
+		t.Errorf("expected AND separator, got %q", lo.Value)
+	}
+}
+
+func TestFilterToAST_OR(t *testing.T) {
+	ast, err := FilterToAST(`a = "1" OR b = "2"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root astGroupJSON
+	if err := json.Unmarshal([]byte(ast), &root); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if root.LogicalOperator != "OR" {
+		t.Errorf("expected OR, got %q", root.LogicalOperator)
+	}
+	if len(root.Children) != 3 {
+		t.Fatalf("expected 3 children (stmt, OR sep, stmt), got %d", len(root.Children))
+	}
+}
+
+func TestFilterToAST_MixedANDOR(t *testing.T) {
+	// a = "1" OR b = "2" c = "3"
+	// Due to precedence: OR-group containing [a="1"] OR [AND-group of b="2" c="3"]
+	ast, err := FilterToAST(`a = "1" OR b = "2" c = "3"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root astGroupJSON
+	if err := json.Unmarshal([]byte(ast), &root); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if root.LogicalOperator != "OR" {
+		t.Errorf("expected root OR, got %q", root.LogicalOperator)
+	}
+	// Children: Statement(a=1), LogicalOperator(OR), Group(AND: b=2, c=3)
+	if len(root.Children) != 3 {
+		t.Fatalf("expected 3 children, got %d", len(root.Children))
+	}
+	// Third child should be a Group
+	var thirdPeek struct {
+		Type string `json:"type"`
+	}
+	json.Unmarshal(root.Children[2], &thirdPeek)
+	if thirdPeek.Type != "Group" {
+		t.Errorf("expected third child to be Group, got %q", thirdPeek.Type)
+	}
+}
+
+func TestFilterToAST_Parentheses(t *testing.T) {
+	ast, err := FilterToAST(`(a = "1" OR b = "2") AND c = "3"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root astGroupJSON
+	if err := json.Unmarshal([]byte(ast), &root); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if root.LogicalOperator != "AND" {
+		t.Errorf("expected AND root, got %q", root.LogicalOperator)
+	}
+
+	// First child should be an explicit group
+	var firstPeek struct {
+		Type     string `json:"type"`
+		Explicit bool   `json:"explicit"`
+	}
+	json.Unmarshal(root.Children[0], &firstPeek)
+	if firstPeek.Type != "Group" {
+		t.Errorf("expected first child to be Group, got %q", firstPeek.Type)
+	}
+	if !firstPeek.Explicit {
+		t.Error("expected first child group to be explicit (parenthesized)")
+	}
+}
+
+func TestFilterToAST_AllOperators(t *testing.T) {
+	operators := []string{"=", "!=", "<", "<=", ">", ">="}
+	for _, op := range operators {
+		t.Run(op, func(t *testing.T) {
+			input := "key " + op + ` "value"`
+			ast, err := FilterToAST(input)
+			if err != nil {
+				t.Fatalf("unexpected error for operator %q: %v", op, err)
+			}
+
+			var root astGroupJSON
+			json.Unmarshal([]byte(ast), &root)
+			var stmt astStatementJSON
+			json.Unmarshal(root.Children[0], &stmt)
+			var opNode astLeafJSON
+			json.Unmarshal(stmt.Operator, &opNode)
+			if opNode.Value != op {
+				t.Errorf("expected operator %q, got %q", op, opNode.Value)
+			}
+		})
+	}
+}
+
+func TestFilterToAST_NotInOperator(t *testing.T) {
+	// "not in" is a supported operator
+	ast, err := FilterToAST(`status not in "active"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root astGroupJSON
+	json.Unmarshal([]byte(ast), &root)
+	var stmt astStatementJSON
+	json.Unmarshal(root.Children[0], &stmt)
+	var op astLeafJSON
+	json.Unmarshal(stmt.Operator, &op)
+	if op.Value != "not in" {
+		t.Errorf("expected operator 'not in', got %q", op.Value)
+	}
+}
+
+func TestFilterToAST_Ranges(t *testing.T) {
+	// Verify range positions are correct
+	// Input: `status = "ERROR"` (16 chars)
+	// Positions: status(0-6) =(7-8) "ERROR"(9-16)
+	ast, err := FilterToAST(`status = "ERROR"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root astGroupJSON
+	json.Unmarshal([]byte(ast), &root)
+
+	// Root range should span entire input
+	if root.Range == nil {
+		t.Fatal("expected range on root")
+	}
+	if root.Range.From != 0 || root.Range.To != 16 {
+		t.Errorf("expected root range {0, 16}, got {%d, %d}", root.Range.From, root.Range.To)
+	}
+
+	var stmt astStatementJSON
+	json.Unmarshal(root.Children[0], &stmt)
+
+	var key astLeafJSON
+	json.Unmarshal(stmt.Key, &key)
+	if key.Range.From != 0 || key.Range.To != 6 {
+		t.Errorf("expected key range {0, 6}, got {%d, %d}", key.Range.From, key.Range.To)
+	}
+
+	var op astLeafJSON
+	json.Unmarshal(stmt.Operator, &op)
+	if op.Range.From != 7 || op.Range.To != 8 {
+		t.Errorf("expected operator range {7, 8}, got {%d, %d}", op.Range.From, op.Range.To)
+	}
+
+	var val astLeafJSON
+	json.Unmarshal(stmt.Value, &val)
+	if val.Range.From != 9 || val.Range.To != 16 {
+		t.Errorf("expected value range {9, 16}, got {%d, %d}", val.Range.From, val.Range.To)
+	}
+}
+
+func TestFilterToAST_Errors(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		errorContains string
+	}{
+		{
+			name:          "empty string",
+			input:         "",
+			errorContains: "empty filter expression",
+		},
+		{
+			name:          "only whitespace",
+			input:         "   ",
+			errorContains: "empty filter expression",
+		},
+		{
+			name:          "unsupported == operator",
+			input:         `status == "ERROR"`,
+			errorContains: "unsupported filter syntax",
+		},
+		{
+			name:          "unterminated string",
+			input:         `status = "ERROR`,
+			errorContains: "unterminated quoted string",
+		},
+		{
+			name:          "unterminated backtick key",
+			input:         "`my field = \"value\"",
+			errorContains: "unterminated backtick",
+		},
+		{
+			name:          "missing value",
+			input:         `status =`,
+			errorContains: "expected value",
+		},
+		{
+			name:          "unsupported wildcard",
+			input:         `status = *`,
+			errorContains: "unsupported filter syntax",
+		},
+		{
+			name:          "unsupported variable",
+			input:         `status = $var`,
+			errorContains: "unsupported filter syntax",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := FilterToAST(tt.input)
+			if err == nil {
+				t.Error("expected error, got nil")
+			} else if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Errorf("expected error containing %q, got %q", tt.errorContains, err.Error())
+			}
+		})
+	}
+}
+
+func TestFilterToAST_AlreadyAST(t *testing.T) {
+	astInput := `{"type":"Group","logicalOperator":"AND","explicit":false,"children":[]}`
+	result, err := FilterToAST(astInput)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != astInput {
+		t.Errorf("expected passthrough of AST, got different result")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AST → DQL (FilterFromAST)
+// ---------------------------------------------------------------------------
+
+func TestFilterFromAST_SingleStatement(t *testing.T) {
+	ast := `{"type":"Group","logicalOperator":"AND","explicit":false,"range":{"from":0,"to":16},"children":[{"type":"Statement","range":{"from":0,"to":16},"key":{"type":"Key","textValue":"status","value":"status","range":{"from":0,"to":6}},"operator":{"type":"ComparisonOperator","textValue":"=","value":"=","range":{"from":7,"to":8}},"value":{"type":"String","textValue":"\"ERROR\"","value":"ERROR","range":{"from":9,"to":16},"isEscaped":true}}]}`
+
+	result, err := FilterFromAST(ast)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := `status = "ERROR"`
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestFilterFromAST_MultiStatementAND(t *testing.T) {
+	// Build an AST with two statements and implicit AND (no separator node)
+	ast := `{"type":"Group","logicalOperator":"AND","explicit":false,"range":{"from":0,"to":19},"children":[{"type":"Statement","range":{"from":0,"to":7},"key":{"type":"Key","textValue":"a","value":"a","range":{"from":0,"to":1}},"operator":{"type":"ComparisonOperator","textValue":"=","value":"=","range":{"from":2,"to":3}},"value":{"type":"String","textValue":"\"1\"","value":"1","range":{"from":4,"to":7},"isEscaped":true}},{"type":"Statement","range":{"from":8,"to":19},"key":{"type":"Key","textValue":"b","value":"b","range":{"from":8,"to":9}},"operator":{"type":"ComparisonOperator","textValue":"=","value":"=","range":{"from":10,"to":11}},"value":{"type":"String","textValue":"\"2\"","value":"2","range":{"from":12,"to":15},"isEscaped":true}}]}`
+
+	result, err := FilterFromAST(ast)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Two statements joined with space (implicit AND)
+	expected := `a = "1" b = "2"`
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestFilterFromAST_ORGroup(t *testing.T) {
+	ast := `{"type":"Group","logicalOperator":"OR","explicit":false,"range":{"from":0,"to":19},"children":[{"type":"Statement","range":{"from":0,"to":7},"key":{"type":"Key","textValue":"a","value":"a","range":{"from":0,"to":1}},"operator":{"type":"ComparisonOperator","textValue":"=","value":"=","range":{"from":2,"to":3}},"value":{"type":"String","textValue":"\"1\"","value":"1","range":{"from":4,"to":7},"isEscaped":true}},{"type":"LogicalOperator","textValue":"OR","value":"OR","range":{"from":8,"to":10}},{"type":"Statement","range":{"from":11,"to":19},"key":{"type":"Key","textValue":"b","value":"b","range":{"from":11,"to":12}},"operator":{"type":"ComparisonOperator","textValue":"=","value":"=","range":{"from":13,"to":14}},"value":{"type":"String","textValue":"\"2\"","value":"2","range":{"from":15,"to":18},"isEscaped":true}}]}`
+
+	result, err := FilterFromAST(ast)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := `a = "1" OR b = "2"`
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestFilterFromAST_NestedGroups(t *testing.T) {
+	// (a = "1" OR b = "2") AND c = "3"
+	// The explicit group should produce parentheses
+	ast := `{"type":"Group","logicalOperator":"AND","explicit":false,"range":{"from":0,"to":31},"children":[{"type":"Group","logicalOperator":"OR","explicit":true,"range":{"from":0,"to":20},"children":[{"type":"Statement","range":{"from":1,"to":8},"key":{"type":"Key","textValue":"a","value":"a","range":{"from":1,"to":2}},"operator":{"type":"ComparisonOperator","textValue":"=","value":"=","range":{"from":3,"to":4}},"value":{"type":"String","textValue":"\"1\"","value":"1","range":{"from":5,"to":8},"isEscaped":true}},{"type":"LogicalOperator","textValue":"OR","value":"OR","range":{"from":9,"to":11}},{"type":"Statement","range":{"from":12,"to":19},"key":{"type":"Key","textValue":"b","value":"b","range":{"from":12,"to":13}},"operator":{"type":"ComparisonOperator","textValue":"=","value":"=","range":{"from":14,"to":15}},"value":{"type":"String","textValue":"\"2\"","value":"2","range":{"from":16,"to":19},"isEscaped":true}}]},{"type":"LogicalOperator","textValue":"AND","value":"AND","range":{"from":21,"to":24}},{"type":"Statement","range":{"from":25,"to":31},"key":{"type":"Key","textValue":"c","value":"c","range":{"from":25,"to":26}},"operator":{"type":"ComparisonOperator","textValue":"=","value":"=","range":{"from":27,"to":28}},"value":{"type":"String","textValue":"\"3\"","value":"3","range":{"from":29,"to":32},"isEscaped":true}}]}`
+
+	result, err := FilterFromAST(ast)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := `(a = "1" OR b = "2") AND c = "3"`
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestFilterFromAST_NotAST(t *testing.T) {
+	// Non-AST input should be passed through
+	input := `status = "ERROR"`
+	result, err := FilterFromAST(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != input {
+		t.Errorf("expected passthrough of non-AST, got %q", result)
+	}
+}
+
+func TestFilterFromAST_Errors(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		errorContains string
+	}{
+		{
+			name:          "empty string",
+			input:         "",
+			errorContains: "empty filter AST",
+		},
+		{
+			name:          "invalid JSON",
+			input:         `{invalid json}`,
+			errorContains: "failed to peek AST node type",
+		},
+		{
+			name:          "unknown type",
+			input:         `{"type":"Unknown"}`,
+			errorContains: "unknown AST node type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := FilterFromAST(tt.input)
+			if err == nil {
+				t.Error("expected error, got nil")
+			} else if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Errorf("expected error containing %q, got %q", tt.errorContains, err.Error())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip tests: DQL → AST → DQL
+// ---------------------------------------------------------------------------
+
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string // expected DQL after round-trip (canonical form)
+	}{
+		{
+			name:     "simple equality",
+			input:    `status = "ERROR"`,
+			expected: `status = "ERROR"`,
+		},
+		{
+			name:     "dotted key",
+			input:    `k8s.cluster.name = "alpha"`,
+			expected: `k8s.cluster.name = "alpha"`,
+		},
+		{
+			name:     "unquoted numeric value",
+			input:    `count = 42`,
+			expected: `count = 42`,
+		},
+		{
+			name:     "backtick key",
+			input:    "`my field` = \"value\"",
+			expected: "`my field` = \"value\"",
+		},
+		{
+			name:     "implicit AND",
+			input:    `a = "1" b = "2"`,
+			expected: `a = "1" b = "2"`,
+		},
+		{
+			name:     "explicit AND",
+			input:    `a = "1" AND b = "2"`,
+			expected: `a = "1" AND b = "2"`,
+		},
+		{
+			name:     "OR expression",
+			input:    `a = "1" OR b = "2"`,
+			expected: `a = "1" OR b = "2"`,
+		},
+		{
+			name:     "parenthesized OR with AND",
+			input:    `(a = "1" OR b = "2") AND c = "3"`,
+			expected: `(a = "1" OR b = "2") AND c = "3"`,
+		},
+		{
+			name:     "not-equal operator",
+			input:    `status != "OK"`,
+			expected: `status != "OK"`,
+		},
+		{
+			name:     "less-than operator",
+			input:    `count < 100`,
+			expected: `count < 100`,
+		},
+		{
+			name:     "greater-or-equal operator",
+			input:    `value >= 3.14`,
+			expected: `value >= 3.14`,
+		},
+		{
+			name:     "dt.system.bucket",
+			input:    `dt.system.bucket = "custom-logs"`,
+			expected: `dt.system.bucket = "custom-logs"`,
+		},
+		{
+			name:     "loglevel OR",
+			input:    `loglevel = "ERROR" OR loglevel = "WARN"`,
+			expected: `loglevel = "ERROR" OR loglevel = "WARN"`,
+		},
+		{
+			name:     "not in operator",
+			input:    `status not in "active"`,
+			expected: `status not in "active"`,
+		},
+		{
+			name:     "mixed precedence",
+			input:    `a = "1" OR b = "2" c = "3"`,
+			expected: `a = "1" OR b = "2" c = "3"`,
+		},
+		{
+			name:     "three AND terms",
+			input:    `a = "1" b = "2" c = "3"`,
+			expected: `a = "1" b = "2" c = "3"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, err := FilterToAST(tt.input)
+			if err != nil {
+				t.Fatalf("FilterToAST failed: %v", err)
+			}
+
+			dql, err := FilterFromAST(ast)
+			if err != nil {
+				t.Fatalf("FilterFromAST failed: %v", err)
+			}
+
+			if dql != tt.expected {
+				t.Errorf("round-trip mismatch:\n  input:    %q\n  ast:      %s\n  output:   %q\n  expected: %q",
+					tt.input, ast, dql, tt.expected)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auto-detection
+// ---------------------------------------------------------------------------
+
+func TestIsFilterAST(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{`{"type":"Group"}`, true},
+		{`{anything}`, true},
+		{`status = "ERROR"`, false},
+		{`(a = "1" OR b = "2")`, false},
+		{``, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := isFilterAST(tt.input); got != tt.expected {
+				t.Errorf("isFilterAST(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// API spec example: verify the exact format from FILTER_AST_PLAN.md
+// ---------------------------------------------------------------------------
+
+func TestFilterToAST_APISpecExample(t *testing.T) {
+	// From the plan: k8s.cluster.name = "alpha" should produce a specific AST structure
+	input := `k8s.cluster.name = "alpha"`
+	ast, err := FilterToAST(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Parse and verify structure matches the expected API format
+	var root astGroupJSON
+	if err := json.Unmarshal([]byte(ast), &root); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if root.Type != "Group" {
+		t.Errorf("expected type 'Group', got %q", root.Type)
+	}
+	if root.LogicalOperator != "AND" {
+		t.Errorf("expected logicalOperator 'AND', got %q", root.LogicalOperator)
+	}
+	if root.Explicit {
+		t.Error("expected explicit=false")
+	}
+	if root.Range.From != 0 || root.Range.To != 26 {
+		t.Errorf("expected root range {0, 26}, got {%d, %d}", root.Range.From, root.Range.To)
+	}
+	if len(root.Children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(root.Children))
+	}
+
+	var stmt astStatementJSON
+	json.Unmarshal(root.Children[0], &stmt)
+	if stmt.Type != "Statement" {
+		t.Errorf("expected Statement, got %q", stmt.Type)
+	}
+	if stmt.Range.From != 0 || stmt.Range.To != 26 {
+		t.Errorf("expected statement range {0, 26}, got {%d, %d}", stmt.Range.From, stmt.Range.To)
+	}
+
+	var key astLeafJSON
+	json.Unmarshal(stmt.Key, &key)
+	if key.Type != "Key" || key.TextValue != "k8s.cluster.name" || key.Value != "k8s.cluster.name" {
+		t.Errorf("unexpected key: %+v", key)
+	}
+	if key.Range.From != 0 || key.Range.To != 16 {
+		t.Errorf("expected key range {0, 16}, got {%d, %d}", key.Range.From, key.Range.To)
+	}
+
+	var op astLeafJSON
+	json.Unmarshal(stmt.Operator, &op)
+	if op.Type != "ComparisonOperator" || op.Value != "=" {
+		t.Errorf("unexpected operator: %+v", op)
+	}
+	if op.Range.From != 17 || op.Range.To != 18 {
+		t.Errorf("expected operator range {17, 18}, got {%d, %d}", op.Range.From, op.Range.To)
+	}
+
+	var val astLeafJSON
+	json.Unmarshal(stmt.Value, &val)
+	if val.Type != "String" || val.Value != "alpha" || val.TextValue != `"alpha"` {
+		t.Errorf("unexpected value: %+v", val)
+	}
+	if val.Range.From != 19 || val.Range.To != 26 {
+		t.Errorf("expected value range {19, 26}, got {%d, %d}", val.Range.From, val.Range.To)
+	}
+	if val.IsEscaped == nil || !*val.IsEscaped {
+		t.Error("expected isEscaped=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// convertIncludesForAPI / convertIncludesForDisplay
+// ---------------------------------------------------------------------------
+
+func TestConvertIncludesForAPI(t *testing.T) {
+	input := `{"name":"test","includes":[{"dataObject":"logs","filter":"status = \"ERROR\""}]}`
+	result, err := convertIncludesForAPI([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The filter field should now be a JSON AST string
+	var parsed struct {
+		Includes []struct {
+			Filter string `json:"filter"`
+		} `json:"includes"`
+	}
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(parsed.Includes) != 1 {
+		t.Fatalf("expected 1 include, got %d", len(parsed.Includes))
+	}
+	if !isFilterAST(parsed.Includes[0].Filter) {
+		t.Errorf("expected filter to be AST, got: %s", parsed.Includes[0].Filter)
+	}
+}
+
+func TestConvertIncludesForAPI_AlreadyAST(t *testing.T) {
+	astFilter := `{"type":"Group","logicalOperator":"AND","explicit":false,"children":[]}`
+	input := `{"name":"test","includes":[{"dataObject":"logs","filter":` + jsonString(astFilter) + `}]}`
+	result, err := convertIncludesForAPI([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed struct {
+		Includes []struct {
+			Filter string `json:"filter"`
+		} `json:"includes"`
+	}
+	json.Unmarshal(result, &parsed)
+	// Should pass through unchanged
+	if parsed.Includes[0].Filter != astFilter {
+		t.Errorf("expected AST passthrough, got: %s", parsed.Includes[0].Filter)
+	}
+}
+
+func TestConvertIncludesForDisplay(t *testing.T) {
+	// Build a segment with AST filters and verify they get converted to DQL
+	astFilter, _ := FilterToAST(`status = "ERROR"`)
+
+	seg := &FilterSegment{
+		UID:  "test-uid",
+		Name: "test",
+		Includes: []Include{
+			{DataObject: "logs", Filter: astFilter},
+		},
+	}
+
+	convertIncludesForDisplay(seg)
+
+	if seg.Includes[0].Filter != `status = "ERROR"` {
+		t.Errorf("expected DQL filter, got: %s", seg.Includes[0].Filter)
+	}
+}
+
+func TestConvertIncludesForDisplay_AlreadyDQL(t *testing.T) {
+	seg := &FilterSegment{
+		UID:  "test-uid",
+		Name: "test",
+		Includes: []Include{
+			{DataObject: "logs", Filter: `status = "ERROR"`},
+		},
+	}
+
+	convertIncludesForDisplay(seg)
+
+	if seg.Includes[0].Filter != `status = "ERROR"` {
+		t.Errorf("expected DQL passthrough, got: %s", seg.Includes[0].Filter)
+	}
+}
+
+func TestConvertIncludesForAPI_NoIncludes(t *testing.T) {
+	input := `{"name":"test"}`
+	result, err := convertIncludesForAPI([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should pass through unchanged
+	if string(result) != input {
+		t.Errorf("expected unchanged output for no includes")
+	}
+}
+
+// jsonString returns a JSON-encoded string literal.
+func jsonString(s string) string {
+	data, _ := json.Marshal(s)
+	return string(data)
+}

--- a/pkg/resources/segment/segment.go
+++ b/pkg/resources/segment/segment.go
@@ -81,8 +81,10 @@ func (h *Handler) List() (*FilterSegmentList, error) {
 		return nil, fmt.Errorf("failed to parse segments response: %w", err)
 	}
 
-	// Populate VariablesDisplay for wide table output
+	// Convert AST filters to human-readable DQL for display, and
+	// populate VariablesDisplay for wide table output.
 	for i := range result.FilterSegments {
+		convertIncludesForDisplay(&result.FilterSegments[i])
 		result.FilterSegments[i].VariablesDisplay = variablesDisplay(result.FilterSegments[i].Variables)
 	}
 
@@ -123,14 +125,23 @@ func (h *Handler) Get(uid string) (*FilterSegment, error) {
 		return nil, fmt.Errorf("failed to parse segment response: %w", err)
 	}
 
+	// Convert AST filters to human-readable DQL for display
+	convertIncludesForDisplay(&result)
+
 	return &result, nil
 }
 
 // Create creates a new filter segment from raw JSON/YAML bytes.
 func (h *Handler) Create(data []byte) (*FilterSegment, error) {
+	// Convert DQL filters to AST for the API
+	converted, err := convertIncludesForAPI(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert filter expressions: %w", err)
+	}
+
 	resp, err := h.client.HTTP().R().
 		SetHeader("Content-Type", "application/json").
-		SetBody(data).
+		SetBody(converted).
 		Post(basePath)
 
 	if err != nil {
@@ -161,10 +172,16 @@ func (h *Handler) Create(data []byte) (*FilterSegment, error) {
 // Update updates an existing filter segment.
 // The version parameter is required for optimistic locking.
 func (h *Handler) Update(uid string, version int, data []byte) error {
+	// Convert DQL filters to AST for the API
+	converted, err := convertIncludesForAPI(data)
+	if err != nil {
+		return fmt.Errorf("failed to convert filter expressions: %w", err)
+	}
+
 	resp, err := h.client.HTTP().R().
 		SetHeader("Content-Type", "application/json").
 		SetQueryParam("optimistic-locking-version", fmt.Sprintf("%d", version)).
-		SetBody(data).
+		SetBody(converted).
 		Put(fmt.Sprintf("%s/%s", basePath, uid))
 
 	if err != nil {
@@ -225,4 +242,80 @@ func (h *Handler) GetRaw(uid string) ([]byte, error) {
 // IsNotFound returns true if the error indicates a segment was not found (404).
 func IsNotFound(err error) bool {
 	return errors.Is(err, ErrNotFound)
+}
+
+// ---------------------------------------------------------------------------
+// Filter format conversion (DQL ↔ AST)
+// ---------------------------------------------------------------------------
+
+// convertIncludesForAPI converts include filters from DQL to AST before
+// sending to the API. It operates on raw JSON bytes so it works with both
+// create and update payloads. If a filter is already JSON AST (starts with
+// '{'), it is passed through unchanged.
+func convertIncludesForAPI(data []byte) ([]byte, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse request body: %w", err)
+	}
+
+	includesRaw, ok := payload["includes"]
+	if !ok {
+		return data, nil // no includes field — pass through unchanged
+	}
+
+	var includes []map[string]json.RawMessage
+	if err := json.Unmarshal(includesRaw, &includes); err != nil {
+		return nil, fmt.Errorf("failed to parse includes: %w", err)
+	}
+
+	changed := false
+	for i, inc := range includes {
+		filterRaw, ok := inc["filter"]
+		if !ok {
+			continue
+		}
+		var filter string
+		if err := json.Unmarshal(filterRaw, &filter); err != nil {
+			continue // not a string — skip
+		}
+
+		ast, err := FilterToAST(filter)
+		if err != nil {
+			return nil, fmt.Errorf("include[%d]: %w", i, err)
+		}
+		if ast != filter {
+			newFilterJSON, err := json.Marshal(ast)
+			if err != nil {
+				return nil, fmt.Errorf("include[%d]: failed to marshal AST: %w", i, err)
+			}
+			inc["filter"] = newFilterJSON
+			changed = true
+		}
+	}
+
+	if !changed {
+		return data, nil
+	}
+
+	newIncludes, err := json.Marshal(includes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal includes: %w", err)
+	}
+	payload["includes"] = newIncludes
+
+	return json.Marshal(payload)
+}
+
+// convertIncludesForDisplay converts include filters from AST to
+// human-readable DQL after receiving from the API. It modifies the
+// FilterSegment in place. If a filter is already plain DQL (doesn't
+// start with '{'), it is left unchanged.
+func convertIncludesForDisplay(seg *FilterSegment) {
+	for i := range seg.Includes {
+		dql, err := FilterFromAST(seg.Includes[i].Filter)
+		if err != nil {
+			continue // leave as-is if conversion fails
+		}
+		seg.Includes[i].Filter = dql
+	}
 }

--- a/pkg/resources/segment/segment.go
+++ b/pkg/resources/segment/segment.go
@@ -1,6 +1,7 @@
 package segment
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -182,7 +183,7 @@ func (h *Handler) Update(uid string, version int, data []byte) error {
 		SetHeader("Content-Type", "application/json").
 		SetQueryParam("optimistic-locking-version", fmt.Sprintf("%d", version)).
 		SetBody(converted).
-		Put(fmt.Sprintf("%s/%s", basePath, uid))
+		Patch(fmt.Sprintf("%s/%s", basePath, uid))
 
 	if err != nil {
 		return fmt.Errorf("failed to update segment: %w", err)
@@ -229,7 +230,9 @@ func (h *Handler) Delete(uid string) error {
 	return nil
 }
 
-// GetRaw gets a segment as raw JSON bytes (for edit command).
+// GetRaw gets a segment as pretty-printed JSON bytes (for edit command).
+// Note: the returned JSON contains DQL filter expressions (not raw API AST)
+// because it delegates to Get, which converts AST filters to DQL.
 func (h *Handler) GetRaw(uid string) ([]byte, error) {
 	seg, err := h.Get(uid)
 	if err != nil {
@@ -252,6 +255,11 @@ func IsNotFound(err error) bool {
 // sending to the API. It operates on raw JSON bytes so it works with both
 // create and update payloads. If a filter is already JSON AST (starts with
 // '{'), it is passed through unchanged.
+//
+// The function preserves the original JSON field order by splicing the
+// converted includes array back into the original bytes rather than
+// re-marshaling the entire payload through a map (which would alphabetize
+// keys).
 func convertIncludesForAPI(data []byte) ([]byte, error) {
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(data, &payload); err != nil {
@@ -297,13 +305,129 @@ func convertIncludesForAPI(data []byte) ([]byte, error) {
 		return data, nil
 	}
 
+	// Re-marshal only the includes array, then splice it into the original
+	// JSON to preserve field order of the top-level object.
 	newIncludes, err := json.Marshal(includes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal includes: %w", err)
 	}
-	payload["includes"] = newIncludes
 
-	return json.Marshal(payload)
+	return replaceJSONField(data, "includes", newIncludes)
+}
+
+// replaceJSONField replaces the value of a top-level JSON object field while
+// preserving the original field order and formatting. It scans the raw JSON
+// bytes for the field key, locates its value span, and splices in newValue.
+func replaceJSONField(data []byte, field string, newValue json.RawMessage) ([]byte, error) {
+	// Build the key pattern to search for: "field":
+	keyPattern := []byte(`"` + field + `"`)
+
+	idx := bytes.Index(data, keyPattern)
+	if idx < 0 {
+		return nil, fmt.Errorf("field %q not found in JSON", field)
+	}
+
+	// Skip past the key and the colon
+	valueStart := idx + len(keyPattern)
+	for valueStart < len(data) && (data[valueStart] == ' ' || data[valueStart] == '\t' || data[valueStart] == '\n' || data[valueStart] == '\r' || data[valueStart] == ':') {
+		valueStart++
+	}
+	if valueStart >= len(data) {
+		return nil, fmt.Errorf("field %q: unexpected end of JSON after key", field)
+	}
+
+	// Find the end of the value by counting balanced brackets/braces and
+	// skipping strings. The value starts at data[valueStart].
+	valueEnd, err := findJSONValueEnd(data, valueStart)
+	if err != nil {
+		return nil, fmt.Errorf("field %q: %w", field, err)
+	}
+
+	// Splice: data[:valueStart] + newValue + data[valueEnd:]
+	var buf bytes.Buffer
+	buf.Grow(valueStart + len(newValue) + (len(data) - valueEnd))
+	buf.Write(data[:valueStart])
+	buf.Write(newValue)
+	buf.Write(data[valueEnd:])
+	return buf.Bytes(), nil
+}
+
+// findJSONValueEnd returns the byte offset just past the JSON value starting
+// at data[start]. It handles objects, arrays, strings, and primitives.
+func findJSONValueEnd(data []byte, start int) (int, error) {
+	if start >= len(data) {
+		return 0, fmt.Errorf("unexpected end of JSON")
+	}
+
+	switch data[start] {
+	case '{', '[':
+		return findJSONBalancedEnd(data, start)
+	case '"':
+		return findJSONStringEnd(data, start)
+	default:
+		// Primitive (number, boolean, null) — ends at comma, }, ], or whitespace
+		i := start
+		for i < len(data) {
+			switch data[i] {
+			case ',', '}', ']', ' ', '\t', '\n', '\r':
+				return i, nil
+			}
+			i++
+		}
+		return i, nil
+	}
+}
+
+// findJSONBalancedEnd finds the closing bracket/brace that matches the opener
+// at data[start], correctly skipping nested structures and strings.
+func findJSONBalancedEnd(data []byte, start int) (int, error) {
+	open := data[start]
+	var close byte
+	if open == '{' {
+		close = '}'
+	} else {
+		close = ']'
+	}
+
+	depth := 1
+	i := start + 1
+	for i < len(data) && depth > 0 {
+		switch data[i] {
+		case '"':
+			end, err := findJSONStringEnd(data, i)
+			if err != nil {
+				return 0, err
+			}
+			i = end
+			continue
+		case open:
+			depth++
+		case close:
+			depth--
+		}
+		i++
+	}
+	if depth != 0 {
+		return 0, fmt.Errorf("unbalanced JSON starting at offset %d", start)
+	}
+	return i, nil
+}
+
+// findJSONStringEnd returns the offset just past the closing quote of a JSON
+// string starting at data[start] (which must be '"').
+func findJSONStringEnd(data []byte, start int) (int, error) {
+	i := start + 1 // skip opening quote
+	for i < len(data) {
+		if data[i] == '\\' {
+			i += 2 // skip escaped character
+			continue
+		}
+		if data[i] == '"' {
+			return i + 1, nil
+		}
+		i++
+	}
+	return 0, fmt.Errorf("unterminated JSON string starting at offset %d", start)
 }
 
 // convertIncludesForDisplay converts include filters from AST to

--- a/pkg/resources/segment/segment_test.go
+++ b/pkg/resources/segment/segment_test.go
@@ -44,6 +44,7 @@ func TestList(t *testing.T) {
 	tests := []struct {
 		name          string
 		statusCode    int
+		buildResponse func(t *testing.T) interface{} // builds response body; nil uses responseBody field
 		responseBody  interface{}
 		expectError   bool
 		errorContains string
@@ -79,6 +80,43 @@ func TestList(t *testing.T) {
 				}
 				if result.FilterSegments[1].Name != "prod-logs" {
 					t.Errorf("expected second segment name 'prod-logs', got %q", result.FilterSegments[1].Name)
+				}
+			},
+		},
+		{
+			name:       "list with AST filters converts to DQL",
+			statusCode: 200,
+			buildResponse: func(t *testing.T) interface{} {
+				return FilterSegmentList{
+					FilterSegments: []FilterSegment{
+						{
+							UID:      "seg-uid-003",
+							Name:     "with-includes",
+							IsPublic: true,
+							Includes: []Include{
+								{DataObject: "logs", Filter: astFilterFor(t, `status = "ERROR"`)},
+								{DataObject: "spans", Filter: astFilterFor(t, `span.kind = "SERVER" OR span.kind = "CLIENT"`)},
+							},
+						},
+					},
+					TotalCount: 1,
+				}
+			},
+			expectError: false,
+			validate: func(t *testing.T, result *FilterSegmentList) {
+				if len(result.FilterSegments) != 1 {
+					t.Fatalf("expected 1 segment, got %d", len(result.FilterSegments))
+				}
+				seg := result.FilterSegments[0]
+				if len(seg.Includes) != 2 {
+					t.Fatalf("expected 2 includes, got %d", len(seg.Includes))
+				}
+				// Verify AST→DQL conversion happened
+				if seg.Includes[0].Filter != `status = "ERROR"` {
+					t.Errorf("expected DQL filter for include[0], got %q", seg.Includes[0].Filter)
+				}
+				if seg.Includes[1].Filter != `span.kind = "SERVER" OR span.kind = "CLIENT"` {
+					t.Errorf("expected DQL filter for include[1], got %q", seg.Includes[1].Filter)
 				}
 			},
 		},
@@ -122,11 +160,15 @@ func TestList(t *testing.T) {
 				if r.URL.Query().Get("page-size") != "" {
 					t.Error("list endpoint should not send page-size (API has no pagination)")
 				}
+				responseBody := tt.responseBody
+				if tt.buildResponse != nil {
+					responseBody = tt.buildResponse(t)
+				}
 				w.WriteHeader(tt.statusCode)
-				if str, ok := tt.responseBody.(string); ok {
+				if str, ok := responseBody.(string); ok {
 					w.Write([]byte(str))
 				} else {
-					json.NewEncoder(w).Encode(tt.responseBody)
+					json.NewEncoder(w).Encode(responseBody)
 				}
 			}))
 			defer server.Close()
@@ -162,17 +204,36 @@ func TestGet(t *testing.T) {
 		name          string
 		uid           string
 		statusCode    int
+		buildResponse func(t *testing.T) interface{} // builds response body; nil uses responseBody field
 		responseBody  interface{}
 		expectError   bool
 		errorContains string
 		validate      func(*testing.T, *FilterSegment)
 	}{
 		{
-			name:         "successful get",
-			uid:          "seg-uid-001",
-			statusCode:   200,
-			responseBody: nil, // set dynamically below
-			expectError:  false,
+			name:       "successful get",
+			uid:        "seg-uid-001",
+			statusCode: 200,
+			buildResponse: func(t *testing.T) interface{} {
+				return FilterSegment{
+					UID:         "seg-uid-001",
+					Name:        "k8s-alpha",
+					Description: "Kubernetes cluster alpha",
+					IsPublic:    true,
+					Owner:       "user@example.invalid",
+					Version:     3,
+					Includes: []Include{
+						{DataObject: "_all_data_object", Filter: astFilterFor(t, `k8s.cluster.name = "alpha"`)},
+						{DataObject: "logs", Filter: astFilterFor(t, `dt.system.bucket = "custom-logs"`)},
+					},
+					Variables: &Variables{
+						Type:  "query",
+						Value: `fetch logs | limit 1`,
+					},
+					AllowedOperations: []string{"READ", "WRITE", "DELETE"},
+				}
+			},
+			expectError: false,
 			validate: func(t *testing.T, seg *FilterSegment) {
 				if seg.UID != "seg-uid-001" {
 					t.Errorf("expected UID 'seg-uid-001', got %q", seg.UID)
@@ -243,26 +304,10 @@ func TestGet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// For "successful get", build response with AST filters (simulating real API)
+			// Build response body: prefer buildResponse function, fall back to static field
 			responseBody := tt.responseBody
-			if responseBody == nil && tt.name == "successful get" {
-				responseBody = FilterSegment{
-					UID:         "seg-uid-001",
-					Name:        "k8s-alpha",
-					Description: "Kubernetes cluster alpha",
-					IsPublic:    true,
-					Owner:       "user@example.invalid",
-					Version:     3,
-					Includes: []Include{
-						{DataObject: "_all_data_object", Filter: astFilterFor(t, `k8s.cluster.name = "alpha"`)},
-						{DataObject: "logs", Filter: astFilterFor(t, `dt.system.bucket = "custom-logs"`)},
-					},
-					Variables: &Variables{
-						Type:  "query",
-						Value: `fetch logs | limit 1`,
-					},
-					AllowedOperations: []string{"READ", "WRITE", "DELETE"},
-				}
+			if tt.buildResponse != nil {
+				responseBody = tt.buildResponse(t)
 			}
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -404,6 +449,9 @@ func TestCreate(t *testing.T) {
 					for i, inc := range reqBody.Includes {
 						if inc.Filter != "" && !isFilterAST(inc.Filter) {
 							t.Errorf("include[%d] filter should be AST in API request, got DQL: %s", i, inc.Filter)
+							w.WriteHeader(http.StatusBadRequest)
+							w.Write([]byte(`{"error":"filter must be AST, got DQL"}`))
+							return
 						}
 					}
 				}
@@ -502,8 +550,8 @@ func TestUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != "PUT" {
-					t.Errorf("expected PUT method, got %s", r.Method)
+				if r.Method != "PATCH" {
+					t.Errorf("expected PATCH method, got %s", r.Method)
 				}
 				expectedPath := fmt.Sprintf("/platform/storage/filter-segments/v1/filter-segments/%s", tt.uid)
 				if r.URL.Path != expectedPath {
@@ -530,6 +578,9 @@ func TestUpdate(t *testing.T) {
 					for i, inc := range reqBody.Includes {
 						if inc.Filter != "" && !isFilterAST(inc.Filter) {
 							t.Errorf("include[%d] filter should be AST in API request, got DQL: %s", i, inc.Filter)
+							w.WriteHeader(http.StatusBadRequest)
+							w.Write([]byte(`{"error":"filter must be AST, got DQL"}`))
+							return
 						}
 					}
 				}
@@ -756,5 +807,104 @@ func TestIsNotFound(t *testing.T) {
 				t.Errorf("IsNotFound(%v) = %v, want %v", tt.err, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestConvertIncludesForAPI_PreservesFieldOrder(t *testing.T) {
+	// Input has fields in a specific order: name, includes, isPublic, description.
+	// convertIncludesForAPI must preserve this order, not alphabetize it.
+	input := []byte(`{"name":"test","includes":[{"dataObject":"logs","filter":"status = \"ERROR\""}],"isPublic":true,"description":"keep order"}`)
+
+	result, err := convertIncludesForAPI(input)
+	if err != nil {
+		t.Fatalf("convertIncludesForAPI() error: %v", err)
+	}
+
+	// The result must still have "name" before "includes" before "isPublic" before "description".
+	resultStr := string(result)
+	nameIdx := strings.Index(resultStr, `"name"`)
+	includesIdx := strings.Index(resultStr, `"includes"`)
+	isPublicIdx := strings.Index(resultStr, `"isPublic"`)
+	descIdx := strings.Index(resultStr, `"description"`)
+
+	if nameIdx < 0 || includesIdx < 0 || isPublicIdx < 0 || descIdx < 0 {
+		t.Fatalf("missing expected fields in result: %s", resultStr)
+	}
+	if nameIdx >= includesIdx {
+		t.Errorf("field order not preserved: 'name' (%d) should come before 'includes' (%d) in: %s", nameIdx, includesIdx, resultStr)
+	}
+	if includesIdx >= isPublicIdx {
+		t.Errorf("field order not preserved: 'includes' (%d) should come before 'isPublic' (%d) in: %s", includesIdx, isPublicIdx, resultStr)
+	}
+	if isPublicIdx >= descIdx {
+		t.Errorf("field order not preserved: 'isPublic' (%d) should come before 'description' (%d) in: %s", isPublicIdx, descIdx, resultStr)
+	}
+
+	// Also verify the filter was actually converted to AST
+	var payload struct {
+		Includes []struct {
+			Filter string `json:"filter"`
+		} `json:"includes"`
+	}
+	if err := json.Unmarshal(result, &payload); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+	if len(payload.Includes) != 1 {
+		t.Fatalf("expected 1 include, got %d", len(payload.Includes))
+	}
+	if !isFilterAST(payload.Includes[0].Filter) {
+		t.Errorf("expected AST filter, got: %s", payload.Includes[0].Filter)
+	}
+}
+
+func TestCreate_InvalidDQL_PropagatesError(t *testing.T) {
+	// The server should never be called — the error should happen client-side
+	// during DQL→AST conversion before the HTTP request is made.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be called when DQL conversion fails")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	h := NewHandler(c)
+
+	// Use "==" which is explicitly rejected by the parser with a helpful message
+	input := []byte(`{"name":"test","includes":[{"dataObject":"logs","filter":"status == \"ERROR\""}]}`)
+	_, err = h.Create(input)
+	if err == nil {
+		t.Fatal("expected error for invalid DQL filter, got nil")
+	}
+	if !strings.Contains(err.Error(), "==") {
+		t.Errorf("expected error message to mention '==', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "include[0]") {
+		t.Errorf("expected error to identify include index, got: %v", err)
+	}
+}
+
+func TestUpdate_InvalidDQL_PropagatesError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be called when DQL conversion fails")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	h := NewHandler(c)
+
+	input := []byte(`{"name":"test","includes":[{"dataObject":"logs","filter":"status == \"ERROR\""}]}`)
+	err = h.Update("seg-uid-001", 1, input)
+	if err == nil {
+		t.Fatal("expected error for invalid DQL filter, got nil")
+	}
+	if !strings.Contains(err.Error(), "==") {
+		t.Errorf("expected error message to mention '==', got: %v", err)
 	}
 }

--- a/pkg/resources/segment/segment_test.go
+++ b/pkg/resources/segment/segment_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,18 @@ import (
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 )
+
+// astFilterFor converts a DQL expression to its AST form for use in mock API
+// responses. Test helpers call this to simulate real API behaviour where the
+// server always stores and returns JSON AST, never plain DQL.
+func astFilterFor(t *testing.T, dql string) string {
+	t.Helper()
+	ast, err := FilterToAST(dql)
+	if err != nil {
+		t.Fatalf("astFilterFor(%q): %v", dql, err)
+	}
+	return ast
+}
 
 func TestNewHandler(t *testing.T) {
 	c, err := client.New("https://test.dynatrace.com", "test-token")
@@ -155,27 +168,11 @@ func TestGet(t *testing.T) {
 		validate      func(*testing.T, *FilterSegment)
 	}{
 		{
-			name:       "successful get",
-			uid:        "seg-uid-001",
-			statusCode: 200,
-			responseBody: FilterSegment{
-				UID:         "seg-uid-001",
-				Name:        "k8s-alpha",
-				Description: "Kubernetes cluster alpha",
-				IsPublic:    true,
-				Owner:       "user@example.invalid",
-				Version:     3,
-				Includes: []Include{
-					{DataObject: "_all_data_object", Filter: `k8s.cluster.name = "alpha"`},
-					{DataObject: "logs", Filter: `dt.system.bucket = "custom-logs"`},
-				},
-				Variables: &Variables{
-					Type:  "query",
-					Value: `fetch logs | limit 1`,
-				},
-				AllowedOperations: []string{"READ", "WRITE", "DELETE"},
-			},
-			expectError: false,
+			name:         "successful get",
+			uid:          "seg-uid-001",
+			statusCode:   200,
+			responseBody: nil, // set dynamically below
+			expectError:  false,
 			validate: func(t *testing.T, seg *FilterSegment) {
 				if seg.UID != "seg-uid-001" {
 					t.Errorf("expected UID 'seg-uid-001', got %q", seg.UID)
@@ -186,8 +183,15 @@ func TestGet(t *testing.T) {
 				if len(seg.Includes) != 2 {
 					t.Errorf("expected 2 includes, got %d", len(seg.Includes))
 				}
+				// Verify AST→DQL conversion happened: filters should be DQL, not AST
 				if seg.Includes[0].DataObject != "_all_data_object" {
 					t.Errorf("expected first include dataObject '_all_data_object', got %q", seg.Includes[0].DataObject)
+				}
+				if seg.Includes[0].Filter != `k8s.cluster.name = "alpha"` {
+					t.Errorf("expected first filter as DQL, got %q", seg.Includes[0].Filter)
+				}
+				if seg.Includes[1].Filter != `dt.system.bucket = "custom-logs"` {
+					t.Errorf("expected second filter as DQL, got %q", seg.Includes[1].Filter)
 				}
 				if seg.Variables == nil {
 					t.Error("expected variables to be non-nil")
@@ -239,6 +243,28 @@ func TestGet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// For "successful get", build response with AST filters (simulating real API)
+			responseBody := tt.responseBody
+			if responseBody == nil && tt.name == "successful get" {
+				responseBody = FilterSegment{
+					UID:         "seg-uid-001",
+					Name:        "k8s-alpha",
+					Description: "Kubernetes cluster alpha",
+					IsPublic:    true,
+					Owner:       "user@example.invalid",
+					Version:     3,
+					Includes: []Include{
+						{DataObject: "_all_data_object", Filter: astFilterFor(t, `k8s.cluster.name = "alpha"`)},
+						{DataObject: "logs", Filter: astFilterFor(t, `dt.system.bucket = "custom-logs"`)},
+					},
+					Variables: &Variables{
+						Type:  "query",
+						Value: `fetch logs | limit 1`,
+					},
+					AllowedOperations: []string{"READ", "WRITE", "DELETE"},
+				}
+			}
+
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				expectedPath := fmt.Sprintf("/platform/storage/filter-segments/v1/filter-segments/%s", tt.uid)
 				if r.URL.Path != expectedPath {
@@ -255,10 +281,10 @@ func TestGet(t *testing.T) {
 					}
 				}
 				w.WriteHeader(tt.statusCode)
-				if str, ok := tt.responseBody.(string); ok {
+				if str, ok := responseBody.(string); ok {
 					w.Write([]byte(str))
 				} else {
-					json.NewEncoder(w).Encode(tt.responseBody)
+					json.NewEncoder(w).Encode(responseBody)
 				}
 			}))
 			defer server.Close()
@@ -366,6 +392,22 @@ func TestCreate(t *testing.T) {
 				if r.URL.Path != "/platform/storage/filter-segments/v1/filter-segments" {
 					t.Errorf("expected path '/platform/storage/filter-segments/v1/filter-segments', got %q", r.URL.Path)
 				}
+
+				// Validate that DQL filters were converted to AST before sending
+				body, _ := io.ReadAll(r.Body)
+				var reqBody struct {
+					Includes []struct {
+						Filter string `json:"filter"`
+					} `json:"includes"`
+				}
+				if err := json.Unmarshal(body, &reqBody); err == nil {
+					for i, inc := range reqBody.Includes {
+						if inc.Filter != "" && !isFilterAST(inc.Filter) {
+							t.Errorf("include[%d] filter should be AST in API request, got DQL: %s", i, inc.Filter)
+						}
+					}
+				}
+
 				w.WriteHeader(tt.statusCode)
 				if str, ok := tt.responseBody.(string); ok {
 					w.Write([]byte(str))
@@ -476,6 +518,22 @@ func TestUpdate(t *testing.T) {
 				if lockVer != expectedVer {
 					t.Errorf("expected optimistic-locking-version %q, got %q", expectedVer, lockVer)
 				}
+
+				// Validate that DQL filters were converted to AST before sending
+				body, _ := io.ReadAll(r.Body)
+				var reqBody struct {
+					Includes []struct {
+						Filter string `json:"filter"`
+					} `json:"includes"`
+				}
+				if err := json.Unmarshal(body, &reqBody); err == nil {
+					for i, inc := range reqBody.Includes {
+						if inc.Filter != "" && !isFilterAST(inc.Filter) {
+							t.Errorf("include[%d] filter should be AST in API request, got DQL: %s", i, inc.Filter)
+						}
+					}
+				}
+
 				w.WriteHeader(tt.statusCode)
 				w.Write([]byte(tt.responseBody))
 			}))
@@ -487,7 +545,7 @@ func TestUpdate(t *testing.T) {
 			}
 			h := NewHandler(c)
 
-			updateData := []byte(`{"name":"updated-segment","isPublic":true}`)
+			updateData := []byte(`{"name":"updated-segment","isPublic":true,"includes":[{"dataObject":"logs","filter":"status = \"ERROR\""}]}`)
 			err = h.Update(tt.uid, tt.version, updateData)
 
 			if tt.expectError {
@@ -578,6 +636,7 @@ func TestDelete(t *testing.T) {
 
 func TestGetRaw(t *testing.T) {
 	t.Run("successful get raw", func(t *testing.T) {
+		// Server returns AST filters (simulating real API behaviour)
 		expectedSegment := FilterSegment{
 			UID:      "seg-uid-001",
 			Name:     "test-segment",
@@ -585,7 +644,7 @@ func TestGetRaw(t *testing.T) {
 			Owner:    "user@example.invalid",
 			Version:  1,
 			Includes: []Include{
-				{DataObject: "logs", Filter: `status = "ERROR"`},
+				{DataObject: "logs", Filter: astFilterFor(t, `status = "ERROR"`)},
 			},
 		}
 
@@ -617,6 +676,13 @@ func TestGetRaw(t *testing.T) {
 		}
 		if seg.Name != expectedSegment.Name {
 			t.Errorf("expected name %q, got %q", expectedSegment.Name, seg.Name)
+		}
+		// Verify AST→DQL conversion happened in GetRaw output
+		if len(seg.Includes) != 1 {
+			t.Fatalf("expected 1 include, got %d", len(seg.Includes))
+		}
+		if seg.Includes[0].Filter != `status = "ERROR"` {
+			t.Errorf("expected DQL filter in GetRaw output, got %q", seg.Includes[0].Filter)
 		}
 	})
 

--- a/test/integration/apply_dashboard_test.go
+++ b/test/integration/apply_dashboard_test.go
@@ -98,7 +98,7 @@ func TestApplyDashboard_VariousFormats(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Apply the dashboard
-			err := applier.Apply([]byte(tc.manifest), apply.ApplyOptions{})
+			_, err := applier.Apply([]byte(tc.manifest), apply.ApplyOptions{})
 			if err != nil {
 				t.Fatalf("failed to apply dashboard: %v", err)
 			}
@@ -141,7 +141,7 @@ func TestApplyDashboard_RoundTrip(t *testing.T) {
 		}
 	}`
 
-	err := applier.Apply([]byte(manifest), apply.ApplyOptions{})
+	_, err := applier.Apply([]byte(manifest), apply.ApplyOptions{})
 	if err != nil {
 		t.Fatalf("failed to create initial dashboard: %v", err)
 	}
@@ -289,7 +289,7 @@ func TestApplyDashboard_FromFile(t *testing.T) {
 
 			// Try to apply (this will actually create the dashboard)
 			// In a real test environment, you'd want to clean these up
-			err = applier.Apply(data, apply.ApplyOptions{DryRun: true})
+			_, err = applier.Apply(data, apply.ApplyOptions{DryRun: true})
 			if err != nil {
 				t.Errorf("failed to dry-run apply dashboard from %s: %v", tf.path, err)
 			}

--- a/test/integration/fixtures.go
+++ b/test/integration/fixtures.go
@@ -414,7 +414,7 @@ func SegmentFixture(prefix string) []byte {
 		"includes": []map[string]interface{}{
 			{
 				"dataObject": "logs",
-				"filter":     "status == \"ERROR\"",
+				"filter":     "status = \"ERROR\"",
 			},
 		},
 	}
@@ -432,11 +432,11 @@ func SegmentFixtureModified(prefix string) []byte {
 		"includes": []map[string]interface{}{
 			{
 				"dataObject": "logs",
-				"filter":     "status == \"ERROR\"",
+				"filter":     "status = \"ERROR\"",
 			},
 			{
 				"dataObject": "spans",
-				"filter":     "span.kind == \"SERVER\"",
+				"filter":     "span.kind = \"SERVER\"",
 			},
 		},
 	}
@@ -521,7 +521,7 @@ func SegmentFixtureMultiInclude(prefix string) []byte {
 		"includes": []map[string]interface{}{
 			{
 				"dataObject": "logs",
-				"filter":     "loglevel == \"ERROR\" OR loglevel == \"WARN\"",
+				"filter":     "loglevel = \"ERROR\" OR loglevel = \"WARN\"",
 			},
 		},
 	}

--- a/test/integration/fixtures.go
+++ b/test/integration/fixtures.go
@@ -529,3 +529,32 @@ func SegmentFixtureMultiInclude(prefix string) []byte {
 	data, _ := json.Marshal(seg)
 	return data
 }
+
+// SegmentFixtureComplexFilter returns a segment with a complex filter
+// expression that exercises parenthesized groups, mixed AND/OR, and implicit
+// AND. This tests DQL→AST→DQL round-trip fidelity for non-trivial filters.
+//
+// Note: The Segments API only supports operators =, starts-with, contains,
+// ends-with, and in. The DQL parser currently handles = and in (single-value
+// only; tuple syntax like `in ("a","b")` is not supported). This fixture uses
+// only the = operator to test structural complexity rather than operator variety.
+func SegmentFixtureComplexFilter(prefix string) []byte {
+	seg := map[string]interface{}{
+		"name":        fmt.Sprintf("%s-segment-complex", prefix),
+		"description": "Integration test segment with complex filter",
+		"isPublic":    false,
+		"includes": []map[string]interface{}{
+			{
+				"dataObject": "logs",
+				"filter":     `(status = "ERROR" OR status = "WARN") AND dt.system.bucket = "custom-logs"`,
+			},
+			{
+				"dataObject": "spans",
+				"filter":     `span.kind = "CLIENT" http.method = "GET"`,
+			},
+		},
+	}
+
+	data, _ := json.Marshal(seg)
+	return data
+}

--- a/test/integration/segment_test.go
+++ b/test/integration/segment_test.go
@@ -1,0 +1,209 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/resources/segment"
+)
+
+// TestSegment_CRUD tests the full create/get/update/delete lifecycle for
+// filter segments, including DQL ↔ AST filter round-tripping.
+func TestSegment_CRUD(t *testing.T) {
+	env := SetupIntegration(t)
+	defer env.Cleanup.Cleanup(t)
+
+	h := segment.NewHandler(env.Client)
+
+	// --- Create ---------------------------------------------------------
+	fixture := SegmentFixture(env.TestPrefix)
+	created, err := h.Create(fixture)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+	env.Cleanup.Track("segment", created.UID, created.Name)
+
+	if created.UID == "" {
+		t.Fatal("expected non-empty UID after create")
+	}
+	t.Logf("Created segment: %s (UID: %s)", created.Name, created.UID)
+
+	// --- Get ------------------------------------------------------------
+	got, err := h.Get(created.UID)
+	if err != nil {
+		t.Fatalf("Get(%s) failed: %v", created.UID, err)
+	}
+
+	if got.Name != created.Name {
+		t.Errorf("Get() name = %q, want %q", got.Name, created.Name)
+	}
+
+	// Verify AST→DQL conversion: the API stores JSON AST, but Get should
+	// return human-readable DQL after convertIncludesForDisplay.
+	if len(got.Includes) == 0 {
+		t.Fatal("expected at least one include after Get")
+	}
+	for i, inc := range got.Includes {
+		if inc.Filter == "" {
+			t.Errorf("include[%d] filter is empty", i)
+		}
+		// The filter should be plain DQL (not start with '{')
+		if len(inc.Filter) > 0 && inc.Filter[0] == '{' {
+			t.Errorf("include[%d] filter is still AST after Get (expected DQL): %s", i, inc.Filter)
+		}
+		t.Logf("include[%d]: dataObject=%s filter=%q", i, inc.DataObject, inc.Filter)
+	}
+
+	// --- List -----------------------------------------------------------
+	list, err := h.List()
+	if err != nil {
+		t.Fatalf("List() failed: %v", err)
+	}
+
+	found := false
+	for _, seg := range list.FilterSegments {
+		if seg.UID == created.UID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("created segment %s not found in List() results", created.UID)
+	}
+
+	// --- Update ---------------------------------------------------------
+	modifiedFixture := SegmentFixtureModified(env.TestPrefix)
+	err = h.Update(created.UID, got.Version, modifiedFixture)
+	if err != nil {
+		t.Fatalf("Update(%s) failed: %v", created.UID, err)
+	}
+
+	// Verify update took effect and DQL round-trip still works
+	updated, err := h.Get(created.UID)
+	if err != nil {
+		t.Fatalf("Get(%s) after update failed: %v", created.UID, err)
+	}
+	if len(updated.Includes) < 2 {
+		t.Errorf("expected at least 2 includes after update, got %d", len(updated.Includes))
+	}
+	for i, inc := range updated.Includes {
+		if len(inc.Filter) > 0 && inc.Filter[0] == '{' {
+			t.Errorf("include[%d] filter is still AST after update+get (expected DQL): %s", i, inc.Filter)
+		}
+	}
+
+	// --- GetRaw (edit workflow) ------------------------------------------
+	raw, err := h.GetRaw(created.UID)
+	if err != nil {
+		t.Fatalf("GetRaw(%s) failed: %v", created.UID, err)
+	}
+	var rawSeg segment.FilterSegment
+	if err := json.Unmarshal(raw, &rawSeg); err != nil {
+		t.Fatalf("GetRaw returned invalid JSON: %v", err)
+	}
+	// GetRaw should also have DQL filters (not AST)
+	for i, inc := range rawSeg.Includes {
+		if len(inc.Filter) > 0 && inc.Filter[0] == '{' {
+			t.Errorf("GetRaw include[%d] filter is still AST (expected DQL): %s", i, inc.Filter)
+		}
+	}
+
+	// --- Delete ---------------------------------------------------------
+	err = h.Delete(created.UID)
+	if err != nil {
+		t.Fatalf("Delete(%s) failed: %v", created.UID, err)
+	}
+	env.Cleanup.Untrack("segment", created.UID)
+
+	// Verify deletion
+	_, err = h.Get(created.UID)
+	if err == nil {
+		t.Error("expected error after deleting segment, got nil")
+	}
+	if !segment.IsNotFound(err) {
+		t.Errorf("expected IsNotFound error, got: %v", err)
+	}
+}
+
+// TestSegment_MultiInclude tests segments with complex filter expressions
+// (OR-combined, multiple includes) to verify DQL round-trip fidelity.
+func TestSegment_MultiInclude(t *testing.T) {
+	env := SetupIntegration(t)
+	defer env.Cleanup.Cleanup(t)
+
+	h := segment.NewHandler(env.Client)
+
+	fixture := SegmentFixtureMultiInclude(env.TestPrefix)
+	created, err := h.Create(fixture)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+	env.Cleanup.Track("segment", created.UID, created.Name)
+
+	got, err := h.Get(created.UID)
+	if err != nil {
+		t.Fatalf("Get(%s) failed: %v", created.UID, err)
+	}
+
+	if len(got.Includes) == 0 {
+		t.Fatal("expected at least one include")
+	}
+
+	// The multi-include fixture uses an OR filter: loglevel = "ERROR" OR loglevel = "WARN"
+	// Verify the round-trip preserves the OR structure.
+	for i, inc := range got.Includes {
+		if len(inc.Filter) > 0 && inc.Filter[0] == '{' {
+			t.Errorf("include[%d] filter is AST (expected DQL): %s", i, inc.Filter)
+		}
+		t.Logf("multi-include[%d]: %q", i, inc.Filter)
+	}
+}
+
+// TestSegment_ComplexFilter tests segments with complex filter expressions
+// (parenthesized groups, mixed AND/OR, implicit AND, multiple operators)
+// to verify DQL round-trip fidelity for non-trivial filters.
+func TestSegment_ComplexFilter(t *testing.T) {
+	env := SetupIntegration(t)
+	defer env.Cleanup.Cleanup(t)
+
+	h := segment.NewHandler(env.Client)
+
+	fixture := SegmentFixtureComplexFilter(env.TestPrefix)
+	created, err := h.Create(fixture)
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+	env.Cleanup.Track("segment", created.UID, created.Name)
+
+	got, err := h.Get(created.UID)
+	if err != nil {
+		t.Fatalf("Get(%s) failed: %v", created.UID, err)
+	}
+
+	if len(got.Includes) < 2 {
+		t.Fatalf("expected at least 2 includes, got %d", len(got.Includes))
+	}
+
+	// Verify all filters came back as DQL (not AST)
+	for i, inc := range got.Includes {
+		if len(inc.Filter) > 0 && inc.Filter[0] == '{' {
+			t.Errorf("include[%d] filter is AST (expected DQL): %s", i, inc.Filter)
+		}
+		t.Logf("complex-include[%d]: %q", i, inc.Filter)
+	}
+
+	// Verify the parenthesized OR group survived the round-trip
+	logsFilter := got.Includes[0].Filter
+	if logsFilter != `(status = "ERROR" OR status = "WARN") AND dt.system.bucket = "custom-logs"` {
+		t.Errorf("unexpected logs filter after round-trip: %q", logsFilter)
+	}
+
+	// Verify implicit AND with equality operators survived
+	spansFilter := got.Includes[1].Filter
+	if spansFilter != `span.kind = "CLIENT" http.method = "GET"` {
+		t.Errorf("unexpected spans filter after round-trip: %q", spansFilter)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes from comprehensive review of PR #134 (transparent DQL ↔ AST filter conversion for segments), plus bugs discovered during integration testing against a real Dynatrace environment.

### Key fixes

- **Segment Update uses PATCH, not PUT** — The filter-segments API rejects PUT requests with "Required request body is missing". Changed to PATCH, which the API accepts. This was a pre-existing bug.
- **Preserve JSON field order** in `convertIncludesForAPI` using byte-level splicing (`replaceJSONField`) instead of `map[string]json.RawMessage` re-marshaling (which alphabetizes keys)
- **Add missing `in` operator** to DQL filter parser (`parseOperator`)
- **Fix JSON escaping** in apply integration test fixtures (`\\\"` → `\"`)
- **Harden mock servers** to reject non-AST filters with HTTP 400
- **Replace fragile string-matching** in TestGet/TestList with `buildResponse` function field
- **Add test coverage**: TestList AST→DQL, field order preservation, invalid DQL error propagation, complex filter integration test
- **Fix pre-existing compile error** in `apply_dashboard_test.go` (Apply return value mismatch)
- **Update GetRaw godoc** to reflect AST→DQL conversion behavior

### Validation

- `go test ./...` — all 45 packages pass
- Integration tests against real Dynatrace environment: TestSegment_CRUD, TestSegment_MultiInclude, TestSegment_ComplexFilter all pass