### PR TITLE
fix: doctor warns instead of fails on platform tokens (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`dtctl doctor` no longer fails on platform tokens** — the authentication check called `/platform/metadata/v1/user`, which requires the `iam:users:read` scope; platform tokens (`dt0s16.*`) cannot currently be granted that scope, so the call always returned `403 Forbidden` and `doctor` reported `[FAIL] Authentication API call failed: failed to fetch user info: 403 Forbidden`; the check now detects platform tokens via `client.IsPlatformToken` and surfaces this as a `warn` with an explanation (`platform token: user identity unavailable via metadata API`) instead of failing the run; OAuth/JWT tokens keep the existing metadata-API + JWT-fallback behaviour; fixes [#190](https://github.com/dynatrace-oss/dtctl/issues/190)
+
 ## [0.26.2] - 2026-04-29
 
 ### Added

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -257,19 +257,28 @@ func runDoctorChecksWithClient(httpClient *http.Client) []checkResult {
 
 	userInfo, authErr := c.CurrentUser()
 	if authErr != nil {
-		// Try fallback to user ID extraction from JWT
-		userID, jwtErr := c.CurrentUserID()
-		if jwtErr != nil {
+		// Platform tokens cannot be granted iam:users:read, so the metadata API
+		// returns 403 by design — surface this as a known limitation, not a
+		// failure. For other (OAuth/JWT) tokens, fall back to decoding the user
+		// ID directly out of the token; CurrentUserID would re-issue the same
+		// metadata call we already failed, so go straight to the JWT path.
+		if client.IsPlatformToken(token) {
 			results = append(results, checkResult{
 				Name:   "Authentication",
-				Status: "fail",
-				Detail: fmt.Sprintf("API call failed: %s", authErr.Error()),
+				Status: "warn",
+				Detail: "platform token: user identity unavailable via metadata API (requires iam:users:read scope, not grantable to platform tokens)",
 			})
-		} else {
+		} else if userID, jwtErr := client.ExtractUserIDFromToken(token); jwtErr == nil {
 			results = append(results, checkResult{
 				Name:   "Authentication",
 				Status: "warn",
 				Detail: fmt.Sprintf("metadata API unavailable, but token is valid (user: %s)", userID),
+			})
+		} else {
+			results = append(results, checkResult{
+				Name:   "Authentication",
+				Status: "fail",
+				Detail: fmt.Sprintf("API call failed: %s", authErr.Error()),
 			})
 		}
 	} else {

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -338,6 +338,72 @@ func TestDoctorURLValidation(t *testing.T) {
 	}
 }
 
+// TestDoctorPlatformToken403 verifies that when the platform metadata API
+// returns 403 because a platform token (dt0s16.*) cannot be granted
+// iam:users:read, the doctor authentication check is reported as "warn"
+// (with an explanation) rather than "fail". Regression test for
+// https://github.com/dynatrace-oss/dtctl/issues/190
+func TestDoctorPlatformToken403(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/platform/metadata/v1/user":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"code":403,"message":"forbidden"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config")
+
+	originalCfgFile := cfgFile
+	defer func() { cfgFile = originalCfgFile }()
+	cfgFile = configPath
+
+	cfg := config.NewConfig()
+	cfg.SetContext("test", server.URL, "platform-token")
+	if err := cfg.SetToken("platform-token", "dt0s16.PLATFORM.test-token-value"); err != nil {
+		t.Fatalf("failed to set token: %v", err)
+	}
+	cfg.CurrentContext = "test"
+	if err := cfg.SaveTo(configPath); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	results := runDoctorChecks()
+
+	found := false
+	for _, r := range results {
+		if r.Name == "Authentication" {
+			found = true
+			if r.Status != "warn" {
+				t.Errorf("expected authentication status 'warn' for platform token + 403, got %q: %s", r.Status, r.Detail)
+			}
+			if !strings.Contains(r.Detail, "platform token") {
+				t.Errorf("expected detail to mention 'platform token', got %q", r.Detail)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected 'Authentication' check in results")
+		for _, r := range results {
+			t.Logf("  %s: %s: %s", r.Name, r.Status, r.Detail)
+		}
+	}
+
+	// The overall command should not return an error: warn-only checks must
+	// not be promoted to a failure.
+	for _, r := range results {
+		if r.Status == "fail" {
+			t.Errorf("unexpected fail check for platform token + 403: %s: %s", r.Name, r.Detail)
+		}
+	}
+}
+
 // TestDoctorFileTokenStorage verifies that when keyring is unavailable but
 // DTCTL_TOKEN_STORAGE=file is set, the doctor check reports "ok" for
 // token storage instead of "warn".

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -310,6 +310,16 @@ func (c *Client) CurrentUserID() (string, error) {
 	return ExtractUserIDFromToken(c.token)
 }
 
+// platformTokenPrefix identifies Dynatrace platform tokens — opaque bearer
+// tokens (not JWTs) that cannot be granted iam:users:read / iam:groups:read,
+// so /platform/metadata/v1/user returns 403 when authenticated with one.
+const platformTokenPrefix = "dt0s16."
+
+// IsPlatformToken reports whether token is a Dynatrace platform token.
+func IsPlatformToken(token string) bool {
+	return strings.HasPrefix(token, platformTokenPrefix)
+}
+
 // ExtractUserIDFromToken extracts the user ID (sub claim) from a JWT token.
 func ExtractUserIDFromToken(token string) (string, error) {
 	parts := strings.Split(token, ".")

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -286,6 +286,53 @@ func TestExtractUserIDFromToken(t *testing.T) {
 	}
 }
 
+func TestIsPlatformToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{
+			name:  "platform token",
+			token: "dt0s16.ABCDEFGHIJK.secret-portion-of-token",
+			want:  true,
+		},
+		{
+			name:  "platform token with empty payload",
+			token: "dt0s16.",
+			want:  true,
+		},
+		{
+			name:  "classic environment API token",
+			token: "dt0c01.ST.test-public.test-secret",
+			want:  false,
+		},
+		{
+			name:  "OAuth client ID prefix",
+			token: "dt0s12.dtctl-prod",
+			want:  false,
+		},
+		{
+			name:  "OAuth access token (JWT shape)",
+			token: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.signature",
+			want:  false,
+		},
+		{
+			name:  "empty",
+			token: "",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPlatformToken(tt.token); got != tt.want {
+				t.Errorf("IsPlatformToken(%q) = %v, want %v", tt.token, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClient_RetryBehavior(t *testing.T) {
 	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

`dtctl doctor` calls `/platform/metadata/v1/user` for the Authentication check. The endpoint requires the `iam:users:read` scope, and platform tokens (`dt0s16.*`) cannot be granted that scope, so the check always fails on a platform-token context with

```
[FAIL] Authentication API call failed: failed to fetch user info: 403 Forbidden
```

Reported in #190

## Change

- new helper `client.IsPlatformToken(token string) bool` (prefix check on `dt0s16.`)
- doctor's Authentication branch treats a 403 as `warn` with an explanation of the IAM-scope limitation when the token is a platform token, instead of failing the run
- the OAuth/JWT fallback now calls `client.ExtractUserIDFromToken` directly; `c.CurrentUserID()` would re-issue the same metadata API call we already failed, so the duplicate hit is gone

After the change `dtctl doctor` against a platform-token context prints:

```
✓ dtctl version
✓ Configuration
✓ Current context
✓ Environment URL
✓ Token storage
✓ Token
✓ Connectivity
⚠ Authentication    platform token: user identity unavailable via metadata API (requires iam:users:read scope, not grantable to platform tokens)
```

and the command exits 0 instead of failing

## Test plan

- new `TestIsPlatformToken` covers prefix detection across platform / classic / OAuth-client-id / JWT / empty inputs
- new `TestDoctorPlatformToken403` boots a mock server that returns 403 on the metadata endpoint and asserts Authentication = `warn`, and that the run does not produce any `fail` checks
- existing `TestDoctor*` tests still pass

```
go build ./...
go vet ./...
go test -race -run "TestIsPlatformToken|TestDoctor" ./pkg/client/ ./cmd/
```

Fixes #190
