### PR TITLE
feat(apply): add --id and --write-id for idempotent document/workflow applies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`apply --write-id` and `apply --id` flags** — two complementary flags for idempotent applies; `--write-id` stamps the generated resource ID back into the source file after a successful create, so every subsequent apply updates in place without creating duplicates; `--id` injects or overrides the resource ID at the CLI level without modifying the file, ideal for CI pipelines using reusable template files; works for dashboards, notebooks, and workflows; a recovery hint is printed to stderr when a resource is created without `--write-id`
 - **`enable gcp|azure monitoring` command** — new `dtctl enable` verb that completes cloud monitoring onboarding in one step: optionally updates the linked connection credentials (service account for GCP; directory/application ID for Azure) and enables the monitoring config; `--serviceAccountId`, `--directoryId`, `--applicationId` are all optional — if omitted, only the enabled state is toggled; supports `--dry-run`
 - **Cloud monitoring configs created as disabled** — `dtctl create gcp monitoring` and `dtctl create azure monitoring` now create configs in a disabled state (`enabled: false`); use `dtctl enable gcp|azure monitoring` to enable
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -28,6 +28,25 @@ This is similar to 'kubectl apply' - use it to keep resources in sync with their
 file definitions. For round-trip workflows, use 'dtctl get <resource> -o yaml' to
 export, edit, and apply back.
 
+Idempotent local workflow (--write-id):
+  Use --write-id on first apply to stamp the generated ID back into the source file.
+  Every subsequent apply will then update in place automatically — no manual ID
+  tracking required.
+
+    dtctl apply -f dashboard.yaml --write-id   # creates, stamps id into file
+    dtctl apply -f dashboard.yaml              # updates the same dashboard
+
+  If you forgot --write-id on the first run, use --id to recover without creating
+  a duplicate:
+
+    dtctl apply -f dashboard.yaml --write-id --id <id-from-first-run>
+
+Template-driven deployments (--id):
+  Keep a reusable template file (no ID) and supply the target ID externally.
+  Ideal for CI pipelines or deploying the same template to a known resource.
+
+    dtctl apply -f template.yaml --id $DASHBOARD_ID
+
 Template variables can be used with the --set flag for reusable configurations,
 making it easy to deploy the same resource across multiple environments.
 
@@ -41,13 +60,19 @@ Supported resource types:
   - Extension monitoring configurations
 
 Examples:
-  # Create a new dashboard (no ID in file)
-  dtctl apply -f dashboard.yaml
+  # Create a new dashboard and stamp the ID back into the file
+  dtctl apply -f dashboard.yaml --write-id
 
   # Update existing dashboard (file exported with 'get' command includes ID)
   dtctl get dashboard my-dash -o yaml > dashboard.yaml
   # Edit dashboard.yaml...
   dtctl apply -f dashboard.yaml  # Updates the existing dashboard
+
+  # Forgot --write-id on first run? Recover without creating a duplicate:
+  dtctl apply -f dashboard.yaml --write-id --id <id-from-first-run>
+
+  # CI/scripting: apply template to a known target resource
+  dtctl apply -f template.yaml --id $DASHBOARD_ID
 
   # Update a settings object
   dtctl get settings <objectId> -o yaml > setting.yaml
@@ -72,8 +97,8 @@ Examples:
   # Apply with wide table (includes URL for dashboards/notebooks)
   dtctl apply -f notebook.yaml -o wide
 
-Note: To update a dashboard via command line, use the apply command with a file
-that contains the dashboard ID. The 'create' command always creates new resources.
+Note: The 'create' command always creates new resources. Use 'apply' to keep
+resources in sync with their file definitions.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		file, _ := cmd.Flags().GetString("file")
@@ -85,6 +110,8 @@ that contains the dashboard ID. The 'create' command always creates new resource
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		showDiff, _ := cmd.Flags().GetBool("show-diff")
 		noHooks, _ := cmd.Flags().GetBool("no-hooks")
+		overrideID, _ := cmd.Flags().GetString("id")
+		writeID, _ := cmd.Flags().GetBool("write-id")
 
 		// Read the file
 		fileData, err := os.ReadFile(file)
@@ -135,6 +162,8 @@ that contains the dashboard ID. The 'create' command always creates new resource
 			TemplateVars: templateVars,
 			DryRun:       dryRun,
 			ShowDiff:     showDiff,
+			OverrideID:   overrideID,
+			WriteID:      writeID,
 		}
 
 		results, err := applier.Apply(fileData, opts)
@@ -188,6 +217,8 @@ func init() {
 	applyCmd.Flags().Bool("dry-run", false, "preview changes without applying")
 	applyCmd.Flags().Bool("show-diff", false, "show diff of changes when updating existing resources")
 	applyCmd.Flags().Bool("no-hooks", false, "skip pre-apply hooks")
+	applyCmd.Flags().String("id", "", "override or inject resource ID (use with --write-id to stamp ID into file)")
+	applyCmd.Flags().Bool("write-id", false, "write the created resource ID back into the source file for idempotent future applies")
 
 	_ = applyCmd.MarkFlagRequired("file")
 }

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -441,6 +441,15 @@ dtctl create workflow -f my-workflow.yaml
 
 # Apply (create or update if exists)
 dtctl apply -f my-workflow.yaml
