### PR TITLE
fix: support array input in apply for bulk resource updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`apply` now accepts array input for bulk resource updates** — `dtctl apply -f` can now process files containing arrays of resources (e.g., the output of `dtctl get settings --schema ... -o yaml`); each element is applied individually with per-item error reporting so a single failure does not abort the batch; works for all resource types, not just settings; fixes [#180](https://github.com/dynatrace-oss/dtctl/issues/180)
+
 ## [0.25.0] - 2026-04-20
 
 ### Added

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -63,6 +63,11 @@ Supported resource types:
   - Settings objects
   - Extension monitoring configurations
 
+Array input (bulk apply):
+  Files containing an array of resources (e.g., from 'dtctl get settings --schema ...
+  -o yaml') are applied element-by-element. Partial failures do not abort the batch;
+  successful results are printed and a summary error reports any failures.
+
 Examples:
   # Create a new dashboard and stamp the ID back into the file
   dtctl apply -f dashboard.yaml --write-id
@@ -82,6 +87,11 @@ Examples:
   dtctl get settings <objectId> -o yaml > setting.yaml
   # Edit setting.yaml (modify the 'value' field)...
   dtctl apply -f setting.yaml  # Updates the existing setting
+
+  # Bulk update settings (round-trip from get --schema)
+  dtctl get settings --schema builtin:rum.web.enablement -o yaml > rum-settings.yaml
+  # Edit rum-settings.yaml (modify values for specific applications)...
+  dtctl apply -f rum-settings.yaml  # Updates all settings in the file
 
   # Apply with template variables
   dtctl apply -f dashboard.yaml --set environment=prod --set owner=team-a
@@ -175,9 +185,12 @@ resources in sync with their file definitions.
 			WriteID:      writeID,
 		}
 
-		results, err := applier.Apply(fileData, opts)
-		if err != nil {
-			return err
+		results, applyErr := applier.Apply(fileData, opts)
+
+		// For ListApplyError (partial batch failure), we still want to print
+		// the successful results before returning the error.
+		if applyErr != nil && len(results) == 0 {
+			return applyErr
 		}
 
 		// Run environment sharing before printing so per-document "Shared X" stderr
@@ -231,7 +244,7 @@ resources in sync with their file definitions.
 		if shareErr != nil {
 			return fmt.Errorf("apply succeeded but environment share failed: %w", shareErr)
 		}
-		return nil
+		return applyErr
 	},
 }
 

--- a/docs/dev/APPLY_TYPE_DETECTION.md
+++ b/docs/dev/APPLY_TYPE_DETECTION.md
@@ -62,6 +62,19 @@ When adding new resources:
 - **Order matters**: Detection checks run sequentially; ambiguous fields may match wrong type
 - **API validation only**: Invalid resource structure is caught by API, not detection
 
+## Array Input
+
+`dtctl apply` accepts both single objects and arrays. When the input is a JSON/YAML array:
+
+1. `detectResourceType()` detects the array, inspects the **first element** to determine the resource type, and returns `isArray=true`
+2. `applyList()` splits the array into individual elements and calls `applySingle()` for each
+3. Partial failures do not abort the batch — successful results are collected alongside errors
+4. A `ListApplyError` reports how many items failed out of the total
+
+This enables round-trip workflows: `dtctl get settings --schema X -o yaml > file.yaml` → edit → `dtctl apply -f file.yaml`.
+
+The `--id` flag is rejected for array input (ambiguous: which element gets the ID?).
+
 ---
 
 **Implementation**: `pkg/apply/applier.go:108-208` | **Tests**: `pkg/apply/applier_test.go`

