### PR TITLE
feat: docs - platform tokens support for live debugger

### DIFF
--- a/docs/LIVE_DEBUGGER.md
+++ b/docs/LIVE_DEBUGGER.md
@@ -23,13 +23,13 @@ The current Live Debugger flow in `dtctl` supports:
 Before using Live Debugger commands:
 
 1. Configure a Dynatrace context with `dtctl config set-context`
-2. Authenticate with OAuth using `dtctl auth login`
+2. Authenticate with OAuth using `dtctl auth login`, or configure platform token credentials
 3. Run Live Debugger commands from the project directory you want associated with the workspace
 
 ### Authentication note
 
-Live Debugger breakpoint operations currently require OAuth authentication.
-The `dev-obs:breakpoints:set` scope is supported via `dtctl auth login`, but is not currently supported when authenticating with API tokens (for example via `dtctl config set-credentials`).
+Live Debugger breakpoint operations support both OAuth authentication and platform tokens.
+When using a platform token, include the `dev-obs:breakpoints:set` scope in the token scopes.
 
 ## 1. Configure workspace filters
 

--- a/docs/TOKEN_SCOPES.md
+++ b/docs/TOKEN_SCOPES.md
@@ -23,6 +23,8 @@ For creating platform tokens, see [Dynatrace Platform Tokens documentation](http
 
 Read-only access for production monitoring and troubleshooting.
 
+This level does not include the Live Debugger write scope `dev-obs:breakpoints:set`.
+
 ```
 document:documents:read,
 document:direct-shares:read,
@@ -76,6 +78,7 @@ document:trash.documents:restore,
 automation:workflows:read,
 automation:workflows:write,
 automation:workflows:run,
+dev-obs:breakpoints:set,
 slo:slos:read,
 slo:slos:write,
 slo:objective-templates:read,
@@ -131,6 +134,7 @@ document:trash.documents:restore,
 automation:workflows:read,
 automation:workflows:write,
 automation:workflows:run,
+dev-obs:breakpoints:set,
 slo:slos:read,
 slo:slos:write,
 slo:objective-templates:read,
@@ -206,6 +210,7 @@ document:trash.documents:delete,
 automation:workflows:read,
 automation:workflows:write,
 automation:workflows:run,
+dev-obs:breakpoints:set,
 slo:slos:read,
 slo:slos:write,
 slo:objective-templates:read,
@@ -395,6 +400,13 @@ email:emails:send
 |-------|-------------|
 | `notification:notifications:read` | Read notification configurations |
 | `notification:notifications:write` | Create/update notification configurations |
+
+### Live Debugger
+| Scope | Description |
+|-------|-------------|
+| `dev-obs:breakpoints:set` | Create, update, and delete Live Debugger breakpoints |
+
+`dev-obs:breakpoints:set` is not included in the `readonly` safety level.
 
 ### IAM
 

--- a/docs/site/_docs/token-scopes.md
+++ b/docs/site/_docs/token-scopes.md
@@ -20,6 +20,8 @@ dtctl's [safety levels](configuration#safety-levels) are a client-side guardrail
 
 Read-only access for monitoring and troubleshooting. Approximately 30 scopes:
 
+This level does not include the Live Debugger write scope `dev-obs:breakpoints:set`.
+
 ```
 automation:workflows:read
 automation:calendars:read
@@ -67,6 +69,7 @@ automation:workflows:write
 automation:workflows:run
 automation:calendars:write
 automation:rules:write
+dev-obs:breakpoints:set
 document:documents:write
 document:documents:delete
 document:trash-documents:delete
@@ -218,6 +221,14 @@ storage:fieldsets:write
 |---|---|
 | List / Get | `notification:notifications:read` |
 | Create / Update | `notification:notifications:write` |
+
+### Live Debugger
+
+| Operation | Required Scope |
+|---|---|
+| Set / update / delete breakpoints | `dev-obs:breakpoints:set` |
+
+`dev-obs:breakpoints:set` is not included in the `readonly` safety level.
 
 ### OpenPipeline
 


### PR DESCRIPTION
## Summary

Update the documentation to reflect that Live Debugger now supports platform tokens.

## Changes

- update the Live Debugger authentication docs to state that breakpoint operations support both OAuth and platform tokens
- document that platform tokens used for Live Debugger breakpoint operations must include the `dev-obs:breakpoints:set` scope
- clarify that `dev-obs:breakpoints:set` is not part of the `readonly` safety level
- add the Live Debugger scope to the token scopes reference under write-capable access

## Why

The existing docs still described Live Debugger breakpoint operations as OAuth-only. That is no longer accurate now that platform token authentication is supported.

## Testing

- docs only
- no code changes
- no tests run