### PR TITLE
fix: strip UTF-8 BOM from auto-detected CSV parse pattern (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`iam:service-users:use` OAuth scope** — added to the `readwrite-mine`, `readwrite-all`, and `dangerously-unrestricted` safety levels so `dtctl create workflow` can use a Dynatrace [service user as the workflow actor](https://docs.dynatrace.com/docs/analyze-explore-automate/workflows/security#service-users); existing sessions need to re-run `dtctl auth login` to pick up the new scope; note that this slightly broadens the privilege footprint of `readwrite-mine` since holders can now act as a service user when creating workflows
 
+### Fixed
+- **`create lookup` now handles CSV files with a UTF-8 BOM** — Excel on macOS/Windows and many editors prepend a byte order mark (`EF BB BF`) when saving as CSV; the BOM was previously embedded in the first column name during parse-pattern auto-detection, producing a DPL pattern the upload API rejected with `Syntax error: extraneous input ''`; the BOM is now stripped before the header is parsed; fixes [#187](https://github.com/dynatrace-oss/dtctl/issues/187)
+
 ## [0.25.1] - 2026-04-21
 
 ### Fixed

--- a/pkg/resources/lookup/handler_test.go
+++ b/pkg/resources/lookup/handler_test.go
@@ -3,8 +3,12 @@ package lookup
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
@@ -49,6 +53,80 @@ func TestCreate_WithDataContent_Success(t *testing.T) {
 	}
 	if resp.Records != 2 {
 		t.Errorf("expected 2 records, got %d", resp.Records)
+	}
+}
+
+// parseUploadRequest reads the multipart upload body sent to the lookup
+// endpoint and returns the JSON request part decoded plus the raw content.
+func parseUploadRequest(t *testing.T, r *http.Request) (UploadRequest, []byte) {
+	t.Helper()
+	_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parse content-type: %v", err)
+	}
+	mr := multipart.NewReader(r.Body, params["boundary"])
+
+	var (
+		req     UploadRequest
+		content []byte
+	)
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("next part: %v", err)
+		}
+		body, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("read part: %v", err)
+		}
+		switch part.FormName() {
+		case "request":
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("decode request part: %v (body=%q)", err, body)
+			}
+		case "content":
+			content = body
+		}
+	}
+	return req, content
+}
+
+// TestCreate_StripsBOMFromAutoDetectedPattern is the regression test for #187:
+// when a CSV file is BOM-prefixed, the auto-detected parsePattern sent to the
+// upload API must not contain the BOM. Otherwise the server-side DPL parser
+// rejects the pattern with "extraneous input ”".
+func TestCreate_StripsBOMFromAutoDetectedPattern(t *testing.T) {
+	var captured UploadRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/storage/resource-store/v1/files/tabular/lookup:upload", func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = parseUploadRequest(t, r)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(UploadResponse{Records: 1})
+	})
+	h, cleanup := newLookupTestHandler(t, mux)
+	defer cleanup()
+
+	bomCSV := append([]byte{0xEF, 0xBB, 0xBF}, []byte("code,description\nERR1,boom")...)
+	if _, err := h.Create(CreateRequest{
+		FilePath:    "/lookups/test/bom",
+		LookupField: "code",
+		DataContent: bomCSV,
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	want := "LD:code ',' LD:description"
+	if captured.ParsePattern != want {
+		t.Errorf("parsePattern = %q, want %q", captured.ParsePattern, want)
+	}
+	if strings.ContainsRune(captured.ParsePattern, '\ufeff') {
+		t.Errorf("parsePattern still contains BOM: %q", captured.ParsePattern)
+	}
+	if captured.SkippedRecords != 1 {
+		t.Errorf("skippedRecords = %d, want 1", captured.SkippedRecords)
 	}
 }
 

--- a/pkg/resources/lookup/lookup.go
+++ b/pkg/resources/lookup/lookup.go
@@ -491,8 +491,19 @@ func ValidatePath(path string) error {
 	return nil
 }
 
-// DetectCSVPattern auto-detects CSV pattern from data
+// utf8BOM is the UTF-8 byte order mark that some editors (notably Excel on
+// Windows/macOS) prepend when saving CSV files. The DPL parser used by the
+// lookup upload API rejects the BOM as invalid input, so it must be stripped
+// before auto-detecting the parse pattern; otherwise the BOM ends up inside
+// the first column name and produces an unparseable pattern.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// DetectCSVPattern auto-detects a DPL parse pattern from CSV data by reading
+// the header row and emitting one LD field per column. A leading UTF-8 BOM is
+// stripped so it is not embedded in the first column name. CRLF line endings
+// are handled transparently by encoding/csv.
 func DetectCSVPattern(data []byte) (pattern string, skippedRecords int, err error) {
+	data = bytes.TrimPrefix(data, utf8BOM)
 	reader := csv.NewReader(bytes.NewReader(data))
 
 	// Read header row

--- a/pkg/resources/lookup/lookup_test.go
+++ b/pkg/resources/lookup/lookup_test.go
@@ -141,6 +141,31 @@ func TestDetectCSVPattern(t *testing.T) {
 			wantErr:            false,
 		},
 		{
+			// Regression test for #187: Excel on macOS/Windows prepends a UTF-8
+			// BOM (0xEF 0xBB 0xBF) when saving as CSV. Without stripping it, the
+			// first column name became "\ufeffcode" and the server-side DPL
+			// parser rejected the resulting pattern with "extraneous input ''".
+			name:               "CSV with UTF-8 BOM",
+			csvData:            "\ufeffcode,description,severity,action\nERR001,timeout,critical,page",
+			wantPattern:        "LD:code ',' LD:description ',' LD:severity ',' LD:action",
+			wantSkippedRecords: 1,
+			wantErr:            false,
+		},
+		{
+			name:               "CSV with BOM and CRLF line endings",
+			csvData:            "\ufeffid,name\r\n1,alice\r\n2,bob",
+			wantPattern:        "LD:id ',' LD:name",
+			wantSkippedRecords: 1,
+			wantErr:            false,
+		},
+		{
+			name:               "BOM-only single column CSV",
+			csvData:            "\ufeffid\n1",
+			wantPattern:        "LD:id",
+			wantSkippedRecords: 1,
+			wantErr:            false,
+		},
+		{
 			name:    "empty CSV",
 			csvData: "",
 			wantErr: true,

--- a/test/e2e/lookup_test.go
+++ b/test/e2e/lookup_test.go
@@ -461,6 +461,81 @@ func TestLookupDelete_NotFound(t *testing.T) {
 	}
 }
 
+// TestLookupCreate_BOMPrefixedCSV is a regression test for issue #187.
+// Files saved as CSV by Excel and many Windows editors are prefixed with a
+// UTF-8 byte order mark (EF BB BF). Before the fix, that BOM was included in
+// the first column name when auto-detecting a parse pattern, producing a DPL
+// expression that the upload API rejected as extraneous-input. This
+// test uploads a BOM-prefixed CSV against the live API and asserts that the
+// auto-detection path now succeeds and parses every data row.
+func TestLookupCreate_BOMPrefixedCSV(t *testing.T) {
+	env := integration.SetupIntegration(t)
+	defer env.Cleanup.Cleanup(t)
+
+	handler := lookup.NewHandler(env.Client)
+	lookupPath := fmt.Sprintf("/lookups/dtctl_test/%s/bom_prefixed", env.TestPrefix)
+
+	// Real-world payload: UTF-8 BOM + CRLF line endings, exactly what Excel on
+	// macOS produces. Reproduces the failure mode from the issue verbatim.
+	csvData := []byte("\xEF\xBB\xBF" +
+		"code,description,severity,action\r\n" +
+		"ERR001,Database connection timeout,critical,page-oncall\r\n" +
+		"ERR002,Rate limit exceeded,warning,notify-slack\r\n" +
+		"ERR003,Authentication failed,high,review-logs\r\n" +
+		"ERR004,Disk space low,warning,expand-volume")
+
+	req := lookup.CreateRequest{
+		FilePath:    lookupPath,
+		LookupField: "code",
+		DataContent: csvData,
+		DisplayName: fmt.Sprintf("BOM Test %s", env.TestPrefix),
+	}
+
+	uploadResp, err := handler.Create(req)
+	if err != nil {
+		t.Fatalf("Create() with BOM-prefixed CSV failed: %v", err)
+	}
+	env.Cleanup.Track("lookup", lookupPath, req.DisplayName)
+
+	if uploadResp.Records != 4 {
+		t.Errorf("Records = %d, want 4 (one per non-header row)", uploadResp.Records)
+	}
+	t.Logf("✓ Created lookup from BOM-prefixed CSV: %d records", uploadResp.Records)
+
+	// Wait for the lookup to be queryable, then verify the column names are
+	// not BOM-corrupted. The first column must be "code", not "\ufeffcode".
+	if err := waitForLookupQueryable(t, handler, lookupPath, 30*time.Second); err != nil {
+		t.Fatalf("Lookup did not become queryable: %v", err)
+	}
+
+	dataResult, err := handler.GetData(lookupPath, 0)
+	if err != nil {
+		t.Fatalf("GetData() failed: %v", err)
+	}
+	if len(dataResult.Records) != 4 {
+		t.Errorf("data row count = %d, want 4", len(dataResult.Records))
+	}
+	if len(dataResult.Records) > 0 {
+		first := dataResult.Records[0]
+		if _, ok := first["code"]; !ok {
+			t.Errorf("first record missing 'code' column; got columns %v", keysOf(first))
+		}
+		for col := range first {
+			if strings.ContainsRune(col, '\ufeff') {
+				t.Errorf("column name contains BOM: %q", col)
+			}
+		}
+	}
+}
+
+func keysOf(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 func TestLookupList(t *testing.T) {
 	env := integration.SetupIntegration(t)
 	defer env.Cleanup.Cleanup(t)


### PR DESCRIPTION
## Summary

- `dtctl create lookup` failed on Excel-exported CSV files because the UTF-8 BOM (`EF BB BF`) was embedded in the first column name during parse-pattern auto-detection, producing a DPL pattern the upload API rejected as `Syntax error: extraneous input ''`.
- The BOM is now stripped before headers are parsed, so the auto-detection path works on real-world spreadsheet exports.
- Added unit + handler tests and a live-API integration test to cover the regression.

Fixes #187.

## Root cause

`DetectCSVPattern` passed the file bytes straight to `csv.NewReader`, which does not strip a leading BOM. For a typical Excel-on-macOS CSV, the first header became `﻿code` and the generated pattern was `LD:﻿code ',' LD:description ',' …`. The DPL parser used by `/platform/storage/resource-store/v1/files/tabular/lookup:upload` treats the BOM as invalid input and returns `400` with the misleading-looking `extraneous input ''` (the BOM is rendered invisibly).

I reproduced the failure verbatim against a live tenant using the exact CSV attached to the issue, then confirmed the fix end-to-end on the same file.

## Test plan

- [x] Unit test: `TestDetectCSVPattern` — added BOM+LF, BOM+CRLF, and BOM-only-single-column cases.
- [x] Handler test: `TestCreate_StripsBOMFromAutoDetectedPattern` — captures the multipart upload body and asserts the on-the-wire `parsePattern` contains no BOM and `skippedRecords == 1`.
- [x] Integration test: `TestLookupCreate_BOMPrefixedCSV` (build tag `integration`) — uploads a BOM + CRLF CSV through the live API, asserts 4 records, and verifies the column names returned by `GetData` are not BOM-corrupted.
- [x] `go test ./...` — all packages pass.
- [x] `go vet ./...` and `golangci-lint run ./pkg/resources/lookup/...` — clean.
- [x] Manually re-uploaded the issue's exact attached CSV with the patched binary against a live tenant: `OK Lookup table "/lookups/dtctltest/issue187fixed" created — Records: 4`.