--- a/docs/site/_docs/settings.md
+++ b/docs/site/_docs/settings.md
@@ -105,6 +105,22 @@ dtctl get settings --schema builtin:openpipeline.logs.pipelines --scope environm
 dtctl apply -f pipeline.yaml
 ```
 
+### Bulk updates
+
+When listing settings by schema, the output is an array of settings objects. This array can be edited and applied back directly:
+
+```bash
+# Export all RUM settings
+dtctl get settings --schema builtin:rum.web.enablement -o yaml > rum-settings.yaml
+
+# Edit rum-settings.yaml (modify values for specific applications)...
+
+# Apply all changes in one command
+dtctl apply -f rum-settings.yaml
+```
+
+Each item is applied individually. If some items fail, the successful ones are still applied and a summary error reports the failures.
+
 The version is automatically handled when using `dtctl apply` with a file that was previously retrieved via `dtctl get`.
 
 ## Deleting Settings Objects

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -140,9 +140,14 @@ func (a *Applier) Apply(fileData []byte, opts ApplyOptions) ([]ApplyResult, erro
 	}
 
 	// Detect resource type
-	resourceType, err := detectResourceType(jsonData)
+	resourceType, isArray, err := detectResourceType(jsonData)
 	if err != nil {
 		return nil, err
+	}
+
+	// Array input: split into individual elements and apply each one
+	if isArray {
+		return a.applyList(resourceType, jsonData, opts)
 	}
 
 	// Inject override ID if provided via --id flag.
@@ -184,6 +189,14 @@ func (a *Applier) Apply(fileData []byte, opts ApplyOptions) ([]ApplyResult, erro
 		return []ApplyResult{result}, nil
 	}
 
+	return a.applySingle(resourceType, jsonData, opts)
+}
+
+// applySingle applies a single resource object and returns the result.
+func (a *Applier) applySingle(resourceType ResourceType, jsonData []byte, opts ApplyOptions) ([]ApplyResult, error) {
+	var result ApplyResult
+	var err error
+
 	// Connection resources can return multiple results
 	switch resourceType {
 	case ResourceAzureConnection:
@@ -195,7 +208,6 @@ func (a *Applier) Apply(fileData []byte, opts ApplyOptions) ([]ApplyResult, erro
 	}
 
 	// Apply single-result resource types
-	var result ApplyResult
 	switch resourceType {
 	case ResourceWorkflow:
 		result, err = a.applyWorkflow(jsonData, opts)
@@ -228,57 +240,130 @@ func (a *Applier) Apply(fileData []byte, opts ApplyOptions) ([]ApplyResult, erro
 	return []ApplyResult{result}, nil
 }
 
-// detectResourceType determines the resource type from JSON data
-func detectResourceType(data []byte) (ResourceType, error) {
-	// Check for array (Azure Connection list)
-	if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
-		var rawList []map[string]interface{}
-		if err := json.Unmarshal(data, &rawList); err == nil && len(rawList) > 0 {
-			if schema, ok := rawList[0]["schemaId"].(string); ok && schema == azureconnection.SchemaID {
-				return ResourceAzureConnection, nil
-			}
-			if schema, ok := rawList[0]["schemaId"].(string); ok && schema == gcpconnection.SchemaID {
-				return ResourceGCPConnection, nil
+// applyList splits a JSON array into individual elements and applies each one.
+// It continues on error, collecting all results and returning a combined error
+// summary so that a single failure does not abort the entire batch.
+func (a *Applier) applyList(resourceType ResourceType, data []byte, opts ApplyOptions) ([]ApplyResult, error) {
+	// --id flag makes no sense for arrays (which element gets the ID?)
+	if opts.OverrideID != "" {
+		return nil, fmt.Errorf("--id flag cannot be used with array input (array contains %s resources)", resourceType)
+	}
+
+	var elements []json.RawMessage
+	if err := json.Unmarshal(data, &elements); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON array: %w", err)
+	}
+
+	// Run pre-apply hook once on the full array (if configured and not skipped)
+	if !opts.NoHooks && a.preApplyHook != "" {
+		result, err := hook.RunPreApply(
+			context.Background(),
+			a.preApplyHook,
+			string(resourceType),
+			a.sourceFile,
+			data,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if result.ExitCode != 0 {
+			return nil, &HookRejectedError{
+				Command:  a.preApplyHook,
+				ExitCode: result.ExitCode,
+				Stderr:   result.Stderr,
 			}
 		}
 	}
 
+	var results []ApplyResult
+	var errors []string
+
+	for i, elem := range elements {
+		if opts.DryRun {
+			r, err := a.dryRun(resourceType, elem)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("item %d: %s", i+1, err))
+				continue
+			}
+			results = append(results, r)
+			continue
+		}
+
+		itemResults, err := a.applySingle(resourceType, elem, opts)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("item %d: %s", i+1, err))
+			continue
+		}
+		results = append(results, itemResults...)
+	}
+
+	if len(errors) > 0 {
+		return results, &ListApplyError{
+			Total:    len(elements),
+			Failed:   len(errors),
+			Messages: errors,
+		}
+	}
+
+	return results, nil
+}
+
+// detectResourceType determines the resource type from JSON data.
+// Returns the resource type and whether the input is an array of resources.
+func detectResourceType(data []byte) (ResourceType, bool, error) {
+	// Check for array input
+	if bytes.HasPrefix(bytes.TrimSpace(data), []byte("[")) {
+		var rawList []json.RawMessage
+		if err := json.Unmarshal(data, &rawList); err != nil {
+			return ResourceUnknown, false, fmt.Errorf("failed to parse JSON array: %w", err)
+		}
+		if len(rawList) == 0 {
+			return ResourceUnknown, false, fmt.Errorf("empty array: cannot detect resource type")
+		}
+		// Detect type from the first element
+		elemType, _, err := detectResourceType(rawList[0])
+		if err != nil {
+			return ResourceUnknown, false, fmt.Errorf("cannot detect resource type from array element: %w", err)
+		}
+		return elemType, true, nil
+	}
+
 	var raw map[string]interface{}
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return ResourceUnknown, fmt.Errorf("failed to parse JSON: %w", err)
+		return ResourceUnknown, false, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
 	// Azure Connection detection (single object)
 	if schema, ok := raw["schemaId"].(string); ok && schema == azureconnection.SchemaID {
-		return ResourceAzureConnection, nil
+		return ResourceAzureConnection, false, nil
 	}
 	if schema, ok := raw["schemaId"].(string); ok && schema == gcpconnection.SchemaID {
-		return ResourceGCPConnection, nil
+		return ResourceGCPConnection, false, nil
 	}
 	// Anomaly Detector detection (raw Settings format)
 	if schema, ok := raw["schemaId"].(string); ok && schema == anomalydetector.SchemaID {
-		return ResourceAnomalyDetector, nil
+		return ResourceAnomalyDetector, false, nil
 	}
 
 	// Azure Monitoring Config detection
 	if scope, ok := raw["scope"].(string); ok && scope == "integration-azure" {
-		return ResourceAzureMonitoringConfig, nil
+		return ResourceAzureMonitoringConfig, false, nil
 	}
 
 	// GCP Monitoring Config detection
 	if scope, ok := raw["scope"].(string); ok && scope == "integration-gcp" {
-		return ResourceGCPMonitoringConfig, nil
+		return ResourceGCPMonitoringConfig, false, nil
 	}
 
 	// Check for explicit type field
 	if typeField, ok := raw["type"].(string); ok {
 		switch typeField {
 		case "dashboard":
-			return ResourceDashboard, nil
+			return ResourceDashboard, false, nil
 		case "notebook":
-			return ResourceNotebook, nil
+			return ResourceNotebook, false, nil
 		case "extension_monitoring_config":
-			return ResourceExtensionConfig, nil
+			return ResourceExtensionConfig, false, nil
 		}
 	}
 
@@ -286,7 +371,7 @@ func detectResourceType(data []byte) (ResourceType, error) {
 	// Workflows have "tasks" and "trigger" fields
 	if _, hasTasks := raw["tasks"]; hasTasks {
 		if _, hasTrigger := raw["trigger"]; hasTrigger {
-			return ResourceWorkflow, nil
+			return ResourceWorkflow, false, nil
 		}
 	}
 
@@ -295,31 +380,31 @@ func detectResourceType(data []byte) (ResourceType, error) {
 		// Further distinguish between dashboard and notebook
 		if typeField, ok := raw["type"].(string); ok {
 			if typeField == "dashboard" {
-				return ResourceDashboard, nil
+				return ResourceDashboard, false, nil
 			}
 			if typeField == "notebook" {
-				return ResourceNotebook, nil
+				return ResourceNotebook, false, nil
 			}
 		}
-		return ResourceDashboard, nil // Default to dashboard for documents
+		return ResourceDashboard, false, nil // Default to dashboard for documents
 	}
 
 	// Check for direct content format (tiles for dashboard, sections for notebook)
 	if _, hasTiles := raw["tiles"]; hasTiles {
-		return ResourceDashboard, nil
+		return ResourceDashboard, false, nil
 	}
 	if _, hasSections := raw["sections"]; hasSections {
-		return ResourceNotebook, nil
+		return ResourceNotebook, false, nil
 	}
 
 	// Also check for "content" field which contains the actual document
 	if content, hasContent := raw["content"]; hasContent {
 		if contentMap, ok := content.(map[string]interface{}); ok {
 			if _, hasTiles := contentMap["tiles"]; hasTiles {
-				return ResourceDashboard, nil
+				return ResourceDashboard, false, nil
 			}
 			if _, hasSections := contentMap["sections"]; hasSections {
-				return ResourceNotebook, nil
+				return ResourceNotebook, false, nil
 			}
 		}
 	}
@@ -329,14 +414,14 @@ func detectResourceType(data []byte) (ResourceType, error) {
 		if _, hasName := raw["name"]; hasName {
 			// Check for SLO-specific fields
 			if _, hasCustomSli := raw["customSli"]; hasCustomSli {
-				return ResourceSLO, nil
+				return ResourceSLO, false, nil
 			}
 			if _, hasSliRef := raw["sliReference"]; hasSliRef {
-				return ResourceSLO, nil
+				return ResourceSLO, false, nil
 			}
 			// If it has criteria and name but no tasks/trigger, it's likely an SLO
 			if _, hasTasks := raw["tasks"]; !hasTasks {
-				return ResourceSLO, nil
+				return ResourceSLO, false, nil
 			}
 		}
 	}
@@ -344,7 +429,7 @@ func detectResourceType(data []byte) (ResourceType, error) {
 	// Buckets have "bucketName" and "table" fields
 	if _, hasBucketName := raw["bucketName"]; hasBucketName {
 		if _, hasTable := raw["table"]; hasTable {
-			return ResourceBucket, nil
+			return ResourceBucket, false, nil
 		}
 	}
 
@@ -363,23 +448,23 @@ func detectResourceType(data []byte) (ResourceType, error) {
 	if hasSchemaID {
 		if schemaIDValue == azureconnection.SchemaID {
 			// This is a single Azure Connection (credential), not a list
-			return ResourceAzureConnection, nil
+			return ResourceAzureConnection, false, nil
 		}
 		if schemaIDValue == gcpconnection.SchemaID {
-			return ResourceGCPConnection, nil
+			return ResourceGCPConnection, false, nil
 		}
 		if schemaIDValue == anomalydetector.SchemaID {
-			return ResourceAnomalyDetector, nil
+			return ResourceAnomalyDetector, false, nil
 		}
 		if _, hasScope := raw["scope"]; hasScope {
 			if _, hasValue := raw["value"]; hasValue {
 				if scope, ok := raw["scope"].(string); ok && scope == "integration-gcp" {
-					return ResourceGCPMonitoringConfig, nil
+					return ResourceGCPMonitoringConfig, false, nil
 				}
 				if scope, ok := raw["scope"].(string); ok && scope == "integration-azure" {
-					return ResourceAzureMonitoringConfig, nil
+					return ResourceAzureMonitoringConfig, false, nil
 				}
-				return ResourceSettings, nil
+				return ResourceSettings, false, nil
 			}
 		}
 	}
@@ -389,7 +474,7 @@ func detectResourceType(data []byte) (ResourceType, error) {
 		if _, hasEventTemplate := raw["eventTemplate"]; hasEventTemplate {
 			if analyzerMap, ok := analyzerRaw.(map[string]interface{}); ok {
 				if _, hasName := analyzerMap["name"]; hasName {
-					return ResourceAnomalyDetector, nil
+					return ResourceAnomalyDetector, false, nil
 				}
 			}
 		}
@@ -399,7 +484,7 @@ func detectResourceType(data []byte) (ResourceType, error) {
 	// We also check for "name" since it's required, and exclude known overlapping resources.
 	if _, hasIncludes := raw["includes"]; hasIncludes {
 		if _, hasIsPublic := raw["isPublic"]; hasIsPublic {
-			return ResourceSegment, nil
+			return ResourceSegment, false, nil
 		}
 		// Fallback: "includes" + "name" without workflow/bucket/SLO markers
 		if _, hasName := raw["name"]; hasName {
@@ -407,12 +492,12 @@ func detectResourceType(data []byte) (ResourceType, error) {
 			_, hasBucketName := raw["bucketName"]
 			_, hasCriteria := raw["criteria"]
 			if !hasTasks && !hasBucketName && !hasCriteria {
-				return ResourceSegment, nil
+				return ResourceSegment, false, nil
 			}
 		}
 	}
 
-	return ResourceUnknown, fmt.Errorf("could not detect resource type from file content")
+	return ResourceUnknown, false, fmt.Errorf("could not detect resource type from file content")
 }
 
 // dryRun validates what would be applied without actually applying.

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -14,10 +14,11 @@ import (
 
 func TestDetectResourceType(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected ResourceType
-		wantErr  bool
+		name      string
+		input     string
+		expected  ResourceType
+		wantArray bool
+		wantErr   bool
 	}{
 		{
 			name: "dashboard with tiles at root",
@@ -140,17 +141,56 @@ func TestDetectResourceType(t *testing.T) {
 			expected: ResourceUnknown,
 			wantErr:  true,
 		},
+		// Array detection tests — regression for #180
+		{
+			name: "array of settings objects",
+			input: `[
+				{"schemaId": "builtin:rum.web.enablement", "scope": "APPLICATION-123", "value": {"enabled": true}},
+				{"schemaId": "builtin:rum.web.enablement", "scope": "APPLICATION-456", "value": {"enabled": false}}
+			]`,
+			expected:  ResourceSettings,
+			wantArray: true,
+		},
+		{
+			name: "array of workflows",
+			input: `[
+				{"tasks": {"t1": {}}, "trigger": {"type": "event"}},
+				{"tasks": {"t2": {}}, "trigger": {"type": "schedule"}}
+			]`,
+			expected:  ResourceWorkflow,
+			wantArray: true,
+		},
+		{
+			name: "array of SLOs",
+			input: `[
+				{"name": "SLO 1", "criteria": {"threshold": 95}, "customSli": {"enabled": true}},
+				{"name": "SLO 2", "criteria": {"threshold": 99}, "customSli": {"enabled": true}}
+			]`,
+			expected:  ResourceSLO,
+			wantArray: true,
+		},
+		{
+			name:     "empty array",
+			input:    `[]`,
+			expected: ResourceUnknown,
+			wantErr:  true,
+		},
+		{
+			name:     "array of unknown objects",
+			input:    `[{"random": "field"}]`,
+			expected: ResourceUnknown,
+			wantErr:  true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Validate JSON
-			var testJSON map[string]interface{}
-			if err := json.Unmarshal([]byte(tt.input), &testJSON); err != nil {
-				t.Fatalf("test input is not valid JSON: %v", err)
+			// Validate JSON (accept both objects and arrays)
+			if !json.Valid([]byte(tt.input)) && !tt.wantErr {
+				t.Fatalf("test input is not valid JSON: %s", tt.input)
 			}
 
-			result, err := detectResourceType([]byte(tt.input))
+			result, isArray, err := detectResourceType([]byte(tt.input))
 
 			if tt.wantErr {
 				if err == nil {
@@ -164,6 +204,9 @@ func TestDetectResourceType(t *testing.T) {
 
 			if result != tt.expected {
 				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+			if isArray != tt.wantArray {
+				t.Errorf("expected isArray=%v, got %v", tt.wantArray, isArray)
 			}
 		})
 	}
@@ -698,7 +741,7 @@ func TestDetectResourceTypeEdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := detectResourceType([]byte(tt.input))
+			result, _, err := detectResourceType([]byte(tt.input))
 
 			if tt.wantErr {
 				if err == nil {

--- a/pkg/apply/apply_integration_test.go
+++ b/pkg/apply/apply_integration_test.go
@@ -1626,3 +1626,275 @@ func TestApply_WorkflowCreate_IDNotFound_NoHint(t *testing.T) {
 		t.Errorf("source file should be unchanged, got:\n%s", content)
 	}
 }
+
+// ── Array apply tests (regression for #180) ──────────────────────────────
+
+// TestApply_SettingsArray_RoundTrip is the primary regression test for #180.
+// It verifies that the output of `get settings --schema X` (a YAML array of
+// settings objects) can be fed back into `apply` without error.
+func TestApply_SettingsArray_RoundTrip(t *testing.T) {
+	createCount := 0
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/classic/environment-api/v2/settings/objects": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			createCount++
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"objectId": fmt.Sprintf("obj-%d", createCount)},
+			})
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	// Simulates the output of: dtctl get settings --schema builtin:rum.web.enablement -o json
+	settingsArray := `[
+		{"schemaId":"builtin:rum.web.enablement","scope":"APPLICATION-111","value":{"enabled":true,"costControl":50}},
+		{"schemaId":"builtin:rum.web.enablement","scope":"APPLICATION-222","value":{"enabled":true,"costControl":100}},
+		{"schemaId":"builtin:rum.web.enablement","scope":"APPLICATION-333","value":{"enabled":false,"costControl":25}}
+	]`
+
+	results, err := a.Apply([]byte(settingsArray), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() settings array error = %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	if createCount != 3 {
+		t.Errorf("expected 3 API calls, got %d", createCount)
+	}
+	for i, r := range results {
+		base := r.(*SettingsApplyResult).ApplyResultBase
+		if base.Action != ActionCreated {
+			t.Errorf("result %d: expected 'created', got %q", i, base.Action)
+		}
+	}
+}
+
+// TestApply_SettingsArray_PartialFailure verifies that a failure in one element
+// does not abort the entire batch and the error reports both succeeded and failed items.
+func TestApply_SettingsArray_PartialFailure(t *testing.T) {
+	callCount := 0
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/classic/environment-api/v2/settings/objects": func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount == 2 {
+				// Second element fails
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(`{"error":{"code":400,"message":"invalid value"}}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"objectId": fmt.Sprintf("obj-%d", callCount)},
+			})
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	settingsArray := `[
+		{"schemaId":"builtin:rum.web.enablement","scope":"APPLICATION-111","value":{"enabled":true}},
+		{"schemaId":"builtin:rum.web.enablement","scope":"APPLICATION-222","value":{"enabled":true}},
+		{"schemaId":"builtin:rum.web.enablement","scope":"APPLICATION-333","value":{"enabled":true}}
+	]`
+
+	results, err := a.Apply([]byte(settingsArray), ApplyOptions{})
+	if err == nil {
+		t.Fatal("expected error for partial failure, got nil")
+	}
+
+	var listErr *ListApplyError
+	if e, ok := err.(*ListApplyError); !ok {
+		t.Fatalf("expected *ListApplyError, got %T: %v", err, err)
+	} else {
+		listErr = e
+	}
+
+	// 2 succeeded, 1 failed
+	if len(results) != 2 {
+		t.Errorf("expected 2 successful results, got %d", len(results))
+	}
+	if listErr.Failed != 1 {
+		t.Errorf("expected 1 failure, got %d", listErr.Failed)
+	}
+	if listErr.Total != 3 {
+		t.Errorf("expected total=3, got %d", listErr.Total)
+	}
+}
+
+// TestApply_SettingsArray_DryRun verifies that dry-run works with array input.
+func TestApply_SettingsArray_DryRun(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	settingsArray := `[
+		{"schemaId":"builtin:rum.web.enablement","scope":"APP-1","value":{"enabled":true}},
+		{"schemaId":"builtin:rum.web.enablement","scope":"APP-2","value":{"enabled":false}}
+	]`
+
+	results, err := a.Apply([]byte(settingsArray), ApplyOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("Apply() dry-run array error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 dry-run results, got %d", len(results))
+	}
+}
+
+// TestApply_Array_OverrideIDRejected verifies that --id flag is rejected for array input.
+func TestApply_Array_OverrideIDRejected(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	settingsArray := `[{"schemaId":"builtin:rum.web.enablement","scope":"APP-1","value":{"enabled":true}}]`
+	_, err := a.Apply([]byte(settingsArray), ApplyOptions{OverrideID: "some-id"})
+	if err == nil {
+		t.Fatal("expected error when --id is used with array input")
+	}
+	if !strings.Contains(err.Error(), "--id flag cannot be used with array input") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestApply_Array_HookRunsOnce verifies that pre-apply hook runs once for array input
+// (not once per element).
+func TestApply_Array_HookRunsOnce(t *testing.T) {
+	hookRunCount := 0
+	// Create a temp script that increments a counter file
+	dir := t.TempDir()
+	counterFile := dir + "/count"
+	os.WriteFile(counterFile, []byte("0"), 0o644)
+
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+		"/platform/classic/environment-api/v2/settings/objects": func(w http.ResponseWriter, r *http.Request) {
+			hookRunCount++ // just track calls
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"objectId": fmt.Sprintf("obj-%d", hookRunCount)},
+			})
+		},
+	})
+	defer srv.Close()
+
+	a := NewApplier(c).
+		WithPreApplyHook("true"). // succeeds
+		WithSourceFile("test.yaml")
+
+	settingsArray := `[
+		{"schemaId":"builtin:rum.web.enablement","scope":"APP-1","value":{"enabled":true}},
+		{"schemaId":"builtin:rum.web.enablement","scope":"APP-2","value":{"enabled":false}}
+	]`
+
+	results, err := a.Apply([]byte(settingsArray), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+}
+
+// TestApply_WorkflowArray verifies that array apply works for non-settings resources too,
+// ensuring the generic approach works across all resource types.
+func TestApply_WorkflowArray(t *testing.T) {
+	createCount := 0
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			createCount++
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":    fmt.Sprintf("wf-%d", createCount),
+				"title": fmt.Sprintf("Workflow %d", createCount),
+			})
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	wfArray := `[
+		{"title":"Workflow A","tasks":{},"trigger":{}},
+		{"title":"Workflow B","tasks":{},"trigger":{}}
+	]`
+
+	results, err := a.Apply([]byte(wfArray), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() workflow array error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if createCount != 2 {
+		t.Errorf("expected 2 API calls, got %d", createCount)
+	}
+}
+
+// TestApply_SettingsArray_YAML_RoundTrip is the exact reproduction of the bug
+// reported in #180 — YAML array input (as produced by `get settings --schema X -o yaml`).
+func TestApply_SettingsArray_YAML_RoundTrip(t *testing.T) {
+	createCount := 0
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/classic/environment-api/v2/settings/objects": func(w http.ResponseWriter, r *http.Request) {
+			createCount++
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"objectId": fmt.Sprintf("obj-%d", createCount)},
+			})
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	// This is exactly what `dtctl get settings --schema builtin:rum.web.enablement -o yaml`
+	// produces — a YAML list of settings objects.
+	yamlArray := `- schemaId: builtin:rum.web.enablement
+  scope: APPLICATION-111
+  value:
+    enabled: true
+    costControl: 50
+- schemaId: builtin:rum.web.enablement
+  scope: APPLICATION-222
+  value:
+    enabled: false
+    costControl: 100
+`
+
+	results, err := a.Apply([]byte(yamlArray), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() YAML settings array error = %v (this was bug #180)", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+}

--- a/pkg/apply/errors.go
+++ b/pkg/apply/errors.go
@@ -24,3 +24,19 @@ func (e *HookRejectedError) Error() string {
 	msg += fmt.Sprintf("\nHook command: %s\nExit code: %d", e.Command, e.ExitCode)
 	return msg
 }
+
+// ListApplyError is returned when some items in a batch apply fail.
+// It includes results for successful items alongside the error details.
+type ListApplyError struct {
+	Total    int
+	Failed   int
+	Messages []string
+}
+
+func (e *ListApplyError) Error() string {
+	msg := fmt.Sprintf("%d of %d items failed to apply", e.Failed, e.Total)
+	for _, m := range e.Messages {
+		msg += "\n  " + m
+	}
+	return msg
+}

--- a/pkg/apply/errors_test.go
+++ b/pkg/apply/errors_test.go
@@ -141,3 +141,33 @@ func TestHookRejectedError_ImplementsError(t *testing.T) {
 		t.Error("Error() returned empty string")
 	}
 }
+
+func TestListApplyError_Message(t *testing.T) {
+	err := &ListApplyError{
+		Total:    5,
+		Failed:   2,
+		Messages: []string{"item 2: invalid value", "item 4: scope not found"},
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "2 of 5 items failed to apply") {
+		t.Errorf("Error() missing summary, got: %s", msg)
+	}
+	if !strings.Contains(msg, "item 2: invalid value") {
+		t.Errorf("Error() missing detail for item 2, got: %s", msg)
+	}
+	if !strings.Contains(msg, "item 4: scope not found") {
+		t.Errorf("Error() missing detail for item 4, got: %s", msg)
+	}
+}
+
+func TestListApplyError_ImplementsError(t *testing.T) {
+	var err error = &ListApplyError{
+		Total:    1,
+		Failed:   1,
+		Messages: []string{"item 1: failed"},
+	}
+	if err.Error() == "" {
+		t.Error("Error() returned empty string")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #180 — `dtctl apply -f` now accepts files containing arrays of resources, enabling the round-trip workflow `get settings --schema X -o yaml` → edit → `apply -f`.

- **Generic array support**: `detectResourceType` detects arrays and identifies the resource type from the first element. Works for all resource types (settings, workflows, SLOs, etc.), not just the previously special-cased Azure/GCP connections.
- **Per-item error handling**: `applyList` iterates array elements individually. Partial failures do not abort the batch — successful results are printed and a `ListApplyError` summarizes failures (e.g., "2 of 48 items failed to apply").
- **Guard rails**: `--id` flag is rejected for array input (ambiguous target). Pre-apply hooks run once on the full array. Dry-run iterates elements individually.

## Test coverage

- Round-trip regression tests: JSON array, YAML array (exact reproduction of #180)
- Partial failure test: verifies successful results are collected alongside errors
- Array detection tests for settings, workflows, SLOs, empty arrays, unknown objects
- `--id` rejection test, hook-runs-once test, dry-run array test
- `ListApplyError` unit tests

## Files changed

| File | Change |
|------|--------|
| `pkg/apply/applier.go` | `detectResourceType` returns `isArray` flag; new `applySingle`/`applyList` methods |
| `pkg/apply/errors.go` | New `ListApplyError` type |
| `cmd/apply.go` | Handle `ListApplyError` (print partial results before error); updated help text with bulk examples |
| `docs/site/_docs/settings.md` | Documented bulk update workflow |
| `docs/dev/APPLY_TYPE_DETECTION.md` | Documented array input behavior |
| `CHANGELOG.md` | Added to Unreleased |