+
+# First apply: stamp the generated ID back into the file for idempotent future applies
+dtctl apply -f my-workflow.yaml --write-id
+
+# Forgot --write-id on the first run? Recover without creating another duplicate:
+dtctl apply -f my-workflow.yaml --write-id --id <id-from-first-run>
+
+# CI/scripting: apply a template file to a specific known workflow
+dtctl apply -f my-workflow.yaml --id $WORKFLOW_ID
 ```
 
 **Example workflow file** (`my-workflow.yaml`):
@@ -658,6 +667,15 @@ dtctl create dashboard -f dashboard.yaml
 
 # Apply a dashboard (creates if new, updates if exists)
 dtctl apply -f dashboard.yaml
+
+# First apply: stamp the generated ID back into the file so future applies update in place
+dtctl apply -f dashboard.yaml --write-id
+
+# Forgot --write-id? Recover without creating another duplicate:
+dtctl apply -f dashboard.yaml --write-id --id <id-from-first-run>
+
+# CI/scripting: apply a template to a specific known dashboard
+dtctl apply -f dashboard.yaml --id $DASHBOARD_ID
 
 # Both commands show tile count and URL:
 # Dashboard "My Dashboard" (abc-123) created successfully [18 tiles]

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -267,6 +267,26 @@ dtctl create settings -f pipeline.yaml --schema ... --dry-run
 dtctl delete workflow "Test Workflow" --dry-run
 ```
 
+### Idempotent Applies
+
+Use `--write-id` and `--id` to prevent duplicate resources on repeated runs:
+
+```bash
+# First apply: stamp the generated ID back into the source file
+dtctl apply -f dashboard.yaml --write-id
+
+# All future runs update the same resource
+dtctl apply -f dashboard.yaml
+
+# Forgot --write-id on the first run? Recover without creating another duplicate:
+dtctl apply -f dashboard.yaml --write-id --id <id-from-first-run>
+
+# CI/scripting: apply a template file to a known target resource
+dtctl apply -f template.yaml --id $DASHBOARD_ID
+```
+
+`--write-id` is a no-op when the file already contains an `id` field.
+
 ### Pipeline Integration
 
 ```bash

--- a/docs/site/_docs/dashboards.md
+++ b/docs/site/_docs/dashboards.md
@@ -54,6 +54,15 @@ dtctl create dashboard -f dashboard.yaml
 
 # Apply (creates if new, updates if existing — idempotent)
 dtctl apply -f dashboard.yaml
+
+# First apply: stamp the generated ID back into the file so future applies update in place
+dtctl apply -f dashboard.yaml --write-id
+
+# Forgot --write-id on the first run? Recover without creating another duplicate:
+dtctl apply -f dashboard.yaml --write-id --id <id-from-first-run>
+
+# CI/scripting: apply a template to a specific known dashboard
+dtctl apply -f dashboard.yaml --id $DASHBOARD_ID
 ```
 
 On success, dtctl prints the tile count and a direct URL to the dashboard in Dynatrace.

--- a/docs/site/_docs/workflows.md
+++ b/docs/site/_docs/workflows.md
@@ -49,6 +49,15 @@ dtctl create workflow -f my-workflow.yaml
 
 # Apply (creates if new, updates if existing — idempotent)
 dtctl apply -f my-workflow.yaml
