### PR TITLE
feat: cancel DQL query on SIGINT/SIGTERM

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -149,6 +151,17 @@ Examples:
 		}
 
 		executor := NewDQLExecutorFromConfig(cfg, c)
+
+		// Set up signal handling so a running Grail query is cancelled on Ctrl+C / SIGTERM.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		go func() {
+			<-sigCh
+			cancel()
+		}()
 
 		queryFile, _ := cmd.Flags().GetString("file")
 		setFlags, _ := cmd.Flags().GetStringArray("set")
@@ -373,10 +386,13 @@ Examples:
 			livePrinter := output.NewLivePrinterWithOpts(printer, interval, os.Stdout, printerOpts)
 
 			// Create data fetcher that re-executes the query
-			fetcher := func(ctx context.Context) (interface{}, error) {
-				result, err := executor.ExecuteQueryWithOptions(query, opts)
+			fetcher := func(fetchCtx context.Context) (interface{}, error) {
+				result, err := executor.ExecuteQueryWithContext(fetchCtx, query, opts)
 				if err != nil {
 					return nil, err
+				}
+				if result == nil {
+					return nil, nil // context cancelled; message already printed
 				}
 				// Extract records
 				records := result.Records
@@ -397,10 +413,10 @@ Examples:
 				return map[string]interface{}{"records": records}, nil
 			}
 
-			return livePrinter.RunLive(context.Background(), fetcher)
+			return livePrinter.RunLive(ctx, fetcher)
 		}
 
-		return executor.ExecuteWithOptions(query, opts)
+		return executor.ExecuteWithContext(ctx, query, opts)
 	},
 }
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -158,6 +158,7 @@ Examples:
 
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(sigCh)
 		go func() {
 			<-sigCh
 			cancel()

--- a/docs/site/_docs/dql-queries.md
+++ b/docs/site/_docs/dql-queries.md
@@ -215,6 +215,10 @@ dtctl query "fetch logs | filter loglevel == 'ERROR' | sort timestamp desc | lim
 
 Press `Ctrl+C` to stop live mode.
 
+## Cancelling Queries
+
+Press `Ctrl+C` (or send `SIGTERM`) at any time to cancel a running query. `dtctl` sends a best-effort `query:cancel` request to Grail so the backend stops executing the query, then exits. A confirmation (`Query cancelled.`) or, if the cancel request fails, a `Failed to cancel query` message is written to **stderr**.
+
 ## Query Warnings
 
 DQL may emit warnings (e.g., result truncation, deprecated syntax). These are printed to **stderr** so they don't interfere with piped output:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -59,6 +59,14 @@ func NewForTesting(baseURL, token string) (*Client, error) {
 	return c, nil
 }
 
