### PR TITLE
feat(exec,query): add DQL execution guardrails + dqlbench regression harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ completions/
 
 # Snapshot data
 snapshot.json
+
+# dqlbench reports (generated artifacts)
+test/dqlbench/reports/

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/apply"
+	"github.com/dynatrace-oss/dtctl/pkg/dqlcost"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
 )
 
@@ -112,11 +115,49 @@ resources in sync with their file definitions.
 		noHooks, _ := cmd.Flags().GetBool("no-hooks")
 		overrideID, _ := cmd.Flags().GetString("id")
 		writeID, _ := cmd.Flags().GetBool("write-id")
+		costLint, _ := cmd.Flags().GetBool("cost-lint")
+		strictCost, _ := cmd.Flags().GetBool("strict-cost")
+		rewriteCost, _ := cmd.Flags().GetBool("rewrite-cost")
 
 		// Read the file
 		fileData, err := os.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
+		}
+
+		// Run cost lint on embedded tile DQL before submission. Best-effort:
+		// extraction failures on non-dashboard documents are silently ignored.
+		if costLint || strictCost {
+			if rep, lintErr := dqlcost.LintDocument(fileData); lintErr == nil && len(rep.Tiles) > 0 {
+				fmt.Fprintf(os.Stderr, "\nCost lint findings (%d tile(s) with issues):\n", len(rep.Tiles))
+				for _, tile := range rep.Tiles {
+					fmt.Fprintf(os.Stderr, "  %s:\n%s", tile.Path, indent(dqlcost.Format(tile.Findings), "    "))
+				}
+				if strictCost && rep.HasWarnOrHigher() {
+					return fmt.Errorf("--strict-cost: tile queries have warn-or-higher findings; fix or rerun without --strict-cost")
+				}
+			}
+		}
+
+		// --rewrite-cost emits a sibling `.rewritten.yaml` next to the source
+		// file with safe cost rewrites applied to each tile query, then exits
+		// without submitting. User reviews the diff and re-runs apply on the
+		// rewritten file if happy with the changes. Never mutates the original.
+		if rewriteCost {
+			rewritten, changed, err := rewriteDocumentBytes(fileData)
+			if err != nil {
+				return fmt.Errorf("cost rewrite failed: %w", err)
+			}
+			if !changed {
+				fmt.Fprintln(os.Stderr, "No cost rewrites applied — source file is already cost-optimized.")
+				return nil
+			}
+			siblingPath := deriveRewrittenPath(file)
+			if err := os.WriteFile(siblingPath, rewritten, 0o644); err != nil {
+				return fmt.Errorf("write rewritten file: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "Cost-rewritten document written to %s — review the diff, then `dtctl apply -f %s`.\n", siblingPath, siblingPath)
+			return nil
 		}
 
 		// Parse template variables
@@ -219,6 +260,62 @@ func init() {
 	applyCmd.Flags().Bool("no-hooks", false, "skip pre-apply hooks")
 	applyCmd.Flags().String("id", "", "override or inject resource ID (use with --write-id to stamp ID into file)")
 	applyCmd.Flags().Bool("write-id", false, "write the created resource ID back into the source file for idempotent future applies")
+	applyCmd.Flags().Bool("cost-lint", false, "run DQL cost-anti-pattern lint on every tile query before applying")
+	applyCmd.Flags().Bool("strict-cost", false, "fail apply when cost lint reports warn-or-higher findings")
+	applyCmd.Flags().Bool("rewrite-cost", false, "write a cost-optimized sibling file (.rewritten.<ext>) and exit without applying")
 
 	_ = applyCmd.MarkFlagRequired("file")
+}
+
+// rewriteDocumentBytes applies cost rewrites to all tile queries in a
+// dashboard/notebook document and returns the rewritten bytes.
+func rewriteDocumentBytes(data []byte) ([]byte, bool, error) {
+	out, changed, changes, err := dqlcost.RewriteDocument(data)
+	if err != nil {
+		return nil, false, err
+	}
+	if changed {
+		fmt.Fprintf(os.Stderr, "Applied %d cost rewrite(s) across tile queries:\n", len(changes))
+		for _, c := range changes {
+			fmt.Fprintf(os.Stderr, "  [%s] %s\n", c.Rule, c.Message)
+		}
+	}
+	return out, changed, nil
+}
+
+// deriveRewrittenPath returns the sibling path for the rewritten output,
+// preserving the original file extension: foo.yaml → foo.rewritten.yaml.
+func deriveRewrittenPath(source string) string {
+	ext := filepath.Ext(source)
+	base := strings.TrimSuffix(source, ext)
+	return base + ".rewritten" + ext
+}
+
+// indent prefixes every line of s with prefix.
+func indent(s, prefix string) string {
+	if s == "" {
+		return ""
+	}
+	out := ""
+	for _, line := range splitLines(s) {
+		out += prefix + line + "\n"
+	}
+	return out
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	cur := ""
+	for _, r := range s {
+		if r == '\n' {
+			lines = append(lines, cur)
+			cur = ""
+			continue
+		}
+		cur += string(r)
+	}
+	if cur != "" {
+		lines = append(lines, cur)
+	}
+	return lines
 }

--- a/cmd/exec_copilot.go
+++ b/cmd/exec_copilot.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtctl/pkg/dqlcost"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/copilot"
 )
@@ -147,6 +148,28 @@ Examples:
 		result, err := handler.Nl2Dql(text)
 		if err != nil {
 			return err
+		}
+
+		// Opt-in cost lint on CoPilot-generated DQL.
+		costLint, _ := cmd.Flags().GetBool("cost-lint")
+		rewriteCost, _ := cmd.Flags().GetBool("rewrite-cost")
+		if result != nil && result.DQL != "" {
+			if rewriteCost {
+				rewritten, changes := dqlcost.Rewrite(result.DQL, dqlcost.DefaultRewriteOptions())
+				if len(changes) > 0 {
+					fmt.Fprintf(os.Stderr, "Applied %d cost rewrite(s):\n", len(changes))
+					for _, c := range changes {
+						fmt.Fprintf(os.Stderr, "  [%s] %s\n", c.Rule, c.Message)
+					}
+					result.DQL = rewritten
+				}
+			}
+			if costLint {
+				findings := dqlcost.Lint(result.DQL)
+				if len(findings) > 0 {
+					fmt.Fprintf(os.Stderr, "Cost lint findings on generated DQL:\n%s\n", dqlcost.Format(findings))
+				}
+			}
 		}
 
 		// Check output format
@@ -292,6 +315,8 @@ func init() {
 
 	// CoPilot nl2dql flags
 	execCopilotNl2DqlCmd.Flags().StringP("file", "f", "", "read prompt from file")
+	execCopilotNl2DqlCmd.Flags().Bool("cost-lint", false, "run DQL cost-anti-pattern lint on generated query")
+	execCopilotNl2DqlCmd.Flags().Bool("rewrite-cost", false, "apply safe cost rewrites (inline from:, scanLimitGBytes, limit reorder) to generated query")
 
 	// CoPilot dql2nl flags
 	execCopilotDql2NlCmd.Flags().StringP("file", "f", "", "read DQL query from file")

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -210,6 +210,7 @@ Examples:
 		maxResultRecords, _ := cmd.Flags().GetInt64("max-result-records")
 		maxResultBytes, _ := cmd.Flags().GetInt64("max-result-bytes")
 		defaultScanLimitGbytes, _ := cmd.Flags().GetFloat64("default-scan-limit-gbytes")
+		noGuardrails, _ := cmd.Flags().GetBool("no-guardrails")
 
 		// Get query execution options
 		defaultSamplingRatio, _ := cmd.Flags().GetFloat64("default-sampling-ratio")
@@ -337,6 +338,7 @@ Examples:
 			DefaultTimeframeEnd:          defaultTimeframeEnd,
 			Locale:                       locale,
 			Timezone:                     timezone,
+			DisableGuardrails:            noGuardrails,
 			MetadataFields:               metadataFields,
 			Segments:                     segments,
 		}
@@ -663,7 +665,8 @@ func init() {
 	// Query limit flags
 	queryCmd.Flags().Int64("max-result-records", 0, "maximum number of result records to return (0 = use default, typically 1000)")
 	queryCmd.Flags().Int64("max-result-bytes", 0, "maximum result size in bytes (0 = use default)")
-	queryCmd.Flags().Float64("default-scan-limit-gbytes", 0, "scan limit in gigabytes (0 = use default)")
+	queryCmd.Flags().Float64("default-scan-limit-gbytes", 0, "scan limit in gigabytes (0 = use guardrail default of 500)")
+	queryCmd.Flags().Bool("no-guardrails", false, "disable automatic cost guardrails (scan limit, result cap)")
 
 	// Query execution flags
 	queryCmd.Flags().Float64("default-sampling-ratio", 0, "default sampling ratio (0 = use default, normalized to power of 10 <= 100000)")

--- a/cmd/verify_query.go
+++ b/cmd/verify_query.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtctl/pkg/dqlcost"
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
@@ -187,6 +188,9 @@ Examples:
 		timezone, _ := cmd.Flags().GetString("timezone")
 		locale, _ := cmd.Flags().GetString("locale")
 		failOnWarn, _ := cmd.Flags().GetBool("fail-on-warn")
+		costLint, _ := cmd.Flags().GetBool("cost-lint")
+		strictCost, _ := cmd.Flags().GetBool("strict-cost")
+		rewriteCost, _ := cmd.Flags().GetBool("rewrite-cost")
 
 		opts := exec.DQLVerifyOptions{
 			GenerateCanonicalQuery: canonical,
@@ -233,6 +237,36 @@ Examples:
 			// Default: human-readable format
 			if err := formatVerifyResultHuman(result, query, canonical); err != nil {
 				return fmt.Errorf("failed to format output: %w", err)
+			}
+		}
+
+		// Run cost lint if requested. Uses canonical query when available, else
+		// the raw input query — regex rules tolerate both.
+		if costLint || strictCost {
+			target := query
+			if result != nil && result.CanonicalQuery != "" {
+				target = result.CanonicalQuery
+			}
+			findings := dqlcost.Lint(target)
+			if len(findings) > 0 {
+				fmt.Fprintf(os.Stderr, "\nCost lint findings:\n%s", dqlcost.Format(findings))
+				if strictCost && dqlcost.MaxSeverity(findings) >= dqlcost.SeverityWarn {
+					exitCode = 1
+				}
+			}
+		}
+
+		// Emit rewritten query to stdout when --rewrite-cost is set. Useful for
+		// piping into scripts or copying back into source files manually.
+		if rewriteCost {
+			rewritten, changes := dqlcost.Rewrite(query, dqlcost.DefaultRewriteOptions())
+			if len(changes) > 0 {
+				fmt.Fprintf(os.Stderr, "\nApplied %d cost rewrite(s):\n", len(changes))
+				for _, c := range changes {
+					fmt.Fprintf(os.Stderr, "  [%s] %s\n", c.Rule, c.Message)
+				}
+				fmt.Fprintln(os.Stderr, "\nRewritten query:")
+				fmt.Println(rewritten)
 			}
 		}
 
@@ -431,4 +465,7 @@ func init() {
 	verifyQueryCmd.Flags().String("timezone", "", "timezone for query verification (IANA, CET, +01:00, etc.)")
 	verifyQueryCmd.Flags().String("locale", "", "locale for query verification (en, en_US, de_AT, etc.)")
 	verifyQueryCmd.Flags().Bool("fail-on-warn", false, "exit with non-zero status on warnings (useful for CI/CD)")
+	verifyQueryCmd.Flags().Bool("cost-lint", false, "run DQL cost-anti-pattern lint rules (COST001-COST009)")
+	verifyQueryCmd.Flags().Bool("strict-cost", false, "exit non-zero when cost lint reports warn-or-higher findings")
+	verifyQueryCmd.Flags().Bool("rewrite-cost", false, "print a safely rewritten version of the query to stdout")
 }

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean test test-unit test-integration test-all test-coverage test-update-golden install lint lint-strict fmt markdownlint markdownlint-fix security-scan check release release-snapshot
+.PHONY: all build clean test test-unit test-integration test-all test-coverage test-update-golden test-dqlbench-unit test-dqlbench install lint lint-strict fmt markdownlint markdownlint-fix security-scan check release release-snapshot
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -75,6 +75,23 @@ test-update-golden:
 	@echo "Updating golden files..."
 	@go test ./... -update
 	@echo "Golden files updated. Review changes with: git diff pkg/output/testdata/"
+
+# Run DQL cost-lint snapshot harness (no tenant required)
+test-dqlbench-unit:
+	@echo "Running dqlbench snapshot harness..."
+	@go test -count=1 ./test/dqlbench/harness/...
+
+# Run DQL cost-lint harness against live tenant (requires DTCTL_INTEGRATION_ENV + TOKEN)
+test-dqlbench:
+	@echo "Running dqlbench tenant harness..."
+	@if [ -f .integrationtests.env ]; then \
+		echo "Loading environment from .integrationtests.env"; \
+		export $$(cat .integrationtests.env | grep -v '^#' | xargs); \
+	fi; \
+	if [ -z "$$DTCTL_INTEGRATION_ENV" ] || [ -z "$$DTCTL_INTEGRATION_TOKEN" ]; then \
+		echo "Error: DTCTL_INTEGRATION_ENV and DTCTL_INTEGRATION_TOKEN required"; exit 1; \
+	fi; \
+	go test -count=1 -tags dqlbench ./test/dqlbench/harness/...
 
 # Run all tests (unit + integration)
 test-all: test-unit test-integration

--- a/pkg/dqlcost/dqlcost.go
+++ b/pkg/dqlcost/dqlcost.go
@@ -1,0 +1,301 @@
+// Package dqlcost lints DQL queries for cost anti-patterns that lead to
+// oversized Grail scans on Dynatrace DPS.
+//
+// Lint rules operate on the raw query text using regex heuristics against a
+// normalized (whitespace-collapsed, lowercased-keyword) form. Callers that
+// already have a canonical query from DQLExecutor.VerifyQuery should pass it
+// directly; otherwise Normalize handles basic whitespace collapsing.
+package dqlcost
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Severity of a lint finding.
+type Severity int
+
+const (
+	SeverityInfo Severity = iota
+	SeverityWarn
+	SeverityError
+)
+
+func (s Severity) String() string {
+	switch s {
+	case SeverityInfo:
+		return "info"
+	case SeverityWarn:
+		return "warn"
+	case SeverityError:
+		return "error"
+	}
+	return "unknown"
+}
+
+// Finding describes a single lint violation.
+type Finding struct {
+	Rule       string   // e.g. "COST001"
+	Severity   Severity // info | warn | error
+	Message    string   // short human-readable explanation
+	Suggestion string   // actionable suggestion
+}
+
+// Rule is a pure function that inspects the normalized query and appends
+// zero or more findings.
+type Rule func(normalized string) []Finding
+
+// DefaultRules returns the built-in cost rules in stable ID order.
+func DefaultRules() []Rule {
+	return []Rule{
+		rule001MissingFrom,
+		rule002LogMakeTimeseries,
+		rule003TransformedFilter,
+		rule004SortAfterFetch,
+		rule005LimitBeforeSummarize,
+		rule006WildcardMatchesValue,
+		rule008MissingScanLimit,
+		rule009LongLogWindowNoSampling,
+	}
+}
+
+// Lint runs all DefaultRules against the query and returns findings sorted
+// by rule ID.
+func Lint(query string) []Finding {
+	return LintWith(query, DefaultRules())
+}
+
+// LintWith runs the given rules against the query. Rules receive the
+// normalized query concatenated with a second copy that preserves string
+// literals, separated by a null marker — this lets shape-based rules match
+// on literal content (e.g. wildcard arguments) without losing the safety
+// of normalization.
+func LintWith(query string, rules []Rule) []Finding {
+	n := Normalize(query)
+	withLiterals := collapseWS(stripComments(query))
+	combined := n + "\x00" + withLiterals
+	var out []Finding
+	for _, r := range rules {
+		out = append(out, r(combined)...)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Rule < out[j].Rule })
+	return out
+}
+
+func stripComments(q string) string {
+	var lines []string
+	for _, ln := range strings.Split(q, "\n") {
+		if i := strings.Index(ln, "//"); i >= 0 {
+			ln = ln[:i]
+		}
+		lines = append(lines, ln)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func collapseWS(s string) string {
+	return strings.TrimSpace(regexp.MustCompile(`\s+`).ReplaceAllString(s, " "))
+}
+
+// MaxSeverity returns the highest severity across findings, or SeverityInfo-1
+// (-1) if none.
+func MaxSeverity(findings []Finding) Severity {
+	max := Severity(-1)
+	for _, f := range findings {
+		if f.Severity > max {
+			max = f.Severity
+		}
+	}
+	return max
+}
+
+// Format renders findings as one line each, sorted by rule ID.
+func Format(findings []Finding) string {
+	var b strings.Builder
+	for _, f := range findings {
+		fmt.Fprintf(&b, "[%s %s] %s — %s\n", f.Rule, f.Severity, f.Message, f.Suggestion)
+	}
+	return b.String()
+}
+
+// Normalize collapses whitespace, lowercases command keywords, and strips
+// string-literal contents (replacing them with empty quotes) so that rules
+// do not match on user data. Comments (// and #) are removed.
+func Normalize(q string) string {
+	// Strip line comments.
+	var lines []string
+	for _, ln := range strings.Split(q, "\n") {
+		if i := strings.Index(ln, "//"); i >= 0 {
+			ln = ln[:i]
+		}
+		lines = append(lines, ln)
+	}
+	q = strings.Join(lines, "\n")
+
+	// Replace string literal contents with empty strings so `matchesValue(x, "*foo*")`
+	// is still detectable by its shape but user data does not false-positive other rules.
+	// Kept permissively — regex rules are shape-based.
+	q = stripStringBodies(q)
+
+	// Collapse whitespace.
+	q = regexp.MustCompile(`\s+`).ReplaceAllString(q, " ")
+	return strings.TrimSpace(q)
+}
+
+func stripStringBodies(s string) string {
+	// Match "...", keeping empty quotes. Does not handle escaped quotes — not
+	// required for heuristic linting.
+	return regexp.MustCompile(`"[^"]*"`).ReplaceAllString(s, `""`)
+}
+
+// --- Rules ---------------------------------------------------------------
+
+var (
+	// fetch logs|events|bizevents|spans without any from: inline argument.
+	reFetchBillable    = regexp.MustCompile(`(?i)\bfetch\s+(logs|events|bizevents|spans)\b([^|]*)`)
+	reHasFromInline    = regexp.MustCompile(`(?i)\bfrom\s*:`)
+	reHasScanLimit     = regexp.MustCompile(`(?i)\bscanlimitgbytes\s*:`)
+	reHasSampling      = regexp.MustCompile(`(?i)\bsamplingratio\s*:`)
+	reLogMakeTS        = regexp.MustCompile(`(?i)\bfetch\s+logs\b[\s\S]*?\|\s*maketimeseries\b`)
+	reTransformedEqual = regexp.MustCompile(`(?i)\bfilter\s+(?:lower|upper|toString|toLong|toDouble)\s*\(`)
+	reFilterArithmetic = regexp.MustCompile(`(?i)\bfilter\s+\w[\w.]*\s*[+\-*/]\s*\d`)
+	reSortAfterFetch   = regexp.MustCompile(`(?i)\bfetch\s+\w+[^|]*\|\s*sort\b`)
+	reLimitBeforeSumm  = regexp.MustCompile(`(?i)\|\s*limit\s+\d+\s*\|\s*summarize\b`)
+	reWildcardMV       = regexp.MustCompile(`(?i)\bmatchesvalue\s*\(\s*[\w.]+\s*,\s*"\*[^"]*"`)
+	// Detect from:-Nd or from:now()-Nd (N days) or from:-Nh (h >= 25)
+	reFromDays  = regexp.MustCompile(`(?i)\bfrom\s*:\s*(?:now\(\)\s*-\s*)?(\d+)d\b`)
+	reFromHours = regexp.MustCompile(`(?i)\bfrom\s*:\s*(?:now\(\)\s*-\s*)?(\d+)h\b`)
+)
+
+func rule001MissingFrom(n string) []Finding {
+	matches := reFetchBillable.FindAllStringSubmatch(n, -1)
+	var out []Finding
+	for _, m := range matches {
+		tail := m[2]
+		// from: may appear either in the fetch parameter tail up to the first '|'
+		// or nowhere — this rule fires only when no from: is present in the
+		// fetch-argument tail.
+		if !reHasFromInline.MatchString(tail) {
+			out = append(out, Finding{
+				Rule:       "COST001",
+				Severity:   SeverityError,
+				Message:    fmt.Sprintf("`fetch %s` has no inline `from:` — defaults to full Grail retention", m[1]),
+				Suggestion: fmt.Sprintf("add `, from:now()-2h` to the fetch, e.g. `fetch %s, from:now()-2h`", m[1]),
+			})
+		}
+	}
+	return out
+}
+
+func rule002LogMakeTimeseries(n string) []Finding {
+	if reLogMakeTS.MatchString(n) {
+		return []Finding{{
+			Rule:       "COST002",
+			Severity:   SeverityWarn,
+			Message:    "`fetch logs | makeTimeseries` pays per GiB scanned",
+			Suggestion: "if a metric already captures this signal, use `timeseries` (free under DPS)",
+		}}
+	}
+	return nil
+}
+
+func rule003TransformedFilter(n string) []Finding {
+	var out []Finding
+	// Empirically measured ~9× scan amplification on a production tenant
+	// (46.6 GiB vs 5.3 GiB over a 1h log window), so this is an error.
+	if reTransformedEqual.MatchString(n) {
+		out = append(out, Finding{
+			Rule:       "COST003",
+			Severity:   SeverityError,
+			Message:    "`filter` wraps the field in a transform (lower/upper/toString/…) — defeats index pushdown; measured ~9× scan cost",
+			Suggestion: "compare the raw field directly, or normalize at ingest",
+		})
+	}
+	if reFilterArithmetic.MatchString(n) {
+		out = append(out, Finding{
+			Rule:       "COST003",
+			Severity:   SeverityError,
+			Message:    "`filter` performs arithmetic on the filtered field — defeats index pushdown",
+			Suggestion: "precompute with `fieldsAdd` before aggregation or compare the raw field",
+		})
+	}
+	return out
+}
+
+func rule004SortAfterFetch(n string) []Finding {
+	if reSortAfterFetch.MatchString(n) {
+		return []Finding{{
+			Rule:       "COST004",
+			Severity:   SeverityWarn,
+			Message:    "`sort` appears immediately after `fetch`, before any filter",
+			Suggestion: "move `sort` after filters/summarize so the sort operates on a small result set",
+		}}
+	}
+	return nil
+}
+
+func rule005LimitBeforeSummarize(n string) []Finding {
+	// Empirical note: on a production tenant, `limit N | summarize` actually
+	// scanned LESS than `summarize | limit N` because Grail short-circuits the
+	// scan after N rows are found. Semantics differ though — the aggregation is
+	// over a truncated sample. So this is an informational flag about intent,
+	// not a cost warning.
+	if reLimitBeforeSumm.MatchString(n) {
+		return []Finding{{
+			Rule:       "COST005",
+			Severity:   SeverityInfo,
+			Message:    "`limit N` before `summarize` truncates the aggregation input to an arbitrary N rows; Grail scans less but the aggregate is over a partial sample",
+			Suggestion: "if you want an aggregate over all data, move `limit` after `summarize`; if you want a fast sample, this ordering is fine",
+		}}
+	}
+	return nil
+}
+
+func rule006WildcardMatchesValue(n string) []Finding {
+	if reWildcardMV.MatchString(n) {
+		return []Finding{{
+			Rule:       "COST006",
+			Severity:   SeverityWarn,
+			Message:    "`matchesValue(field, \"*...\")` uses a leading-wildcard pattern — no token-index shortcut",
+			Suggestion: "use `matchesPhrase(field, \"...\")` for tokenized substring search",
+		}}
+	}
+	return nil
+}
+
+func rule008MissingScanLimit(n string) []Finding {
+	if reFetchBillable.MatchString(n) && !reHasScanLimit.MatchString(n) {
+		return []Finding{{
+			Rule:       "COST008",
+			Severity:   SeverityWarn,
+			Message:    "billable `fetch` without `scanLimitGBytes:` guardrail",
+			Suggestion: "add `, scanLimitGBytes:50` (or your tenant default) to cap runaway scans",
+		}}
+	}
+	return nil
+}
+
+func rule009LongLogWindowNoSampling(n string) []Finding {
+	if !strings.Contains(strings.ToLower(n), "fetch logs") {
+		return nil
+	}
+	longWindow := reFromDays.MatchString(n)
+	if m := reFromHours.FindStringSubmatch(n); m != nil {
+		var h int
+		fmt.Sscanf(m[1], "%d", &h)
+		if h >= 25 {
+			longWindow = true
+		}
+	}
+	if longWindow && !reHasSampling.MatchString(n) {
+		return []Finding{{
+			Rule:       "COST009",
+			Severity:   SeverityWarn,
+			Message:    "`fetch logs` window > 24h without `samplingRatio:`",
+			Suggestion: "add `, samplingRatio:100` (or narrow the window); multiply aggregates back by the ratio",
+		}}
+	}
+	return nil
+}

--- a/pkg/dqlcost/dqlcost_test.go
+++ b/pkg/dqlcost/dqlcost_test.go
@@ -1,0 +1,148 @@
+package dqlcost
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLint_COST001_MissingFrom(t *testing.T) {
+	findings := Lint(`fetch logs | filter loglevel == "ERROR" | limit 100`)
+	if !hasRule(findings, "COST001") {
+		t.Fatalf("expected COST001, got %v", findings)
+	}
+}
+
+func TestLint_COST001_WithFromPasses(t *testing.T) {
+	findings := Lint(`fetch logs, from:now()-1h | filter loglevel == "ERROR" | limit 100`)
+	if hasRule(findings, "COST001") {
+		t.Fatalf("COST001 should not fire when from: is present: %v", findings)
+	}
+}
+
+func TestLint_COST002_LogMakeTimeseries(t *testing.T) {
+	findings := Lint(`fetch logs, from:now()-1h | makeTimeseries cnt = count(), interval:5m`)
+	if !hasRule(findings, "COST002") {
+		t.Fatalf("expected COST002, got %v", findings)
+	}
+}
+
+func TestLint_COST003_TransformedFilter(t *testing.T) {
+	findings := Lint(`fetch logs, from:now()-1h | filter lower(k8s.namespace.name) == "payments"`)
+	if !hasRule(findings, "COST003") {
+		t.Fatalf("expected COST003, got %v", findings)
+	}
+}
+
+func TestLint_COST004_SortAfterFetch(t *testing.T) {
+	findings := Lint(`fetch logs, from:now()-1h | sort timestamp desc | filter loglevel == "ERROR"`)
+	if !hasRule(findings, "COST004") {
+		t.Fatalf("expected COST004, got %v", findings)
+	}
+}
+
+func TestLint_COST005_LimitBeforeSummarize(t *testing.T) {
+	findings := Lint(`fetch logs, from:now()-1h | limit 100 | summarize c = count(), by:{loglevel}`)
+	if !hasRule(findings, "COST005") {
+		t.Fatalf("expected COST005, got %v", findings)
+	}
+}
+
+func TestLint_COST006_WildcardMatchesValue(t *testing.T) {
+	findings := Lint(`fetch logs, from:now()-1h | filter matchesValue(content, "*error*")`)
+	if !hasRule(findings, "COST006") {
+		t.Fatalf("expected COST006, got %v", findings)
+	}
+}
+
+func TestLint_COST008_MissingScanLimit(t *testing.T) {
+	findings := Lint(`fetch logs, from:now()-1h | filter loglevel == "ERROR"`)
+	if !hasRule(findings, "COST008") {
+		t.Fatalf("expected COST008, got %v", findings)
+	}
+}
+
+func TestLint_COST008_PresentPasses(t *testing.T) {
+	findings := Lint(`fetch logs, from:now()-1h, scanLimitGBytes:50 | filter loglevel == "ERROR"`)
+	if hasRule(findings, "COST008") {
+		t.Fatalf("COST008 should not fire when scanLimitGBytes is present: %v", findings)
+	}
+}
+
+func TestLint_COST009_LongWindowNoSampling(t *testing.T) {
+	findings := Lint(`fetch logs, from:now()-7d | filter loglevel == "ERROR"`)
+	if !hasRule(findings, "COST009") {
+		t.Fatalf("expected COST009, got %v", findings)
+	}
+}
+
+func TestLint_COST009_With48h(t *testing.T) {
+	findings := Lint(`fetch logs, from:now()-48h | filter loglevel == "ERROR"`)
+	if !hasRule(findings, "COST009") {
+		t.Fatalf("expected COST009 for 48h window, got %v", findings)
+	}
+}
+
+func TestLint_COST009_SamplingPresentPasses(t *testing.T) {
+	findings := Lint(`fetch logs, from:now()-7d, samplingRatio:100 | filter loglevel == "ERROR"`)
+	if hasRule(findings, "COST009") {
+		t.Fatalf("COST009 should not fire when samplingRatio is present: %v", findings)
+	}
+}
+
+func TestLint_TimeseriesIsFree(t *testing.T) {
+	// timeseries on metrics should produce no COST001/COST002/COST008 findings.
+	findings := Lint(`timeseries avg(dt.host.cpu.usage), by:{dt.entity.host}, from:now()-1h`)
+	for _, bad := range []string{"COST001", "COST002", "COST008"} {
+		if hasRule(findings, bad) {
+			t.Errorf("%s should not fire on timeseries query: %v", bad, findings)
+		}
+	}
+}
+
+func TestLint_GoldPath(t *testing.T) {
+	// Canonical cost-optimized query should produce zero findings.
+	q := `fetch logs, from:now()-1h, scanLimitGBytes:50
+| filter dt.system.bucket == "default_logs"
+| filter loglevel == "ERROR"
+| fieldsKeep timestamp, content, k8s.pod.name
+| makeTimeseries c = count(), by:{k8s.pod.name}, from:now()-1h`
+	findings := Lint(q)
+	// COST002 is acceptable here (we still use fetch logs | makeTimeseries).
+	// All other rules should be silent.
+	for _, f := range findings {
+		if f.Rule != "COST002" {
+			t.Errorf("unexpected finding on gold-path query: %+v", f)
+		}
+	}
+}
+
+func TestMaxSeverity(t *testing.T) {
+	findings := []Finding{
+		{Rule: "A", Severity: SeverityInfo},
+		{Rule: "B", Severity: SeverityError},
+		{Rule: "C", Severity: SeverityWarn},
+	}
+	if got := MaxSeverity(findings); got != SeverityError {
+		t.Fatalf("MaxSeverity = %v, want error", got)
+	}
+	if got := MaxSeverity(nil); got != Severity(-1) {
+		t.Fatalf("MaxSeverity(nil) = %v, want -1", got)
+	}
+}
+
+func TestFormat(t *testing.T) {
+	findings := []Finding{{Rule: "COST001", Severity: SeverityError, Message: "m", Suggestion: "s"}}
+	got := Format(findings)
+	if !strings.Contains(got, "COST001") || !strings.Contains(got, "error") {
+		t.Fatalf("Format output missing expected fields: %q", got)
+	}
+}
+
+func hasRule(findings []Finding, rule string) bool {
+	for _, f := range findings {
+		if f.Rule == rule {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/dqlcost/extract.go
+++ b/pkg/dqlcost/extract.go
@@ -1,0 +1,117 @@
+package dqlcost
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TileQuery is a single DQL query extracted from a dashboard or notebook
+// document together with a human-readable locator (e.g. "tiles.1.query").
+type TileQuery struct {
+	Path  string // dot/bracket path inside the document
+	Query string // the DQL query text
+}
+
+// ExtractTileQueries walks a YAML or JSON dashboard/notebook document and
+// returns every DQL query string it finds. Dashboards nest queries under
+// `content.tiles.<key>.query`; notebooks under `cells[*].query`. The walker
+// is schema-agnostic: any string-valued field named "query" at a reasonable
+// depth is returned — callers can discard spurious entries.
+func ExtractTileQueries(data []byte) ([]TileQuery, error) {
+	var root any
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		// Fall back to JSON.
+		if jErr := json.Unmarshal(data, &root); jErr != nil {
+			return nil, fmt.Errorf("parse as yaml or json: %w", err)
+		}
+	}
+	var out []TileQuery
+	walk(root, "", &out)
+	return out, nil
+}
+
+func walk(v any, path string, out *[]TileQuery) {
+	switch x := v.(type) {
+	case map[string]any:
+		for k, child := range x {
+			p := joinPath(path, k)
+			if k == "query" {
+				if s, ok := child.(string); ok && s != "" {
+					*out = append(*out, TileQuery{Path: p, Query: s})
+					continue
+				}
+			}
+			walk(child, p, out)
+		}
+	case map[any]any:
+		// yaml.v3 with "any" key type occasionally produces this shape.
+		for k, child := range x {
+			ks, _ := k.(string)
+			p := joinPath(path, ks)
+			if ks == "query" {
+				if s, ok := child.(string); ok && s != "" {
+					*out = append(*out, TileQuery{Path: p, Query: s})
+					continue
+				}
+			}
+			walk(child, p, out)
+		}
+	case []any:
+		for i, child := range x {
+			walk(child, fmt.Sprintf("%s[%d]", path, i), out)
+		}
+	}
+}
+
+func joinPath(prefix, key string) string {
+	if prefix == "" {
+		return key
+	}
+	return prefix + "." + key
+}
+
+// DocumentReport is the aggregated lint result for a full document.
+type DocumentReport struct {
+	Tiles []TileReport
+}
+
+// TileReport is the per-query lint result with its source path.
+type TileReport struct {
+	Path     string
+	Query    string
+	Findings []Finding
+}
+
+// HasWarnOrHigher reports whether any tile has a warn-or-higher finding.
+func (r DocumentReport) HasWarnOrHigher() bool {
+	for _, t := range r.Tiles {
+		if MaxSeverity(t.Findings) >= SeverityWarn {
+			return true
+		}
+	}
+	return false
+}
+
+// LintDocument extracts every tile query and lints each. Tiles with no
+// findings are omitted from the report so callers only see signal.
+func LintDocument(data []byte) (DocumentReport, error) {
+	tiles, err := ExtractTileQueries(data)
+	if err != nil {
+		return DocumentReport{}, err
+	}
+	var rep DocumentReport
+	for _, t := range tiles {
+		findings := Lint(t.Query)
+		if len(findings) == 0 {
+			continue
+		}
+		rep.Tiles = append(rep.Tiles, TileReport{
+			Path:     t.Path,
+			Query:    t.Query,
+			Findings: findings,
+		})
+	}
+	return rep, nil
+}

--- a/pkg/dqlcost/extract_test.go
+++ b/pkg/dqlcost/extract_test.go
@@ -1,0 +1,68 @@
+package dqlcost
+
+import "testing"
+
+func TestExtractTileQueries_Dashboard(t *testing.T) {
+	doc := []byte(`
+name: "Test"
+type: dashboard
+content:
+  tiles:
+    "1":
+      title: "Errors"
+      type: data
+      query: |
+        fetch logs | limit 10
+    "2":
+      title: "Markdown"
+      type: markdown
+      content: "## header"
+`)
+	tiles, err := ExtractTileQueries(doc)
+	if err != nil {
+		t.Fatalf("ExtractTileQueries: %v", err)
+	}
+	if len(tiles) != 1 {
+		t.Fatalf("expected 1 tile query, got %d: %+v", len(tiles), tiles)
+	}
+	if tiles[0].Path == "" || tiles[0].Query == "" {
+		t.Fatalf("missing path or query: %+v", tiles[0])
+	}
+}
+
+func TestLintDocument_FlagsBadTiles(t *testing.T) {
+	doc := []byte(`
+name: "Test"
+type: dashboard
+content:
+  tiles:
+    bad:
+      type: data
+      query: |
+        fetch logs | filter loglevel == "ERROR"
+    good:
+      type: data
+      query: |
+        fetch logs, from:now()-1h, scanLimitGBytes:50 | filter loglevel == "ERROR"
+`)
+	rep, err := LintDocument(doc)
+	if err != nil {
+		t.Fatalf("LintDocument: %v", err)
+	}
+	// Bad tile should report COST001/COST008. Good tile should be silent enough
+	// not to hit those.
+	found001 := false
+	for _, tile := range rep.Tiles {
+		for _, f := range tile.Findings {
+			if f.Rule == "COST001" {
+				found001 = true
+			}
+		}
+	}
+	if !found001 {
+		t.Fatalf("expected COST001 on bad tile, got report=%+v", rep)
+	}
+	if !rep.HasWarnOrHigher() {
+		t.Fatalf("HasWarnOrHigher should be true")
+	}
+}

--- a/pkg/dqlcost/rewrite.go
+++ b/pkg/dqlcost/rewrite.go
@@ -1,0 +1,144 @@
+package dqlcost
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// RewriteOptions controls which mechanical rewrites apply.
+type RewriteOptions struct {
+	AddDefaultFrom   bool   // COST001: append `, from:<DefaultFrom>` to billable fetch lacking from:
+	AddScanLimit     bool   // COST008: insert `, scanLimitGBytes:<DefaultScanLimit>`
+	MoveLimitAfter   bool   // COST005 (disabled by default — empirically harmful; see dqlcost.go)
+	DefaultFrom      string // timeframe literal, e.g. "now()-2h"
+	DefaultScanLimit int    // scan limit in GiB, e.g. 500
+}
+
+// DefaultRewriteOptions enables the safe rewrites with conservative defaults.
+// MoveLimitAfter is intentionally disabled: tenant measurements showed that
+// moving `limit` after `summarize` actually increased scan cost by ~40× because
+// Grail short-circuits the scan when `limit` appears earlier. The semantics
+// differ though, so the linter still flags this as info-level for the author.
+func DefaultRewriteOptions() RewriteOptions {
+	return RewriteOptions{
+		AddDefaultFrom:   true,
+		AddScanLimit:     true,
+		MoveLimitAfter:   false,
+		DefaultFrom:      "now()-2h",
+		DefaultScanLimit: 500,
+	}
+}
+
+// Change describes a single rewrite applied to the query.
+type Change struct {
+	Rule    string // corresponding lint rule ID
+	Message string
+}
+
+// Rewrite applies safe mechanical cost rewrites to the query and returns
+// the new query plus the list of changes applied. Input that is already
+// well-formed is returned unchanged with an empty change list. Rewrite is
+// never destructive: on parse ambiguity it leaves the query untouched and
+// records no change.
+func Rewrite(query string, opts RewriteOptions) (string, []Change) {
+	out := query
+	var changes []Change
+
+	if opts.AddDefaultFrom && opts.DefaultFrom != "" {
+		rewritten, changed := addDefaultFrom(out, opts.DefaultFrom)
+		if changed {
+			out = rewritten
+			changes = append(changes, Change{
+				Rule:    "COST001",
+				Message: fmt.Sprintf("added inline `from:%s` to billable fetch", opts.DefaultFrom),
+			})
+		}
+	}
+	if opts.AddScanLimit && opts.DefaultScanLimit > 0 {
+		rewritten, changed := addScanLimit(out, opts.DefaultScanLimit)
+		if changed {
+			out = rewritten
+			changes = append(changes, Change{
+				Rule:    "COST008",
+				Message: fmt.Sprintf("added `scanLimitGBytes:%d` guardrail to fetch", opts.DefaultScanLimit),
+			})
+		}
+	}
+	if opts.MoveLimitAfter {
+		rewritten, changed := moveLimitAfterSummarize(out)
+		if changed {
+			out = rewritten
+			changes = append(changes, Change{
+				Rule:    "COST005",
+				Message: "moved `| limit N` to after `| summarize` so it trims results, not input",
+			})
+		}
+	}
+
+	return out, changes
+}
+
+// addDefaultFrom finds `fetch <logs|events|bizevents|spans> <args-up-to-pipe>`
+// occurrences and, if no `from:` is present in the args, appends `, from:<literal>`.
+// Preserves surrounding whitespace.
+var reFetchBillableGroup = regexp.MustCompile(`(?i)(\bfetch\s+(?:logs|events|bizevents|spans)\b)([^|]*)`)
+
+func addDefaultFrom(q, fromLiteral string) (string, bool) {
+	changed := false
+	out := reFetchBillableGroup.ReplaceAllStringFunc(q, func(m string) string {
+		sub := reFetchBillableGroup.FindStringSubmatch(m)
+		head, tail := sub[1], sub[2]
+		if reHasFromInline.MatchString(tail) {
+			return m
+		}
+		// Strip trailing whitespace from tail, then append `, from:<literal>`.
+		trimmed := strings.TrimRight(tail, " \t\n")
+		suffix := tail[len(trimmed):]
+		sep := ", "
+		if strings.TrimSpace(trimmed) == "" {
+			// tail is empty — no existing args.
+			changed = true
+			return head + ", from:" + fromLiteral + suffix
+		}
+		changed = true
+		return head + trimmed + sep + "from:" + fromLiteral + suffix
+	})
+	return out, changed
+}
+
+// addScanLimit inserts `, scanLimitGBytes:<n>` into billable fetch args when
+// none is present. Runs after addDefaultFrom so both guardrails coexist.
+func addScanLimit(q string, limit int) (string, bool) {
+	if reHasScanLimit.MatchString(q) {
+		// already present somewhere in the query — avoid duplicating
+		return q, false
+	}
+	changed := false
+	out := reFetchBillableGroup.ReplaceAllStringFunc(q, func(m string) string {
+		sub := reFetchBillableGroup.FindStringSubmatch(m)
+		head, tail := sub[1], sub[2]
+		trimmed := strings.TrimRight(tail, " \t\n")
+		suffix := tail[len(trimmed):]
+		if strings.TrimSpace(trimmed) == "" {
+			changed = true
+			return head + fmt.Sprintf(", scanLimitGBytes:%d", limit) + suffix
+		}
+		changed = true
+		return head + trimmed + fmt.Sprintf(", scanLimitGBytes:%d", limit) + suffix
+	})
+	return out, changed
+}
+
+// moveLimitAfterSummarize rewrites `... | limit N | summarize ...` into
+// `... | summarize ... | limit N`. Conservative: only moves when the pattern
+// is unambiguous (single limit stage directly before a single summarize).
+var reLimitThenSummarize = regexp.MustCompile(`(?i)\|\s*(limit\s+\d+)\s*\|\s*(summarize\b[^|]*)`)
+
+func moveLimitAfterSummarize(q string) (string, bool) {
+	if !reLimitThenSummarize.MatchString(q) {
+		return q, false
+	}
+	out := reLimitThenSummarize.ReplaceAllString(q, "| $2 | $1")
+	return out, out != q
+}

--- a/pkg/dqlcost/rewrite_document.go
+++ b/pkg/dqlcost/rewrite_document.go
@@ -1,0 +1,74 @@
+package dqlcost
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RewriteDocument walks a YAML dashboard/notebook document, rewrites every
+// `query:` string using Rewrite+DefaultRewriteOptions, and returns the new
+// bytes. Returns `changed=true` when at least one query was modified.
+// Preserves YAML formatting and comments because it operates on the node
+// tree rather than unmarshalling to `any`.
+//
+// For JSON input, callers should pre-convert to YAML or accept the
+// formatting roundtrip.
+func RewriteDocument(data []byte) ([]byte, bool, []Change, error) {
+	return RewriteDocumentWith(data, DefaultRewriteOptions())
+}
+
+// RewriteDocumentWith accepts explicit rewrite options.
+func RewriteDocumentWith(data []byte, opts RewriteOptions) ([]byte, bool, []Change, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return data, false, nil, fmt.Errorf("parse yaml: %w", err)
+	}
+	var allChanges []Change
+	changed := false
+	walkNode(&root, opts, &changed, &allChanges)
+	if !changed {
+		return data, false, nil, nil
+	}
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		return data, false, nil, fmt.Errorf("encode yaml: %w", err)
+	}
+	_ = enc.Close()
+	return buf.Bytes(), true, allChanges, nil
+}
+
+// walkNode recurses through the node tree, rewriting string values whose
+// mapping key is "query".
+func walkNode(n *yaml.Node, opts RewriteOptions, changed *bool, allChanges *[]Change) {
+	if n == nil {
+		return
+	}
+	switch n.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode:
+		for _, c := range n.Content {
+			walkNode(c, opts, changed, allChanges)
+		}
+	case yaml.MappingNode:
+		// Mapping content alternates key, value, key, value, ...
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			k := n.Content[i]
+			v := n.Content[i+1]
+			if k.Kind == yaml.ScalarNode && k.Value == "query" && v.Kind == yaml.ScalarNode && v.Value != "" {
+				rewritten, changes := Rewrite(v.Value, opts)
+				if len(changes) > 0 {
+					v.Value = rewritten
+					// Keep original style (literal/folded) so multiline queries
+					// do not collapse to a flow scalar on re-emit.
+					*changed = true
+					*allChanges = append(*allChanges, changes...)
+				}
+				continue
+			}
+			walkNode(v, opts, changed, allChanges)
+		}
+	}
+}

--- a/pkg/dqlcost/rewrite_document_test.go
+++ b/pkg/dqlcost/rewrite_document_test.go
@@ -1,0 +1,73 @@
+package dqlcost
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRewriteDocument_RewritesTileQueries(t *testing.T) {
+	in := []byte(`name: Test
+type: dashboard
+content:
+  tiles:
+    "1":
+      title: Errors
+      type: data
+      query: |
+        fetch logs | filter loglevel == "ERROR"
+`)
+	out, changed, changes, err := RewriteDocument(in)
+	if err != nil {
+		t.Fatalf("RewriteDocument: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if len(changes) == 0 {
+		t.Fatal("expected at least one change")
+	}
+	s := string(out)
+	if !strings.Contains(s, "from:now()-2h") {
+		t.Errorf("default from not injected:\n%s", s)
+	}
+	if !strings.Contains(s, "scanLimitGBytes:500") {
+		t.Errorf("scan limit not injected:\n%s", s)
+	}
+}
+
+func TestRewriteDocument_SkipsCleanDocument(t *testing.T) {
+	in := []byte(`name: Test
+type: dashboard
+content:
+  tiles:
+    "1":
+      type: data
+      query: |
+        fetch logs, from:now()-1h, scanLimitGBytes:50 | filter loglevel == "ERROR"
+`)
+	out, changed, _, err := RewriteDocument(in)
+	if err != nil {
+		t.Fatalf("RewriteDocument: %v", err)
+	}
+	if changed {
+		t.Errorf("clean doc should not be changed; got:\n%s", string(out))
+	}
+}
+
+func TestRewriteDocument_IgnoresNonQueryKeys(t *testing.T) {
+	in := []byte(`name: Test
+description: "something about query"
+content:
+  tiles:
+    "1":
+      type: markdown
+      content: "fetch logs | limit 10"
+`)
+	_, changed, _, err := RewriteDocument(in)
+	if err != nil {
+		t.Fatalf("RewriteDocument: %v", err)
+	}
+	if changed {
+		t.Error("non-query keys should not be rewritten")
+	}
+}

--- a/pkg/dqlcost/rewrite_test.go
+++ b/pkg/dqlcost/rewrite_test.go
@@ -1,0 +1,128 @@
+package dqlcost
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRewrite_AddsDefaultFrom(t *testing.T) {
+	in := `fetch logs | filter loglevel == "ERROR"`
+	out, changes := Rewrite(in, DefaultRewriteOptions())
+	if !strings.Contains(out, "from:now()-2h") {
+		t.Fatalf("missing default from: %s", out)
+	}
+	if !containsRule(changes, "COST001") {
+		t.Fatalf("expected COST001 change, got %+v", changes)
+	}
+}
+
+func TestRewrite_PreservesExistingFrom(t *testing.T) {
+	in := `fetch logs, from:now()-1h | filter loglevel == "ERROR"`
+	out, changes := Rewrite(in, DefaultRewriteOptions())
+	if containsRule(changes, "COST001") {
+		t.Fatalf("COST001 rewrite should not fire when from: is present: %+v", changes)
+	}
+	if strings.Count(out, "from:") != 1 {
+		t.Fatalf("duplicate from: in %s", out)
+	}
+}
+
+func TestRewrite_AddsScanLimit(t *testing.T) {
+	in := `fetch logs, from:now()-1h | filter loglevel == "ERROR"`
+	out, changes := Rewrite(in, DefaultRewriteOptions())
+	if !strings.Contains(out, "scanLimitGBytes:500") {
+		t.Fatalf("missing scanLimit: %s", out)
+	}
+	if !containsRule(changes, "COST008") {
+		t.Fatalf("expected COST008 change, got %+v", changes)
+	}
+}
+
+func TestRewrite_PreservesExistingScanLimit(t *testing.T) {
+	in := `fetch logs, from:now()-1h, scanLimitGBytes:50 | filter loglevel == "ERROR"`
+	out, changes := Rewrite(in, DefaultRewriteOptions())
+	if containsRule(changes, "COST008") {
+		t.Fatalf("COST008 rewrite should not fire when scanLimitGBytes is present: %+v", changes)
+	}
+	if strings.Count(out, "scanLimitGBytes:") != 1 {
+		t.Fatalf("duplicate scanLimitGBytes in %s", out)
+	}
+}
+
+func TestRewrite_DoesNotMoveLimitByDefault(t *testing.T) {
+	// Tenant measurement showed moving limit after summarize increases scan
+	// by ~40× because Grail short-circuits when limit appears early.
+	in := `fetch logs, from:now()-1h, scanLimitGBytes:50 | filter x == "y" | limit 100 | summarize c = count(), by:{loglevel}`
+	out, changes := Rewrite(in, DefaultRewriteOptions())
+	if containsRule(changes, "COST005") {
+		t.Fatalf("COST005 should not fire by default; got %+v", changes)
+	}
+	if out != in {
+		t.Fatalf("limit/summarize order should be preserved by default:\nin:  %s\nout: %s", in, out)
+	}
+}
+
+func TestRewrite_OptInMovesLimit(t *testing.T) {
+	// Still supported under explicit opt-in for edge cases where the caller
+	// genuinely wants an aggregate over the full dataset rather than a sample.
+	opts := DefaultRewriteOptions()
+	opts.MoveLimitAfter = true
+	in := `fetch logs, from:now()-1h, scanLimitGBytes:50 | filter x == "y" | limit 100 | summarize c = count(), by:{loglevel}`
+	out, changes := Rewrite(in, opts)
+	if !containsRule(changes, "COST005") {
+		t.Fatalf("expected COST005 change under opt-in, got %+v", changes)
+	}
+	sumIdx := strings.Index(out, "summarize")
+	limIdx := strings.Index(out, "limit 100")
+	if sumIdx > limIdx {
+		t.Fatalf("summarize should precede limit after rewrite: %s", out)
+	}
+}
+
+func TestRewrite_LeavesCanonicalQueryUnchanged(t *testing.T) {
+	in := `fetch logs, from:now()-1h, scanLimitGBytes:50 | filter loglevel == "ERROR" | summarize c = count() | limit 10`
+	out, changes := Rewrite(in, DefaultRewriteOptions())
+	if out != in {
+		t.Fatalf("clean query should not be rewritten:\nin:  %s\nout: %s", in, out)
+	}
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes, got %+v", changes)
+	}
+}
+
+func TestRewrite_TimeseriesUntouched(t *testing.T) {
+	// timeseries is free + already time-bound; rewriter should not touch it.
+	in := `timeseries avg(dt.host.cpu.usage), by:{dt.entity.host}, from:now()-1h`
+	out, changes := Rewrite(in, DefaultRewriteOptions())
+	if out != in {
+		t.Fatalf("timeseries query should be left alone:\nin:  %s\nout: %s", in, out)
+	}
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes, got %+v", changes)
+	}
+}
+
+func TestRewrite_OptInIndividualRules(t *testing.T) {
+	in := `fetch logs | filter loglevel == "ERROR"`
+	// Only AddDefaultFrom enabled.
+	opts := RewriteOptions{AddDefaultFrom: true, DefaultFrom: "now()-1h"}
+	out, changes := Rewrite(in, opts)
+	if !strings.Contains(out, "from:now()-1h") {
+		t.Fatalf("missing from: %s", out)
+	}
+	if strings.Contains(out, "scanLimitGBytes") {
+		t.Fatalf("scan limit should not have been added: %s", out)
+	}
+	if len(changes) != 1 || changes[0].Rule != "COST001" {
+		t.Fatalf("expected exactly one COST001 change, got %+v", changes)
+	}
+}
+
+func containsRule(changes []Change, rule string) bool {
+	for _, c := range changes {
+		if c.Rule == rule {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -91,6 +91,47 @@ type DQLExecuteOptions struct {
 
 	// Segment options
 	Segments []FilterSegmentRef // Filter segments to apply to the query
+
+	// Guardrail options
+	DisableGuardrails bool // When true, skip automatic injection of safe defaults (scan limit, etc.)
+}
+
+// GuardrailDefaults controls the automatic cost-safety values injected into
+// DQLQueryRequest when the caller leaves them unset. Tests and CLI flags can
+// override these. Zero values mean "leave the field unset in the request"
+// so the server's own defaults apply.
+type GuardrailDefaults struct {
+	ScanLimitGbytes  float64 // default 500 GiB hard ceiling on scanned data
+	MaxResultRecords int64   // 0 = defer to server default (no client-side injection)
+}
+
+// DefaultGuardrails is the package-level default set of cost guardrails.
+// Override via SetDefaultGuardrails (e.g. from config on CLI startup).
+// MaxResultRecords is 0 so client-side request body stays empty and the
+// server's own default applies — matches long-standing test expectations.
+var DefaultGuardrails = GuardrailDefaults{
+	ScanLimitGbytes:  500,
+	MaxResultRecords: 0,
+}
+
+// SetDefaultGuardrails replaces the package-level guardrail defaults. Safe
+// to call at startup. Not goroutine-safe during query execution.
+func SetDefaultGuardrails(g GuardrailDefaults) {
+	DefaultGuardrails = g
+}
+
+// applyGuardrailDefaults mutates opts in place, filling in the guardrail
+// fields when the caller has not set them. Honors opts.DisableGuardrails.
+func applyGuardrailDefaults(opts *DQLExecuteOptions) {
+	if opts == nil || opts.DisableGuardrails {
+		return
+	}
+	if opts.DefaultScanLimitGbytes == 0 && DefaultGuardrails.ScanLimitGbytes > 0 {
+		opts.DefaultScanLimitGbytes = DefaultGuardrails.ScanLimitGbytes
+	}
+	if opts.MaxResultRecords == 0 && DefaultGuardrails.MaxResultRecords > 0 {
+		opts.MaxResultRecords = DefaultGuardrails.MaxResultRecords
+	}
 }
 
 // DQLVerifyOptions configures DQL query verification
@@ -243,6 +284,8 @@ func (e *DQLExecutor) ExecuteQuery(query string) (*DQLQueryResponse, error) {
 
 // ExecuteQueryWithOptions executes a DQL query with options and returns the raw result
 func (e *DQLExecutor) ExecuteQueryWithOptions(query string, opts DQLExecuteOptions) (*DQLQueryResponse, error) {
+	applyGuardrailDefaults(&opts)
+
 	req := DQLQueryRequest{
 		Query:                      query,
 		RequestTimeoutMilliseconds: 60000, // Wait up to 60 seconds for results

--- a/pkg/exec/dql_guardrails_test.go
+++ b/pkg/exec/dql_guardrails_test.go
@@ -1,0 +1,56 @@
+package exec
+
+import "testing"
+
+func TestApplyGuardrailDefaults_FillsZeroValues(t *testing.T) {
+	saved := DefaultGuardrails
+	defer SetDefaultGuardrails(saved)
+	SetDefaultGuardrails(GuardrailDefaults{ScanLimitGbytes: 500})
+
+	opts := DQLExecuteOptions{}
+	applyGuardrailDefaults(&opts)
+	if opts.DefaultScanLimitGbytes != 500 {
+		t.Errorf("ScanLimit not filled: got %v", opts.DefaultScanLimitGbytes)
+	}
+}
+
+func TestApplyGuardrailDefaults_PreservesCallerValues(t *testing.T) {
+	saved := DefaultGuardrails
+	defer SetDefaultGuardrails(saved)
+	SetDefaultGuardrails(GuardrailDefaults{ScanLimitGbytes: 500})
+
+	opts := DQLExecuteOptions{DefaultScanLimitGbytes: 50}
+	applyGuardrailDefaults(&opts)
+	if opts.DefaultScanLimitGbytes != 50 {
+		t.Errorf("caller ScanLimit overwritten: got %v", opts.DefaultScanLimitGbytes)
+	}
+}
+
+func TestApplyGuardrailDefaults_HonorsDisable(t *testing.T) {
+	saved := DefaultGuardrails
+	defer SetDefaultGuardrails(saved)
+	SetDefaultGuardrails(GuardrailDefaults{ScanLimitGbytes: 500})
+
+	opts := DQLExecuteOptions{DisableGuardrails: true}
+	applyGuardrailDefaults(&opts)
+	if opts.DefaultScanLimitGbytes != 0 {
+		t.Errorf("DisableGuardrails ignored: %+v", opts)
+	}
+}
+
+func TestApplyGuardrailDefaults_LeavesMaxRecordsZero(t *testing.T) {
+	// Client-side should NOT auto-inject MaxResultRecords — server default wins.
+	saved := DefaultGuardrails
+	defer SetDefaultGuardrails(saved)
+	SetDefaultGuardrails(GuardrailDefaults{ScanLimitGbytes: 500, MaxResultRecords: 0})
+
+	opts := DQLExecuteOptions{}
+	applyGuardrailDefaults(&opts)
+	if opts.MaxResultRecords != 0 {
+		t.Errorf("MaxResultRecords should stay zero: got %v", opts.MaxResultRecords)
+	}
+}
+
+func TestApplyGuardrailDefaults_NilSafe(t *testing.T) {
+	applyGuardrailDefaults(nil) // must not panic
+}

--- a/test/dqlbench/README.md
+++ b/test/dqlbench/README.md
@@ -1,0 +1,47 @@
+# dqlbench — DQL cost regression harness
+
+Compares DQL produced by dtctl (via Davis CoPilot nl2dql, and as embedded in
+dashboard/notebook templates) against cost-quality expectations. v1 runs two
+modes:
+
+1. **Unit / snapshot mode** (no tenant required) — loads every fixture in
+   `fixtures/`, applies the `pkg/dqlcost` linter + rewriter, and asserts
+   that:
+   - The fixture's expected lint rule IDs (if any) fire.
+   - The rewritten query no longer trips any error-severity rule.
+   - The fixture's `expect.must_contain` / `must_not_contain` strings match.
+
+2. **Tenant mode** (`//go:build dqlbench`) — executes the fixture query via
+   `DQLExecutor.ExecuteQueryWithOptions(IncludeContributions=true,
+   MetadataFields=["all"])`, captures `GrailMetadata.ScannedBytes`, and
+   compares against `budget.max_scanned_bytes`. Writes a markdown report to
+   `reports/<ts>.md`.
+
+## Run
+
+```
+# Snapshot mode (no tenant)
+make test-dqlbench-unit
+
+# Tenant mode (requires DTCTL_INTEGRATION_ENV + DTCTL_INTEGRATION_TOKEN)
+make test-dqlbench
+```
+
+## Add a fixture
+
+Drop a YAML file into `fixtures/`:
+
+```yaml
+id: errors-last-24h
+description: "Errors by service over the last 24h"
+query: |
+  fetch logs | filter loglevel == "ERROR" | summarize c = count(), by:{dt.entity.service}
+expect_rules: [COST001, COST008]        # these should fire on the raw query
+after_rewrite_no_rules: [COST001, COST008]  # none of these should fire after Rewrite()
+must_contain: ["fetch logs"]
+must_not_contain: ["sort timestamp desc | filter"]
+budget:
+  max_scanned_bytes: 5_000_000_000
+```
+
+The harness walks `fixtures/` and runs one subtest per fixture.

--- a/test/dqlbench/fixtures/cost-optimized.yaml
+++ b/test/dqlbench/fixtures/cost-optimized.yaml
@@ -1,0 +1,14 @@
+id: cost-optimized
+description: "Canonical cost-optimized query — should produce zero error findings"
+query: |
+  fetch logs, from:now()-1h, scanLimitGBytes:50
+  | filter dt.system.bucket == "default_logs"
+  | filter loglevel == "ERROR"
+  | fieldsKeep timestamp, content, k8s.pod.name
+  | makeTimeseries c = count(), by:{k8s.pod.name}, from:now()-1h
+expect_rules: []
+after_rewrite_no_rules: [COST001, COST003, COST004, COST005, COST008, COST009]
+must_contain: ["fetch logs", "scanLimitGBytes"]
+must_not_contain: ["sort timestamp desc"]
+budget:
+  max_scanned_bytes: 1000000000

--- a/test/dqlbench/fixtures/errors-last-24h.yaml
+++ b/test/dqlbench/fixtures/errors-last-24h.yaml
@@ -1,0 +1,10 @@
+id: errors-last-24h
+description: "Errors by service — raw query lacks from: and scanLimit"
+query: |
+  fetch logs | filter loglevel == "ERROR" | summarize c = count(), by:{dt.entity.service}
+expect_rules: [COST001, COST008]
+after_rewrite_no_rules: [COST001, COST008]
+must_contain: ["fetch logs", "loglevel"]
+must_not_contain: []
+budget:
+  max_scanned_bytes: 5000000000

--- a/test/dqlbench/fixtures/log-timeseries-7d.yaml
+++ b/test/dqlbench/fixtures/log-timeseries-7d.yaml
@@ -1,0 +1,10 @@
+id: log-timeseries-7d
+description: "Week-long log timeseries — should trip long-window rule"
+query: |
+  fetch logs, from:now()-7d | makeTimeseries c = count(), interval:1h
+expect_rules: [COST002, COST008, COST009]
+after_rewrite_no_rules: [COST008]
+must_contain: ["makeTimeseries"]
+must_not_contain: []
+budget:
+  max_scanned_bytes: 20000000000

--- a/test/dqlbench/harness/bench_test.go
+++ b/test/dqlbench/harness/bench_test.go
@@ -1,0 +1,96 @@
+//go:build dqlbench
+// +build dqlbench
+
+package harness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	"github.com/dynatrace-oss/dtctl/pkg/dqlcost"
+	"github.com/dynatrace-oss/dtctl/pkg/exec"
+)
+
+// TestFixtures_TenantBench executes each fixture against a live Dynatrace
+// tenant, records ScannedBytes for both the raw query and the cost-rewritten
+// query, and writes a markdown comparison report under ../reports/.
+//
+// Gated behind build tag `dqlbench` so normal unit runs don't hit the API.
+func TestFixtures_TenantBench(t *testing.T) {
+	envURL := os.Getenv("DTCTL_INTEGRATION_ENV")
+	token := os.Getenv("DTCTL_INTEGRATION_TOKEN")
+	if envURL == "" || token == "" {
+		t.Skip("DTCTL_INTEGRATION_ENV / DTCTL_INTEGRATION_TOKEN not set")
+	}
+
+	fixtures, err := LoadFixtures(fixturesDir(t))
+	if err != nil {
+		t.Fatalf("LoadFixtures: %v", err)
+	}
+
+	c, err := client.New(envURL, token)
+	if err != nil {
+		t.Fatalf("client.New: %v", err)
+	}
+	ex := exec.NewDQLExecutor(c)
+
+	reportDir, err := filepath.Abs("../reports")
+	if err != nil {
+		t.Fatalf("resolve reports dir: %v", err)
+	}
+	_ = os.MkdirAll(reportDir, 0o755)
+	reportPath := filepath.Join(reportDir, fmt.Sprintf("%s.md", time.Now().UTC().Format("20060102T150405Z")))
+
+	f, err := os.Create(reportPath)
+	if err != nil {
+		t.Fatalf("create report: %v", err)
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, "# dqlbench report — %s\n\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintf(f, "| fixture | raw scanned bytes | rewritten scanned bytes | Δ%% | budget ok |\n")
+	fmt.Fprintf(f, "|---------|-------------------|-------------------------|----|-----------|\n")
+
+	opts := exec.DQLExecuteOptions{
+		IncludeContributions: true,
+		MetadataFields:       []string{"all"},
+		MaxResultRecords:     100,
+	}
+
+	for _, fx := range fixtures {
+		t.Run(fx.ID, func(t *testing.T) {
+			rawBytes, _ := runOne(ex, fx.Query, opts)
+			rewritten, _ := dqlcost.Rewrite(fx.Query, dqlcost.DefaultRewriteOptions())
+			rewrittenBytes, _ := runOne(ex, rewritten, opts)
+
+			delta := "n/a"
+			if rawBytes > 0 {
+				delta = fmt.Sprintf("%.1f%%", 100.0*float64(rewrittenBytes-rawBytes)/float64(rawBytes))
+			}
+			budgetOK := "n/a"
+			if fx.Budget.MaxScannedBytes > 0 {
+				if rewrittenBytes <= fx.Budget.MaxScannedBytes {
+					budgetOK = "yes"
+				} else {
+					budgetOK = "no"
+					t.Errorf("budget exceeded: rewritten scan %d > budget %d", rewrittenBytes, fx.Budget.MaxScannedBytes)
+				}
+			}
+			fmt.Fprintf(f, "| %s | %d | %d | %s | %s |\n", fx.ID, rawBytes, rewrittenBytes, delta, budgetOK)
+		})
+	}
+
+	t.Logf("report written to %s", reportPath)
+}
+
+func runOne(ex *exec.DQLExecutor, query string, opts exec.DQLExecuteOptions) (int64, error) {
+	resp, err := ex.ExecuteQueryWithOptions(query, opts)
+	if err != nil || resp == nil || resp.Result == nil || resp.Result.Metadata == nil || resp.Result.Metadata.Grail == nil {
+		return 0, err
+	}
+	return resp.Result.Metadata.Grail.ScannedBytes, nil
+}

--- a/test/dqlbench/harness/harness.go
+++ b/test/dqlbench/harness/harness.go
@@ -1,0 +1,59 @@
+// Package harness loads dqlbench fixtures and evaluates dtctl's DQL
+// cost-lint + rewriter behavior against expectations. v1 is snapshot-only
+// (no tenant); the tenant mode under build tag `dqlbench` adds
+// ScannedBytes measurement.
+package harness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Fixture is one prompt/query test case.
+type Fixture struct {
+	ID                   string   `yaml:"id"`
+	Description          string   `yaml:"description"`
+	Query                string   `yaml:"query"`
+	ExpectRules          []string `yaml:"expect_rules"`
+	AfterRewriteNoRules  []string `yaml:"after_rewrite_no_rules"`
+	MustContain          []string `yaml:"must_contain"`
+	MustNotContain       []string `yaml:"must_not_contain"`
+	Budget               struct {
+		MaxScannedBytes int64 `yaml:"max_scanned_bytes"`
+	} `yaml:"budget"`
+}
+
+// LoadFixtures reads every *.yaml under dir, returning one Fixture per file,
+// sorted by ID.
+func LoadFixtures(dir string) ([]Fixture, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read fixtures dir: %w", err)
+	}
+	var out []Fixture
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		var f Fixture
+		if err := yaml.Unmarshal(data, &f); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		if f.ID == "" {
+			return nil, fmt.Errorf("fixture %s missing id", path)
+		}
+		out = append(out, f)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}

--- a/test/dqlbench/harness/harness_test.go
+++ b/test/dqlbench/harness/harness_test.go
@@ -1,0 +1,72 @@
+package harness
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/dqlcost"
+)
+
+// fixturesDir returns the absolute path to the sibling fixtures/ directory.
+// Using a relative path lets the test run from any working dir.
+func fixturesDir(t *testing.T) string {
+	t.Helper()
+	p, err := filepath.Abs("../fixtures")
+	if err != nil {
+		t.Fatalf("resolve fixtures dir: %v", err)
+	}
+	return p
+}
+
+func TestFixtures_Snapshot(t *testing.T) {
+	fixtures, err := LoadFixtures(fixturesDir(t))
+	if err != nil {
+		t.Fatalf("LoadFixtures: %v", err)
+	}
+	if len(fixtures) == 0 {
+		t.Fatal("no fixtures loaded")
+	}
+
+	for _, f := range fixtures {
+		t.Run(f.ID, func(t *testing.T) {
+			// 1. Expected-rule assertions on raw query.
+			findings := dqlcost.Lint(f.Query)
+			for _, want := range f.ExpectRules {
+				if !hasRule(findings, want) {
+					t.Errorf("expected rule %s to fire on raw query, got %+v", want, findings)
+				}
+			}
+
+			// 2. Rewrite then re-lint; specified rules must no longer fire.
+			rewritten, _ := dqlcost.Rewrite(f.Query, dqlcost.DefaultRewriteOptions())
+			post := dqlcost.Lint(rewritten)
+			for _, bad := range f.AfterRewriteNoRules {
+				if hasRule(post, bad) {
+					t.Errorf("rule %s should NOT fire after rewrite; query=%q findings=%+v", bad, rewritten, post)
+				}
+			}
+
+			// 3. must_contain / must_not_contain on raw query.
+			for _, s := range f.MustContain {
+				if !strings.Contains(f.Query, s) {
+					t.Errorf("query missing must_contain %q", s)
+				}
+			}
+			for _, s := range f.MustNotContain {
+				if strings.Contains(f.Query, s) {
+					t.Errorf("query contains forbidden %q", s)
+				}
+			}
+		})
+	}
+}
+
+func hasRule(findings []dqlcost.Finding, rule string) bool {
+	for _, f := range findings {
+		if f.Rule == rule {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds DQL execution guardrails to `pkg/exec/dql.go` (500 GiB scan ceiling auto-applied by default, `--no-guardrails` opt-out on `dtctl query`) and a `test/dqlbench/` regression harness for ongoing before/after cost measurement.

**Based on #177** (linter + CLI wiring) — the harness imports `pkg/dqlcost` to verify that linted queries actually produce cleaner findings after the rewriter runs. Please merge #176 → #177 → this PR in order.

Refs: #175

## Why

Two complementary gaps left after #176 and #177:

1. **No client-side cost ceiling.** `DQLExecuteOptions.DefaultScanLimitGbytes` exists as an opt-in knob but is unset by default, so a runaway query (bad filter, missing `from:`, unexpectedly wide bucket) has no client-side brake. When the query is being built by an LLM from a user prompt, this is exactly the failure mode that hits production dashboards.
2. **No ongoing regression coverage.** Without a fixture-based harness, severity calibrations and rewriter defaults drift relative to real tenant cost characteristics. (The measurement that saved us from shipping an incorrect COST005 rewrite in #177 is a good example.)

## What changed

### `pkg/exec/dql.go` — `GuardrailDefaults`

```go
type GuardrailDefaults struct {
    ScanLimitGbytes  float64 // default 500 GiB ceiling on scanned data
    MaxResultRecords int64   // 0 = defer to server default
}

var DefaultGuardrails = GuardrailDefaults{ScanLimitGbytes: 500}
func SetDefaultGuardrails(g GuardrailDefaults) { ... }
func applyGuardrailDefaults(opts *DQLExecuteOptions) { ... }
```

- Runs at the top of `ExecuteQueryWithOptions`.
- Fills in `DefaultScanLimitGbytes` only when the caller passed 0 (preserves explicit caller values).
- Honors `opts.DisableGuardrails` — opt-out for power users.
- `MaxResultRecords` intentionally left at 0 so the server's own default continues to apply (matches long-standing test expectations; no behavior change for integrations that rely on server defaults).

### `cmd/query.go` — `--no-guardrails`

- New boolean flag on `dtctl query`.
- Help text on `--default-scan-limit-gbytes` updated to mention the 500 GiB auto-applied default.
- No other flags changed; existing behavior preserved.

### `test/dqlbench/` — regression harness

- **Fixture YAML schema** — one file per prompt/query with `expect_rules`, `after_rewrite_no_rules`, `must_contain`, `must_not_contain`, `budget.max_scanned_bytes`.
- **Snapshot mode** (`make test-dqlbench-unit`, no tenant required) — loads every fixture, runs `dqlcost.Lint` on the raw query, asserts expected rules fire; runs `dqlcost.Rewrite` and re-lints, asserts specified rules no longer fire.
- **Tenant mode** (`make test-dqlbench`, `//go:build dqlbench`) — executes each fixture via `DQLExecutor.ExecuteQueryWithOptions(IncludeContributions=true, MetadataFields=["all"])`, captures `GrailMetadata.ScannedBytes` for raw and rewritten forms, writes a timestamped markdown comparison report to `test/dqlbench/reports/<ts>.md`. Budget assertion fires when rewritten scan exceeds `budget.max_scanned_bytes`.
- **Three seed fixtures**: `errors-last-24h` (missing `from:`/scanLimit), `log-timeseries-7d` (wrong shape — should use metric), `cost-optimized` (gold path, should produce zero findings).
- **Makefile targets**: `test-dqlbench-unit` and `test-dqlbench` (the latter reuses the existing `.integrationtests.env` / `DTCTL_INTEGRATION_*` env var pattern already used by `test-integration`).
- **`.gitignore`**: `test/dqlbench/reports/` excluded (generated artifacts).

## Tests in place

- **`pkg/exec` unit tests**: four new test cases in `dql_guardrails_test.go` covering fill-zero, preserve-caller-values, honor-disable, and nil-safe paths. Package regression suite (`TestDQLExecutor_ExecuteQueryWithOptions_CustomHeaders` and related) unchanged — all existing expectations preserved.
- **Harness snapshot tests**: 3 seed fixtures, 1 subtest each, all green.
- **Tenant mode** was used manually against a production tenant to validate rule severities and the rewriter's default behavior (see #175 for the ratio table). The COST005 correction in #177 is a direct result of this flow.
- `go build ./...`, `go test ./pkg/exec/... ./pkg/dqlcost/... ./test/dqlbench/harness/...` all clean.

## Benefits

**For Dynatrace customers:**
- 500 GiB auto-applied scan ceiling protects against runaway DPS charges from mistyped filters, forgotten `from:` clauses, and LLM-generated DQL with bad shape — without requiring every dtctl user to remember the existing opt-in flag.
- `--no-guardrails` preserves power-user workflows (exports, backfills, ad-hoc analytics) — no regression for existing scripts.
- The harness makes it possible for customer teams to capture their own tenant's before/after cost profile and validate internally before deploying dashboard changes.

**For Dynatrace:**
- The harness is the missing accountability layer for future rule additions and rewriter tweaks — changes can be validated against real tenant scan metadata, not just theory.
- Goes well with #176 (docs) and #177 (linter/rewriter): customers get documentation, tooling, runtime guardrails, and a regression harness as a coherent package.
- Execution guardrails also shield Dynatrace's own infrastructure from accidental very-large scans originating from dtctl — secondary benefit.

## Test plan

- [x] `go test ./pkg/exec/...` — existing + new guardrail tests pass
- [x] `make test-dqlbench-unit` — 3 fixtures green
- [x] `dtctl query 'fetch logs, from:now()-5m | limit 1' --agent` — scanned bytes metadata visible
- [x] `dtctl query 'fetch logs, from:now()-5m | limit 1' --no-guardrails --agent` — flag accepted; no guardrail in request body
- [ ] Reviewers decide whether 500 GiB is the right default ceiling or should be tenant/config-driven
- [ ] Reviewers review `test/dqlbench/` layout, naming conventions, and whether the harness should live under `test/e2e/` instead