+
+# First apply: stamp the generated ID back into the file so future applies update in place
+dtctl apply -f my-workflow.yaml --write-id
+
+# Forgot --write-id on the first run? Recover without creating another duplicate:
+dtctl apply -f my-workflow.yaml --write-id --id <id-from-first-run>
+
+# CI/scripting: apply a template to a specific known workflow
+dtctl apply -f my-workflow.yaml --id $WORKFLOW_ID
 ```
 
 ### Example Workflow YAML

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -95,7 +95,9 @@ type ApplyOptions struct {
 	DryRun       bool
 	Force        bool
 	ShowDiff     bool
-	NoHooks      bool // skip pre-apply hooks
+	NoHooks      bool   // skip pre-apply hooks
+	OverrideID   string // override or inject resource ID (from --id flag)
+	WriteID      bool   // write created resource ID back into the source file (from --write-id flag)
 }
 
 // ResourceType represents the type of resource
@@ -143,6 +145,16 @@ func (a *Applier) Apply(fileData []byte, opts ApplyOptions) ([]ApplyResult, erro
 		return nil, err
 	}
 
+	// Inject override ID if provided via --id flag.
+	// This merges the ID into the JSON before any resource handler sees it,
+	// so all resource types benefit uniformly.
+	if opts.OverrideID != "" {
+		jsonData, err = injectID(jsonData, opts.OverrideID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inject --id into resource: %w", err)
+		}
+	}
+
 	// Run pre-apply hook (if configured and not skipped)
 	if !opts.NoHooks && a.preApplyHook != "" {
 		result, err := hook.RunPreApply(
@@ -186,7 +198,7 @@ func (a *Applier) Apply(fileData []byte, opts ApplyOptions) ([]ApplyResult, erro
 	var result ApplyResult
 	switch resourceType {
 	case ResourceWorkflow:
-		result, err = a.applyWorkflow(jsonData)
+		result, err = a.applyWorkflow(jsonData, opts)
 	case ResourceDashboard:
 		result, err = a.applyDocument(jsonData, "dashboard", opts)
 	case ResourceNotebook:
@@ -449,4 +461,14 @@ func capitalize(s string) string {
 		return s
 	}
 	return string(s[0]-32) + s[1:]
+}
+
+// injectID sets the "id" field in a JSON object, overwriting any existing value.
+func injectID(data []byte, id string) ([]byte, error) {
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	doc["id"] = id
+	return json.Marshal(doc)
 }

--- a/pkg/apply/apply_document.go
+++ b/pkg/apply/apply_document.go
@@ -65,14 +65,9 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 			resultID = "(ID not returned)"
 		}
 
-		if opts.WriteID && resultID != "(ID not returned)" {
-			if err := writeIDToFile(a.sourceFile, resultID); err != nil {
-				stderrWarn(&resultWarnings, "could not write ID back to file: %v", err)
-			} else if a.sourceFile != "" {
-				fmt.Fprintf(os.Stderr, "Wrote id %s to %s\n", resultID, a.sourceFile)
-			}
-		} else {
-			printWriteIDHint(a.sourceFile, resultID, docType)
+		// File had no id field before this apply — stamp it back or hint.
+		if resultID != "(ID not returned)" {
+			applyWriteBack(a.sourceFile, resultID, docType, opts.WriteID, false, &resultWarnings)
 		}
 
 		return a.buildDocumentResult(ActionCreated, docType, resultID, resultName, tileCount, resultWarnings), nil
@@ -120,15 +115,11 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 			resultID = id
 		}
 
-		if opts.WriteID {
-			if err := writeIDToFile(a.sourceFile, resultID); err != nil {
-				stderrWarn(&resultWarnings, "could not write ID back to file: %v", err)
-			} else if a.sourceFile != "" {
-				fmt.Fprintf(os.Stderr, "Wrote id %s to %s\n", resultID, a.sourceFile)
-			}
-		} else {
-			printWriteIDHint(a.sourceFile, resultID, docType)
-		}
+		// For the UUID case the API generated a fresh id — stamp it if requested.
+		// For the non-UUID case the file already carries the id field, so neither
+		// the write-back nor the hint is needed (applyWriteBack treats it as a no-op).
+		fileAlreadyHasID := !isUUID(id) // non-UUID id was in the file and is preserved
+		applyWriteBack(a.sourceFile, resultID, docType, opts.WriteID, fileAlreadyHasID, &resultWarnings)
 
 		return a.buildDocumentResult(ActionCreated, docType, resultID, resultName, tileCount, resultWarnings), nil
 	}

--- a/pkg/apply/apply_document.go
+++ b/pkg/apply/apply_document.go
@@ -65,6 +65,16 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 			resultID = "(ID not returned)"
 		}
 
+		if opts.WriteID && resultID != "(ID not returned)" {
+			if err := writeIDToFile(a.sourceFile, resultID); err != nil {
+				stderrWarn(&resultWarnings, "could not write ID back to file: %v", err)
+			} else if a.sourceFile != "" {
+				fmt.Fprintf(os.Stderr, "Wrote id %s to %s\n", resultID, a.sourceFile)
+			}
+		} else {
+			printWriteIDHint(a.sourceFile, resultID, docType)
+		}
+
 		return a.buildDocumentResult(ActionCreated, docType, resultID, resultName, tileCount, resultWarnings), nil
 	}
 
@@ -108,6 +118,16 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 		resultID := result.ID
 		if resultID == "" {
 			resultID = id
+		}
+
+		if opts.WriteID {
+			if err := writeIDToFile(a.sourceFile, resultID); err != nil {
+				stderrWarn(&resultWarnings, "could not write ID back to file: %v", err)
+			} else if a.sourceFile != "" {
+				fmt.Fprintf(os.Stderr, "Wrote id %s to %s\n", resultID, a.sourceFile)
+			}
+		} else {
+			printWriteIDHint(a.sourceFile, resultID, docType)
 		}
 
 		return a.buildDocumentResult(ActionCreated, docType, resultID, resultName, tileCount, resultWarnings), nil

--- a/pkg/apply/apply_integration_test.go
+++ b/pkg/apply/apply_integration_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
@@ -1423,4 +1425,204 @@ func errorAs(err error, target interface{}) bool {
 		err = u.Unwrap()
 	}
 	return false
+}
+
+// ── WriteID / OverrideID end-to-end tests ──────────────────────────────────
+
+// workflowCreateHandlers returns the standard mock handlers for workflow creation.
+func workflowCreateHandlers(t *testing.T, returnID string) map[string]http.HandlerFunc {
+	t.Helper()
+	return map[string]http.HandlerFunc{
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":    returnID,
+				"title": "My Workflow",
+			})
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	}
+}
+
+// dashboardCreateHandlers returns mock handlers for document creation returning the given id.
+func dashboardCreateHandlers(t *testing.T, returnID string) map[string]http.HandlerFunc {
+	t.Helper()
+	return map[string]http.HandlerFunc{
+		"/platform/document/v1/documents": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			boundary := "resp-boundary"
+			w.Header().Set("Content-Type", fmt.Sprintf("multipart/form-data; boundary=%s", boundary))
+			fmt.Fprintf(w,
+				"--%s\r\nContent-Disposition: form-data; name=\"metadata\"\r\nContent-Type: application/json\r\n\r\n{\"id\":%q,\"name\":\"My Dashboard\",\"type\":\"dashboard\",\"version\":1}\r\n--%s--\r\n",
+				boundary, returnID, boundary,
+			)
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	}
+}
+
+// TestApply_WorkflowCreate_WriteID verifies that when --write-id is set, the
+// generated ID is stamped into the source file after a successful create.
+func TestApply_WorkflowCreate_WriteID(t *testing.T) {
+	srv, c := newApplyTestServer(t, workflowCreateHandlers(t, "wf-stamped-001"))
+	defer srv.Close()
+
+	// Write a temporary workflow file without an id field.
+	dir := t.TempDir()
+	srcFile := dir + "/wf.yaml"
+	if err := os.WriteFile(srcFile, []byte("title: My Workflow\ntasks: {}\ntrigger: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewApplier(c).WithSourceFile(srcFile)
+	wfJSON := `{"title":"My Workflow","tasks":{},"trigger":{}}`
+	_, err := a.Apply([]byte(wfJSON), ApplyOptions{WriteID: true})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	got, err := os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatalf("read source file: %v", err)
+	}
+	if !strings.Contains(string(got), "wf-stamped-001") {
+		t.Errorf("expected id 'wf-stamped-001' to be stamped into file, got:\n%s", got)
+	}
+}
+
+// TestApply_WorkflowCreate_OverrideID verifies that --id injects the given ID
+// into the workflow JSON sent to the API, routing to a PUT (update) rather than POST.
+func TestApply_WorkflowCreate_OverrideID(t *testing.T) {
+	putCalled := false
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/workflows/wf-override-42": func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				// Resource exists — verify the override ID caused a GET.
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    "wf-override-42",
+					"title": "Existing Workflow",
+					"owner": "",
+				})
+			case http.MethodPut:
+				putCalled = true
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    "wf-override-42",
+					"title": "My Workflow",
+				})
+			default:
+				t.Errorf("unexpected method %s", r.Method)
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+
+	a := NewApplier(c)
+	// Template has no id — OverrideID injects it before the apply logic runs.
+	wfJSON := `{"title":"My Workflow","tasks":{},"trigger":{}}`
+	results, err := a.Apply([]byte(wfJSON), ApplyOptions{OverrideID: "wf-override-42"})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if !putCalled {
+		t.Error("expected PUT (update) to be called when OverrideID points to existing resource")
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	base := results[0].(*WorkflowApplyResult).ApplyResultBase
+	if base.Action != ActionUpdated {
+		t.Errorf("expected action 'updated', got %q", base.Action)
+	}
+}
+
+// TestApply_DashboardCreate_WriteID verifies write-back for dashboard creation.
+func TestApply_DashboardCreate_WriteID(t *testing.T) {
+	srv, c := newApplyTestServer(t, dashboardCreateHandlers(t, "dash-stamped-007"))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	srcFile := dir + "/dashboard.yaml"
+	if err := os.WriteFile(srcFile, []byte("type: dashboard\ntiles:\n  items: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewApplier(c).WithSourceFile(srcFile)
+	dashJSON := `{"type":"dashboard","tiles":{"items":[]}}`
+	_, err := a.Apply([]byte(dashJSON), ApplyOptions{WriteID: true})
+	if err != nil {
+		t.Fatalf("Apply() dashboard create error = %v", err)
+	}
+
+	got, err := os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatalf("read source file: %v", err)
+	}
+	if !strings.Contains(string(got), "dash-stamped-007") {
+		t.Errorf("expected id 'dash-stamped-007' to be stamped into file, got:\n%s", got)
+	}
+}
+
+// TestApply_WorkflowCreate_IDNotFound_NoHint verifies that when a file already
+// has an id field but the resource doesn't exist yet, no misleading hint is
+// emitted (the file is already self-contained after creation).
+func TestApply_WorkflowCreate_IDNotFound_NoHint(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/workflows/wf-missing-2": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		},
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":    "wf-missing-2",
+				"title": "New Workflow",
+			})
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+
+	// Use a temp file with the id already present.
+	dir := t.TempDir()
+	srcFile := dir + "/wf.yaml"
+	if err := os.WriteFile(srcFile, []byte("id: wf-missing-2\ntitle: New Workflow\ntasks: {}\ntrigger: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewApplier(c).WithSourceFile(srcFile)
+	wfJSON := `{"id":"wf-missing-2","title":"New Workflow","tasks":{},"trigger":{}}`
+	results, err := a.Apply([]byte(wfJSON), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	base := results[0].(*WorkflowApplyResult).ApplyResultBase
+	if base.Action != ActionCreated {
+		t.Errorf("expected action 'created', got %q", base.Action)
+	}
+	// Source file must be unchanged — no new id stamped (it already had one).
+	content, _ := os.ReadFile(srcFile)
+	if string(content) != "id: wf-missing-2\ntitle: New Workflow\ntasks: {}\ntrigger: {}\n" {
+		t.Errorf("source file should be unchanged, got:\n%s", content)
+	}
 }

--- a/pkg/apply/apply_workflow.go
+++ b/pkg/apply/apply_workflow.go
@@ -3,7 +3,6 @@ package apply
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
@@ -33,15 +32,8 @@ func (a *Applier) applyWorkflow(data []byte, opts ApplyOptions) (ApplyResult, er
 		}
 
 		var warnings []string
-		if opts.WriteID && result.ID != "" {
-			if err := writeIDToFile(a.sourceFile, result.ID); err != nil {
-				stderrWarn(&warnings, "could not write ID back to file: %v", err)
-			} else if a.sourceFile != "" {
-				fmt.Fprintf(os.Stderr, "Wrote id %s to %s\n", result.ID, a.sourceFile)
-			}
-		} else {
-			printWriteIDHint(a.sourceFile, result.ID, "workflow")
-		}
+		// File had no id field before this apply — stamp it back or hint.
+		applyWriteBack(a.sourceFile, result.ID, "workflow", opts.WriteID, false, &warnings)
 
 		return &WorkflowApplyResult{
 			ApplyResultBase: ApplyResultBase{
@@ -69,15 +61,9 @@ func (a *Applier) applyWorkflow(data []byte, opts ApplyOptions) (ApplyResult, er
 		}
 
 		var warnings []string
-		if opts.WriteID && result.ID != "" {
-			if err := writeIDToFile(a.sourceFile, result.ID); err != nil {
-				stderrWarn(&warnings, "could not write ID back to file: %v", err)
-			} else if a.sourceFile != "" {
-				fmt.Fprintf(os.Stderr, "Wrote id %s to %s\n", result.ID, a.sourceFile)
-			}
-		} else {
-			printWriteIDHint(a.sourceFile, result.ID, "workflow")
-		}
+		// File already had an id field (we got here because the resource wasn't found).
+		// No stamp or hint needed — the file is already self-contained.
+		applyWriteBack(a.sourceFile, result.ID, "workflow", opts.WriteID, true, &warnings)
 
 		return &WorkflowApplyResult{
 			ApplyResultBase: ApplyResultBase{

--- a/pkg/apply/apply_workflow.go
+++ b/pkg/apply/apply_workflow.go
@@ -3,13 +3,14 @@ package apply
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 )
 
 // applyWorkflow applies a workflow resource
-func (a *Applier) applyWorkflow(data []byte) (ApplyResult, error) {
+func (a *Applier) applyWorkflow(data []byte, opts ApplyOptions) (ApplyResult, error) {
 	// Parse to check for ID
 	var wf map[string]interface{}
 	if err := json.Unmarshal(data, &wf); err != nil {
@@ -30,12 +31,25 @@ func (a *Applier) applyWorkflow(data []byte) (ApplyResult, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create workflow: %w", err)
 		}
+
+		var warnings []string
+		if opts.WriteID && result.ID != "" {
+			if err := writeIDToFile(a.sourceFile, result.ID); err != nil {
+				stderrWarn(&warnings, "could not write ID back to file: %v", err)
+			} else if a.sourceFile != "" {
+				fmt.Fprintf(os.Stderr, "Wrote id %s to %s\n", result.ID, a.sourceFile)
+			}
+		} else {
+			printWriteIDHint(a.sourceFile, result.ID, "workflow")
+		}
+
 		return &WorkflowApplyResult{
 			ApplyResultBase: ApplyResultBase{
 				Action:       ActionCreated,
 				ResourceType: "workflow",
 				ID:           result.ID,
 				Name:         result.Title,
+				Warnings:     warnings,
 			},
 		}, nil
 	}
@@ -53,12 +67,25 @@ func (a *Applier) applyWorkflow(data []byte) (ApplyResult, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create workflow: %w", err)
 		}
+
+		var warnings []string
+		if opts.WriteID && result.ID != "" {
+			if err := writeIDToFile(a.sourceFile, result.ID); err != nil {
+				stderrWarn(&warnings, "could not write ID back to file: %v", err)
+			} else if a.sourceFile != "" {
+				fmt.Fprintf(os.Stderr, "Wrote id %s to %s\n", result.ID, a.sourceFile)
+			}
+		} else {
+			printWriteIDHint(a.sourceFile, result.ID, "workflow")
+		}
+
 		return &WorkflowApplyResult{
 			ApplyResultBase: ApplyResultBase{
 				Action:       ActionCreated,
 				ResourceType: "workflow",
 				ID:           result.ID,
 				Name:         result.Title,
+				Warnings:     warnings,
 			},
 		}, nil
 	}

--- a/pkg/apply/writeback.go
+++ b/pkg/apply/writeback.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -55,7 +56,6 @@ func isJSONContent(content []byte) bool {
 // injectIDIntoJSON inserts "id": "<id>" as the first key in a JSON object.
 // Returns nil if the file already has an "id" key.
 func injectIDIntoJSON(content []byte, id string) ([]byte, error) {
-	// Quick check: if "id" key already present, no-op
 	if jsonHasIDKey(content) {
 		return nil, nil
 	}
@@ -110,7 +110,8 @@ func injectIDIntoYAML(content []byte, id string) ([]byte, error) {
 		}
 	}
 
-	idLine := fmt.Sprintf("id: %q", id)
+	// Use bare YAML scalar (no quotes) — idiomatic and more readable.
+	idLine := "id: " + id
 	newLines := make([]string, 0, len(lines)+1)
 	newLines = append(newLines, lines[:insertAt]...)
 	newLines = append(newLines, idLine)
@@ -119,11 +120,18 @@ func injectIDIntoYAML(content []byte, id string) ([]byte, error) {
 	return []byte(strings.Join(newLines, "\n")), nil
 }
 
-// jsonHasIDKey does a fast (non-parsing) check for a top-level "id" key.
+// jsonHasIDKey checks whether the JSON object has a top-level "id" key.
+// Uses proper JSON parsing to avoid false positives from string values that
+// happen to contain the characters "id".
 func jsonHasIDKey(content []byte) bool {
-	return bytes.Contains(content, []byte(`"id"`)) ||
-		bytes.Contains(content, []byte(`"id" `)) ||
-		bytes.Contains(content, []byte(`"id":"`))
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(content, &doc); err != nil {
+		// Fall back to conservative behaviour: assume id is present so we don't
+		// corrupt a file we can't parse.
+		return true
+	}
+	_, ok := doc["id"]
+	return ok
 }
 
 // detectJSONIndent returns the leading whitespace of the first real key after '{'.
