### PR TITLE
fix: enable ANSI/VT escape sequence processing on Windows console

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/sys v0.42.0
 	golang.org/x/term v0.41.0
 	golang.org/x/text v0.35.0
 	google.golang.org/protobuf v1.36.11
@@ -58,7 +59,6 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/grpc v1.80.0 // indirect

--- a/pkg/output/console_other.go
+++ b/pkg/output/console_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package output
+
+// enableVTProcessing is a no-op on non-Windows platforms where ANSI/VT
+// escape sequences are natively supported by terminals.
+func enableVTProcessing() bool {
+	return true
+}

--- a/pkg/output/console_test.go
+++ b/pkg/output/console_test.go
@@ -1,0 +1,40 @@
+package output
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnableVTProcessing_ReturnsTrue(t *testing.T) {
+	// On non-Windows platforms, enableVTProcessing is a no-op that always
+	// returns true. On Windows in CI, it should also succeed (Windows 10+
+	// supports VT processing) or return false gracefully if stdout is not
+	// a console (e.g., piped in CI).
+	result := enableVTProcessing()
+
+	// We can't assert a specific value in CI because stdout may be a pipe,
+	// but we verify the function doesn't panic and returns a valid bool.
+	_ = result
+}
+
+func TestDetectColor_VTProcessingIntegration(t *testing.T) {
+	// When FORCE_COLOR=1 is set, detectColor bypasses the TTY check and
+	// VT processing call, so color is enabled regardless of platform.
+	ResetColorCache()
+	os.Unsetenv("NO_COLOR")
+	t.Setenv("FORCE_COLOR", "1")
+
+	if !ColorEnabled() {
+		t.Error("ColorEnabled() should return true with FORCE_COLOR=1")
+	}
+
+	// When stdout is not a TTY (typical in tests/CI) and no FORCE_COLOR,
+	// detectColor should return false before even calling enableVTProcessing.
+	ResetColorCache()
+	os.Unsetenv("NO_COLOR")
+	os.Unsetenv("FORCE_COLOR")
+
+	if ColorEnabled() {
+		t.Error("ColorEnabled() should return false when stdout is not a TTY and FORCE_COLOR is not set")
+	}
+}

--- a/pkg/output/console_windows.go
+++ b/pkg/output/console_windows.go
@@ -9,17 +9,37 @@ import (
 )
 
 // enableVTProcessing enables ANSI/VT escape sequence processing on the
-// Windows console. Returns true if VT sequences are supported, false otherwise.
+// Windows console for both stdout and stderr. Returns true if VT sequences
+// are supported on stdout, false otherwise.
 //
 // On Windows 10+, the console supports VT sequences but they must be
 // explicitly enabled via SetConsoleMode with ENABLE_VIRTUAL_TERMINAL_PROCESSING.
 // See: https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
 func enableVTProcessing() bool {
-	handle := windows.Handle(os.Stdout.Fd())
+	if !enableVTOnHandle(os.Stdout.Fd()) {
+		return false
+	}
+
+	// Best-effort: also enable on stderr so colored diagnostics render correctly.
+	// Failure here is non-fatal — stderr may be redirected to a file/pipe.
+	_ = enableVTOnHandle(os.Stderr.Fd())
+
+	return true
+}
+
+// enableVTOnHandle enables ENABLE_VIRTUAL_TERMINAL_PROCESSING on a single
+// console handle. Returns false if the handle is not a console or the mode
+// cannot be set.
+func enableVTOnHandle(fd uintptr) bool {
+	handle := windows.Handle(fd)
 
 	var mode uint32
 	if err := windows.GetConsoleMode(handle, &mode); err != nil {
 		return false
+	}
+
+	if mode&windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0 {
+		return true // already enabled
 	}
 
 	if err := windows.SetConsoleMode(handle, mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {

--- a/pkg/output/console_windows.go
+++ b/pkg/output/console_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package output
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// enableVTProcessing enables ANSI/VT escape sequence processing on the
+// Windows console. Returns true if VT sequences are supported, false otherwise.
+//
+// On Windows 10+, the console supports VT sequences but they must be
+// explicitly enabled via SetConsoleMode with ENABLE_VIRTUAL_TERMINAL_PROCESSING.
+// See: https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
+func enableVTProcessing() bool {
+	handle := windows.Handle(os.Stdout.Fd())
+
+	var mode uint32
+	if err := windows.GetConsoleMode(handle, &mode); err != nil {
+		return false
+	}
+
+	if err := windows.SetConsoleMode(handle, mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {
+		return false
+	}
+
+	return true
+}

--- a/pkg/output/styles.go
+++ b/pkg/output/styles.go
@@ -55,7 +55,14 @@ func detectColor() bool {
 	}
 
 	// Auto-detect: only use color when stdout is a TTY
-	return term.IsTerminal(int(os.Stdout.Fd()))
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return false
+	}
+
+	// On Windows, ANSI/VT escape sequences must be explicitly enabled via
+	// SetConsoleMode. If the call fails (e.g., older Windows), disable color
+	// to avoid printing raw escape sequences. On other platforms this is a no-op.
+	return enableVTProcessing()
 }
 
 // ResetColorCache resets the cached color detection result.


### PR DESCRIPTION
## Summary

- Enable `ENABLE_VIRTUAL_TERMINAL_PROCESSING` on Windows console via `SetConsoleMode` so ANSI escape sequences render correctly instead of printing raw control characters
- Gracefully disable color output if VT processing cannot be enabled (e.g. older Windows versions)

Fixes #183

## Details

On Windows, the console supports ANSI/VT escape sequences but they are **off by default**. The existing `detectColor()` logic correctly checks for TTY via `term.IsTerminal()`, but on Windows that returns `true` even when the console can't render escape sequences without opt-in.

This PR adds a platform-specific `enableVTProcessing()` function:
- **Windows** (`console_windows.go`): Calls `windows.SetConsoleMode()` with `ENABLE_VIRTUAL_TERMINAL_PROCESSING`. Returns `false` if the call fails, causing color to be disabled.
- **Other platforms** (`console_other.go`): No-op, returns `true`.

No new dependencies — `golang.org/x/sys` was already an indirect dependency.

## Testing

- All existing tests pass (`go test -short ./pkg/...` — 43 packages)
- Cross-compiles cleanly for `windows/amd64`
- Golden tests unaffected (no output format changes)