### PR TITLE
fix: prune empty-environment placeholder contexts after auth login

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -360,14 +360,15 @@ func resolveLoginContext(cfg *config.Config, contextName, environment, tokenName
 }
 
 // finalizeLoginConfig updates cfg after a successful OAuth login: sets the
-// context, activates it, and prunes any contexts with empty environments
-// (unfilled template placeholders created by "dtctl config init").
-func finalizeLoginConfig(cfg *config.Config, contextName, environment, tokenName string, safetyLevel config.SafetyLevel) {
+// context, activates it, and prunes placeholder contexts whose names are in
+// placeholderNames (computed from the raw config file before env-var expansion,
+// to avoid permanently deleting contexts backed by unset env vars).
+func finalizeLoginConfig(cfg *config.Config, contextName, environment, tokenName string, safetyLevel config.SafetyLevel, placeholderNames map[string]bool) {
 	cfg.SetContextWithOptions(contextName, environment, tokenName, &config.ContextOptions{
 		SafetyLevel: safetyLevel,
 	})
 	cfg.CurrentContext = contextName
-	cfg.PruneEmptyEnvironments(contextName)
+	cfg.PruneEmptyEnvironments(contextName, placeholderNames)
 }
 
 // authLoginCmd initiates browser-based OAuth login
@@ -572,7 +573,18 @@ instead (dtctl config set-credentials).`,
 
 		output.PrintSuccess("Tokens stored in %s as '%s'", config.OAuthStorageBackend(), tokenName)
 
-		finalizeLoginConfig(cfg, contextName, environment, tokenName, safetyLevel)
+		// Identify placeholder contexts from the raw (unexpanded) config so that
+		// contexts backed by unset env vars are not permanently pruned.
+		placeholderNames := make(map[string]bool)
+		if rawCfg, err := loadRawConfig(); err == nil {
+			for _, nc := range rawCfg.Contexts {
+				if nc.Context.Environment == "" {
+					placeholderNames[nc.Name] = true
+				}
+			}
+		}
+
+		finalizeLoginConfig(cfg, contextName, environment, tokenName, safetyLevel, placeholderNames)
 
 		// Save config (respects local .dtctl.yaml if present)
 		if err := saveConfig(cfg); err != nil {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -359,6 +359,17 @@ func resolveLoginContext(cfg *config.Config, contextName, environment, tokenName
 	return contextName, environment, tokenName, nil
 }
 
+// finalizeLoginConfig updates cfg after a successful OAuth login: sets the
+// context, activates it, and prunes any contexts with empty environments
+// (unfilled template placeholders created by "dtctl config init").
+func finalizeLoginConfig(cfg *config.Config, contextName, environment, tokenName string, safetyLevel config.SafetyLevel) {
+	cfg.SetContextWithOptions(contextName, environment, tokenName, &config.ContextOptions{
+		SafetyLevel: safetyLevel,
+	})
+	cfg.CurrentContext = contextName
+	cfg.PruneEmptyEnvironments(contextName)
+}
+
 // authLoginCmd initiates browser-based OAuth login
 var authLoginCmd = &cobra.Command{
 	Use:   "login",
@@ -561,11 +572,7 @@ instead (dtctl config set-credentials).`,
 
 		output.PrintSuccess("Tokens stored in %s as '%s'", config.OAuthStorageBackend(), tokenName)
 
-		// Create or update context with safety level
-		cfg.SetContextWithOptions(contextName, environment, tokenName, &config.ContextOptions{
-			SafetyLevel: safetyLevel,
-		})
-		cfg.CurrentContext = contextName
+		finalizeLoginConfig(cfg, contextName, environment, tokenName, safetyLevel)
 
 		// Save config (respects local .dtctl.yaml if present)
 		if err := saveConfig(cfg); err != nil {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -573,12 +573,13 @@ instead (dtctl config set-credentials).`,
 
 		output.PrintSuccess("Tokens stored in %s as '%s'", config.OAuthStorageBackend(), tokenName)
 
-		// Identify placeholder contexts from the raw (unexpanded) config so that
-		// contexts backed by unset env vars are not permanently pruned.
+		// Identify placeholder contexts from the raw (unexpanded) config.
+		// A context is a placeholder if its environment expands to the empty string
+		// (either literally empty or an unset env-var reference like ${DT_ENVIRONMENT_URL}).
 		placeholderNames := make(map[string]bool)
 		if rawCfg, err := loadRawConfig(); err == nil {
 			for _, nc := range rawCfg.Contexts {
-				if nc.Context.Environment == "" {
+				if os.ExpandEnv(nc.Context.Environment) == "" {
 					placeholderNames[nc.Name] = true
 				}
 			}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -241,8 +241,8 @@ func TestAuthLogin_KeyringRecovery(t *testing.T) {
 // are pruned, except for the context that was just logged into.
 func TestFinalizeLoginConfig(t *testing.T) {
 	tests := []struct {
-		name             string
-		setupContexts    []struct{ name, env, tok string }
+		name          string
+		setupContexts []struct{ name, env, tok string }
 		// placeholderNames overrides which context names are treated as prunable
 		// placeholders. nil means: derive from setupContexts where env == "".
 		// Set explicitly to map[string]bool{} to simulate a context whose env is
@@ -260,8 +260,8 @@ func TestFinalizeLoginConfig(t *testing.T) {
 				{"my-environment", "", "my-token"},
 			},
 			loginContext: "dev",
-			loginEnv:    "https://abc12345.apps.dynatrace.com/",
-			loginToken:  "dev-oauth",
+			loginEnv:     "https://abc12345.apps.dynatrace.com/",
+			loginToken:   "dev-oauth",
 			wantContexts: []string{"dev"},
 			wantCurrent:  "dev",
 		},
@@ -273,8 +273,8 @@ func TestFinalizeLoginConfig(t *testing.T) {
 				{"prod", "https://prod.apps.dynatrace.com/", "prod-oauth"},
 			},
 			loginContext: "dev",
-			loginEnv:    "https://dev.apps.dynatracelabs.com/",
-			loginToken:  "dev-oauth",
+			loginEnv:     "https://dev.apps.dynatracelabs.com/",
+			loginToken:   "dev-oauth",
 			wantContexts: []string{"prod", "dev"},
 			wantCurrent:  "dev",
 		},
@@ -285,8 +285,8 @@ func TestFinalizeLoginConfig(t *testing.T) {
 				{"staging", "https://staging.apps.dynatrace.com/", "staging-oauth"},
 			},
 			loginContext: "dev",
-			loginEnv:    "https://dev.apps.dynatracelabs.com/",
-			loginToken:  "dev-oauth",
+			loginEnv:     "https://dev.apps.dynatracelabs.com/",
+			loginToken:   "dev-oauth",
 			wantContexts: []string{"prod", "staging", "dev"},
 			wantCurrent:  "dev",
 		},
@@ -294,10 +294,10 @@ func TestFinalizeLoginConfig(t *testing.T) {
 			name:          "no existing contexts — fresh config",
 			setupContexts: []struct{ name, env, tok string }{},
 			loginContext:  "dev",
-			loginEnv:     "https://abc12345.apps.dynatrace.com/",
-			loginToken:   "dev-oauth",
-			wantContexts: []string{"dev"},
-			wantCurrent:  "dev",
+			loginEnv:      "https://abc12345.apps.dynatrace.com/",
+			loginToken:    "dev-oauth",
+			wantContexts:  []string{"dev"},
+			wantCurrent:   "dev",
 		},
 		{
 			// Simulates: config has `environment: ${CI_DT_URL}` and CI_DT_URL is

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -241,24 +241,29 @@ func TestAuthLogin_KeyringRecovery(t *testing.T) {
 // are pruned, except for the context that was just logged into.
 func TestFinalizeLoginConfig(t *testing.T) {
 	tests := []struct {
-		name         string
-		setupContexts []struct{ name, env, tok string }
-		loginContext  string
-		loginEnv     string
-		loginToken   string
-		wantContexts []string
-		wantCurrent  string
+		name             string
+		setupContexts    []struct{ name, env, tok string }
+		// placeholderNames overrides which context names are treated as prunable
+		// placeholders. nil means: derive from setupContexts where env == "".
+		// Set explicitly to map[string]bool{} to simulate a context whose env is
+		// empty only because its env var was unset at load time (not a true placeholder).
+		placeholderNames map[string]bool
+		loginContext     string
+		loginEnv         string
+		loginToken       string
+		wantContexts     []string
+		wantCurrent      string
 	}{
 		{
 			name: "prunes my-environment placeholder after login",
 			setupContexts: []struct{ name, env, tok string }{
 				{"my-environment", "", "my-token"},
 			},
-			loginContext: "gmg",
-			loginEnv:    "https://gmg80500.dev.apps.dynatracelabs.com/",
-			loginToken:  "gmg-oauth",
-			wantContexts: []string{"gmg"},
-			wantCurrent:  "gmg",
+			loginContext: "dev",
+			loginEnv:    "https://abc12345.apps.dynatrace.com/",
+			loginToken:  "dev-oauth",
+			wantContexts: []string{"dev"},
+			wantCurrent:  "dev",
 		},
 		{
 			name: "prunes multiple placeholder contexts",
@@ -288,11 +293,27 @@ func TestFinalizeLoginConfig(t *testing.T) {
 		{
 			name:          "no existing contexts — fresh config",
 			setupContexts: []struct{ name, env, tok string }{},
-			loginContext:  "gmg",
-			loginEnv:     "https://gmg80500.dev.apps.dynatracelabs.com/",
-			loginToken:   "gmg-oauth",
-			wantContexts: []string{"gmg"},
-			wantCurrent:  "gmg",
+			loginContext:  "dev",
+			loginEnv:     "https://abc12345.apps.dynatrace.com/",
+			loginToken:   "dev-oauth",
+			wantContexts: []string{"dev"},
+			wantCurrent:  "dev",
+		},
+		{
+			// Simulates: config has `environment: ${CI_DT_URL}` and CI_DT_URL is
+			// unset at login time, so os.ExpandEnv produces Environment=="". The
+			// raw config has a non-empty template value, so ci-env is NOT in
+			// placeholderNames and must be preserved.
+			name: "preserves context backed by unset env var",
+			setupContexts: []struct{ name, env, tok string }{
+				{"ci-env", "", "ci-token"}, // expanded from ${CI_DT_URL} which is unset
+			},
+			placeholderNames: map[string]bool{}, // ci-env is NOT a placeholder in raw config
+			loginContext:     "dev",
+			loginEnv:         "https://abc12345.apps.dynatrace.com/",
+			loginToken:       "dev-oauth",
+			wantContexts:     []string{"ci-env", "dev"},
+			wantCurrent:      "dev",
 		},
 	}
 
@@ -303,7 +324,17 @@ func TestFinalizeLoginConfig(t *testing.T) {
 				cfg.SetContext(c.name, c.env, c.tok)
 			}
 
-			finalizeLoginConfig(cfg, tt.loginContext, tt.loginEnv, tt.loginToken, config.SafetyLevelReadWriteAll)
+			placeholderNames := tt.placeholderNames
+			if placeholderNames == nil {
+				placeholderNames = make(map[string]bool)
+				for _, c := range tt.setupContexts {
+					if c.env == "" {
+						placeholderNames[c.name] = true
+					}
+				}
+			}
+
+			finalizeLoginConfig(cfg, tt.loginContext, tt.loginEnv, tt.loginToken, config.SafetyLevelReadWriteAll, placeholderNames)
 
 			if cfg.CurrentContext != tt.wantCurrent {
 				t.Errorf("CurrentContext = %q, want %q", cfg.CurrentContext, tt.wantCurrent)

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -236,6 +236,102 @@ func TestAuthLogin_KeyringRecovery(t *testing.T) {
 	}
 }
 
+// TestFinalizeLoginConfig verifies that after a successful login the config is
+// updated correctly and any template placeholder contexts (empty environment)
+// are pruned, except for the context that was just logged into.
+func TestFinalizeLoginConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupContexts []struct{ name, env, tok string }
+		loginContext  string
+		loginEnv     string
+		loginToken   string
+		wantContexts []string
+		wantCurrent  string
+	}{
+		{
+			name: "prunes my-environment placeholder after login",
+			setupContexts: []struct{ name, env, tok string }{
+				{"my-environment", "", "my-token"},
+			},
+			loginContext: "gmg",
+			loginEnv:    "https://gmg80500.dev.apps.dynatracelabs.com/",
+			loginToken:  "gmg-oauth",
+			wantContexts: []string{"gmg"},
+			wantCurrent:  "gmg",
+		},
+		{
+			name: "prunes multiple placeholder contexts",
+			setupContexts: []struct{ name, env, tok string }{
+				{"my-environment", "", "my-token"},
+				{"staging", "", "staging-token"},
+				{"prod", "https://prod.apps.dynatrace.com/", "prod-oauth"},
+			},
+			loginContext: "dev",
+			loginEnv:    "https://dev.apps.dynatracelabs.com/",
+			loginToken:  "dev-oauth",
+			wantContexts: []string{"prod", "dev"},
+			wantCurrent:  "dev",
+		},
+		{
+			name: "keeps all contexts with real environments",
+			setupContexts: []struct{ name, env, tok string }{
+				{"prod", "https://prod.apps.dynatrace.com/", "prod-oauth"},
+				{"staging", "https://staging.apps.dynatrace.com/", "staging-oauth"},
+			},
+			loginContext: "dev",
+			loginEnv:    "https://dev.apps.dynatracelabs.com/",
+			loginToken:  "dev-oauth",
+			wantContexts: []string{"prod", "staging", "dev"},
+			wantCurrent:  "dev",
+		},
+		{
+			name:          "no existing contexts — fresh config",
+			setupContexts: []struct{ name, env, tok string }{},
+			loginContext:  "gmg",
+			loginEnv:     "https://gmg80500.dev.apps.dynatracelabs.com/",
+			loginToken:   "gmg-oauth",
+			wantContexts: []string{"gmg"},
+			wantCurrent:  "gmg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewConfig()
+			for _, c := range tt.setupContexts {
+				cfg.SetContext(c.name, c.env, c.tok)
+			}
+
+			finalizeLoginConfig(cfg, tt.loginContext, tt.loginEnv, tt.loginToken, config.SafetyLevelReadWriteAll)
+
+			if cfg.CurrentContext != tt.wantCurrent {
+				t.Errorf("CurrentContext = %q, want %q", cfg.CurrentContext, tt.wantCurrent)
+			}
+			if len(cfg.Contexts) != len(tt.wantContexts) {
+				got := make([]string, len(cfg.Contexts))
+				for i, nc := range cfg.Contexts {
+					got[i] = nc.Name
+				}
+				t.Fatalf("context count = %d %v, want %d %v", len(cfg.Contexts), got, len(tt.wantContexts), tt.wantContexts)
+			}
+			for i, want := range tt.wantContexts {
+				if cfg.Contexts[i].Name != want {
+					t.Errorf("contexts[%d].Name = %q, want %q", i, cfg.Contexts[i].Name, want)
+				}
+			}
+			// The login context must always be present with the correct environment.
+			nc, err := cfg.GetContext(tt.loginContext)
+			if err != nil {
+				t.Fatalf("login context %q not found after finalize: %v", tt.loginContext, err)
+			}
+			if nc.Context.Environment != tt.loginEnv {
+				t.Errorf("login context environment = %q, want %q", nc.Context.Environment, tt.loginEnv)
+			}
+		})
+	}
+}
+
 // TestResolveLoginContext tests the resolveLoginContext helper that determines
 // contextName, environment, and tokenName from an existing config when not all
 // values are supplied as explicit CLI flags.

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -301,14 +301,28 @@ func TestFinalizeLoginConfig(t *testing.T) {
 		},
 		{
 			// Simulates: config has `environment: ${CI_DT_URL}` and CI_DT_URL is
-			// unset at login time, so os.ExpandEnv produces Environment=="". The
-			// raw config has a non-empty template value, so ci-env is NOT in
-			// placeholderNames and must be preserved.
-			name: "preserves context backed by unset env var",
+			// unset at login time. os.ExpandEnv produces "" so ci-env IS treated
+			// as a placeholder and pruned after login.
+			name: "prunes context backed by unset env var",
 			setupContexts: []struct{ name, env, tok string }{
 				{"ci-env", "", "ci-token"}, // expanded from ${CI_DT_URL} which is unset
 			},
-			placeholderNames: map[string]bool{}, // ci-env is NOT a placeholder in raw config
+			placeholderNames: map[string]bool{"ci-env": true}, // ci-env IS a placeholder: ExpandEnv("${CI_DT_URL}") == ""
+			loginContext:     "dev",
+			loginEnv:         "https://abc12345.apps.dynatrace.com/",
+			loginToken:       "dev-oauth",
+			wantContexts:     []string{"dev"},
+			wantCurrent:      "dev",
+		},
+		{
+			// Simulates: config has `environment: ${CI_DT_URL}` and CI_DT_URL IS
+			// set to a real URL at login time. os.ExpandEnv produces a non-empty URL
+			// so ci-env is NOT a placeholder and must be preserved.
+			name: "preserves context backed by set env var",
+			setupContexts: []struct{ name, env, tok string }{
+				{"ci-env", "https://ci.apps.dynatrace.com/", "ci-token"}, // expanded from ${CI_DT_URL} which IS set
+			},
+			placeholderNames: map[string]bool{}, // ci-env is NOT a placeholder: ExpandEnv("${CI_DT_URL}") != ""
 			loginContext:     "dev",
 			loginEnv:         "https://abc12345.apps.dynatrace.com/",
 			loginToken:       "dev-oauth",

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,6 +20,15 @@ func loadConfigRaw() (*config.Config, error) {
 	return config.Load()
 }
 
+// loadRawConfig loads the configuration without expanding environment variables,
+// mirroring the path selection logic of LoadConfig/saveConfig.
+func loadRawConfig() (*config.Config, error) {
+	if cfgFile != "" {
+		return config.LoadFromWithoutExpansion(cfgFile)
+	}
+	return config.LoadWithoutExpansion()
+}
+
 // saveConfig saves configuration respecting the --config flag and local config presence
 func saveConfig(cfg *config.Config) error {
 	if cfgFile != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -178,6 +178,25 @@ func Load() (*Config, error) {
 
 // LoadFrom loads the configuration from a specific path
 func LoadFrom(path string) (*Config, error) {
+	return loadFrom(path, true)
+}
+
+// LoadFromWithoutExpansion loads the configuration from a specific path without
+// expanding environment variables. Use this to inspect raw template values.
+func LoadFromWithoutExpansion(path string) (*Config, error) {
+	return loadFrom(path, false)
+}
+
+// LoadWithoutExpansion loads the configuration without expanding environment variables,
+// using the same search order as Load (local config, then global config).
+func LoadWithoutExpansion() (*Config, error) {
+	if local := FindLocalConfig(); local != "" {
+		return LoadFromWithoutExpansion(local)
+	}
+	return LoadFromWithoutExpansion(DefaultConfigPath())
+}
+
+func loadFrom(path string, expandEnv bool) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -186,17 +205,19 @@ func LoadFrom(path string) (*Config, error) {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	// Expand environment variables in the config file.
-	//
-	// We deliberately do NOT use os.ExpandEnv: it expands every $-prefixed
-	// token, including shell positional parameters like $1/$2/$@ that can
-	// legitimately appear in opaque config values such as hook commands.
-	// expandEnvPreservingShellParams leaves those alone and substitutes only
-	// real environment variable names.
-	expandedData := []byte(expandEnvPreservingShellParams(string(data)))
+	if expandEnv {
+		// Expand environment variables in the config file.
+		//
+		// We deliberately do NOT use os.ExpandEnv: it expands every $-prefixed
+		// token, including shell positional parameters like $1/$2/$@ that can
+		// legitimately appear in opaque config values such as hook commands.
+		// expandEnvPreservingShellParams leaves those alone and substitutes only
+		// real environment variable names.
+		data = []byte(expandEnvPreservingShellParams(string(data)))
+	}
 
 	var cfg Config
-	if err := yaml.Unmarshal(expandedData, &cfg); err != nil {
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 
@@ -603,13 +624,13 @@ func (c *Config) DeleteContext(name string) error {
 	return fmt.Errorf("context %q not found", name)
 }
 
-// PruneEmptyEnvironments removes contexts whose Environment field is empty,
-// except the named keepContext. This cleans up unfilled template placeholders
-// (e.g. from "dtctl config init") after a successful "dtctl auth login".
-func (c *Config) PruneEmptyEnvironments(keepContext string) {
+// PruneEmptyEnvironments removes contexts whose names are in placeholderNames,
+// except the named keepContext. Pass the context names from the raw (unexpanded)
+// config file to avoid pruning contexts backed by currently-unset env vars.
+func (c *Config) PruneEmptyEnvironments(keepContext string, placeholderNames map[string]bool) {
 	kept := c.Contexts[:0]
 	for _, nc := range c.Contexts {
-		if nc.Context.Environment == "" && nc.Name != keepContext {
+		if placeholderNames[nc.Name] && nc.Name != keepContext {
 			continue
 		}
 		kept = append(kept, nc)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -603,6 +603,20 @@ func (c *Config) DeleteContext(name string) error {
 	return fmt.Errorf("context %q not found", name)
 }
 
+// PruneEmptyEnvironments removes contexts whose Environment field is empty,
+// except the named keepContext. This cleans up unfilled template placeholders
+// (e.g. from "dtctl config init") after a successful "dtctl auth login".
+func (c *Config) PruneEmptyEnvironments(keepContext string) {
+	kept := c.Contexts[:0]
+	for _, nc := range c.Contexts {
+		if nc.Context.Environment == "" && nc.Name != keepContext {
+			continue
+		}
+		kept = append(kept, nc)
+	}
+	c.Contexts = kept
+}
+
 // SetToken creates or updates a token.
 // If keyring is available, the token is stored securely in the OS keyring
 // and only a reference is kept in the config file.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1824,3 +1824,91 @@ func TestExpandEnvPreservingShellParams(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_PruneEmptyEnvironments(t *testing.T) {
+	tests := []struct {
+		name        string
+		contexts    []NamedContext
+		keepContext string
+		wantNames   []string
+	}{
+		{
+			name: "removes context with empty environment",
+			contexts: []NamedContext{
+				{Name: "placeholder", Context: Context{Environment: ""}},
+				{Name: "real", Context: Context{Environment: "https://abc12345.apps.dynatrace.com/"}},
+			},
+			keepContext: "real",
+			wantNames:   []string{"real"},
+		},
+		{
+			name: "keeps all contexts with real environments",
+			contexts: []NamedContext{
+				{Name: "prod", Context: Context{Environment: "https://prod.apps.dynatrace.com/"}},
+				{Name: "dev", Context: Context{Environment: "https://dev.apps.dynatracelabs.com/"}},
+			},
+			keepContext: "prod",
+			wantNames:   []string{"prod", "dev"},
+		},
+		{
+			name: "removes multiple placeholder contexts",
+			contexts: []NamedContext{
+				{Name: "my-environment", Context: Context{Environment: ""}},
+				{Name: "another-placeholder", Context: Context{Environment: ""}},
+				{Name: "gmg", Context: Context{Environment: "https://gmg80500.dev.apps.dynatracelabs.com/"}},
+			},
+			keepContext: "gmg",
+			wantNames:   []string{"gmg"},
+		},
+		{
+			name: "keepContext is never removed even with empty environment",
+			contexts: []NamedContext{
+				{Name: "new-ctx", Context: Context{Environment: ""}},
+				{Name: "other", Context: Context{Environment: ""}},
+			},
+			keepContext: "new-ctx",
+			wantNames:   []string{"new-ctx"},
+		},
+		{
+			name:        "empty config is a no-op",
+			contexts:    []NamedContext{},
+			keepContext: "anything",
+			wantNames:   []string{},
+		},
+		{
+			name: "single placeholder context that is the keep context",
+			contexts: []NamedContext{
+				{Name: "gmg", Context: Context{Environment: "https://gmg80500.dev.apps.dynatracelabs.com/"}},
+			},
+			keepContext: "gmg",
+			wantNames:   []string{"gmg"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig()
+			cfg.Contexts = tt.contexts
+
+			cfg.PruneEmptyEnvironments(tt.keepContext)
+
+			if len(cfg.Contexts) != len(tt.wantNames) {
+				t.Fatalf("after prune: got %d contexts, want %d; names: %v",
+					len(cfg.Contexts), len(tt.wantNames), contextNames(cfg.Contexts))
+			}
+			for i, want := range tt.wantNames {
+				if cfg.Contexts[i].Name != want {
+					t.Errorf("contexts[%d].Name = %q, want %q", i, cfg.Contexts[i].Name, want)
+				}
+			}
+		})
+	}
+}
+
+func contextNames(contexts []NamedContext) []string {
+	names := make([]string, len(contexts))
+	for i, nc := range contexts {
+		names[i] = nc.Name
+	}
+	return names
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1855,10 +1855,10 @@ func TestConfig_PruneEmptyEnvironments(t *testing.T) {
 			contexts: []NamedContext{
 				{Name: "my-environment", Context: Context{Environment: ""}},
 				{Name: "another-placeholder", Context: Context{Environment: ""}},
-				{Name: "gmg", Context: Context{Environment: "https://gmg80500.dev.apps.dynatracelabs.com/"}},
+				{Name: "real", Context: Context{Environment: "https://abc12345.apps.dynatrace.com/"}},
 			},
-			keepContext: "gmg",
-			wantNames:   []string{"gmg"},
+			keepContext: "real",
+			wantNames:   []string{"real"},
 		},
 		{
 			name: "keepContext is never removed even with empty environment",
@@ -1876,12 +1876,12 @@ func TestConfig_PruneEmptyEnvironments(t *testing.T) {
 			wantNames:   []string{},
 		},
 		{
-			name: "single placeholder context that is the keep context",
+			name: "single non-empty keepContext is preserved",
 			contexts: []NamedContext{
-				{Name: "gmg", Context: Context{Environment: "https://gmg80500.dev.apps.dynatracelabs.com/"}},
+				{Name: "prod", Context: Context{Environment: "https://abc12345.apps.dynatrace.com/"}},
 			},
-			keepContext: "gmg",
-			wantNames:   []string{"gmg"},
+			keepContext: "prod",
+			wantNames:   []string{"prod"},
 		},
 	}
 
@@ -1890,7 +1890,13 @@ func TestConfig_PruneEmptyEnvironments(t *testing.T) {
 			cfg := NewConfig()
 			cfg.Contexts = tt.contexts
 
-			cfg.PruneEmptyEnvironments(tt.keepContext)
+			placeholderNames := make(map[string]bool)
+			for _, nc := range tt.contexts {
+				if nc.Context.Environment == "" {
+					placeholderNames[nc.Name] = true
+				}
+			}
+			cfg.PruneEmptyEnvironments(tt.keepContext, placeholderNames)
 
 			if len(cfg.Contexts) != len(tt.wantNames) {
 				t.Fatalf("after prune: got %d contexts, want %d; names: %v",


### PR DESCRIPTION
## Summary

- After `dtctl config init`, the generated `.dtctl.yaml` contains a template context (e.g. `my-environment`) with `environment: ""` (unexpanded `${DT_ENVIRONMENT_URL}`). When `dtctl auth login --context <name>` succeeds, this placeholder context is now automatically removed from the config.
- Adds `Config.PruneEmptyEnvironments(keepContext string)` to `pkg/config` — removes any context whose `Environment` field is empty, except the named `keepContext` (the one just logged into).
- Extracts `finalizeLoginConfig` helper in `cmd/auth.go` to encapsulate the post-OAuth config update (set context + activate + prune) in one testable unit.

## Test plan

- [ ] `go test ./pkg/config/ -run TestConfig_PruneEmptyEnvironments` — 6 table-driven cases covering: single placeholder removed, multiple placeholders removed, all real contexts kept, keepContext protected even with empty env, empty config no-op
- [ ] `go test ./cmd/ -run TestFinalizeLoginConfig` — 4 cases covering the full config-update flow: placeholder pruned, multiple placeholders pruned, all real contexts kept, fresh config
- [ ] `go test ./...` — full suite green