### PR TITLE
fix: auth login --context uses named context URL, not current context URL

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -134,6 +134,41 @@ JWT token's 'sub' claim.`,
 	},
 }
 
+// resolveLoginContext fills in any missing contextName, environment, and tokenName
+// values by looking up the named context in cfg.
+//
+// The key invariant: when contextName is already known (provided via --context),
+// the environment and tokenName fallbacks are read from THAT named context — not
+// from the currently active context. This prevents a bug where
+//
+//	dtctl auth login --context <other-context>
+//
+// would silently overwrite the other context's environment URL with the current
+// context's URL.
+//
+// Returns an error only when contextName cannot be determined (no --context flag
+// and no current context is set in cfg).
+func resolveLoginContext(cfg *config.Config, contextName, environment, tokenName string) (string, string, string, error) {
+	if contextName == "" {
+		if cfg.CurrentContext == "" {
+			return "", "", "", fmt.Errorf("no current context set")
+		}
+		contextName = cfg.CurrentContext
+	}
+	// Resolve missing environment / tokenName from the *named* context.
+	if environment == "" || tokenName == "" {
+		if nc, err := cfg.GetContext(contextName); err == nil {
+			if environment == "" {
+				environment = nc.Context.Environment
+			}
+			if tokenName == "" && nc.Context.TokenRef != "" {
+				tokenName = nc.Context.TokenRef
+			}
+		}
+	}
+	return contextName, environment, tokenName, nil
+}
+
 // authLoginCmd initiates browser-based OAuth login
 var authLoginCmd = &cobra.Command{
 	Use:   "login",
@@ -172,43 +207,39 @@ you'll need to use API token authentication instead (dtctl config set-credential
 		timeoutStr, _ := cmd.Flags().GetString("timeout")
 		safetyLevelStr, _ := cmd.Flags().GetString("safety-level")
 
-		// If --context or --environment are not provided, fall back to the current context
+		// Resolve contextName, environment and tokenName from the config when not
+		// supplied as explicit flags.
 		if contextName == "" || environment == "" {
 			contextHint := "Use 'dtctl ctx' to list available context names, then pass --context <name> --environment <url>"
 			cfg, err := LoadConfig()
 			if err != nil {
-				return &diagnostic.Error{
-					Operation:   "auth login",
-					Message:     "--context and --environment are required (no existing config found)",
-					Suggestions: []string{contextHint},
-					Err:         err,
+				if contextName == "" {
+					return &diagnostic.Error{
+						Operation:   "auth login",
+						Message:     "--context and --environment are required (no existing config found)",
+						Suggestions: []string{contextHint},
+						Err:         err,
+					}
+				}
+				// contextName provided but config unreadable — environment must be supplied explicitly.
+			} else {
+				var resolveErr error
+				contextName, environment, tokenName, resolveErr = resolveLoginContext(cfg, contextName, environment, tokenName)
+				if resolveErr != nil {
+					return &diagnostic.Error{
+						Operation:   "auth login",
+						Message:     "--context and --environment are required when no current context is set",
+						Suggestions: []string{contextHint, "Set a current context with 'dtctl ctx use-context <name>'"},
+					}
 				}
 			}
-			if cfg.CurrentContext == "" {
-				return &diagnostic.Error{
-					Operation:   "auth login",
-					Message:     "--context and --environment are required when no current context is set",
-					Suggestions: []string{contextHint, "Set a current context with 'dtctl ctx use-context <name>'"},
-				}
-			}
-			ctx, err := cfg.CurrentContextObj()
-			if err != nil {
-				return &diagnostic.Error{
-					Operation:   "auth login",
-					Message:     "--context and --environment are required (failed to load current context)",
-					Suggestions: []string{contextHint},
-					Err:         err,
-				}
-			}
-			if contextName == "" {
-				contextName = cfg.CurrentContext
-			}
+			// If environment is still empty, the named context is new — --environment must be provided.
 			if environment == "" {
-				environment = ctx.Environment
-			}
-			// Preserve the existing token name so the stored token is updated in-place
-			if tokenName == "" && ctx.TokenRef != "" {
-				tokenName = ctx.TokenRef
+				return &diagnostic.Error{
+					Operation:   "auth login",
+					Message:     fmt.Sprintf("--environment is required: context %q not found in config", contextName),
+					Suggestions: []string{contextHint},
+				}
 			}
 		}
 

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -29,6 +29,22 @@ func setupAuthTestConfig(t *testing.T, contextName, environment, tokenRef string
 	return configPath
 }
 
+// resetAuthLoginFlags resets all auth login command flags to their default values.
+// This is needed because cobra/pflag retains flag values across Execute() calls when
+// the global rootCmd is reused in tests — a flag not present in the args of a new
+// Execute() call keeps the value set by the previous call.
+func resetAuthLoginFlags(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"context", "environment", "token-name", "timeout", "safety-level"} {
+		if f := authLoginCmd.Flags().Lookup(name); f != nil {
+			if err := f.Value.Set(f.DefValue); err != nil {
+				t.Logf("warning: could not reset flag %q: %v", name, err)
+			}
+			f.Changed = false
+		}
+	}
+}
+
 // TestAuthLogin_FlagValidation checks that the login command fails correctly when
 // neither flags nor a current context are available.
 func TestAuthLogin_FlagValidation(t *testing.T) {
@@ -140,6 +156,7 @@ func TestAuthLogin_CurrentContextFallback(t *testing.T) {
 // --environment) causes the missing value to be filled from the current context.
 func TestAuthLogin_PartialFlags_EnvironmentFromContext(t *testing.T) {
 	viper.Reset()
+	resetAuthLoginFlags(t)
 
 	const (
 		ctxName  = "my-context"
@@ -151,11 +168,12 @@ func TestAuthLogin_PartialFlags_EnvironmentFromContext(t *testing.T) {
 	cfgFile = configPath
 	defer func() { cfgFile = "" }()
 
+	// --context is the active context, so environment resolution uses its own URL.
 	rootCmd.SetArgs([]string{"auth", "login", "--context", ctxName})
 	err := rootCmd.Execute()
 
 	if err != nil && strings.Contains(err.Error(), "--context and --environment are required") {
-		t.Errorf("expected environment to be filled from current context, but got: %v", err)
+		t.Errorf("expected environment to be filled from named context, got: %v", err)
 	}
 }
 
@@ -213,6 +231,186 @@ func TestAuthLogin_KeyringRecovery(t *testing.T) {
 	// keyring gate error about requiring a working keyring.
 	if err != nil && strings.Contains(err.Error(), "OAuth login requires a working system keyring") {
 		t.Errorf("expected recovery to succeed and proceed past keyring gate, got: %v", err)
+	}
+}
+
+// TestResolveLoginContext tests the resolveLoginContext helper that determines
+// contextName, environment, and tokenName from an existing config when not all
+// values are supplied as explicit CLI flags.
+func TestResolveLoginContext(t *testing.T) {
+	const (
+		prodURL  = "https://irc65933.apps.dynatrace.com/"
+		hardURL  = "https://eva38390.sprint.apps.dynatracelabs.com/"
+		prodTok  = "prod1sfm-oauth"
+		hardTok  = "hardsfm-oauth"
+	)
+
+	makeCfg := func() *config.Config {
+		cfg := config.NewConfig()
+		cfg.SetContext("prod1sfm", prodURL, prodTok)
+		cfg.SetContext("hardsfm", hardURL, hardTok)
+		cfg.CurrentContext = "prod1sfm"
+		return cfg
+	}
+
+	tests := []struct {
+		name        string
+		contextName string
+		environment string
+		tokenName   string
+		currentCtx  string // override CurrentContext ("" means use default "prod1sfm")
+		wantContext string
+		wantEnv     string
+		wantToken   string
+		wantErr     bool
+	}{
+		{
+			name:        "no flags uses current context",
+			wantContext: "prod1sfm",
+			wantEnv:     prodURL,
+			wantToken:   prodTok,
+		},
+		{
+			// Regression: before the fix, this would return prodURL for environment.
+			name:        "explicit context uses named context URL not current context URL",
+			contextName: "hardsfm",
+			wantContext: "hardsfm",
+			wantEnv:     hardURL,
+			wantToken:   hardTok,
+		},
+		{
+			name:        "explicit context and explicit environment uses provided values",
+			contextName: "hardsfm",
+			environment: "https://custom.example.invalid/",
+			wantContext: "hardsfm",
+			wantEnv:     "https://custom.example.invalid/",
+			wantToken:   hardTok, // token still resolved from named context
+		},
+		{
+			name:        "all flags explicit skips lookup entirely",
+			contextName: "hardsfm",
+			environment: "https://custom.example.invalid/",
+			tokenName:   "my-explicit-token",
+			wantContext: "hardsfm",
+			wantEnv:     "https://custom.example.invalid/",
+			wantToken:   "my-explicit-token",
+		},
+		{
+			name:        "explicit context not in config returns empty environment",
+			contextName: "new-context",
+			wantContext: "new-context",
+			wantEnv:     "", // caller must check and error
+			wantToken:   "",
+		},
+		{
+			name:       "no flags no current context returns error",
+			currentCtx: "none", // sentinel: clear CurrentContext
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := makeCfg()
+			if tt.currentCtx == "none" {
+				cfg.CurrentContext = ""
+			}
+
+			gotCtx, gotEnv, gotToken, err := resolveLoginContext(cfg, tt.contextName, tt.environment, tt.tokenName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotCtx != tt.wantContext {
+				t.Errorf("context = %q, want %q", gotCtx, tt.wantContext)
+			}
+			if gotEnv != tt.wantEnv {
+				t.Errorf("environment = %q, want %q", gotEnv, tt.wantEnv)
+			}
+			if gotToken != tt.wantToken {
+				t.Errorf("tokenName = %q, want %q", gotToken, tt.wantToken)
+			}
+		})
+	}
+}
+
+// TestAuthLogin_ContextOnly_UsesNamedContextURL is the integration-level regression
+// test for the bug where dtctl auth login --context <non-active-context> would
+// silently overwrite the target context's environment URL with the active context's URL.
+//
+// Config: prod1sfm (active, prod URL) + hardsfm (sprint URL)
+// Command: auth login --context hardsfm   (no --environment)
+// Expected: hardsfm's sprint URL is used, command fails at keyring gate (not URL resolution).
+func TestAuthLogin_ContextOnly_UsesNamedContextURL(t *testing.T) {
+	viper.Reset()
+	resetAuthLoginFlags(t)
+	t.Setenv("DTCTL_DISABLE_KEYRING", "1")
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	cfg := config.NewConfig()
+	cfg.SetContext("prod1sfm", "https://irc65933.apps.dynatrace.com/", "prod1sfm-oauth")
+	cfg.SetContext("hardsfm", "https://eva38390.sprint.apps.dynatracelabs.com/", "hardsfm-oauth")
+	cfg.CurrentContext = "prod1sfm"
+
+	if err := cfg.SaveTo(configPath); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+	cfgFile = configPath
+	defer func() { cfgFile = "" }()
+
+	rootCmd.SetArgs([]string{"auth", "login", "--context", "hardsfm"})
+	err := rootCmd.Execute()
+
+	// The command must NOT fail with a context/environment validation error —
+	// that would indicate hardsfm's URL was not resolved from config.
+	if err != nil && strings.Contains(err.Error(), "--context and --environment are required") {
+		t.Errorf("expected hardsfm's URL to be resolved from config, got: %v", err)
+	}
+	if err != nil && strings.Contains(err.Error(), "not found in config") {
+		t.Errorf("expected hardsfm to be found in config, got: %v", err)
+	}
+	// The command should fail at the keyring gate (disabled in tests), not earlier.
+	if err != nil && !strings.Contains(err.Error(), "keyring") {
+		t.Errorf("expected keyring error after successful URL resolution, got: %v", err)
+	}
+}
+
+// TestAuthLogin_NewContext_RequiresEnvironment verifies that when --context names
+// a context that does not exist in config yet, --environment must be supplied.
+func TestAuthLogin_NewContext_RequiresEnvironment(t *testing.T) {
+	viper.Reset()
+	resetAuthLoginFlags(t)
+	t.Setenv("DTCTL_DISABLE_KEYRING", "1")
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	cfg := config.NewConfig()
+	cfg.SetContext("existing", "https://abc12345.apps.dynatrace.com/", "existing-oauth")
+	cfg.CurrentContext = "existing"
+
+	if err := cfg.SaveTo(configPath); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+	cfgFile = configPath
+	defer func() { cfgFile = "" }()
+
+	rootCmd.SetArgs([]string{"auth", "login", "--context", "brand-new-context"})
+	err := rootCmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error for new context without --environment, got nil")
+	}
+	if !strings.Contains(err.Error(), "--environment is required") {
+		t.Errorf("expected --environment required error, got: %v", err)
 	}
 }
 

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -239,10 +239,10 @@ func TestAuthLogin_KeyringRecovery(t *testing.T) {
 // values are supplied as explicit CLI flags.
 func TestResolveLoginContext(t *testing.T) {
 	const (
-		prodURL  = "https://irc65933.apps.dynatrace.com/"
-		hardURL  = "https://eva38390.sprint.apps.dynatracelabs.com/"
-		prodTok  = "prod1sfm-oauth"
-		hardTok  = "hardsfm-oauth"
+		prodURL = "https://irc65933.apps.dynatrace.com/"
+		hardURL = "https://eva38390.sprint.apps.dynatracelabs.com/"
+		prodTok = "prod1sfm-oauth"
+		hardTok = "hardsfm-oauth"
 	)
 
 	makeCfg := func() *config.Config {

--- a/pkg/config/keyring_test.go
+++ b/pkg/config/keyring_test.go
@@ -92,11 +92,9 @@ func TestEnsureKeyringCollection_Smoke(t *testing.T) {
 		if !secretServiceErr {
 			t.Errorf("expected Secret Service unavailability error, got: %v", err)
 		}
-	} else {
+	} else if !strings.Contains(err.Error(), "only supported on Linux") {
 		// On non-Linux platforms the stub should report the OS.
-		if !strings.Contains(err.Error(), "only supported on Linux") {
-			t.Errorf("expected 'only supported on Linux' error, got: %v", err)
-		}
+		t.Errorf("expected 'only supported on Linux' error, got: %v", err)
 	}
 }
 

--- a/pkg/config/keyring_test.go
+++ b/pkg/config/keyring_test.go
@@ -81,9 +81,16 @@ func TestEnsureKeyringCollection_Smoke(t *testing.T) {
 	t.Logf("EnsureKeyringCollection() error (expected in CI): %v", err)
 
 	if runtime.GOOS == "linux" {
-		// On Linux without D-Bus we expect a connection error.
-		if !strings.Contains(err.Error(), "cannot connect to Secret Service") {
-			t.Errorf("expected 'cannot connect to Secret Service' error, got: %v", err)
+		// On Linux the Secret Service may be unavailable in two ways:
+		//   1. D-Bus session is unreachable → "cannot connect to Secret Service"
+		//   2. D-Bus is reachable but org.freedesktop.secrets is not registered
+		//      (common in headless CI) → error contains "org.freedesktop.secrets"
+		//      or "failed to create keyring collection"
+		secretServiceErr := strings.Contains(err.Error(), "cannot connect to Secret Service") ||
+			strings.Contains(err.Error(), "org.freedesktop.secrets") ||
+			strings.Contains(err.Error(), "failed to create keyring collection")
+		if !secretServiceErr {
+			t.Errorf("expected Secret Service unavailability error, got: %v", err)
 		}
 	} else {
 		// On non-Linux platforms the stub should report the OS.


### PR DESCRIPTION
## Description

When running `dtctl auth login --context <name>` without `--environment`, the missing
environment URL was incorrectly resolved from the **currently active** context instead of
from the **named** context. This caused the named context's environment URL to be silently
overwritten with the active context's URL after a successful login.

**Root cause:** The fallback block in `authLoginCmd.RunE` always called
`cfg.CurrentContextObj()` to resolve missing fields, regardless of whether `contextName`
was already provided via `--context`.

**Fix:** Extract a new `resolveLoginContext()` helper that resolves environment and
tokenName from the *named* context (`cfg.GetContext(contextName)`) so that
re-authenticating a non-active context never inherits the active context's URL.

Additionally, if the named context does not yet exist in config (new context) and
`--environment` is omitted, the command now returns a clear diagnostic error instead of
silently proceeding with an empty or wrong URL.

A `resetAuthLoginFlags()` test helper was added to prevent cobra flag state from leaking
across `Execute()` calls when reusing the shared global `rootCmd` in tests.

Fixes #139

## Related Issues

Closes #139

## Testing

New tests added in `cmd/auth_test.go`:

| Test | Coverage |
|------|----------|
| `TestResolveLoginContext` (6 sub-tests) | Unit tests for the new helper — including the regression case that explicitly asserts the named context's URL is used, **not** the current context's URL |
| `TestAuthLogin_ContextOnly_UsesNamedContextURL` | Integration test: `auth login --context hardsfm` (non-active context) resolves the correct URL and reaches the keyring gate |
| `TestAuthLogin_NewContext_RequiresEnvironment` | New context without `--environment` returns a helpful error |

- [x] Tests pass (`go test ./...` — pre-existing Windows-only failures in `pkg/hook` / `pkg/apply` due to missing `sh`; CI on Linux passes)
- [x] Linting passes (`golangci-lint run` — 0 issues in changed files; all other issues are pre-existing)