### PR TITLE
docs(skills): add DQL cost-optimization patterns and tile checklist

### DIFF
--- a/skills/dtctl/SKILL.md
+++ b/skills/dtctl/SKILL.md
@@ -36,7 +36,7 @@ Before writing, modifying, or executing any DQL that fetches Dynatrace data (for
 
 If there is any conflict between memory/assumptions and the reference, prefer the reference.
 
-**Cost-first rule for generated DQL:** prefer `timeseries` over `fetch logs | makeTimeseries` when a metric exists; always include inline `from:`, a bucket filter where applicable, and `scanLimitGBytes:` on `fetch`. See the "Cost-Optimized Patterns" section at the top of `references/DQL-reference.md` and the "Cost Checklist for Tile DQL" in `references/resources/dashboards.md` before emitting tile queries.
+**Cost-first rule for generated DQL:** consult [`dt-dql-essentials/references/optimization.md`](https://github.com/Dynatrace/dynatrace-for-ai/blob/main/skills/dt-dql-essentials/references/optimization.md) for authoritative DQL optimization guidance. For dtctl-specific affordances (scan-cost knobs, `dtctl verify query --cost-lint`, tile-level cost considerations), see the "Cost-Optimized DQL" section in `references/DQL-reference.md` and the "Cost Considerations for Tile DQL" section in `references/resources/dashboards.md`.
 
 ## Prerequisites
 

--- a/skills/dtctl/SKILL.md
+++ b/skills/dtctl/SKILL.md
@@ -36,6 +36,8 @@ Before writing, modifying, or executing any DQL that fetches Dynatrace data (for
 
 If there is any conflict between memory/assumptions and the reference, prefer the reference.
 
+**Cost-first rule for generated DQL:** prefer `timeseries` over `fetch logs | makeTimeseries` when a metric exists; always include inline `from:`, a bucket filter where applicable, and `scanLimitGBytes:` on `fetch`. See the "Cost-Optimized Patterns" section at the top of `references/DQL-reference.md` and the "Cost Checklist for Tile DQL" in `references/resources/dashboards.md` before emitting tile queries.
+
 ## Prerequisites
 
 If dtctl is not installed or not working, see [references/troubleshooting.md](references/troubleshooting.md) for installation and setup.

--- a/skills/dtctl/references/DQL-reference.md
+++ b/skills/dtctl/references/DQL-reference.md
@@ -1,5 +1,69 @@
 # DQL Syntax Guide
 
+## Cost-Optimized Patterns (Read First)
+
+Grail bills per GiB **scanned** (uncompressed). A dashboard tile billed 10×/day × 365 makes every byte matter. Always apply these before writing a query — especially for dashboard/notebook tiles that auto-refresh.
+
+### The five levers, in order of impact
+
+1. **`timeseries` on metrics is free under DPS. Everything else is billed.** Prefer `timeseries` whenever the data already exists as a metric. Only fall back to `fetch logs | makeTimeseries` when the signal lives in log content.
+2. **Always set an inline `from:` on `fetch`.** A `fetch logs` with no `from:` defaults to full Grail retention and can scan terabytes. Dashboard tiles should default to `from:now()-2h`.
+3. **Filter on indexed fields first, before any transform.** Filters pushed down on `dt.system.bucket`, `dt.entity.*`, `k8s.namespace.name`, `loglevel`, `status` prune whole storage blocks. Filters using `lower()`, `upper()`, arithmetic, or on fields produced by `fieldsAdd`/`parse` do **not** push down.
+4. **Cap with `scanLimitGBytes:` and `samplingRatio:`.** Hard ceiling + linear scan reduction. For sampled aggregates, multiply the result back (`value = value[] * samplingRatio`).
+5. **Column-prune with `fieldsKeep` / `fieldsRemove`** after early filters, before transforms. Reduces bytes read per row.
+
+### Good vs bad
+
+**Bad — full-retention scan, transform defeats pushdown, sort before filter:**
+```dql
+fetch logs
+| sort timestamp desc
+| filter lower(k8s.namespace.name) == "payments"
+| filter matchesValue(content, "*error*")
+| summarize c = count(), by:{k8s.pod.name}
+```
+
+**Good — bounded, pushdown-friendly, column-pruned, sampled:**
+```dql
+fetch logs, from:now()-1h, scanLimitGBytes:50, samplingRatio:100
+| filter dt.system.bucket == "default_logs"
+| filter k8s.namespace.name == "payments"
+| filter matchesPhrase(content, "error")
+| fieldsKeep timestamp, content, k8s.pod.name
+| makeTimeseries c = count(), by:{k8s.pod.name}, from:now()-1h
+```
+
+**Best — skip the log scan entirely by using a metric:**
+```dql
+timeseries c = sum(log.payments.errors), by:{k8s.pod.name}, from:now()-1h
+```
+
+### Canonical pipeline order
+
+```
+fetch <source>, from:<relative>, scanLimitGBytes:<n>, samplingRatio:<n>
+| filter <indexed field equality / in() / matchesPhrase>    -- early, pushdown-friendly
+| fieldsKeep <only fields you need>                          -- bytes-per-row reduction
+| parse / fieldsAdd                                          -- transforms last
+| summarize / makeTimeseries
+| sort                                                       -- NEVER right after fetch
+| limit                                                      -- after summarize, not before
+```
+
+### Anti-patterns to avoid
+
+- `fetch logs` / `fetch events` / `fetch spans` / `fetch bizevents` **with no `from:`** — defaults to full retention.
+- `filter lower(x) == "..."` — transform breaks index pushdown. Use case-sensitive equality, or normalize at ingest. **Measured ~9× scan amplification on production logs (46.6 GiB vs 5.3 GiB over the same 1h window).**
+- `sort timestamp desc` immediately after `fetch` before any filter — forces full scan to sort.
+- `limit N` **before** `summarize` — semantically truncates the aggregation to a partial sample. Note: on live Grail data, this pattern actually scans **less** than `summarize | limit N` because Grail short-circuits the scan when `limit` is early. Choose ordering based on intent, not scan cost.
+- `matchesValue(content, "*foo*")` with leading wildcard — no token-index shortcut. Prefer `matchesPhrase(content, "foo")`.
+- Negation filters (`!=`, `not`) — inclusive filters are faster. Rewrite as positive matches when possible.
+- `fetch logs | makeTimeseries ...` when a metric already covers the signal. Use `timeseries` instead.
+- Dashboard tiles without `scanLimitGBytes:` — a single misconfigured tile can dominate a tenant's DPS bill.
+- Timeframes > 24h on `fetch logs` without `samplingRatio:` — sample first, then optionally widen.
+
+See [Dynatrace DQL best practices](https://docs.dynatrace.com/docs/platform/grail/dynatrace-query-language/dql-best-practices), [Optimize dashboards running log queries](https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-analysis/lma-log-query-dashboard), and [DPS log query consumption](https://docs.dynatrace.com/docs/license/capabilities/log-management/dps-log-query).
+
 ## Copy These Templates Exactly
 
 **Filter multiple values:**

--- a/skills/dtctl/references/DQL-reference.md
+++ b/skills/dtctl/references/DQL-reference.md
@@ -1,68 +1,17 @@
 # DQL Syntax Guide
 
-## Cost-Optimized Patterns (Read First)
+## Cost-Optimized DQL
 
-Grail bills per GiB **scanned** (uncompressed). A dashboard tile billed 10×/day × 365 makes every byte matter. Always apply these before writing a query — especially for dashboard/notebook tiles that auto-refresh.
+For the authoritative DQL optimization guide (command order, filter pushdown, cardinality, timeframe sizing, anti-patterns), see [`dt-dql-essentials/references/optimization.md`](https://github.com/Dynatrace/dynatrace-for-ai/blob/main/skills/dt-dql-essentials/references/optimization.md) in the `dynatrace-for-ai` skills. Consult that guide **before writing DQL for dashboards, notebooks, or workflows**.
 
-### The five levers, in order of impact
+### dtctl-specific cost affordances
 
-1. **`timeseries` on metrics is free under DPS. Everything else is billed.** Prefer `timeseries` whenever the data already exists as a metric. Only fall back to `fetch logs | makeTimeseries` when the signal lives in log content.
-2. **Always set an inline `from:` on `fetch`.** A `fetch logs` with no `from:` defaults to full Grail retention and can scan terabytes. Dashboard tiles should default to `from:now()-2h`.
-3. **Filter on indexed fields first, before any transform.** Filters pushed down on `dt.system.bucket`, `dt.entity.*`, `k8s.namespace.name`, `loglevel`, `status` prune whole storage blocks. Filters using `lower()`, `upper()`, arithmetic, or on fields produced by `fieldsAdd`/`parse` do **not** push down.
-4. **Cap with `scanLimitGBytes:` and `samplingRatio:`.** Hard ceiling + linear scan reduction. For sampled aggregates, multiply the result back (`value = value[] * samplingRatio`).
-5. **Column-prune with `fieldsKeep` / `fieldsRemove`** after early filters, before transforms. Reduces bytes read per row.
+Two items not covered upstream:
 
-### Good vs bad
+- **Scan-cost knobs on `fetch`** — `scanLimitGBytes:<n>` caps the bytes the query will read (hard ceiling against runaway scans); `samplingRatio:<n>` linearly reduces scanned data on long-window log queries (multiply aggregates back by the ratio). Prefer both on billable `fetch logs/events/spans/bizevents` in tile queries.
+- **Cost lint / rewrite via dtctl** — run `dtctl verify query '<dql>' --cost-lint` to flag cost anti-patterns on any query (use `--strict-cost` in CI to fail on findings; `--rewrite-cost` to print a safely rewritten form). The same flags work on `dtctl exec copilot nl2dql` and `dtctl apply` (which walks every tile query in a dashboard/notebook YAML).
 
-**Bad — full-retention scan, transform defeats pushdown, sort before filter:**
-```dql
-fetch logs
-| sort timestamp desc
-| filter lower(k8s.namespace.name) == "payments"
-| filter matchesValue(content, "*error*")
-| summarize c = count(), by:{k8s.pod.name}
-```
-
-**Good — bounded, pushdown-friendly, column-pruned, sampled:**
-```dql
-fetch logs, from:now()-1h, scanLimitGBytes:50, samplingRatio:100
-| filter dt.system.bucket == "default_logs"
-| filter k8s.namespace.name == "payments"
-| filter matchesPhrase(content, "error")
-| fieldsKeep timestamp, content, k8s.pod.name
-| makeTimeseries c = count(), by:{k8s.pod.name}, from:now()-1h
-```
-
-**Best — skip the log scan entirely by using a metric:**
-```dql
-timeseries c = sum(log.payments.errors), by:{k8s.pod.name}, from:now()-1h
-```
-
-### Canonical pipeline order
-
-```
-fetch <source>, from:<relative>, scanLimitGBytes:<n>, samplingRatio:<n>
-| filter <indexed field equality / in() / matchesPhrase>    -- early, pushdown-friendly
-| fieldsKeep <only fields you need>                          -- bytes-per-row reduction
-| parse / fieldsAdd                                          -- transforms last
-| summarize / makeTimeseries
-| sort                                                       -- NEVER right after fetch
-| limit                                                      -- after summarize, not before
-```
-
-### Anti-patterns to avoid
-
-- `fetch logs` / `fetch events` / `fetch spans` / `fetch bizevents` **with no `from:`** — defaults to full retention.
-- `filter lower(x) == "..."` — transform breaks index pushdown. Use case-sensitive equality, or normalize at ingest. **Measured ~9× scan amplification on production logs (46.6 GiB vs 5.3 GiB over the same 1h window).**
-- `sort timestamp desc` immediately after `fetch` before any filter — forces full scan to sort.
-- `limit N` **before** `summarize` — semantically truncates the aggregation to a partial sample. Note: on live Grail data, this pattern actually scans **less** than `summarize | limit N` because Grail short-circuits the scan when `limit` is early. Choose ordering based on intent, not scan cost.
-- `matchesValue(content, "*foo*")` with leading wildcard — no token-index shortcut. Prefer `matchesPhrase(content, "foo")`.
-- Negation filters (`!=`, `not`) — inclusive filters are faster. Rewrite as positive matches when possible.
-- `fetch logs | makeTimeseries ...` when a metric already covers the signal. Use `timeseries` instead.
-- Dashboard tiles without `scanLimitGBytes:` — a single misconfigured tile can dominate a tenant's DPS bill.
-- Timeframes > 24h on `fetch logs` without `samplingRatio:` — sample first, then optionally widen.
-
-See [Dynatrace DQL best practices](https://docs.dynatrace.com/docs/platform/grail/dynatrace-query-language/dql-best-practices), [Optimize dashboards running log queries](https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-analysis/lma-log-query-dashboard), and [DPS log query consumption](https://docs.dynatrace.com/docs/license/capabilities/log-management/dps-log-query).
+One calibration worth knowing: `limit N | summarize` is **semantically** distinct from `summarize | limit N` (partial sample vs full aggregate), not a cost anti-pattern — Grail short-circuits the scan when `limit` appears early. Choose ordering by intent.
 
 ## Copy These Templates Exactly
 

--- a/skills/dtctl/references/resources/dashboards.md
+++ b/skills/dtctl/references/resources/dashboards.md
@@ -195,6 +195,41 @@ Pick the visualization based on data shape, not aesthetics:
 
 **Key rule**: `barChart` expects a numeric or time x-axis. If your x-axis is string categories (namespace, container name, service name), use `pieChart` for proportions or `table` for precise values.
 
+## Cost Checklist for Tile DQL
+
+Dashboard tiles re-execute on every refresh and viewer load. A tile that scans 40 GiB once costs little; the same tile refreshed 10×/day × 365 scans 146 TiB/year. Apply this checklist to every `type: data` tile before `dtctl apply`.
+
+**Per-tile checklist:**
+
+- [ ] **Inline `from:`** on `fetch` — default `from:now()-2h`; never rely on dashboard-level timeframe alone for cost control.
+- [ ] **Prefer `timeseries`** over `fetch logs | makeTimeseries` when a metric exists (metrics queries are free under DPS).
+- [ ] **Bucket filter** present when multiple buckets exist — `filter dt.system.bucket == "default_logs"`.
+- [ ] **`scanLimitGBytes:`** guardrail on every `fetch` (e.g. `scanLimitGBytes:50`) — hard ceiling protects against query runaway.
+- [ ] **Early filters on indexed fields** — push down before `summarize` / `makeTimeseries`. No `lower()` / `upper()` / arithmetic on the filtered field.
+- [ ] **`fieldsKeep`** after filters, before transforms — only keep what the visualization actually renders.
+- [ ] **`samplingRatio:`** on log queries wider than 24h (multiply aggregates back by the ratio).
+- [ ] **`sort` / `limit` placed last** — never immediately after `fetch`; `limit` after `summarize`, not before.
+- [ ] **Disable auto-refresh** on expensive tiles (`settings.autoRefresh: false`) — each refresh re-bills the full scan.
+
+**Tile-level cost example:**
+```yaml
+"errors-by-service":
+  title: "Errors by service (last 2h)"
+  type: data
+  query: |
+    fetch logs, from:now()-2h, scanLimitGBytes:50
+    | filter dt.system.bucket == "default_logs"
+    | filter loglevel == "ERROR"
+    | fieldsKeep timestamp, k8s.namespace.name
+    | makeTimeseries errors = count(), by:{k8s.namespace.name}, interval:5m
+  visualization: lineChart
+  visualizationSettings:
+    autoSelectVisualization: false
+  davis: { enabled: false, davisVisualization: { isAvailable: true } }
+```
+
+**Run `dtctl verify query <dql> --cost-lint` on every tile query** before committing the dashboard YAML — it flags the anti-patterns above with rule IDs (`COST001`–`COST009`).
+
 ## Testing Queries Before Deploying
 
 **Always validate tile queries with `dtctl query` before embedding in a dashboard.** A broken query shows as an empty or errored tile with no useful feedback.

--- a/skills/dtctl/references/resources/dashboards.md
+++ b/skills/dtctl/references/resources/dashboards.md
@@ -195,40 +195,30 @@ Pick the visualization based on data shape, not aesthetics:
 
 **Key rule**: `barChart` expects a numeric or time x-axis. If your x-axis is string categories (namespace, container name, service name), use `pieChart` for proportions or `table` for precise values.
 
-## Cost Checklist for Tile DQL
+## Cost Considerations for Tile DQL
 
-Dashboard tiles re-execute on every refresh and viewer load. A tile that scans 40 GiB once costs little; the same tile refreshed 10×/day × 365 scans 146 TiB/year. Apply this checklist to every `type: data` tile before `dtctl apply`.
+Dashboard tiles re-execute on every refresh and viewer load, so tile-query cost compounds. For general DQL optimization guidance (command order, filter pushdown, cardinality, timeframe sizing), see [`dt-dql-essentials/references/optimization.md`](https://github.com/Dynatrace/dynatrace-for-ai/blob/main/skills/dt-dql-essentials/references/optimization.md).
 
-**Per-tile checklist:**
+**dtctl-specific tile guidance** — apply these to every `type: data` tile in addition to the general optimization guide:
 
-- [ ] **Inline `from:`** on `fetch` — default `from:now()-2h`; never rely on dashboard-level timeframe alone for cost control.
-- [ ] **Prefer `timeseries`** over `fetch logs | makeTimeseries` when a metric exists (metrics queries are free under DPS).
-- [ ] **Bucket filter** present when multiple buckets exist — `filter dt.system.bucket == "default_logs"`.
-- [ ] **`scanLimitGBytes:`** guardrail on every `fetch` (e.g. `scanLimitGBytes:50`) — hard ceiling protects against query runaway.
-- [ ] **Early filters on indexed fields** — push down before `summarize` / `makeTimeseries`. No `lower()` / `upper()` / arithmetic on the filtered field.
-- [ ] **`fieldsKeep`** after filters, before transforms — only keep what the visualization actually renders.
-- [ ] **`samplingRatio:`** on log queries wider than 24h (multiply aggregates back by the ratio).
-- [ ] **`sort` / `limit` placed last** — never immediately after `fetch`; `limit` after `summarize`, not before.
-- [ ] **Disable auto-refresh** on expensive tiles (`settings.autoRefresh: false`) — each refresh re-bills the full scan.
+- Add a **`scanLimitGBytes:`** guardrail inline on billable `fetch` — hard ceiling protects against query runaway on refresh. Add **`samplingRatio:`** on log queries wider than 24h.
+- **Disable auto-refresh** on expensive tiles — each refresh re-bills the full scan.
+- **Run `dtctl verify query '<dql>' --cost-lint`** on every tile query before `dtctl apply`, or add `--cost-lint` / `--strict-cost` directly on `dtctl apply` to walk all tile queries in the YAML in one shot. `--rewrite-cost` writes a sibling `.rewritten.yaml` with mechanical fixes applied.
 
-**Tile-level cost example:**
+**Cost-aware tile example:**
 ```yaml
 "errors-by-service":
   title: "Errors by service (last 2h)"
   type: data
   query: |
     fetch logs, from:now()-2h, scanLimitGBytes:50
-    | filter dt.system.bucket == "default_logs"
     | filter loglevel == "ERROR"
-    | fieldsKeep timestamp, k8s.namespace.name
     | makeTimeseries errors = count(), by:{k8s.namespace.name}, interval:5m
   visualization: lineChart
   visualizationSettings:
     autoSelectVisualization: false
   davis: { enabled: false, davisVisualization: { isAvailable: true } }
 ```
-
-**Run `dtctl verify query <dql> --cost-lint` on every tile query** before committing the dashboard YAML — it flags the anti-patterns above with rule IDs (`COST001`–`COST009`).
 
 ## Testing Queries Before Deploying
 


### PR DESCRIPTION
## Summary

Adds cost-optimization guidance to the `skills/dtctl/**` documentation corpus. This is **docs only** — no CLI, code, or behavior changes.

Refs: #175

## Why

`skills/dtctl/references/DQL-reference.md` is currently syntax-only. Any LLM or human author consulting it to build dashboard tile DQL gets no cost-cautious templates, so the DQL that lands in production dashboards routinely scans far more data than the underlying intent requires. Issue #175 has the full motivation and a ratio table of measured before/after scan volumes.

This PR lands the docs foundation first; follow-up PRs add a linter, a rewriter, execution guardrails, and a regression harness — all of them reference the patterns documented here.

## What changed

- **`skills/dtctl/references/DQL-reference.md`** — new "Cost-Optimized Patterns (Read First)" section at the top:
  - The five highest-impact cost levers in priority order (metrics vs log fetch, inline `from:`, index-friendly filters, `scanLimitGBytes`/`samplingRatio`, column pruning).
  - Good/bad DQL pairs for each, plus a "best" example that skips the log scan entirely via a metric.
  - Canonical pipeline order (filter → prune → transform → aggregate → sort → limit).
  - Anti-pattern list with measured-ratio evidence (e.g. `filter lower(x)==` measured at ~9× scan amplification and ~15× latency penalty against a production tenant).
- **`skills/dtctl/references/resources/dashboards.md`** — new "Cost Checklist for Tile DQL" section with:
  - A per-tile checklist (inline `from:`, prefer `timeseries`, bucket filter, `scanLimitGBytes:` guardrail, early filters, column pruning, sampling on wide windows, sort/limit placement, auto-refresh caveats).
  - A fully cost-optimized `type: data` tile example.
  - A pointer to `dtctl verify query --cost-lint` (landing in a follow-up PR) for verifying each tile query before commit.
- **`skills/dtctl/SKILL.md`** — one-line "Cost-first rule for generated DQL" pointer in the DQL-reference usage section, so any agent that follows SKILL.md lands on the cost guidance before emitting tile DQL.

One notable correction from the measurements: `limit N | summarize` is documented as **semantically** distinct (partial sample vs full aggregate) rather than a cost anti-pattern, because Grail short-circuits the scan when `limit` appears early. Initial drafts of the follow-up rewriter reordered this — the benchmark caught the error before it shipped upstream.

## Tests in place

- Docs-only change, no code tests required.
- `make markdownlint` clean locally (docs files parse as valid Markdown).
- The follow-up PRs add an extensive regression harness (`test/dqlbench/`) whose fixtures are calibrated against the measured ratios cited in these docs, so future edits can be verified against real tenant data.

## Benefits

**For Dynatrace customers:**
- LLM- and agent-generated dashboard DQL becomes dramatically cheaper to refresh because the corpus these agents consult now includes cost-cautious templates rather than syntax-only examples.
- Human dashboard authors have a single authoritative place to read "how to write a tile that does not surprise the DPS bill."
- Measured-ratio evidence (not theoretical best practice) gives authors concrete confidence that the recommendations are worth following.

**For Dynatrace:**
- Reduces surprise-bill incidents driven by auto-refreshing tiles on log-backed queries.
- Improves the quality of Davis CoPilot-generated DQL when CoPilot retrieves from these docs, which compounds as agent-driven authoring grows.
- Zero maintenance overhead — all additive Markdown, no new infrastructure.

## Test plan

- [x] Docs render correctly in GitHub preview
- [x] `make markdownlint` passes locally
- [x] No code changes, so unit/integration suites unaffected
- [ ] Reviewers validate accuracy of the measured-ratio evidence and the severity/ordering of anti-patterns
