### PR TITLE
feat: expose Document API filter/sort/add-fields/admin-access flags

### DIFF
--- a/cmd/get_documents.go
+++ b/cmd/get_documents.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/prompt"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/document"
@@ -56,22 +57,9 @@ Examples:
 		}
 
 		// List all dashboards
-		nameFilter, _ := cmd.Flags().GetString("name")
-		mineOnly, _ := cmd.Flags().GetBool("mine")
-
-		filters := document.DocumentFilters{
-			Type:      "dashboard",
-			Name:      nameFilter,
-			ChunkSize: GetChunkSize(),
-		}
-
-		// If --mine flag is set, get current user ID and filter by owner
-		if mineOnly {
-			userID, err := c.CurrentUserID()
-			if err != nil {
-				return fmt.Errorf("failed to get current user ID for --mine filter: %w", err)
-			}
-			filters.Owner = userID
+		filters, err := buildDocumentFilters(cmd, c, "dashboard")
+		if err != nil {
+			return err
 		}
 
 		// Check if watch mode is enabled
@@ -140,22 +128,9 @@ Examples:
 		}
 
 		// List all notebooks
-		nameFilter, _ := cmd.Flags().GetString("name")
-		mineOnly, _ := cmd.Flags().GetBool("mine")
-
-		filters := document.DocumentFilters{
-			Type:      "notebook",
-			Name:      nameFilter,
-			ChunkSize: GetChunkSize(),
-		}
-
-		// If --mine flag is set, get current user ID and filter by owner
-		if mineOnly {
-			userID, err := c.CurrentUserID()
-			if err != nil {
-				return fmt.Errorf("failed to get current user ID for --mine filter: %w", err)
-			}
-			filters.Owner = userID
+		filters, err := buildDocumentFilters(cmd, c, "notebook")
+		if err != nil {
+			return err
 		}
 
 		// Check if watch mode is enabled
@@ -546,22 +521,10 @@ Examples:
 		// Check for --types flag (type discovery)
 		typesMode, _ := cmd.Flags().GetBool("types")
 		typeFilter, _ := cmd.Flags().GetString("type")
-		nameFilter, _ := cmd.Flags().GetString("name")
-		mineOnly, _ := cmd.Flags().GetBool("mine")
 
-		filters := document.DocumentFilters{
-			Type:      typeFilter,
-			Name:      nameFilter,
-			ChunkSize: GetChunkSize(),
-		}
-
-		// If --mine flag is set, get current user ID and filter by owner
-		if mineOnly {
-			userID, err := c.CurrentUserID()
-			if err != nil {
-				return fmt.Errorf("failed to get current user ID for --mine filter: %w", err)
-			}
-			filters.Owner = userID
+		filters, err := buildDocumentFilters(cmd, c, typeFilter)
+		if err != nil {
+			return err
 		}
 
 		if typesMode {
@@ -680,6 +643,56 @@ Examples:
 	},
 }
 
+// buildDocumentFilters reads the listing flags from cmd. implicitType is the
+// type baked into the subcommand (empty for `dtctl get documents`).
+func buildDocumentFilters(cmd *cobra.Command, c *client.Client, implicitType string) (document.DocumentFilters, error) {
+	rawFilter, _ := cmd.Flags().GetString("filter")
+	nameFilter, _ := cmd.Flags().GetString("name")
+	mineOnly, _ := cmd.Flags().GetBool("mine")
+	sortOrder, _ := cmd.Flags().GetString("sort")
+	addFields, _ := cmd.Flags().GetStringSlice("add-fields")
+	adminAccess, _ := cmd.Flags().GetBool("admin-access")
+
+	filters := document.DocumentFilters{
+		ChunkSize:   GetChunkSize(),
+		Sort:        sortOrder,
+		AddFields:   addFields,
+		AdminAccess: adminAccess,
+	}
+
+	if rawFilter != "" {
+		if nameFilter != "" || mineOnly || implicitType != "" {
+			fmt.Fprintln(os.Stderr, "warning: --filter overrides --name/--type/--mine; the raw filter is sent verbatim to the API")
+		}
+		filters.Filter = rawFilter
+		return filters, nil
+	}
+
+	filters.Type = implicitType
+	filters.Name = nameFilter
+	if mineOnly {
+		userID, err := c.CurrentUserID()
+		if err != nil {
+			return filters, fmt.Errorf("failed to get current user ID for --mine filter: %w", err)
+		}
+		filters.Owner = userID
+	}
+	return filters, nil
+}
+
+// addDocumentListFlags registers the flags shared by dashboards/notebooks/documents listing commands.
+func addDocumentListFlags(cmd *cobra.Command, includeType bool) {
+	if includeType {
+		cmd.Flags().String("type", "", "Filter by document type (e.g. dashboard, notebook, launchpad)")
+	}
+	cmd.Flags().String("name", "", "Filter by name (partial match, case-insensitive)")
+	cmd.Flags().Bool("mine", false, "Show only documents owned by current user")
+	cmd.Flags().String("filter", "", "Raw Document API filter expression, sent verbatim (overrides --name/--type/--mine)")
+	cmd.Flags().String("sort", "", "Sort fields, comma-separated, prefix with '-' for descending (e.g. \"name,-modificationInfo.lastModifiedTime\")")
+	cmd.Flags().StringSlice("add-fields", nil, "Request fields the API omits by default (e.g. originExtensionId,labels,shareInfo.isShared)")
+	cmd.Flags().Bool("admin-access", false, "List documents as effective owner; requires document:documents:admin permission")
+}
+
 func init() {
 	// Watch flags
 	addWatchFlags(getDashboardsCmd)
@@ -688,17 +701,13 @@ func init() {
 	addWatchFlags(getDocumentsCmd)
 
 	// Dashboard flags
-	getDashboardsCmd.Flags().String("name", "", "Filter by dashboard name (partial match, case-insensitive)")
-	getDashboardsCmd.Flags().Bool("mine", false, "Show only dashboards owned by current user")
+	addDocumentListFlags(getDashboardsCmd, false)
 
 	// Notebook flags
-	getNotebooksCmd.Flags().String("name", "", "Filter by notebook name (partial match, case-insensitive)")
-	getNotebooksCmd.Flags().Bool("mine", false, "Show only notebooks owned by current user")
+	addDocumentListFlags(getNotebooksCmd, false)
 
 	// Generic document flags
-	getDocumentsCmd.Flags().String("type", "", "Filter by document type (e.g. dashboard, notebook, launchpad)")
-	getDocumentsCmd.Flags().String("name", "", "Filter by document name (partial match, case-insensitive)")
-	getDocumentsCmd.Flags().Bool("mine", false, "Show only documents owned by current user")
+	addDocumentListFlags(getDocumentsCmd, true)
 	getDocumentsCmd.Flags().Bool("types", false, "List distinct document types and counts")
 
 	// Trash flags

--- a/cmd/get_documents_test.go
+++ b/cmd/get_documents_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newDocFlagsCmd(includeType bool) *cobra.Command {
+	cmd := &cobra.Command{Use: "get"}
+	addDocumentListFlags(cmd, includeType)
+	return cmd
+}
+
+func TestAddDocumentListFlags_RegistersAll(t *testing.T) {
+	cmd := newDocFlagsCmd(true)
+	for _, name := range []string{"type", "name", "mine", "filter", "sort", "add-fields", "admin-access"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected flag %q registered with includeType=true", name)
+		}
+	}
+}
+
+func TestAddDocumentListFlags_SkipsTypeForImplicitTypeCommands(t *testing.T) {
+	cmd := newDocFlagsCmd(false)
+	if cmd.Flags().Lookup("type") != nil {
+		t.Error("expected --type flag NOT registered when includeType=false")
+	}
+	for _, name := range []string{"name", "mine", "filter", "sort", "add-fields", "admin-access"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected flag %q registered", name)
+		}
+	}
+}
+
+func TestBuildDocumentFilters_DefaultsImplicitType(t *testing.T) {
+	cmd := newDocFlagsCmd(false)
+	filters, err := buildDocumentFilters(cmd, nil, "dashboard")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if filters.Type != "dashboard" {
+		t.Errorf("expected Type=dashboard, got %q", filters.Type)
+	}
+	if filters.Filter != "" {
+		t.Errorf("expected empty Filter, got %q", filters.Filter)
+	}
+	if filters.Owner != "" {
+		t.Errorf("expected empty Owner, got %q", filters.Owner)
+	}
+}
+
+func TestBuildDocumentFilters_RawFilterOverrides(t *testing.T) {
+	cmd := newDocFlagsCmd(true)
+	_ = cmd.Flags().Set("filter", "originAppId exists")
+	_ = cmd.Flags().Set("name", "ignored")
+
+	filters, err := buildDocumentFilters(cmd, nil, "dashboard")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if filters.Filter != "originAppId exists" {
+		t.Errorf("expected raw Filter passed through, got %q", filters.Filter)
+	}
+	if filters.Type != "" {
+		t.Errorf("expected Type cleared when raw Filter set, got %q", filters.Type)
+	}
+	if filters.Name != "" {
+		t.Errorf("expected Name cleared when raw Filter set, got %q", filters.Name)
+	}
+}
+
+func TestBuildDocumentFilters_WiresSortAddFieldsAdminAccess(t *testing.T) {
+	cmd := newDocFlagsCmd(true)
+	_ = cmd.Flags().Set("sort", "name,-modificationInfo.lastModifiedTime")
+	_ = cmd.Flags().Set("add-fields", "originExtensionId,labels")
+	_ = cmd.Flags().Set("admin-access", "true")
+
+	filters, err := buildDocumentFilters(cmd, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if filters.Sort != "name,-modificationInfo.lastModifiedTime" {
+		t.Errorf("expected Sort wired, got %q", filters.Sort)
+	}
+	if len(filters.AddFields) != 2 || filters.AddFields[0] != "originExtensionId" || filters.AddFields[1] != "labels" {
+		t.Errorf("expected AddFields [originExtensionId labels], got %v", filters.AddFields)
+	}
+	if !filters.AdminAccess {
+		t.Errorf("expected AdminAccess=true, got false")
+	}
+}

--- a/pkg/resources/document/document.go
+++ b/pkg/resources/document/document.go
@@ -58,17 +58,34 @@ type Document struct {
 	Content     []byte    `json:"-" table:"-"`
 }
 
-// DocumentMetadata represents detailed document metadata
+// DocumentMetadata represents detailed document metadata.
+// Fields after Access are only populated when requested via DocumentFilters.AddFields.
 type DocumentMetadata struct {
-	ID               string           `json:"id"`
-	Name             string           `json:"name"`
-	Type             string           `json:"type"`
-	Description      string           `json:"description,omitempty"`
-	Version          int              `json:"version"`
-	Owner            string           `json:"owner"`
-	IsPrivate        bool             `json:"isPrivate"`
-	ModificationInfo ModificationInfo `json:"modificationInfo"`
-	Access           []string         `json:"access,omitempty"`
+	ID                string           `json:"id"`
+	Name              string           `json:"name"`
+	Type              string           `json:"type"`
+	Description       string           `json:"description,omitempty"`
+	Version           int              `json:"version"`
+	Owner             string           `json:"owner"`
+	IsPrivate         bool             `json:"isPrivate"`
+	ModificationInfo  ModificationInfo `json:"modificationInfo"`
+	Access            []string         `json:"access,omitempty"`
+	OriginAppID       string           `json:"originAppId,omitempty" yaml:"originAppId,omitempty"`
+	OriginExtensionID string           `json:"originExtensionId,omitempty" yaml:"originExtensionId,omitempty"`
+	Labels            []string         `json:"labels,omitempty" yaml:"labels,omitempty"`
+	ShareInfo         *ShareInfo       `json:"shareInfo,omitempty" yaml:"shareInfo,omitempty"`
+	UserContext       *UserContext     `json:"userContext,omitempty" yaml:"userContext,omitempty"`
+}
+
+// ShareInfo describes share state for a document.
+type ShareInfo struct {
+	IsShared                bool `json:"isShared" yaml:"isShared"`
+	IsSharedWithCurrentUser bool `json:"isSharedWithCurrentUser,omitempty" yaml:"isSharedWithCurrentUser,omitempty"`
+}
+
+// UserContext describes per-user metadata for a document.
+type UserContext struct {
+	LastAccessedTime time.Time `json:"lastAccessedTime" yaml:"lastAccessedTime"`
 }
 
 // UnmarshalJSON custom unmarshaler for DocumentMetadata to handle version as string or int.
@@ -108,13 +125,17 @@ type DocumentList struct {
 	NextPageKey string             `json:"nextPageKey,omitempty"`
 }
 
-// DocumentFilters contains filter options for listing documents
+// DocumentFilters contains filter options for listing documents.
+// When Filter is non-empty it is sent verbatim and overrides Type/Name/Owner.
 type DocumentFilters struct {
-	Type      string // e.g., "dashboard", "notebook"
-	Name      string // Filter by name
-	Owner     string // Filter by owner ID
-	Filter    string // Raw filter string for complex queries
-	ChunkSize int64  // Page size for pagination (0 = no chunking, use API default)
+	Type        string   // e.g., "dashboard", "notebook"
+	Name        string   // Filter by name
+	Owner       string   // Filter by owner ID
+	Filter      string   // Raw filter string, sent verbatim (overrides Type/Name/Owner)
+	ChunkSize   int64    // Page size for pagination (0 = no chunking, use API default)
+	Sort        string   // Sort fields, comma-separated, prefix with "-" for descending
+	AddFields   []string // Fields the API omits by default (e.g. "originExtensionId", "labels")
+	AdminAccess bool     // List as effective owner; requires document:documents:admin
 }
 
 // List retrieves documents matching the provided filters with automatic pagination
@@ -143,6 +164,17 @@ func (h *Handler) List(filters DocumentFilters) (*DocumentList, error) {
 		}
 	}
 
+	queryFilters := map[string]string{"filter": filterStr}
+	if filters.Sort != "" {
+		queryFilters["sort"] = filters.Sort
+	}
+	if len(filters.AddFields) > 0 {
+		queryFilters["add-fields"] = strings.Join(filters.AddFields, ",")
+	}
+	if filters.AdminAccess {
+		queryFilters["admin-access"] = "true"
+	}
+
 	for {
 		var result DocumentList
 		req := h.client.HTTP().R().SetResult(&result)
@@ -153,7 +185,7 @@ func (h *Handler) List(filters DocumentFilters) (*DocumentList, error) {
 			PageSizeParam: "page-size",
 			NextPageKey:   nextPageKey,
 			PageSize:      int64(filters.ChunkSize),
-			Filters:       map[string]string{"filter": filterStr},
+			Filters:       queryFilters,
 		}.Apply(req)
 
 		resp, err := req.Get("/platform/document/v1/documents")

--- a/pkg/resources/document/handler_test.go
+++ b/pkg/resources/document/handler_test.go
@@ -79,6 +79,111 @@ func TestList_WithFilters(t *testing.T) {
 	}
 }
 
+func TestList_RawFilterPassthrough(t *testing.T) {
+	rawFilter := "originAppId exists and type in ('dashboard','notebook')"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/documents", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("filter") != rawFilter {
+			t.Errorf("expected filter %q sent verbatim, got %q", rawFilter, r.URL.Query().Get("filter"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(DocumentList{TotalCount: 0})
+	})
+	h, cleanup := newDocTestHandler(t, mux)
+	defer cleanup()
+
+	// Type/Name/Owner are ignored when Filter is set
+	_, err := h.List(DocumentFilters{
+		Filter: rawFilter,
+		Type:   "dashboard",
+		Name:   "ignored",
+		Owner:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("List() with raw filter error = %v", err)
+	}
+}
+
+func TestList_SortAddFieldsAdminAccess(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/documents", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("sort") != "name,-modificationInfo.lastModifiedTime" {
+			t.Errorf("expected sort param, got %q", r.URL.Query().Get("sort"))
+		}
+		if r.URL.Query().Get("add-fields") != "originExtensionId,labels,shareInfo.isShared" {
+			t.Errorf("expected add-fields joined comma-separated, got %q", r.URL.Query().Get("add-fields"))
+		}
+		if r.URL.Query().Get("admin-access") != "true" {
+			t.Errorf("expected admin-access=true, got %q", r.URL.Query().Get("admin-access"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(DocumentList{TotalCount: 0})
+	})
+	h, cleanup := newDocTestHandler(t, mux)
+	defer cleanup()
+
+	_, err := h.List(DocumentFilters{
+		Sort:        "name,-modificationInfo.lastModifiedTime",
+		AddFields:   []string{"originExtensionId", "labels", "shareInfo.isShared"},
+		AdminAccess: true,
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+}
+
+func TestList_OmitsUnsetExtraQueryParams(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/documents", func(w http.ResponseWriter, r *http.Request) {
+		for _, p := range []string{"sort", "add-fields", "admin-access"} {
+			if r.URL.Query().Has(p) {
+				t.Errorf("expected %q not sent when unset, got %q", p, r.URL.Query().Get(p))
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(DocumentList{TotalCount: 0})
+	})
+	h, cleanup := newDocTestHandler(t, mux)
+	defer cleanup()
+
+	if _, err := h.List(DocumentFilters{Type: "dashboard"}); err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+}
+
+func TestDocumentMetadata_AddFieldsRoundTrip(t *testing.T) {
+	body := []byte(`{
+		"id": "doc-1",
+		"name": "test",
+		"type": "dashboard",
+		"version": 1,
+		"originAppId": "cloud-monitoring",
+		"originExtensionId": "ext-id",
+		"labels": ["a","b"],
+		"shareInfo": {"isShared": true, "isSharedWithCurrentUser": false},
+		"userContext": {"lastAccessedTime": "2026-04-29T10:00:00Z"}
+	}`)
+	var m DocumentMetadata
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if m.OriginAppID != "cloud-monitoring" {
+		t.Errorf("expected OriginAppID %q, got %q", "cloud-monitoring", m.OriginAppID)
+	}
+	if m.OriginExtensionID != "ext-id" {
+		t.Errorf("expected OriginExtensionID %q, got %q", "ext-id", m.OriginExtensionID)
+	}
+	if len(m.Labels) != 2 || m.Labels[0] != "a" || m.Labels[1] != "b" {
+		t.Errorf("expected Labels [a b], got %v", m.Labels)
+	}
+	if m.ShareInfo == nil || !m.ShareInfo.IsShared {
+		t.Errorf("expected ShareInfo.IsShared=true, got %+v", m.ShareInfo)
+	}
+	if m.UserContext == nil || m.UserContext.LastAccessedTime.IsZero() {
+		t.Errorf("expected UserContext.LastAccessedTime set, got %+v", m.UserContext)
+	}
+}
+
 func TestList_ServerError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/platform/document/v1/documents", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
closes #196

exposes the four query parameters the Document API supports but dtctl was not passing through:

- \`--filter \"<expr>\"\` sends the raw filter dsl verbatim. when set, --name/--type/--mine are ignored and a warning is printed. lets you do \`--filter \"originAppId exists\"\` or \`--filter \"type in ('dashboard','notebook') and name contains 'report'\"\` that the implicit Type/Name builder can't express
- \`--sort \"name,-modificationInfo.lastModifiedTime\"\` comma-separated sort fields, prefix with \`-\` for desc
- \`--add-fields \"originExtensionId,labels,shareInfo.isShared\"\` requests fields the api omits by default
- \`--admin-access\` lists as effective owner, requires \`document:documents:admin\`

works on \`get dashboards\` / \`get notebooks\` / \`get documents\`. extracted the shared listing flag setup into addDocumentListFlags / buildDocumentFilters since all three commands were duplicating the same name/mine boilerplate.

DocumentMetadata grows optional Labels / OriginAppID / OriginExtensionID / ShareInfo / UserContext fields, tagged omitempty so existing json/yaml output is unchanged when the api doesn't return them.

tests in pkg/resources/document/handler_test.go cover: raw filter passthrough, sort/add-fields/admin-access wired correctly, omitted when unset, metadata round-trips with the new fields populated.