### PR TITLE
fix: production-readiness fixes for watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Eight `--watch` mode correctness bugs** — `--watch-only` no longer floods output with false `ADDED` events on the first poll (differ baseline was never seeded); `Watcher.Stop()` no longer panics on a second call (guarded with `sync.Once`); Ctrl+C no longer hangs for seconds during rate-limit or network-error backoff (`time.Sleep` replaced with a context-aware helper); `Retry-After` headers on HTTP 429 responses are now parsed and honoured instead of always being ignored (stub replaced with a real parser, capped at 5 min); `--interval` values below 1 s are now correctly clamped to 1 s instead of 2 s; `--watch`/`--watch-only` flags no longer appear in `--help` for commands that never call `executeWithWatch` (`buckets`, `slos`, `notifications`, `workflow-executions`, `extensions`, `segments`); transient errors (timeout, temporary failure, connection reset) now back off for one interval before retrying instead of hammering the endpoint immediately; resources keyed by `objectId`/`entityId` (no `id`/`name` field) now participate in change detection via a stable content hash instead of being silently dropped every poll; fixes [#189](https://github.com/dynatrace-oss/dtctl/issues/189)
+
 ### Added
 - **`iam:service-users:use` OAuth scope** — added to the `readwrite-mine`, `readwrite-all`, and `dangerously-unrestricted` safety levels so `dtctl create workflow` can use a Dynatrace [service user as the workflow actor](https://docs.dynatrace.com/docs/analyze-explore-automate/workflows/security#service-users); existing sessions need to re-run `dtctl auth login` to pick up the new scope; note that this slightly broadens the privilege footprint of `readwrite-mine` since holders can now act as a service user when creating workflows
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -73,7 +73,7 @@ func executeWithWatch(cmd *cobra.Command, fetcher watch.ResourceFetcher, printer
 	watchOnly, _ := cmd.Flags().GetBool("watch-only")
 
 	if interval < time.Second {
-		interval = 2 * time.Second
+		interval = time.Second
 	}
 
 	cfg, err := LoadConfig()

--- a/cmd/get_buckets.go
+++ b/cmd/get_buckets.go
@@ -117,8 +117,6 @@ Examples:
 }
 
 func init() {
-	addWatchFlags(getBucketsCmd)
-
 	// Delete confirmation flags
 	deleteBucketCmd.Flags().BoolVarP(&forceDelete, "yes", "y", false, "Skip confirmation prompt")
 	deleteBucketCmd.Flags().String("confirm", "", "Confirm deletion by providing the bucket name (for non-interactive use)")

--- a/cmd/get_extensions.go
+++ b/cmd/get_extensions.go
@@ -104,8 +104,6 @@ Examples:
 }
 
 func init() {
-	addWatchFlags(getExtensionsCmd)
-
 	// Extension flags
 	getExtensionsCmd.Flags().String("name", "", "Filter extensions by name")
 

--- a/cmd/get_notifications.go
+++ b/cmd/get_notifications.go
@@ -120,8 +120,6 @@ Examples:
 }
 
 func init() {
-	addWatchFlags(getNotificationsCmd)
-
 	// Notification flags
 	getNotificationsCmd.Flags().String("type", "", "Filter by notification type")
 

--- a/cmd/get_segments.go
+++ b/cmd/get_segments.go
@@ -133,8 +133,6 @@ Examples:
 }
 
 func init() {
-	addWatchFlags(getSegmentsCmd)
-
 	// Delete confirmation flags
 	deleteSegmentCmd.Flags().BoolVarP(&forceDelete, "yes", "y", false, "Skip confirmation prompt")
 	deleteSegmentCmd.Flags().String("confirm", "", "Confirm deletion by providing the segment UID (for non-interactive use)")

--- a/cmd/get_slos.go
+++ b/cmd/get_slos.go
@@ -157,8 +157,6 @@ Examples:
 }
 
 func init() {
-	addWatchFlags(getSLOsCmd)
-
 	// SLO flags
 	getSLOsCmd.Flags().String("filter", "", "Filter SLOs (e.g., \"name~'production'\")")
 	getSLOTemplatesCmd.Flags().String("filter", "", "Filter templates (e.g., \"builtIn==true\")")

--- a/cmd/get_workflows.go
+++ b/cmd/get_workflows.go
@@ -264,7 +264,6 @@ Examples:
 
 func init() {
 	addWatchFlags(getWorkflowsCmd)
-	addWatchFlags(getWorkflowExecutionsCmd)
 
 	getWorkflowExecutionsCmd.Flags().StringVarP(&workflowFilter, "workflow", "w", "", "Filter executions by workflow ID")
 	getWorkflowsCmd.Flags().Bool("mine", false, "Show only workflows owned by current user")

--- a/pkg/watch/differ.go
+++ b/pkg/watch/differ.go
@@ -1,6 +1,8 @@
 package watch
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -22,9 +24,14 @@ func (d *Differ) Detect(current []interface{}) []Change {
 	currentMap := make(map[string]interface{})
 	for _, item := range current {
 		id := extractID(item)
-		if id != "" {
-			currentMap[id] = item
+		if id == "" {
+			// Resource has no id/Id/ID/name/Name field - fall back to a content
+			// hash so the item still participates in change detection. Two
+			// items with identical content collide, but that's fine: they're
+			// indistinguishable to the user too.
+			id = "hash:" + contentHash(item)
 		}
+		currentMap[id] = item
 	}
 
 	// Detect additions and modifications - only return actual changes
@@ -120,6 +127,15 @@ func extractID(item interface{}) string {
 	}
 
 	return ""
+}
+
+func contentHash(item interface{}) string {
+	b, err := json.Marshal(item)
+	if err != nil {
+		return fmt.Sprintf("%p", item)
+	}
+	sum := sha1.Sum(b)
+	return hex.EncodeToString(sum[:])
 }
 
 func deepEqual(a, b interface{}) bool {

--- a/pkg/watch/differ.go
+++ b/pkg/watch/differ.go
@@ -132,7 +132,11 @@ func extractID(item interface{}) string {
 func contentHash(item interface{}) string {
 	b, err := json.Marshal(item)
 	if err != nil {
-		return fmt.Sprintf("%p", item)
+		// Stable sentinel: all unmarshalable items share this key and collide,
+		// which is fine — they're equally indistinguishable to the user.
+		// A pointer address (%p) would change across polls, making every such
+		// item appear as a new addition on every tick.
+		return "unmarshalable"
 	}
 	sum := sha1.Sum(b)
 	return hex.EncodeToString(sum[:])

--- a/pkg/watch/differ_test.go
+++ b/pkg/watch/differ_test.go
@@ -4,6 +4,41 @@ import (
 	"testing"
 )
 
+func TestDiffer_KeylessItems_ParticipateInDiff(t *testing.T) {
+	// Items with no id/Id/ID/name/Name field used to be silently dropped,
+	// causing watch mode to never report any changes for resources keyed by
+	// objectId, entityId, etc.
+	differ := NewDiffer()
+
+	initial := []interface{}{
+		map[string]interface{}{"objectId": "x", "value": 1},
+		map[string]interface{}{"objectId": "y", "value": 2},
+	}
+	changes := differ.Detect(initial)
+	if len(changes) != 2 {
+		t.Errorf("first call should classify both items as added, got %d", len(changes))
+	}
+
+	// Identical second call - no changes expected. Without the hash fallback,
+	// the differ would re-add both items every poll.
+	changes = differ.Detect(initial)
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes for identical re-poll, got %d (%v)", len(changes), changes)
+	}
+
+	// Mutating one item must surface as a real change.
+	updated := []interface{}{
+		map[string]interface{}{"objectId": "x", "value": 1},
+		map[string]interface{}{"objectId": "y", "value": 99},
+	}
+	changes = differ.Detect(updated)
+	// One Added (new hash) and one Deleted (old hash gone) is acceptable.
+	// What's NOT acceptable is zero changes, which is what the bug produced.
+	if len(changes) == 0 {
+		t.Errorf("expected hash-based diff to detect mutation; got 0 changes")
+	}
+}
+
 func TestDiffer_DetectAdditions(t *testing.T) {
 	differ := NewDiffer()
 

--- a/pkg/watch/types.go
+++ b/pkg/watch/types.go
@@ -1,6 +1,7 @@
 package watch
 
 import (
+	"sync"
 	"time"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
@@ -34,5 +35,6 @@ type Watcher struct {
 	differ      *Differ
 	printer     output.Printer
 	stopCh      chan struct{}
+	stopOnce    sync.Once
 	showInitial bool
 }

--- a/pkg/watch/watcher.go
+++ b/pkg/watch/watcher.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log"
 	"reflect"
+	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/dynatrace-oss/dtctl/pkg/output"
@@ -11,7 +13,7 @@ import (
 
 func NewWatcher(opts WatcherOptions) *Watcher {
 	if opts.Interval < time.Second {
-		opts.Interval = 2 * time.Second
+		opts.Interval = time.Second
 	}
 
 	return &Watcher{
@@ -47,16 +49,19 @@ func (w *Watcher) Start(ctx context.Context) error {
 				}
 				if isRateLimited(err) {
 					backoff := extractRetryAfter(err)
-					if backoff > 0 {
-						time.Sleep(backoff)
-					} else {
-						time.Sleep(w.interval * 2)
+					if backoff <= 0 {
+						backoff = w.interval * 2
+					}
+					if !w.sleep(ctx, backoff) {
+						return nil
 					}
 					continue
 				}
 				if isNetworkError(err) {
 					log.Printf("Warning: Connection lost, retrying...\n")
-					time.Sleep(w.interval * 2)
+					if !w.sleep(ctx, w.interval*2) {
+						return nil
+					}
 					continue
 				}
 				return err
@@ -65,8 +70,26 @@ func (w *Watcher) Start(ctx context.Context) error {
 	}
 }
 
+// sleep waits for d, returning false if the watcher was cancelled
+// (via ctx or Stop) during the wait.
+func (w *Watcher) sleep(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	case <-w.stopCh:
+		return false
+	}
+}
+
 func (w *Watcher) Stop() {
-	close(w.stopCh)
+	w.stopOnce.Do(func() { close(w.stopCh) })
 }
 
 func (w *Watcher) poll(ctx context.Context, initial bool) error {
@@ -80,10 +103,12 @@ func (w *Watcher) poll(ctx context.Context, initial bool) error {
 		return err
 	}
 
-	if initial && w.showInitial {
-		// Initialize differ state so next poll doesn't see everything as "added"
+	if initial {
+		// Always seed the differ's baseline on the initial poll, so that
+		// the next poll has something to diff against. Without this,
+		// --watch-only would print every existing resource as ADDED.
 		w.differ.Detect(resources)
-		if w.printer != nil {
+		if w.showInitial && w.printer != nil {
 			return w.printer.PrintList(resources)
 		}
 		return nil
@@ -168,8 +193,28 @@ func isNetworkError(err error) bool {
 		contains(errStr, "network unreachable")
 }
 
+// retryAfterPattern matches "Retry-After: <seconds>" in an error message,
+// case-insensitively. Dynatrace clients surface this as part of the rate-limit
+// error string. The header value is in seconds per RFC 7231.
+var retryAfterPattern = regexp.MustCompile(`(?i)retry[-_ ]?after[:=\s]+(\d+)`)
+
 func extractRetryAfter(err error) time.Duration {
-	return 0
+	if err == nil {
+		return 0
+	}
+	m := retryAfterPattern.FindStringSubmatch(err.Error())
+	if len(m) < 2 {
+		return 0
+	}
+	secs, parseErr := strconv.Atoi(m[1])
+	if parseErr != nil || secs <= 0 {
+		return 0
+	}
+	// Cap the back-off so a hostile or buggy server can't pin us forever.
+	if secs > 300 {
+		secs = 300
+	}
+	return time.Duration(secs) * time.Second
 }
 
 func contains(s, substr string) bool {

--- a/pkg/watch/watcher.go
+++ b/pkg/watch/watcher.go
@@ -199,6 +199,8 @@ func isNetworkError(err error) bool {
 // retryAfterPattern matches "Retry-After: <seconds>" in an error message,
 // case-insensitively. Dynatrace clients surface this as part of the rate-limit
 // error string. The header value is in seconds per RFC 7231.
+// Note: RFC 7231 also allows an HTTP-date value (e.g. "Thu, 01 Jan 2026 …");
+// that form is not handled here. Dynatrace only ever sends the integer form.
 var retryAfterPattern = regexp.MustCompile(`(?i)retry[-_ ]?after[:=\s]+(\d+)`)
 
 func extractRetryAfter(err error) time.Duration {

--- a/pkg/watch/watcher.go
+++ b/pkg/watch/watcher.go
@@ -45,6 +45,9 @@ func (w *Watcher) Start(ctx context.Context) error {
 			if err := w.poll(ctx, false); err != nil {
 				if isTransient(err) {
 					log.Printf("Warning: Temporary error, retrying: %v\n", err)
+					if !w.sleep(ctx, w.interval) {
+						return nil
+					}
 					continue
 				}
 				if isRateLimited(err) {

--- a/pkg/watch/watcher_test.go
+++ b/pkg/watch/watcher_test.go
@@ -45,9 +45,21 @@ func TestNewWatcher_MinInterval(t *testing.T) {
 
 	watcher := NewWatcher(opts)
 
-	if watcher.interval < time.Second {
-		t.Errorf("Expected interval to be at least 1s, got %v", watcher.interval)
+	if watcher.interval != time.Second {
+		t.Errorf("Expected sub-1s interval to clamp to documented 1s minimum, got %v", watcher.interval)
 	}
+}
+
+func TestWatcher_StopIsIdempotent(t *testing.T) {
+	w := NewWatcher(WatcherOptions{
+		Interval: time.Second,
+		Fetcher:  func() (interface{}, error) { return []interface{}{}, nil },
+	})
+
+	// Multiple calls must not panic with "close of closed channel".
+	w.Stop()
+	w.Stop()
+	w.Stop()
 }
 
 func TestWatcher_Stop(t *testing.T) {
@@ -94,6 +106,145 @@ func TestWatcher_ContextCancellation(t *testing.T) {
 	err := watcher.Start(ctx)
 	if err != nil {
 		t.Errorf("Expected no error on context cancellation, got %v", err)
+	}
+}
+
+// recordingPrinter captures Print/PrintList/PrintChanges calls so tests can
+// assert on what watch mode actually emits.
+type recordingPrinter struct {
+	listCalls    int
+	printCalls   int
+	changeCalls  int
+	lastChanges  []Change
+}
+
+func (p *recordingPrinter) Print(_ interface{}) error      { p.printCalls++; return nil }
+func (p *recordingPrinter) PrintList(_ interface{}) error  { p.listCalls++; return nil }
+func (p *recordingPrinter) PrintChanges(c []Change) error {
+	p.changeCalls++
+	p.lastChanges = append([]Change(nil), c...)
+	return nil
+}
+
+func TestWatcher_WatchOnly_DoesNotEmitInitialState(t *testing.T) {
+	// Reproduces the bug where --watch-only (ShowInitial=false) caused every
+	// existing resource to be reported as ChangeTypeAdded on the first poll
+	// because the differ's baseline was never seeded.
+	resources := []interface{}{
+		map[string]interface{}{"id": "a", "v": 1},
+		map[string]interface{}{"id": "b", "v": 1},
+	}
+	calls := 0
+	fetcher := func() (interface{}, error) {
+		calls++
+		return resources, nil
+	}
+
+	printer := &recordingPrinter{}
+	w := NewWatcher(WatcherOptions{
+		Interval:    time.Second,
+		Fetcher:     fetcher,
+		Printer:     printer,
+		ShowInitial: false,
+	})
+
+	if err := w.poll(context.Background(), true); err != nil {
+		t.Fatalf("initial poll: %v", err)
+	}
+
+	if printer.listCalls != 0 {
+		t.Errorf("--watch-only must suppress initial PrintList; got %d calls", printer.listCalls)
+	}
+	if printer.changeCalls != 0 {
+		t.Errorf("--watch-only must not invoke PrintChanges on first poll; got %d", printer.changeCalls)
+	}
+	if printer.printCalls != 0 {
+		t.Errorf("--watch-only must not emit individual prints on first poll; got %d", printer.printCalls)
+	}
+
+	// A subsequent poll with the same data must report no actual changes -
+	// proving the differ was seeded silently on the initial poll. Pre-fix,
+	// it would report two ChangeTypeAdded entries here.
+	if err := w.poll(context.Background(), false); err != nil {
+		t.Fatalf("second poll: %v", err)
+	}
+	if len(printer.lastChanges) != 0 {
+		t.Errorf("expected no changes on identical second poll; got %d: %v", len(printer.lastChanges), printer.lastChanges)
+	}
+}
+
+func TestWatcher_ShowInitial_PrintsThenSeedsBaseline(t *testing.T) {
+	resources := []interface{}{map[string]interface{}{"id": "a", "v": 1}}
+	fetcher := func() (interface{}, error) { return resources, nil }
+
+	printer := &recordingPrinter{}
+	w := NewWatcher(WatcherOptions{
+		Interval:    time.Second,
+		Fetcher:     fetcher,
+		Printer:     printer,
+		ShowInitial: true,
+	})
+
+	if err := w.poll(context.Background(), true); err != nil {
+		t.Fatalf("initial poll: %v", err)
+	}
+	if printer.listCalls != 1 {
+		t.Errorf("ShowInitial=true must call PrintList once; got %d", printer.listCalls)
+	}
+
+	// Identical second poll must produce no actual changes.
+	if err := w.poll(context.Background(), false); err != nil {
+		t.Fatalf("second poll: %v", err)
+	}
+	if len(printer.lastChanges) != 0 {
+		t.Errorf("expected no changes on identical second poll; got %v", printer.lastChanges)
+	}
+}
+
+func TestExtractRetryAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected time.Duration
+	}{
+		{"nil", nil, 0},
+		{"no header", errors.New("rate limit exceeded"), 0},
+		{"basic", errors.New("HTTP 429: Retry-After: 30"), 30 * time.Second},
+		{"case insensitive", errors.New("retry-after=12"), 12 * time.Second},
+		{"capped", errors.New("Retry-After: 9999"), 300 * time.Second},
+		{"zero is ignored", errors.New("Retry-After: 0"), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractRetryAfter(tt.err)
+			if got != tt.expected {
+				t.Errorf("got %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWatcher_Sleep_HonoursContextCancel(t *testing.T) {
+	w := NewWatcher(WatcherOptions{
+		Interval: time.Second,
+		Fetcher:  func() (interface{}, error) { return []interface{}{}, nil },
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	ok := w.sleep(ctx, 5*time.Second)
+	elapsed := time.Since(start)
+
+	if ok {
+		t.Error("sleep must return false when ctx is cancelled")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("sleep should return promptly on cancel; took %v", elapsed)
 	}
 }
 

--- a/pkg/watch/watcher_test.go
+++ b/pkg/watch/watcher_test.go
@@ -112,14 +112,14 @@ func TestWatcher_ContextCancellation(t *testing.T) {
 // recordingPrinter captures Print/PrintList/PrintChanges calls so tests can
 // assert on what watch mode actually emits.
 type recordingPrinter struct {
-	listCalls    int
-	printCalls   int
-	changeCalls  int
-	lastChanges  []Change
+	listCalls   int
+	printCalls  int
+	changeCalls int
+	lastChanges []Change
 }
 
-func (p *recordingPrinter) Print(_ interface{}) error      { p.printCalls++; return nil }
-func (p *recordingPrinter) PrintList(_ interface{}) error  { p.listCalls++; return nil }
+func (p *recordingPrinter) Print(_ interface{}) error     { p.printCalls++; return nil }
+func (p *recordingPrinter) PrintList(_ interface{}) error { p.listCalls++; return nil }
 func (p *recordingPrinter) PrintChanges(c []Change) error {
 	p.changeCalls++
 	p.lastChanges = append([]Change(nil), c...)

--- a/pkg/watch/watcher_test.go
+++ b/pkg/watch/watcher_test.go
@@ -201,6 +201,40 @@ func TestWatcher_ShowInitial_PrintsThenSeedsBaseline(t *testing.T) {
 	}
 }
 
+func TestWatcher_TransientError_HonoursContextDuringBackoff(t *testing.T) {
+	// Verify that context cancellation is honoured during the transient-error
+	// backoff sleep (i.e. sleep uses w.sleep, not time.Sleep).
+	call := 0
+	fetcher := func() (interface{}, error) {
+		call++
+		if call == 2 {
+			return nil, errors.New("connection timeout")
+		}
+		return []interface{}{}, nil
+	}
+
+	const interval = 50 * time.Millisecond
+	w := NewWatcher(WatcherOptions{
+		Interval: interval,
+		Fetcher:  fetcher,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel mid-backoff: after initial poll + first ticker + a bit into backoff sleep.
+	go func() {
+		time.Sleep(interval + 10*time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_ = w.Start(ctx)
+	elapsed := time.Since(start)
+
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("watcher did not stop promptly on context cancel during transient backoff; took %v", elapsed)
+	}
+}
+
 func TestExtractRetryAfter(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Fixes eight bugs in the watch mode introduced in #19. Six were in the original branch; two more were found during code review.

### Original fixes (commit 7d543ff)

1. **`--watch-only` flooded output** — differ baseline was never seeded when `ShowInitial=false`, so every existing resource was reported as `ChangeTypeAdded` on the first poll. Baseline is now seeded unconditionally on the initial poll; `PrintList` is gated on `ShowInitial`.

2. **`Watcher.Stop()` panicked on second call** — closing an already-closed channel. Guarded with `sync.Once`.

3. **`time.Sleep` in backoff blocked cancellation** — Ctrl+C hung for seconds during rate-limit or network-error backoff. Replaced with a context-aware `sleep` helper that unblocks immediately on `ctx.Done()` or `Stop()`.

4. **`extractRetryAfter` was a stub** — always returned 0, so `Retry-After` headers on 429 responses were ignored. Now parses `Retry-After: <seconds>` from the error message and caps at 5 min.

5. **Sub-1s `--interval` clamped to 2s** instead of the documented 1s minimum.

6. **`addWatchFlags` registered on six commands that never call `executeWithWatch`** — the flag appeared in `--help` but was silently ignored. Registrations removed from `buckets`, `slos`, `notifications`, `workflow-executions`, `extensions`, `segments`.

Also: differ now falls back to a content hash for items lacking `id`/`Id`/`ID`/`name`/`Name` fields, so resources keyed by `objectId`/`entityId` participate in change detection instead of being silently dropped.

### Code-review fixes (commit 2335800)

7. **Sub-1s clamp was unreachable** — `executeWithWatch` in `cmd/get.go` clamped any sub-1s interval to `2 * time.Second` before calling `NewWatcher`, so the corrected 1s clamp in `NewWatcher` never fired in practice. Both sites now clamp to `time.Second`.

8. **Transient errors had no backoff** — `isTransient` (timeout, temporary failure, connection reset) logged a warning and immediately continued, retrying at the very next ticker tick with no extra delay. Rate-limited and network errors both back off with `w.sleep`; transient errors now do the same (`w.sleep(ctx, w.interval)`), consistent with the other error paths and less aggressive toward a struggling endpoint.

## Test plan

- [ ] `go test ./...` passes (all packages, including `pkg/watch` and `cmd`)
- [ ] `dtctl get workflows --watch` shows initial list then diffs on change
- [ ] `dtctl get workflows --watch-only` shows no output until something changes
- [ ] Ctrl+C during `--watch` exits immediately (no multi-second hang)
- [ ] `dtctl get workflows --watch --interval 500ms` uses a 1s interval, not 2s