@@ -136,6 +144,28 @@ func detectJSONIndent(afterBrace []byte) string {
 		}
 	}
 	return "  " // fallback: 2 spaces
+}
+
+// applyWriteBack either writes the resource ID back into the source file (when
+// --write-id is set) or prints a recovery hint to stderr (when it is not).
+// fileAlreadyHasID must be true when the source file already contained an "id"
+// field before the apply — in that case neither the write-back nor the hint is
+// needed, and the function is a no-op.
+// If resourceID is empty the function is always a no-op.
+func applyWriteBack(sourceFile, resourceID, resourceType string, writeID bool, fileAlreadyHasID bool, warnings *[]string) {
+	if fileAlreadyHasID || resourceID == "" {
+		// File already had an id, or the API didn't return one — nothing to do.
+		return
+	}
+	if writeID {
+		if err := writeIDToFile(sourceFile, resourceID); err != nil {
+			stderrWarn(warnings, "could not write ID back to file: %v", err)
+		} else if sourceFile != "" {
+			fmt.Fprintf(os.Stderr, "Wrote id %s to %s\n", resourceID, sourceFile)
+		}
+	} else {
+		printWriteIDHint(sourceFile, resourceID, resourceType)
+	}
 }
 
 // printWriteIDHint prints a stderr hint when a resource was created without --write-id.