+// noopRestyLogger discards all resty-internal log output.
+// Error information is surfaced through returned error values, not internal logs.
+type noopRestyLogger struct{}
+
+func (noopRestyLogger) Errorf(string, ...interface{}) {}
+func (noopRestyLogger) Warnf(string, ...interface{})  {}
+func (noopRestyLogger) Debugf(string, ...interface{}) {}
+
 // New creates a new client with base URL and token
 func New(baseURL, token string) (*Client, error) {
 	if baseURL == "" {
@@ -78,6 +86,7 @@ func New(baseURL, token string) (*Client, error) {
 	}
 
 	httpClient := resty.New().
+		SetLogger(&noopRestyLogger{}).
 		SetBaseURL(baseURL).
 		SetAuthScheme("Bearer").
 		SetAuthToken(token).
@@ -100,9 +109,9 @@ func New(baseURL, token string) (*Client, error) {
 // isRetryable determines if a request should be retried
 func isRetryable(r *resty.Response, err error) bool {
 	if err != nil {
-		// Don't retry on context deadline exceeded - this is expected for long-running
-		// queries that should use polling instead of resubmitting the query
-		if errors.Is(err, context.DeadlineExceeded) {
+		// Don't retry on context cancellation — retrying is pointless when the context
+		// is already done (covers both user-initiated cancellation and deadline exceeded).
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return false
 		}
 		return true

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -632,6 +632,17 @@ func TestIsRetryable_ContextDeadline(t *testing.T) {
 	}
 }
 
+func TestIsRetryable_ContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	// context.Canceled is the error produced when the user presses Ctrl+C.
+	// It must not trigger retries, otherwise the resty WARN/ERROR logs
+	// reappear and the process hangs for the full retry back-off period.
+	if isRetryable(nil, context.Canceled) {
+		t.Error("isRetryable() should return false for context.Canceled")
+	}
+}
+
 func TestIsRetryable_StatusCodes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -32,6 +32,11 @@ func (e *DQLExecutor) WithTokenRefresher(refresher func() (string, error)) *DQLE
 	return e
 }
 
+// pollRequestTimeoutMs is the server-side hold time per poll HTTP round trip in milliseconds.
+// The server will return after this duration even if the query is still running, allowing
+// the client to loop and re-poll. Must stay in sync with the execute request timeout.
+const pollRequestTimeoutMs = 1000
+
 // DecodeMode controls snapshot payload decoding behavior.
 type DecodeMode int
 
@@ -229,9 +234,17 @@ func (e *DQLExecutor) Execute(query string, outputFormat string) error {
 
 // ExecuteWithOptions executes a DQL query with full options
 func (e *DQLExecutor) ExecuteWithOptions(query string, opts DQLExecuteOptions) error {
-	result, err := e.ExecuteQueryWithOptions(query, opts)
+	return e.ExecuteWithContext(context.Background(), query, opts)
+}
+
+// ExecuteWithContext executes a DQL query with a cancellable context and prints the results.
+func (e *DQLExecutor) ExecuteWithContext(ctx context.Context, query string, opts DQLExecuteOptions) error {
+	result, err := e.ExecuteQueryWithContext(ctx, query, opts)
 	if err != nil {
 		return err
+	}
+	if result == nil {
+		return nil // context was cancelled; message already printed to stderr
 	}
 	return e.printResults(result, opts)
 }
@@ -243,9 +256,16 @@ func (e *DQLExecutor) ExecuteQuery(query string) (*DQLQueryResponse, error) {
 
 // ExecuteQueryWithOptions executes a DQL query with options and returns the raw result
 func (e *DQLExecutor) ExecuteQueryWithOptions(query string, opts DQLExecuteOptions) (*DQLQueryResponse, error) {
+	return e.ExecuteQueryWithContext(context.Background(), query, opts)
+}
+
+// ExecuteQueryWithContext executes a DQL query with a cancellable context.
+// If ctx is cancelled while the query is polling, a best-effort cancel request is sent
+// to the Grail backend before returning.
+func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string, opts DQLExecuteOptions) (*DQLQueryResponse, error) {
 	req := DQLQueryRequest{
 		Query:                      query,
-		RequestTimeoutMilliseconds: 60000, // Wait up to 60 seconds for results
+		RequestTimeoutMilliseconds: pollRequestTimeoutMs,
 	}
 
 	// Set query limit parameters in request body if specified
@@ -304,14 +324,15 @@ func (e *DQLExecutor) ExecuteQueryWithOptions(query string, opts DQLExecuteOptio
 
 	var result DQLQueryResponse
 
-	// Create context with 5 minute timeout to accommodate Grail's maximum query time
-	// The server will return 202 if query takes longer than requestTimeoutMilliseconds
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	// The initial execute request uses an independent context (not the caller's)
+	// so that it always completes and returns the requestToken. Without the token
+	// we cannot cancel the query on the backend.
+	execCtx, execCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer execCancel()
 
 	// Note: Client-level retries won't trigger for 202 responses (success status)
 	httpReq := e.client.HTTP().R().
-		SetContext(ctx).
+		SetContext(execCtx).
 		SetHeader("Content-Type", "application/json").
 		SetBody(req).
 		SetResult(&result)
@@ -322,16 +343,36 @@ func (e *DQLExecutor) ExecuteQueryWithOptions(query string, opts DQLExecuteOptio
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
 
+	// If the caller's context was cancelled while the initial request was in-flight
+	// (e.g. SIGINT), cancel the backend query now that we have the token.
+	if ctx.Err() != nil {
+		if result.RequestToken != "" {
+			e.CancelQuery(result.RequestToken)
+		} else {
+			fmt.Fprintln(os.Stderr, "\nQuery cancelled.")
+		}
+		return nil, nil
+	}
+
 	// Handle both 200 (completed) and 202 (accepted/running) responses
 	if resp.StatusCode() == 202 || (resp.StatusCode() == 200 && result.State == "RUNNING") {
 		if result.RequestToken == "" {
 			return nil, fmt.Errorf("query is running but no request token provided")
 		}
-		// Query is running, poll for results
-		result, err = e.pollForResultsWithOptions(result.RequestToken, opts)
-		if err != nil {
-			return nil, err
+		// Poll for results using the caller's context (cancellable by signal).
+		pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer pollCancel()
+
+		pollResult, pollErr := e.pollForResultsWithContext(pollCtx, result.RequestToken, opts)
+		if pollErr != nil {
+			// If context was cancelled, send a best-effort cancel to the backend
+			if pollCtx.Err() != nil {
+				e.CancelQuery(result.RequestToken)
+				return nil, nil
+			}
+			return nil, pollErr
 		}
+		result = pollResult
 	} else if resp.IsError() {
 		return nil, enhanceQueryError(resp.StatusCode(), resp.Body())
 	}
@@ -660,21 +701,40 @@ func (e *DQLExecutor) pollForResults(requestToken string) (DQLQueryResponse, err
 
 // pollForResultsWithOptions polls the query:poll endpoint until the query completes with options
 func (e *DQLExecutor) pollForResultsWithOptions(requestToken string, opts DQLExecuteOptions) (DQLQueryResponse, error) {
+	return e.pollForResultsWithContext(context.Background(), requestToken, opts)
+}
+
+// pollForResultsWithContext polls the query:poll endpoint until the query completes.
+// It returns immediately if ctx is cancelled; the caller is responsible for calling
+// CancelQuery if backend cancellation is desired.
+func (e *DQLExecutor) pollForResultsWithContext(ctx context.Context, requestToken string, opts DQLExecuteOptions) (DQLQueryResponse, error) {
 	var result DQLQueryResponse
 	// tokenJustRefreshed prevents an infinite refresh loop: if we get a 401 immediately
 	// after a successful token refresh the credentials are fundamentally broken, so we abort.
 	tokenJustRefreshed := false
 
 	for {
+		// Check for cancellation before each poll attempt
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
+
 		result = DQLQueryResponse{}
 		httpReq := e.client.HTTP().R().
+			SetContext(ctx).
 			SetQueryParam("request-token", requestToken).
-			SetQueryParam("request-timeout-milliseconds", "60000").
+			SetQueryParam("request-timeout-milliseconds", fmt.Sprintf("%d", pollRequestTimeoutMs)).
 			SetResult(&result)
 
 		resp, err := httpReq.Get("/platform/storage/query/v1/query:poll")
 
 		if err != nil {
+			// If the error is due to context cancellation, return that directly
+			if ctx.Err() != nil {
+				return result, ctx.Err()
+			}
 			return result, fmt.Errorf("failed to poll query: %w", err)
 		}
 
@@ -712,6 +772,32 @@ func (e *DQLExecutor) pollForResultsWithOptions(requestToken string, opts DQLExe
 	}
 
 	return result, nil
+}
+
+// CancelQuery sends a best-effort cancellation request for a running query.
+// It uses a fresh context so the HTTP call can complete even if the parent context is cancelled.
+// Errors are written to stderr but not returned — cancellation is best-effort.
+func (e *DQLExecutor) CancelQuery(requestToken string) {
+	if requestToken == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	resp, err := e.client.HTTP().R().
+		SetContext(ctx).
+		SetQueryParam("request-token", requestToken).
+		Post("/platform/storage/query/v1/query:cancel")
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\nFailed to cancel query: %v\n", err)
+		return
+	}
+	if resp.IsError() {
+		fmt.Fprintf(os.Stderr, "\nFailed to cancel query (status %d)\n", resp.StatusCode())
+		return
+	}
+	fmt.Fprintln(os.Stderr, "\nQuery cancelled.")
 }
 
 // ExecuteFromFile executes a DQL query from a file

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -365,8 +365,10 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 
 		pollResult, pollErr := e.pollForResultsWithContext(pollCtx, result.RequestToken, opts)
 		if pollErr != nil {
-			// If context was cancelled, send a best-effort cancel to the backend
-			if pollCtx.Err() != nil {
+			// If the caller's context was cancelled (e.g. SIGINT), send a best-effort
+			// cancel to the backend. The internal poll deadline (pollCtx) is treated
+			// as a normal error so the caller sees the timeout.
+			if ctx.Err() != nil {
 				e.CancelQuery(result.RequestToken)
 				return nil, nil
 			}

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -35,7 +35,7 @@ func (e *DQLExecutor) WithTokenRefresher(refresher func() (string, error)) *DQLE
 // pollRequestTimeoutMs is the server-side hold time per poll HTTP round trip in milliseconds.
 // The server will return after this duration even if the query is still running, allowing
 // the client to loop and re-poll. Must stay in sync with the execute request timeout.
-const pollRequestTimeoutMs = 1000
+const pollRequestTimeoutMs = 5000
 
 // DecodeMode controls snapshot payload decoding behavior.
 type DecodeMode int

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -700,6 +700,8 @@ func (e *DQLExecutor) pollForResults(requestToken string) (DQLQueryResponse, err
 }
 
 // pollForResultsWithOptions polls the query:poll endpoint until the query completes with options
+//
+//nolint:unused // Reserved for future polling features
 func (e *DQLExecutor) pollForResultsWithOptions(requestToken string, opts DQLExecuteOptions) (DQLQueryResponse, error) {
 	return e.pollForResultsWithContext(context.Background(), requestToken, opts)
 }

--- a/pkg/exec/dql_signal_integration_test.go
+++ b/pkg/exec/dql_signal_integration_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package exec
 
 import (
@@ -7,7 +9,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/signal"
-	"runtime"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -23,10 +24,6 @@ import (
 // (sent to this process) and a real HTTP server, so it covers the signal
 // plumbing that the unit tests skip by calling cancel() directly.
 func TestDQLExecutor_SIGINT_CancelsBackendQuery(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("os.Interrupt cannot be sent to self on windows")
-	}
-
 	pollStarted := make(chan struct{})
 	var cancelCalled atomic.Bool
 	var cancelToken atomic.Value

--- a/pkg/exec/dql_signal_integration_test.go
+++ b/pkg/exec/dql_signal_integration_test.go
@@ -1,0 +1,176 @@
+package exec
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/signal"
+	"runtime"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+)
+
+// TestDQLExecutor_SIGINT_CancelsBackendQuery is an integration-style test that
+// exercises the full SIGINT -> cancel flow that cmd/query.go wires up: an OS
+// signal triggers context cancellation, the in-flight poll is aborted, and a
+// best-effort query:cancel is sent to the backend. It uses a real OS signal
+// (sent to this process) and a real HTTP server, so it covers the signal
+// plumbing that the unit tests skip by calling cancel() directly.
+func TestDQLExecutor_SIGINT_CancelsBackendQuery(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Interrupt cannot be sent to self on windows")
+	}
+
+	pollStarted := make(chan struct{})
+	var cancelCalled atomic.Bool
+	var cancelToken atomic.Value
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/platform/storage/query/v1/query:execute":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(DQLQueryResponse{
+				State:        "RUNNING",
+				RequestToken: "tok-sigint",
+			})
+		case "/platform/storage/query/v1/query:poll":
+			// Signal that the poll is in-flight so the test can deliver SIGINT,
+			// then block long enough for the cancel to propagate.
+			select {
+			case <-pollStarted:
+				// Already signalled by an earlier poll iteration.
+			default:
+				close(pollStarted)
+			}
+			select {
+			case <-r.Context().Done():
+				// Client aborted the request because of cancellation - good.
+				return
+			case <-time.After(2 * time.Second):
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(DQLQueryResponse{
+				State:        "RUNNING",
+				RequestToken: "tok-sigint",
+			})
+		case "/platform/storage/query/v1/query:cancel":
+			cancelCalled.Store(true)
+			cancelToken.Store(r.URL.Query().Get("request-token"))
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	// Replicate the signal plumbing from cmd/query.go.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	type outcome struct {
+		result *DQLQueryResponse
+		err    error
+	}
+	done := make(chan outcome, 1)
+
+	executor := NewDQLExecutor(c)
+	go func() {
+		result, err := executor.ExecuteQueryWithContext(ctx, "fetch logs", DQLExecuteOptions{})
+		done <- outcome{result, err}
+	}()
+
+	// Wait until the poll is in-flight, then deliver SIGINT to ourselves.
+	select {
+	case <-pollStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for poll to start")
+	}
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("failed to send SIGINT: %v", err)
+	}
+
+	select {
+	case o := <-done:
+		if o.err != nil {
+			t.Fatalf("expected nil error after SIGINT cancellation, got: %v", o.err)
+		}
+		if o.result != nil {
+			t.Errorf("expected nil result after SIGINT cancellation, got: %+v", o.result)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ExecuteQueryWithContext did not return after SIGINT")
+	}
+
+	// The cancel call is a best-effort POST that runs after the poll returns;
+	// give the goroutine a moment to issue it.
+	deadline := time.Now().Add(2 * time.Second)
+	for !cancelCalled.Load() && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !cancelCalled.Load() {
+		t.Fatal("expected /query:cancel to be called after SIGINT")
+	}
+	if got, _ := cancelToken.Load().(string); got != "tok-sigint" {
+		t.Errorf("cancel token = %q, want %q", got, "tok-sigint")
+	}
+}
+
+// TestDQLExecutor_PollErrorPropagatesWhenCallerCtxAlive verifies that a poll
+// failure that is unrelated to caller cancellation (e.g. backend 5xx) is
+// surfaced as an error rather than being silently swallowed as a
+// "cancelled" outcome.
+func TestDQLExecutor_PollErrorPropagatesWhenCallerCtxAlive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/platform/storage/query/v1/query:execute":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(DQLQueryResponse{
+				State:        "RUNNING",
+				RequestToken: "tok-poll-error",
+			})
+		case "/platform/storage/query/v1/query:poll":
+			// Return a non-cancellation error from the backend.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"message":"internal"}}`))
+		}
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewDQLExecutor(c)
+	// Caller's context is alive throughout; only the poll fails.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result, err := executor.ExecuteQueryWithContext(ctx, "fetch logs", DQLExecuteOptions{})
+	if err == nil {
+		t.Fatal("expected an error when poll fails and caller ctx is alive, got nil")
+	}
+	if result != nil {
+		t.Errorf("expected nil result on poll error, got: %+v", result)
+	}
+}

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 )
@@ -1896,5 +1898,167 @@ func TestDQLExecutor_PollTokenRefresh_NoRefresherReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "401") {
 		t.Errorf("expected error to contain status 401, got: %v", err)
+	}
+}
+
+// TestDQLExecutor_CancelDuringPoll verifies that cancelling the context during polling
+// returns a context.Canceled error and sends a cancel request to the backend.
+func TestDQLExecutor_CancelDuringPoll(t *testing.T) {
+	cancelCalled := false
+	cancelToken := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/platform/storage/query/v1/query:execute":
+			resp := DQLQueryResponse{State: "RUNNING", RequestToken: "tok-cancel-test"}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case "/platform/storage/query/v1/query:poll":
+			// Always return RUNNING so the poll loop keeps going
+			resp := DQLQueryResponse{State: "RUNNING", RequestToken: "tok-cancel-test"}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case "/platform/storage/query/v1/query:cancel":
+			cancelCalled = true
+			cancelToken = r.URL.Query().Get("request-token")
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewDQLExecutor(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a short delay to let at least one poll round trip
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	result, err := executor.ExecuteQueryWithContext(ctx, "fetch logs", DQLExecuteOptions{})
+	if err != nil {
+		t.Fatalf("expected nil error on cancellation (clean exit), got: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result on cancellation, got: %+v", result)
+	}
+
+	if !cancelCalled {
+		t.Error("expected cancel API to be called after context cancellation")
+	}
+	if cancelToken != "tok-cancel-test" {
+		t.Errorf("cancel called with wrong token: %q, want %q", cancelToken, "tok-cancel-test")
+	}
+}
+
+// TestDQLExecutor_NoCancelOnImmediateSuccess verifies that when a query succeeds
+// immediately (no polling), the cancel endpoint is never called.
+func TestDQLExecutor_NoCancelOnImmediateSuccess(t *testing.T) {
+	cancelCalled := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/platform/storage/query/v1/query:cancel" {
+			cancelCalled = true
+		}
+		resp := DQLQueryResponse{
+			State:  "SUCCEEDED",
+			Result: &DQLResult{Records: []map[string]interface{}{{"k": "v"}}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewDQLExecutor(c)
+	result, err := executor.ExecuteQueryWithContext(context.Background(), "fetch logs", DQLExecuteOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.State != "SUCCEEDED" {
+		t.Errorf("expected SUCCEEDED, got %s", result.State)
+	}
+	if cancelCalled {
+		t.Error("cancel should not be called for an immediately successful query")
+	}
+}
+
+// TestDQLExecutor_CancelQuery_BestEffort verifies that CancelQuery does not propagate
+// errors when the server returns an error response.
+func TestDQLExecutor_CancelQuery_BestEffort(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewDQLExecutor(c)
+	// Should not panic or return an error
+	executor.CancelQuery("some-token")
+}
+
+// TestDQLExecutor_CancelQuery_EmptyToken verifies that CancelQuery is a no-op for empty tokens.
+func TestDQLExecutor_CancelQuery_EmptyToken(t *testing.T) {
+	cancelCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cancelCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewDQLExecutor(c)
+	executor.CancelQuery("") // should be a no-op
+
+	if cancelCalled {
+		t.Error("cancel API should not be called for an empty token")
+	}
+}
+
+// TestDQLExecutor_ExecuteQueryWithOptions_StillWorks verifies that the refactored
+// ExecuteQueryWithOptions delegate still behaves correctly.
+func TestDQLExecutor_ExecuteQueryWithOptions_StillWorks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := DQLQueryResponse{
+			State:  "SUCCEEDED",
+			Result: &DQLResult{Records: []map[string]interface{}{{"k": "v"}}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewDQLExecutor(c)
+	result, err := executor.ExecuteQueryWithOptions("fetch logs", DQLExecuteOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.State != "SUCCEEDED" {
+		t.Errorf("expected SUCCEEDED, got %s", result.State)
 	}
 }

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -1959,6 +1959,88 @@ func TestDQLExecutor_CancelDuringPoll(t *testing.T) {
 	}
 }
 
+// TestDQLExecutor_CancelWhilePollInFlight covers the scenario where ctx is cancelled
+// while a poll HTTP request is already in-flight and the poll response arrives after
+// the cancellation.  The test uses two channels to enforce this ordering:
+//
+//  1. pollStarted  – closed by the handler once the poll request is received,
+//     signalling to the test goroutine that the GET is in-flight.
+//  2. releasePoll  – closed by the test goroutine after calling cancel(), letting
+//     the handler write the RUNNING response and return.
+//
+// After the poll response is received (or the transport aborts it), the loop-top
+// ctx.Done() guard must fire and query:cancel must be called with the correct token.
+func TestDQLExecutor_CancelWhilePollInFlight(t *testing.T) {
+	pollStarted := make(chan struct{})
+	releasePoll := make(chan struct{})
+	cancelCalled := false
+	cancelToken := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/platform/storage/query/v1/query:execute":
+			resp := DQLQueryResponse{State: "RUNNING", RequestToken: "tok-inflight"}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case "/platform/storage/query/v1/query:poll":
+			// Signal that the poll GET is in-flight, then hold the response
+			// until the test goroutine has cancelled the context.
+			close(pollStarted)
+			<-releasePoll
+			resp := DQLQueryResponse{State: "RUNNING", RequestToken: "tok-inflight"}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case "/platform/storage/query/v1/query:cancel":
+			cancelCalled = true
+			cancelToken = r.URL.Query().Get("request-token")
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type outcome struct {
+		result *DQLQueryResponse
+		err    error
+	}
+	done := make(chan outcome, 1)
+
+	executor := NewDQLExecutor(c)
+	go func() {
+		result, err := executor.ExecuteQueryWithContext(ctx, "fetch logs", DQLExecuteOptions{})
+		done <- outcome{result, err}
+	}()
+
+	// Poll is now in-flight — cancel the context, then release the poll response.
+	<-pollStarted
+	cancel()
+	close(releasePoll)
+
+	o := <-done
+	if o.err != nil {
+		t.Fatalf("expected nil error after in-flight cancellation, got: %v", o.err)
+	}
+	if o.result != nil {
+		t.Errorf("expected nil result after cancellation, got: %+v", o.result)
+	}
+	if !cancelCalled {
+		t.Error("expected query:cancel to be called after in-flight poll was released")
+	}
+	if cancelToken != "tok-inflight" {
+		t.Errorf("cancel token = %q, want %q", cancelToken, "tok-inflight")
+	}
+}
+
 // TestDQLExecutor_NoCancelOnImmediateSuccess verifies that when a query succeeds
 // immediately (no polling), the cancel endpoint is never called.
 func TestDQLExecutor_NoCancelOnImmediateSuccess(t *testing.T) {
@@ -2032,6 +2114,70 @@ func TestDQLExecutor_CancelQuery_EmptyToken(t *testing.T) {
 
 	if cancelCalled {
 		t.Error("cancel API should not be called for an empty token")
+	}
+}
+
+// TestDQLExecutor_CancelAfterExecute verifies the code path where ctx is cancelled
+// after the initial query:execute POST returns (and a requestToken is available) but
+// before any poll request is sent.  ExecuteQueryWithContext must call query:cancel with
+// the correct token and return (nil, nil).
+func TestDQLExecutor_CancelAfterExecute(t *testing.T) {
+	executeReturned := make(chan struct{})
+	cancelCalled := false
+	cancelToken := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/platform/storage/query/v1/query:execute":
+			resp := DQLQueryResponse{State: "RUNNING", RequestToken: "tok-after-execute"}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(resp)
+			// Signal that the execute response has been written; the test will now
+			// cancel the context before any poll request can be issued.
+			close(executeReturned)
+
+		case "/platform/storage/query/v1/query:cancel":
+			cancelCalled = true
+			cancelToken = r.URL.Query().Get("request-token")
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			// query:poll must never be reached in this test
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Cancel the context as soon as the execute response is delivered, so that
+	// the ctx.Err() check immediately after the POST fires before any poll.
+	go func() {
+		<-executeReturned
+		cancel()
+	}()
+
+	executor := NewDQLExecutor(c)
+	result, err := executor.ExecuteQueryWithContext(ctx, "fetch logs", DQLExecuteOptions{})
+	if err != nil {
+		t.Fatalf("expected nil error on post-execute cancellation, got: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result on cancellation, got: %+v", result)
+	}
+	if !cancelCalled {
+		t.Error("expected query:cancel to be called after context cancellation")
+	}
+	if cancelToken != "tok-after-execute" {
+		t.Errorf("cancel called with wrong token: %q, want %q", cancelToken, "tok-after-execute")
 	}
 }
 

--- a/pkg/output/live.go
+++ b/pkg/output/live.go
@@ -63,6 +63,7 @@ func (p *LivePrinter) RunLive(ctx context.Context, fetcher DataFetcher) error {
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
 
 	// Set up resize signal handling for fullscreen mode (Unix only)
 	p.setupResizeSignal()

--- a/pkg/output/live.go
+++ b/pkg/output/live.go
@@ -83,8 +83,20 @@ func (p *LivePrinter) RunLive(ctx context.Context, fetcher DataFetcher) error {
 					if err != nil || n == 0 {
 						return
 					}
+					key := rune(buf[0])
+					// For quit keys, cancel the context immediately so that any
+					// in-progress fetchAndPrint (which may be blocked on HTTP I/O)
+					// is interrupted without waiting for the select loop to unblock.
+					if key == 'q' || key == 'Q' || key == '\x03' {
+						cancel()
+						select {
+						case keyCh <- key:
+						default:
+						}
+						return
+					}
 					select {
-					case keyCh <- rune(buf[0]):
+					case keyCh <- key:
 					case <-ctx.Done():
 						return
 					}
@@ -114,7 +126,7 @@ func (p *LivePrinter) RunLive(ctx context.Context, fetcher DataFetcher) error {
 			return nil
 		case key := <-keyCh:
 			// Handle 'q' or 'Q' to quit
-			if key == 'q' || key == 'Q' {
+			if key == 'q' || key == 'Q' || key == '\x03' { // 'q', 'Q', or Ctrl+C (raw mode intercepts the byte before OS delivers SIGINT)
 				_, _ = fmt.Fprintln(p.writer, "\nLive mode stopped.")
 				return nil
 			}
@@ -149,6 +161,9 @@ func (p *LivePrinter) fetchAndPrint(ctx context.Context, fetcher DataFetcher) er
 	data, err := fetcher(ctx)
 	if err != nil {
 		return err
+	}
+	if data == nil {
+		return nil // context cancelled; nothing to display
 	}
 
 	// Clear screen and move cursor to top-left

--- a/pkg/output/live_test.go
+++ b/pkg/output/live_test.go
@@ -1,0 +1,78 @@
+package output
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// TestFetchAndPrint_NilDataReturnsNil verifies that fetchAndPrint returns nil
+// without clearing the screen or calling printer.Print when the fetcher returns
+// (nil, nil) — the signal used by the DQL executor to indicate context cancellation.
+func TestFetchAndPrint_NilDataReturnsNil(t *testing.T) {
+	printCalled := false
+	printer := &recordingPrinter{onPrint: func(data interface{}) error {
+		printCalled = true
+		return nil
+	}}
+
+	var buf bytes.Buffer
+	p := &LivePrinter{
+		printer:  printer,
+		interval: DefaultLiveInterval,
+		writer:   &buf,
+	}
+
+	fetcher := func(_ context.Context) (interface{}, error) {
+		return nil, nil // simulates context-cancelled path
+	}
+
+	err := p.fetchAndPrint(context.Background(), fetcher)
+	if err != nil {
+		t.Fatalf("fetchAndPrint returned unexpected error: %v", err)
+	}
+	if printCalled {
+		t.Error("printer.Print should not be called when fetcher returns nil data")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("no output expected for nil data, got: %q", buf.String())
+	}
+}
+
+// TestFetchAndPrint_FetcherError propagates the error from the fetcher without
+// touching the printer or writing any output.
+func TestFetchAndPrint_FetcherError(t *testing.T) {
+	printCalled := false
+	printer := &recordingPrinter{onPrint: func(data interface{}) error {
+		printCalled = true
+		return nil
+	}}
+
+	var buf bytes.Buffer
+	p := &LivePrinter{
+		printer:  printer,
+		interval: DefaultLiveInterval,
+		writer:   &buf,
+	}
+
+	wantErr := context.Canceled
+	fetcher := func(_ context.Context) (interface{}, error) {
+		return nil, wantErr
+	}
+
+	err := p.fetchAndPrint(context.Background(), fetcher)
+	if err != wantErr {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+	if printCalled {
+		t.Error("printer.Print should not be called when fetcher returns an error")
+	}
+}
+
+// recordingPrinter is a minimal Printer implementation for testing.
+type recordingPrinter struct {
+	onPrint func(data interface{}) error
+}
+
+func (r *recordingPrinter) Print(data interface{}) error      { return r.onPrint(data) }
+func (r *recordingPrinter) PrintList(data interface{}) error  { return nil }

--- a/pkg/output/live_test.go
+++ b/pkg/output/live_test.go
@@ -74,5 +74,5 @@ type recordingPrinter struct {
 	onPrint func(data interface{}) error
 }
 
-func (r *recordingPrinter) Print(data interface{}) error      { return r.onPrint(data) }
-func (r *recordingPrinter) PrintList(data interface{}) error  { return nil }
+func (r *recordingPrinter) Print(data interface{}) error     { return r.onPrint(data) }
+func (r *recordingPrinter) PrintList(data interface{}) error { return nil }


### PR DESCRIPTION
## Summary

- **Cancel running Grail query on exit**: when dtctl is interrupted while a DQL
  query is polling, `POST /query:cancel` is now sent (best-effort, 3 s timeout)
  before the process exits.
- **Poll hold time**: reduced to 5 s (from 60 s); constant deduplicated. This
  increases polling frequency but is an acceptable trade-off — dtctl is typically
  invoked by AI agents where intermediate results are not consumed, and 5 s is
  still short enough for prompt cancellation behaviour. An upcoming backend
  optimization will additionally benefit from the shorter hold time.

## Test plan

- [x] `TestDQLExecutor_CancelAfterExecute` — cancel between POST and first poll
  triggers `CancelQuery` with the correct token
- [x] `TestDQLExecutor_CancelWhilePollInFlight` — two-channel barrier confirms
  `CancelQuery` fires after poll response returns on cancel
- Manual: interrupt `dtctl query dql '...'` mid-poll → "Query cancelled." printed
  to stderr; query is cancelled on the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)