### PR TITLE
docs: update token scopes documentation URL

### DIFF
--- a/cmd/help_topics.go
+++ b/cmd/help_topics.go
@@ -29,7 +29,7 @@ Quick Reference:
   dangerously-unrestricted    Dev environments, bucket management     Full access token
 
 For the full list of scopes per safety level, see:
-  https://dtctl.dev/docs/token-scopes/
+  https://dynatrace-oss.github.io/dtctl/docs/token-scopes/
 
 For creating platform tokens, see:
   https://docs.dynatrace.com/docs/manage/identity-access-management/access-tokens-and-oauth-clients/platform-tokens`,


### PR DESCRIPTION
The domain name in the URL is invalid. I've updated to the correct one.