### PR TITLE
fix: add helpful redirect when users try 'update settings'

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 // updateCmd represents the update command.
 var updateCmd = &cobra.Command{
@@ -32,6 +36,26 @@ Available resources:
 	RunE: requireSubcommand,
 }
 
+// updateSettingsHintCmd redirects users to 'apply' for file-based settings updates.
+var updateSettingsHintCmd = &cobra.Command{
+	Use:     "settings",
+	Aliases: []string{"setting"},
+	Short:   "Update a settings object (use 'apply' instead)",
+	Hidden:  true,
+	// Accept any args/flags so the command doesn't fail before RunE.
+	Args:               cobra.ArbitraryArgs,
+	DisableFlagParsing: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("to update settings objects from a file, use 'dtctl apply -f <file>' instead\n\n" +
+			"The file should include objectId, schemaId, scope, and value fields.\n" +
+			"If the objectId exists it will be updated; otherwise a new object is created.\n\n" +
+			"Example:\n" +
+			"  dtctl apply -f settings.yaml\n" +
+			"  dtctl apply -f settings.yaml --dry-run")
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(updateCmd)
+	updateCmd.AddCommand(updateSettingsHintCmd)
 }

--- a/cmd/update_settings_test.go
+++ b/cmd/update_settings_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUpdateSettingsRedirectsToApply(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"settings with file flag", []string{"update", "settings", "some-id", "-f", "config.yaml"}},
+		{"setting alias", []string{"update", "setting", "some-id", "-f", "config.yaml"}},
+		{"settings without flags", []string{"update", "settings"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd.SetArgs(tt.args)
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatal("expected error with redirect hint")
+			}
+			errMsg := err.Error()
+			if !strings.Contains(errMsg, "dtctl apply -f") {
+				t.Errorf("expected hint to use 'dtctl apply -f', got: %s", errMsg)
+			}
+			if !strings.Contains(errMsg, "objectId") {
+				t.Errorf("expected hint to mention objectId, got: %s", errMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a hidden `settings`/`setting` subcommand under `update` that catches `dtctl update settings ...` and returns a clear redirect to `dtctl apply -f <file>` instead of the confusing "unknown flag --f" error
- Includes tests covering both aliases and with/without flags

## Context

A user reported that `dtctl update settings <UUID> -f config.yaml` produces `unknown flag --f`. The functionality they need already exists via `dtctl apply -f`, which does create-or-update for settings objects. Rather than adding a redundant verb, this PR intercepts the incorrect command and points users to the right one.

### Before
```
$ dtctl update settings <id> -f config.yaml
Error: unknown flag --f
```

### After
```
$ dtctl update settings <id> -f config.yaml
Error: to update settings objects from a file, use 'dtctl apply -f <file>' instead

The file should include objectId, schemaId, scope, and value fields.
If the objectId exists it will be updated; otherwise a new object is created.

Example:
  dtctl apply -f settings.yaml
  dtctl apply -f settings.yaml --dry-run
```