### PR TITLE
feat: add dt-client-context header to DQL query operations

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -332,6 +332,8 @@ Examples:
 			return fmt.Errorf("--segment-var requires at least one --segment or --segments-file")
 		}
 
+		clientContext, _ := cmd.Flags().GetString("client-context")
+
 		opts := exec.DQLExecuteOptions{
 			OutputFormat:                 outputFormat,
 			Decode:                       decodeMode,
@@ -353,6 +355,7 @@ Examples:
 			Timezone:                     timezone,
 			MetadataFields:               metadataFields,
 			Segments:                     segments,
+			ClientContext:                clientContext,
 		}
 
 		// Handle live mode
@@ -735,6 +738,10 @@ takes precedence over --segments-file variables`)
 	_ = queryCmd.RegisterFlagCompletionFunc("segments-file", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"yaml", "yml"}, cobra.ShellCompDirectiveFilterFileExt
 	})
+
+	// Client context flag
+	queryCmd.Flags().String("client-context", "", `optional caller context included in the dt-client-context request header
+useful for AI agents or scripts to declare their intent (e.g. "root-cause-analysis", "anomaly-investigation")`)
 }
 
 // metadataFieldCompletion provides shell completion for --metadata flag values.

--- a/cmd/verify_query.go
+++ b/cmd/verify_query.go
@@ -187,11 +187,13 @@ Examples:
 		timezone, _ := cmd.Flags().GetString("timezone")
 		locale, _ := cmd.Flags().GetString("locale")
 		failOnWarn, _ := cmd.Flags().GetBool("fail-on-warn")
+		clientContext, _ := cmd.Flags().GetString("client-context")
 
 		opts := exec.DQLVerifyOptions{
 			GenerateCanonicalQuery: canonical,
 			Timezone:               timezone,
 			Locale:                 locale,
+			ClientContext:          clientContext,
 		}
 
 		// Call VerifyQuery and handle response
@@ -431,4 +433,6 @@ func init() {
 	verifyQueryCmd.Flags().String("timezone", "", "timezone for query verification (IANA, CET, +01:00, etc.)")
 	verifyQueryCmd.Flags().String("locale", "", "locale for query verification (en, en_US, de_AT, etc.)")
 	verifyQueryCmd.Flags().Bool("fail-on-warn", false, "exit with non-zero status on warnings (useful for CI/CD)")
+	verifyQueryCmd.Flags().String("client-context", "", `optional caller context included in the dt-client-context request header
+useful for AI agents or scripts to declare their intent (e.g. "root-cause-analysis")`)
 }

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dynatrace-oss/dtctl/pkg/aidetect"
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
+	"github.com/dynatrace-oss/dtctl/pkg/version"
 )
 
 // DQLExecutor handles DQL query execution
@@ -30,6 +32,23 @@ func NewDQLExecutor(c *client.Client) *DQLExecutor {
 func (e *DQLExecutor) WithTokenRefresher(refresher func() (string, error)) *DQLExecutor {
 	e.tokenRefresher = refresher
 	return e
+}
+
+// dtClientContextHeader builds the JSON value for the dt-client-context HTTP header.
+// callerContext is the optional caller-supplied semantic string (empty = omit field).
+func dtClientContextHeader(callerContext string) string {
+	type payload struct {
+		App     string `json:"app"`
+		Version string `json:"version"`
+		Agent   string `json:"agent,omitempty"`
+		Context string `json:"context,omitempty"`
+	}
+	p := payload{App: "dtctl", Version: version.Version, Context: callerContext}
+	if info := aidetect.Detect(); info.Detected {
+		p.Agent = info.Name
+	}
+	b, _ := json.Marshal(p)
+	return string(b)
 }
 
 // pollRequestTimeoutMs is the server-side hold time per poll HTTP round trip in milliseconds.
@@ -96,6 +115,10 @@ type DQLExecuteOptions struct {
 
 	// Segment options
 	Segments []FilterSegmentRef // Filter segments to apply to the query
+
+	// ClientContext is an optional caller-supplied semantic string included as the "context"
+	// field in the dt-client-context request header (e.g. "root-cause-analysis").
+	ClientContext string
 }
 
 // DQLVerifyOptions configures DQL query verification
@@ -103,6 +126,7 @@ type DQLVerifyOptions struct {
 	GenerateCanonicalQuery bool   // Generate a canonical (normalized) version of the query
 	Timezone               string // Query timezone (e.g., "UTC", "Europe/Paris")
 	Locale                 string // Query locale (e.g., "en_US")
+	ClientContext          string // Optional caller-supplied semantic string for the dt-client-context header
 }
 
 // DQLQueryRequest represents a DQL query request
@@ -334,6 +358,7 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 	httpReq := e.client.HTTP().R().
 		SetContext(execCtx).
 		SetHeader("Content-Type", "application/json").
+		SetHeader("dt-client-context", dtClientContextHeader(opts.ClientContext)).
 		SetBody(req).
 		SetResult(&result)
 
@@ -347,7 +372,7 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 	// (e.g. SIGINT), cancel the backend query now that we have the token.
 	if ctx.Err() != nil {
 		if result.RequestToken != "" {
-			e.CancelQuery(result.RequestToken)
+			e.cancelQuery(result.RequestToken, dtClientContextHeader(opts.ClientContext))
 		} else {
 			fmt.Fprintln(os.Stderr, "\nQuery cancelled.")
 		}
@@ -369,7 +394,7 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 			// cancel to the backend. The internal poll deadline (pollCtx) is treated
 			// as a normal error so the caller sees the timeout.
 			if ctx.Err() != nil {
-				e.CancelQuery(result.RequestToken)
+				e.cancelQuery(result.RequestToken, dtClientContextHeader(opts.ClientContext))
 				return nil, nil
 			}
 			return nil, pollErr
@@ -457,6 +482,7 @@ func (e *DQLExecutor) VerifyQuery(query string, opts DQLVerifyOptions) (*DQLVeri
 	httpReq := e.client.HTTP().R().
 		SetContext(ctx).
 		SetHeader("Content-Type", "application/json").
+		SetHeader("dt-client-context", dtClientContextHeader(opts.ClientContext)).
 		SetBody(req).
 		SetResult(&result)
 
@@ -728,6 +754,7 @@ func (e *DQLExecutor) pollForResultsWithContext(ctx context.Context, requestToke
 		result = DQLQueryResponse{}
 		httpReq := e.client.HTTP().R().
 			SetContext(ctx).
+			SetHeader("dt-client-context", dtClientContextHeader(opts.ClientContext)).
 			SetQueryParam("request-token", requestToken).
 			SetQueryParam("request-timeout-milliseconds", fmt.Sprintf("%d", pollRequestTimeoutMs)).
 			SetResult(&result)
@@ -782,6 +809,13 @@ func (e *DQLExecutor) pollForResultsWithContext(ctx context.Context, requestToke
 // It uses a fresh context so the HTTP call can complete even if the parent context is cancelled.
 // Errors are written to stderr but not returned — cancellation is best-effort.
 func (e *DQLExecutor) CancelQuery(requestToken string) {
+	e.cancelQuery(requestToken, dtClientContextHeader(""))
+}
+
+// cancelQuery is the internal implementation of CancelQuery that accepts a pre-built
+// dt-client-context header value so the full caller context can be threaded through
+// from ExecuteQueryWithContext.
+func (e *DQLExecutor) cancelQuery(requestToken, clientContextHeader string) {
 	if requestToken == "" {
 		return
 	}
@@ -790,6 +824,7 @@ func (e *DQLExecutor) CancelQuery(requestToken string) {
 
 	resp, err := e.client.HTTP().R().
 		SetContext(ctx).
+		SetHeader("dt-client-context", clientContextHeader).
 		SetQueryParam("request-token", requestToken).
 		Post("/platform/storage/query/v1/query:cancel")
 

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -2305,11 +2305,11 @@ func TestDTClientContextHeader_WithAIAgentAndContext(t *testing.T) {
 
 func TestDQLExecutor_ClientContextHeader_OnExecuteAndPoll(t *testing.T) {
 	tests := []struct {
-		name            string
-		clientContext   string
-		wantContext     string // empty means key must be absent
-		setAIAgentEnv   bool
-		wantAgent       string
+		name          string
+		clientContext string
+		wantContext   string // empty means key must be absent
+		setAIAgentEnv bool
+		wantAgent     string
 	}{
 		{
 			name:          "no context no agent",

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -2208,3 +2208,339 @@ func TestDQLExecutor_ExecuteQueryWithOptions_StillWorks(t *testing.T) {
 		t.Errorf("expected SUCCEEDED, got %s", result.State)
 	}
 }
+
+// parseDTClientContext unmarshals the dt-client-context header value into a map.
+func parseDTClientContext(t *testing.T, raw string) map[string]string {
+	t.Helper()
+	if raw == "" {
+		t.Fatal("dt-client-context header is empty")
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("dt-client-context is not valid JSON: %v — value: %s", err, raw)
+	}
+	return m
+}
+
+// clearAIAgentEnvVars overrides every env var that aidetect checks to "0" so that
+// agent detection is disabled for the duration of the test. This is necessary because
+// the test process may itself be running inside an AI agent (e.g. Claude Code sets
+// CLAUDECODE=1), which would otherwise bleed into tests that expect no agent field.
+func clearAIAgentEnvVars(t *testing.T) {
+	t.Helper()
+	for _, env := range []string{
+		"CLAUDECODE", "CURSOR_AGENT", "GITHUB_COPILOT", "CODEIUM_AGENT",
+		"TABNINE_AGENT", "AMAZON_Q", "JUNIE", "KIRO", "OPENCODE", "OPENCLAW", "AI_AGENT",
+	} {
+		t.Setenv(env, "0")
+	}
+}
+
+func TestDTClientContextHeader_DefaultFields(t *testing.T) {
+	clearAIAgentEnvVars(t)
+
+	h := dtClientContextHeader("")
+	m := parseDTClientContext(t, h)
+
+	if m["app"] != "dtctl" {
+		t.Errorf("app = %q, want %q", m["app"], "dtctl")
+	}
+	if m["version"] == "" {
+		t.Error("version field must not be empty")
+	}
+	if _, hasCtx := m["context"]; hasCtx {
+		t.Error("context field should be omitted when callerContext is empty")
+	}
+	if _, hasAgent := m["agent"]; hasAgent {
+		t.Error("agent field should be omitted when no AI agent env var is set")
+	}
+}
+
+func TestDTClientContextHeader_WithCallerContext(t *testing.T) {
+	clearAIAgentEnvVars(t)
+
+	h := dtClientContextHeader("root-cause-analysis")
+	m := parseDTClientContext(t, h)
+
+	if m["context"] != "root-cause-analysis" {
+		t.Errorf("context = %q, want %q", m["context"], "root-cause-analysis")
+	}
+	if m["app"] != "dtctl" {
+		t.Errorf("app = %q, want %q", m["app"], "dtctl")
+	}
+}
+
+func TestDTClientContextHeader_WithAIAgent(t *testing.T) {
+	clearAIAgentEnvVars(t)
+	t.Setenv("AI_AGENT", "1") // triggers "generic-ai" in aidetect
+
+	h := dtClientContextHeader("")
+	m := parseDTClientContext(t, h)
+
+	if m["agent"] != "generic-ai" {
+		t.Errorf("agent = %q, want %q", m["agent"], "generic-ai")
+	}
+	if _, hasCtx := m["context"]; hasCtx {
+		t.Error("context field should be omitted when callerContext is empty")
+	}
+}
+
+func TestDTClientContextHeader_WithAIAgentAndContext(t *testing.T) {
+	clearAIAgentEnvVars(t)
+	t.Setenv("AI_AGENT", "1")
+
+	h := dtClientContextHeader("anomaly-investigation")
+	m := parseDTClientContext(t, h)
+
+	if m["app"] != "dtctl" {
+		t.Errorf("app = %q, want %q", m["app"], "dtctl")
+	}
+	if m["agent"] != "generic-ai" {
+		t.Errorf("agent = %q, want %q", m["agent"], "generic-ai")
+	}
+	if m["context"] != "anomaly-investigation" {
+		t.Errorf("context = %q, want %q", m["context"], "anomaly-investigation")
+	}
+}
+
+func TestDQLExecutor_ClientContextHeader_OnExecuteAndPoll(t *testing.T) {
+	tests := []struct {
+		name            string
+		clientContext   string
+		wantContext     string // empty means key must be absent
+		setAIAgentEnv   bool
+		wantAgent       string
+	}{
+		{
+			name:          "no context no agent",
+			clientContext: "",
+			wantContext:   "",
+			wantAgent:     "",
+		},
+		{
+			name:          "with caller context",
+			clientContext: "root-cause-analysis",
+			wantContext:   "root-cause-analysis",
+			wantAgent:     "",
+		},
+		{
+			name:          "with AI agent auto-detected",
+			clientContext: "",
+			setAIAgentEnv: true,
+			wantAgent:     "generic-ai",
+		},
+		{
+			name:          "with both caller context and AI agent",
+			clientContext: "incident-response",
+			setAIAgentEnv: true,
+			wantContext:   "incident-response",
+			wantAgent:     "generic-ai",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearAIAgentEnvVars(t) // prevent CLAUDECODE (or similar) from leaking in from the test runner
+			if tt.setAIAgentEnv {
+				t.Setenv("AI_AGENT", "1")
+			}
+
+			var executeHeader, pollHeader string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/platform/storage/query/v1/query:execute":
+					executeHeader = r.Header.Get("dt-client-context")
+					// Return 202 to force a poll cycle
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusAccepted)
+					_ = json.NewEncoder(w).Encode(DQLQueryResponse{
+						State:        "RUNNING",
+						RequestToken: "tok-abc",
+					})
+				case "/platform/storage/query/v1/query:poll":
+					pollHeader = r.Header.Get("dt-client-context")
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(DQLQueryResponse{
+						State:  "SUCCEEDED",
+						Result: &DQLResult{Records: []map[string]interface{}{{"k": "v"}}},
+					})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			c, err := client.NewForTesting(server.URL, "test-token")
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+
+			executor := NewDQLExecutor(c)
+			_, err = executor.ExecuteQueryWithContext(context.Background(), "fetch logs", DQLExecuteOptions{
+				ClientContext: tt.clientContext,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for label, raw := range map[string]string{"execute": executeHeader, "poll": pollHeader} {
+				m := parseDTClientContext(t, raw)
+				if m["app"] != "dtctl" {
+					t.Errorf("[%s] app = %q, want %q", label, m["app"], "dtctl")
+				}
+				if m["version"] == "" {
+					t.Errorf("[%s] version must not be empty", label)
+				}
+				if tt.wantContext != "" && m["context"] != tt.wantContext {
+					t.Errorf("[%s] context = %q, want %q", label, m["context"], tt.wantContext)
+				}
+				if tt.wantContext == "" {
+					if _, hasCtx := m["context"]; hasCtx {
+						t.Errorf("[%s] context field should be absent when ClientContext is empty", label)
+					}
+				}
+				if tt.wantAgent != "" && m["agent"] != tt.wantAgent {
+					t.Errorf("[%s] agent = %q, want %q", label, m["agent"], tt.wantAgent)
+				}
+				if tt.wantAgent == "" {
+					if _, hasAgent := m["agent"]; hasAgent {
+						t.Errorf("[%s] agent field should be absent when no AI agent env var is set", label)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestDQLExecutor_ClientContextHeader_OnVerify(t *testing.T) {
+	clearAIAgentEnvVars(t)
+	var receivedHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeader = r.Header.Get("dt-client-context")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DQLVerifyResponse{Valid: true})
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewDQLExecutor(c)
+	_, err = executor.VerifyQuery("fetch logs", DQLVerifyOptions{
+		ClientContext: "syntax-check",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := parseDTClientContext(t, receivedHeader)
+	if m["app"] != "dtctl" {
+		t.Errorf("app = %q, want %q", m["app"], "dtctl")
+	}
+	if m["context"] != "syntax-check" {
+		t.Errorf("context = %q, want %q", m["context"], "syntax-check")
+	}
+}
+
+func TestDQLExecutor_ClientContextHeader_OnPublicCancel(t *testing.T) {
+	clearAIAgentEnvVars(t)
+	var receivedHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeader = r.Header.Get("dt-client-context")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewDQLExecutor(c)
+	executor.CancelQuery("tok-xyz")
+
+	m := parseDTClientContext(t, receivedHeader)
+	if m["app"] != "dtctl" {
+		t.Errorf("app = %q, want %q", m["app"], "dtctl")
+	}
+	if _, hasCtx := m["context"]; hasCtx {
+		t.Error("public CancelQuery should omit context field (no caller context available)")
+	}
+}
+
+func TestDQLExecutor_ClientContextHeader_OnInternalCancel(t *testing.T) {
+	// When a context is cancelled while poll is in-flight, the internal cancel path
+	// should carry the full ClientContext from the opts.
+	clearAIAgentEnvVars(t)
+
+	var cancelHeader string
+	cancelCalled := make(chan struct{}, 1)
+	// unblockPoll lets the test release the poll handler after cancellation so the
+	// httptest server can close without blocking.
+	unblockPoll := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/platform/storage/query/v1/query:execute":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(DQLQueryResponse{
+				State:        "RUNNING",
+				RequestToken: "tok-cancel-test",
+			})
+		case "/platform/storage/query/v1/query:cancel":
+			cancelHeader = r.Header.Get("dt-client-context")
+			cancelCalled <- struct{}{}
+			w.WriteHeader(http.StatusOK)
+		case "/platform/storage/query/v1/query:poll":
+			// Hold the poll response until the test unblocks it, simulating a long-running query.
+			<-unblockPoll
+			w.WriteHeader(http.StatusServiceUnavailable) // any non-success is fine; the context is cancelled
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	executor := NewDQLExecutor(c)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := executor.ExecuteQueryWithContext(ctx, "fetch logs", DQLExecuteOptions{
+			ClientContext: "incident-response",
+		})
+		done <- err
+	}()
+
+	// Cancel once poll is in-flight, then unblock the poll handler.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	close(unblockPoll)
+
+	select {
+	case <-cancelCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for query:cancel to be called")
+	}
+	<-done
+
+	m := parseDTClientContext(t, cancelHeader)
+	if m["app"] != "dtctl" {
+		t.Errorf("app = %q, want %q", m["app"], "dtctl")
+	}
+	if m["context"] != "incident-response" {
+		t.Errorf("context = %q, want %q", m["context"], "incident-response")
+	}
+}


### PR DESCRIPTION
## Description

Sets the `dt-client-context` request header on all DQL query API calls
(`query:execute`, `query:poll`, `query:cancel`, `query:verify`).

The header value is a JSON object that identifies the calling application
and its intent:

```json
{"app":"dtctl","version":"0.25.0","agent":"claude-code","context":"root-cause-analysis"}
```

- **`app` / `version`** — always present, identifies dtctl and its version
- **`agent`** — automatically populated when dtctl is running under a known
  AI agent (Claude Code, Cursor, GitHub Copilot, etc.), using the existing
  `aidetect` package that already drives the `User-Agent` header
- **`context`** — optional caller-supplied semantic string, set via the new
  `--client-context` flag on both `query` and `verify query` commands

### Motivation

dtctl is increasingly used by AI agents for tasks like root-cause analysis,
anomaly investigation, and incident response. The `dt-client-context` header
gives the Dynatrace backend structured, attributable context about who is
issuing queries and why — without requiring any changes to the query itself.

### New flag

```
--client-context string   optional caller context included in the
                          dt-client-context request header
                          (e.g. "root-cause-analysis")
```

Available on: `dtctl query` and `dtctl verify query`

## Related Issues

Closes #

## Testing

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
- New unit tests in `pkg/exec/dql_test.go` cover:
  - Header helper function (default fields, with context, with AI agent, combined)
  - Header presence on `query:execute` and `query:poll` (table-driven, 4 cases)
  - Header presence on `query:verify`
  - Header presence on `CancelQuery` (public path, no context)
  - Full context threading on internal cancel (context cancellation path)