### PR TITLE
fix: register token-scopes help topic command

### DIFF
--- a/cmd/help_topics.go
+++ b/cmd/help_topics.go
@@ -1,0 +1,36 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func init() {
+	rootCmd.AddCommand(tokenScopesHelpTopicCmd)
+}
+
+// tokenScopesHelpTopicCmd is a help-topic-only command (no Run function).
+// It makes "dtctl help token-scopes" work as advertised in error messages.
+var tokenScopesHelpTopicCmd = &cobra.Command{
+	Use:   "token-scopes",
+	Short: "Required token scopes for each safety level",
+	Long: `Token Scopes Reference
+
+Lists the Dynatrace platform token scopes required for each dtctl safety level.
+Copy the scope list for your desired safety level when creating a token in Dynatrace.
+
+Note: Safety levels are client-side only. The token scopes you configure in
+Dynatrace are what actually controls access. Configure your tokens with the
+minimum required scopes for your use case.
+
+Quick Reference:
+
+  Safety Level                Use Case                                Token Type
+  readonly                    Production monitoring, troubleshooting  Read-only token
+  readwrite-mine              Personal development, sandbox           Standard token
+  readwrite-all               Team environments, administration       Standard token
+  dangerously-unrestricted    Dev environments, bucket management     Full access token
+
+For the full list of scopes per safety level, see:
+  https://dtctl.dev/docs/token-scopes/
+
+For creating platform tokens, see:
+  https://docs.dynatrace.com/docs/manage/identity-access-management/access-tokens-and-oauth-clients/platform-tokens`,
+}


### PR DESCRIPTION
## Summary

- Registers a `token-scopes` Cobra help-topic command so `dtctl help token-scopes` works as advertised in error messages
- Displays a summary of required token scopes per safety level with links to full documentation

Fixes #156