--- a/pkg/apply/writeback.go
+++ b/pkg/apply/writeback.go
@@ -1,0 +1,152 @@
+package apply
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// writeIDToFile injects the given id into the top of a YAML or JSON source file
+// so that subsequent applies update in place instead of creating duplicates.
+//
+// For YAML files: inserts "id: <id>" as the first non-comment, non-blank line.
+// For JSON files: inserts "id" as the first key inside the opening brace.
+//
+// If the file already contains an id field the function is a no-op (returns nil).
+// Errors writing the file are returned but do NOT affect the already-completed apply.
+func writeIDToFile(filename, id string) error {
+	if filename == "" {
+		return fmt.Errorf("no source file to write ID back to")
+	}
+
+	original, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", filename, err)
+	}
+
+	updated, err := injectIDIntoFileContent(original, id)
+	if err != nil {
+		return err
+	}
+	if updated == nil {
+		// already has an id — nothing to do
+		return nil
+	}
+
+	return os.WriteFile(filename, updated, 0o644)
+}
+
+// injectIDIntoFileContent returns the file content with the id field injected,
+// or nil if the file already contains an id field (no-op).
+func injectIDIntoFileContent(content []byte, id string) ([]byte, error) {
+	trimmed := bytes.TrimSpace(content)
+
+	if isJSONContent(trimmed) {
+		return injectIDIntoJSON(content, id)
+	}
+	return injectIDIntoYAML(content, id)
+}
+
+func isJSONContent(content []byte) bool {
+	return len(content) > 0 && content[0] == '{'
+}
+
+// injectIDIntoJSON inserts "id": "<id>" as the first key in a JSON object.
+// Returns nil if the file already has an "id" key.
+func injectIDIntoJSON(content []byte, id string) ([]byte, error) {
+	// Quick check: if "id" key already present, no-op
+	if jsonHasIDKey(content) {
+		return nil, nil
+	}
+
+	// Find the opening brace
+	idx := bytes.IndexByte(content, '{')
+	if idx < 0 {
+		return nil, fmt.Errorf("no opening brace found in JSON file")
+	}
+
+	idEntry := fmt.Sprintf(`"id": %q`, id)
+
+	// Peek at what follows the brace to decide formatting
+	rest := bytes.TrimLeft(content[idx+1:], " \t\r\n")
+	var insertion string
+	if len(rest) == 0 || rest[0] == '}' {
+		// Empty object
+		insertion = idEntry + "\n"
+	} else {
+		// Non-empty — detect indentation of first real key
+		indent := detectJSONIndent(content[idx+1:])
+		insertion = "\n" + indent + idEntry + ","
+	}
+
+	var buf bytes.Buffer
+	buf.Write(content[:idx+1])
+	buf.WriteString(insertion)
+	buf.Write(content[idx+1:])
+	return buf.Bytes(), nil
+}
+
+// injectIDIntoYAML inserts "id: <id>" as the first non-comment, non-blank line.
+// Returns nil if the file already has an "id:" key.
+func injectIDIntoYAML(content []byte, id string) ([]byte, error) {
+	lines := strings.Split(string(content), "\n")
+
+	// Check for existing id key (simple scan — no full YAML parse needed)
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "id:") || strings.HasPrefix(trimmed, "id :") {
+			return nil, nil // already has id
+		}
+	}
+
+	// Find insertion point: first non-comment, non-blank line
+	insertAt := 0
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+			insertAt = i
+			break
+		}
+	}
+
+	idLine := fmt.Sprintf("id: %q", id)
+	newLines := make([]string, 0, len(lines)+1)
+	newLines = append(newLines, lines[:insertAt]...)
+	newLines = append(newLines, idLine)
+	newLines = append(newLines, lines[insertAt:]...)
+
+	return []byte(strings.Join(newLines, "\n")), nil
+}
+
+// jsonHasIDKey does a fast (non-parsing) check for a top-level "id" key.
+func jsonHasIDKey(content []byte) bool {
+	return bytes.Contains(content, []byte(`"id"`)) ||
+		bytes.Contains(content, []byte(`"id" `)) ||
+		bytes.Contains(content, []byte(`"id":"`))
+}
+
+// detectJSONIndent returns the leading whitespace of the first real key after '{'.
+func detectJSONIndent(afterBrace []byte) string {
+	lines := bytes.Split(afterBrace, []byte("\n"))
+	for _, line := range lines {
+		trimmed := bytes.TrimLeft(line, " \t")
+		if len(trimmed) > 0 {
+			return string(line[:len(line)-len(trimmed)])
+		}
+	}
+	return "  " // fallback: 2 spaces
+}
+
+// printWriteIDHint prints a stderr hint when a resource was created without --write-id.
+// It suggests the exact command to recover without creating another duplicate.
+func printWriteIDHint(sourceFile, resourceID, resourceType string) {
+	if sourceFile == "" {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"Hint: to update this %s in future runs without creating duplicates:\n"+
+			"  dtctl apply -f %s --write-id --id %s\n",
+		resourceType, sourceFile, resourceID,
+	)
+}

--- a/pkg/apply/writeback_test.go
+++ b/pkg/apply/writeback_test.go
@@ -24,7 +24,7 @@ content:
   tiles: []
 `,
 			id:          "abc-123",
-			wantContain: `id: "abc-123"`,
+			wantContain: `id: abc-123`,
 			wantFirst:   true,
 		},
 		{
@@ -42,14 +42,14 @@ name: My Dashboard
 name: My Workflow
 `,
 			id:          "wf-456",
-			wantContain: `id: "wf-456"`,
+			wantContain: `id: wf-456`,
 		},
 		{
 			name: "yaml: empty file gets id prepended",
 			content: `name: Minimal
 `,
 			id:          "min-001",
-			wantContain: `id: "min-001"`,
+			wantContain: `id: min-001`,
 		},
 		// ── JSON ──────────────────────────────────────────────────────────────────
 		{
@@ -130,7 +130,7 @@ content:
 		}
 
 		got := readFileForTest(t, f)
-		if !strings.Contains(got, `id: "dash-abc-123"`) {
+		if !strings.Contains(got, `id: dash-abc-123`) {
 			t.Errorf("id not found in file:\n%s", got)
 		}
 		if !strings.Contains(got, "name: Test Dashboard") {

--- a/pkg/apply/writeback_test.go
+++ b/pkg/apply/writeback_test.go
@@ -1,0 +1,244 @@
+package apply
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestInjectIDIntoFileContent(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		id          string
+		wantNil     bool   // expect no-op (already has id)
+		wantContain string // substring the result must contain
+		wantFirst   bool   // id line should be near the top
+	}{
+		// ── YAML ──────────────────────────────────────────────────────────────────
+		{
+			name: "yaml: injects id as first content line",
+			content: `name: My Dashboard
+type: dashboard
+content:
+  tiles: []
+`,
+			id:          "abc-123",
+			wantContain: `id: "abc-123"`,
+			wantFirst:   true,
+		},
+		{
+			name: "yaml: no-op when id already present",
+			content: `id: existing-id
+name: My Dashboard
+`,
+			id:      "new-id",
+			wantNil: true,
+		},
+		{
+			name: "yaml: preserves leading comments",
+			content: `# This is a comment
+# Another comment
+name: My Workflow
+`,
+			id:          "wf-456",
+			wantContain: `id: "wf-456"`,
+		},
+		{
+			name: "yaml: empty file gets id prepended",
+			content: `name: Minimal
+`,
+			id:          "min-001",
+			wantContain: `id: "min-001"`,
+		},
+		// ── JSON ──────────────────────────────────────────────────────────────────
+		{
+			name:        "json: injects id as first key",
+			content:     "{\n  \"name\": \"My Dashboard\",\n  \"type\": \"dashboard\"\n}\n",
+			id:          "dash-789",
+			wantContain: `"id": "dash-789"`,
+		},
+		{
+			name: "json: no-op when id already present",
+			content: `{
+  "id": "existing",
+  "name": "test"
+}
+`,
+			id:      "new-id",
+			wantNil: true,
+		},
+		{
+			name:        "json: handles compact object",
+			content:     `{"name":"test","type":"dashboard"}`,
+			id:          "compact-1",
+			wantContain: `"id": "compact-1"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := injectIDIntoFileContent([]byte(tt.content), tt.id)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil (no-op), got:\n%s", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected non-nil result, got nil")
+			}
+
+			out := string(result)
+			if !strings.Contains(out, tt.wantContain) {
+				t.Errorf("result missing %q:\n%s", tt.wantContain, out)
+			}
+
+			if tt.wantFirst {
+				// The id line should appear before any other key
+				idIdx := strings.Index(out, tt.id)
+				nameIdx := strings.Index(out, "name:")
+				if nameIdx >= 0 && idIdx > nameIdx {
+					t.Errorf("id line appears after 'name:' line; full output:\n%s", out)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteIDToFile_roundtrip(t *testing.T) {
+	t.Run("yaml file gets id stamped and re-read correctly", func(t *testing.T) {
+		dir := t.TempDir()
+		f := dir + "/dashboard.yaml"
+
+		original := `name: Test Dashboard
+type: dashboard
+content:
+  tiles: []
+`
+		if err := writeFileForTest(f, original); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := writeIDToFile(f, "dash-abc-123"); err != nil {
+			t.Fatalf("writeIDToFile: %v", err)
+		}
+
+		got := readFileForTest(t, f)
+		if !strings.Contains(got, `id: "dash-abc-123"`) {
+			t.Errorf("id not found in file:\n%s", got)
+		}
+		if !strings.Contains(got, "name: Test Dashboard") {
+			t.Errorf("original content lost:\n%s", got)
+		}
+
+		// Running again must be a no-op (file already has id)
+		if err := writeIDToFile(f, "different-id"); err != nil {
+			t.Fatalf("second writeIDToFile: %v", err)
+		}
+		got2 := readFileForTest(t, f)
+		if strings.Contains(got2, "different-id") {
+			t.Error("second call should not overwrite existing id")
+		}
+	})
+
+	t.Run("json file gets id stamped", func(t *testing.T) {
+		dir := t.TempDir()
+		f := dir + "/workflow.json"
+
+		original := "{\n  \"name\": \"My Workflow\",\n  \"type\": \"workflow\"\n}\n"
+		if err := writeFileForTest(f, original); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := writeIDToFile(f, "wf-xyz-999"); err != nil {
+			t.Fatalf("writeIDToFile: %v", err)
+		}
+
+		got := readFileForTest(t, f)
+		if !strings.Contains(got, `"id": "wf-xyz-999"`) {
+			t.Errorf("id not found in file:\n%s", got)
+		}
+	})
+
+	t.Run("empty filename returns error", func(t *testing.T) {
+		err := writeIDToFile("", "some-id")
+		if err == nil {
+			t.Error("expected error for empty filename")
+		}
+	})
+
+	t.Run("nonexistent file returns error", func(t *testing.T) {
+		err := writeIDToFile("/nonexistent/path/file.yaml", "some-id")
+		if err == nil {
+			t.Error("expected error for nonexistent file")
+		}
+	})
+}
+
+func TestInjectID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		id      string
+		wantID  string
+		wantErr bool
+	}{
+		{
+			name:   "injects id into object without id",
+			input:  `{"name":"test","type":"dashboard"}`,
+			id:     "new-id",
+			wantID: "new-id",
+		},
+		{
+			name:   "overwrites existing id",
+			input:  `{"id":"old-id","name":"test"}`,
+			id:     "new-id",
+			wantID: "new-id",
+		},
+		{
+			name:    "invalid json returns error",
+			input:   `{not json}`,
+			id:      "some-id",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := injectID([]byte(tt.input), tt.id)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(string(result), `"`+tt.wantID+`"`) {
+				t.Errorf("want id %q in output, got: %s", tt.wantID, result)
+			}
+		})
+	}
+}
+
+// helpers
+
+func writeFileForTest(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func readFileForTest(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Summary

Closes #159.

Applying a dashboard, notebook, or workflow from a file without an `id` field creates a new resource every time — leading to duplicates on repeated runs. This PR adds two complementary flags to solve that ergonomically.

## New flags

### `--write-id`

After a successful **CREATE**, stamps the generated ID back into the source file (YAML or JSON). Every subsequent apply finds the ID and does an in-place update.

```bash
# First run: creates the dashboard and writes id into dashboard.yaml
dtctl apply -f dashboard.yaml --write-id

# All future runs: updates the same dashboard
dtctl apply -f dashboard.yaml
```

### `--id <id>`

Injects or overrides the resource ID at the CLI level without modifying the file. Useful for CI/scripting pipelines with reusable template files.

```bash
dtctl apply -f template.yaml --id $DASHBOARD_ID
```

### Recovery hint

When a resource is created **without** `--write-id`, a hint is printed to stderr pointing to the exact command to recover without creating another duplicate:

```
Hint: to update this dashboard in future runs without creating duplicates:
  dtctl apply -f dashboard.yaml --write-id --id <id-from-first-run>
```

The two flags together make the recovery correct: `--id` targets the already-created resource (PUT instead of POST), `--write-id` stamps it into the file so you never need `--id` again.

## Details

- Works for **dashboards**, **notebooks**, and **workflows**
- Write-back handles both YAML and JSON; is a no-op when `id` is already present; never blocks a successful apply if the file write fails (warns on stderr instead)
- `--id` overrides any `id` already in the file; if they agree, proceeds silently
- `--dry-run` is unaffected (no file mutation, no API calls)

## Files changed

| File | Change |
|---|---|
| `cmd/apply.go` | New `--id` / `--write-id` flags; updated help text with examples |
| `pkg/apply/applier.go` | `OverrideID` / `WriteID` in `ApplyOptions`; `injectID` helper; pass opts to `applyWorkflow` |
| `pkg/apply/apply_document.go` | Write-back + hint after CREATE paths |
| `pkg/apply/apply_workflow.go` | Write-back + hint after CREATE paths |
| `pkg/apply/writeback.go` | `writeIDToFile`, `injectIDIntoFileContent`, `printWriteIDHint` |
| `pkg/apply/writeback_test.go` | Full test coverage: YAML/JSON injection, round-trip, no-op, error cases |
| `docs/QUICK_START.md` | Updated workflow and dashboard sections with new flag examples |