### PR TITLE
fix(auth): clear stale OAuth cache on rotation or if invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`dtctl doctor` no longer fails on platform tokens** — the authentication check called `/platform/metadata/v1/user`, which requires the `iam:users:read` scope; platform tokens (`dt0s16.*`) cannot currently be granted that scope, so the call always returned `403 Forbidden` and `doctor` reported `[FAIL] Authentication API call failed: failed to fetch user info: 403 Forbidden`; the check now detects platform tokens via `client.IsPlatformToken` and surfaces this as a `warn` with an explanation (`platform token: user identity unavailable via metadata API`) instead of failing the run; OAuth/JWT tokens keep the existing metadata-API + JWT-fallback behaviour; fixes [#190](https://github.com/dynatrace-oss/dtctl/issues/190)
+- **`dtctl config set-credentials` now invalidates stale OAuth token cache** — when a platform token is rotated and re-added under the same name, the cached OAuth access/refresh tokens from the previous credential are now deleted from both the OS keyring and the file-based token store; previously the cached refresh token would be reused, causing `token expired and refresh failed` errors even after supplying a fresh platform token
+- **Stale OAuth session no longer blocks platform token fallback** — when a cached OAuth refresh token has been revoked server-side (`invalid_grant`), dtctl now automatically evicts the stale cache entry and falls back to the underlying platform token stored via `dtctl config set-credentials`; previously the `invalid_grant` error was surfaced directly, requiring the user to either create a new token name or manually re-run `set-credentials` to clear the cache
 
 ## [0.26.2] - 2026-04-29
 

--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -3,12 +3,18 @@ package auth
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 )
+
+// ErrOAuthSessionRevoked indicates the cached OAuth refresh token has been
+// invalidated server-side (HTTP 400 invalid_grant). Callers should evict the
+// cache and fall back to a non-OAuth credential where available.
+var ErrOAuthSessionRevoked = errors.New("OAuth session revoked")
 
 const (
 	// OAuthTokenPrefix is prepended to OAuth token names in keyring
@@ -81,6 +87,10 @@ func (tm *TokenManager) GetToken(tokenName string) (string, error) {
 	if stored.AccessToken == "" && stored.RefreshToken != "" && stored.ExpiresAt.IsZero() {
 		refreshed, err := tm.RefreshToken(tokenName)
 		if err != nil {
+			if isInvalidGrantError(err) {
+				_ = tm.DeleteToken(tokenName)
+				return "", fmt.Errorf("token %q: %w; re-authenticate with `dtctl auth login` or re-run `dtctl config set-credentials`", tokenName, ErrOAuthSessionRevoked)
+			}
 			return "", fmt.Errorf("failed to refresh token from compact storage: %w", err)
 		}
 		return refreshed.AccessToken, nil
@@ -90,7 +100,11 @@ func (tm *TokenManager) GetToken(tokenName string) (string, error) {
 	if tm.needsRefresh(&stored.TokenSet) {
 		refreshed, err := tm.RefreshToken(tokenName)
 		if err != nil {
-			// If refresh fails, try to use existing token if not expired
+			if isInvalidGrantError(err) {
+				_ = tm.DeleteToken(tokenName)
+				return "", fmt.Errorf("token %q: %w; re-authenticate with `dtctl auth login` or re-run `dtctl config set-credentials`", tokenName, ErrOAuthSessionRevoked)
+			}
+			// Transient failure (network, 5xx): use existing token if not yet expired
 			if time.Now().Before(stored.ExpiresAt) {
 				return stored.AccessToken, nil
 			}
@@ -100,6 +114,14 @@ func (tm *TokenManager) GetToken(tokenName string) (string, error) {
 	}
 
 	return stored.AccessToken, nil
+}
+
+// isInvalidGrantError reports whether err is an OAuth2 invalid_grant error,
+// meaning the refresh token has been revoked or expired server-side.
+// This string only appears in 400 responses from the OAuth token endpoint —
+// never in network errors or 5xx responses — so it is a safe, specific match.
+func isInvalidGrantError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "invalid_grant")
 }
 
 // RefreshToken refreshes an OAuth token

--- a/pkg/auth/token_manager_test.go
+++ b/pkg/auth/token_manager_test.go
@@ -1,6 +1,12 @@
 package auth
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -249,5 +255,200 @@ func TestMediumCompactStoredTokenForKeyring(t *testing.T) {
 
 	if mediumCompactStoredTokenForKeyring(nil) != nil {
 		t.Error("expected nil input to return nil")
+	}
+}
+
+func TestIsInvalidGrantError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "invalid_grant", err: fmt.Errorf("token refresh failed: 400 Bad Request - {\"error\":\"invalid_grant\"}"), want: true},
+		{name: "wrapped invalid_grant", err: fmt.Errorf("failed to refresh token: %w", fmt.Errorf("token refresh failed: 400 Bad Request - {\"error\":\"invalid_grant\",\"error_description\":\"UNSUCCESSFUL_OAUTH_REFRESH_TOKEN_VALIDATION_FAILED\"}")), want: true},
+		{name: "network error", err: fmt.Errorf("token refresh request failed: dial tcp: connection refused"), want: false},
+		{name: "server error", err: fmt.Errorf("token refresh failed: 500 Internal Server Error"), want: false},
+		{name: "expired access token", err: fmt.Errorf("token expired and refresh failed"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInvalidGrantError(tt.err); got != tt.want {
+				t.Errorf("isInvalidGrantError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// invalidGrantHTTPDo returns a fake httpDo that always responds with 400 invalid_grant.
+func invalidGrantHTTPDo(_ *http.Request) (*http.Response, error) {
+	body := `{"error":"invalid_grant","error_description":"UNSUCCESSFUL_OAUTH_REFRESH_TOKEN_VALIDATION_FAILED"}`
+	return &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Status:     "400 Bad Request",
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+// newTMWithFakeKeyring builds a TokenManager whose storage is backed by an
+// in-memory map, so tests never touch the OS keyring. The returned map can be
+// inspected and mutated directly by test code.
+func newTMWithFakeKeyring(t *testing.T) (*TokenManager, map[string]string) {
+	t.Helper()
+	store := make(map[string]string)
+
+	oauthCfg := OAuthConfigForEnvironment(EnvironmentProd, config.DefaultSafetyLevel)
+	tm, err := NewTokenManager(oauthCfg)
+	if err != nil {
+		t.Fatalf("NewTokenManager() error: %v", err)
+	}
+
+	tm.deps.keyringAvailable = func() bool { return true }
+	tm.deps.getToken = func(_ *config.TokenStore, name string) (string, error) {
+		v, ok := store[name]
+		if !ok {
+			return "", fmt.Errorf("token %q not found in keyring", name)
+		}
+		return v, nil
+	}
+	tm.deps.setToken = func(_ *config.TokenStore, name, val string) error {
+		store[name] = val
+		return nil
+	}
+	tm.deps.deleteToken = func(_ *config.TokenStore, name string) error {
+		delete(store, name)
+		return nil
+	}
+	tm.deps.fileStoreAvailable = func() bool { return false }
+
+	return tm, store
+}
+
+func TestTokenManager_GetToken_InvalidGrant_CompactFormat(t *testing.T) {
+	t.Parallel()
+	tm, store := newTMWithFakeKeyring(t)
+	tm.flow.httpDo = invalidGrantHTTPDo
+
+	// Seed compact format: only refresh token, no access token, no expiry.
+	key := tm.getKeyringName("my-token")
+	compact, _ := json.Marshal(&StoredToken{
+		Name:     "my-token",
+		TokenSet: TokenSet{RefreshToken: "stale-refresh"},
+	})
+	store[key] = string(compact)
+
+	_, err := tm.GetToken("my-token")
+
+	// Error must wrap ErrOAuthSessionRevoked so the caller falls back to the platform token.
+	if err == nil {
+		t.Fatal("GetToken() returned nil, want error")
+	}
+	if !errors.Is(err, ErrOAuthSessionRevoked) {
+		t.Errorf("error %q should wrap ErrOAuthSessionRevoked", err.Error())
+	}
+
+	// Stale cache entry must be gone.
+	if _, ok := store[key]; ok {
+		t.Error("stale OAuth cache entry still present after invalid_grant")
+	}
+}
+
+func TestTokenManager_GetToken_InvalidGrant_ExpiredToken(t *testing.T) {
+	t.Parallel()
+	tm, store := newTMWithFakeKeyring(t)
+	tm.flow.httpDo = invalidGrantHTTPDo
+
+	key := tm.getKeyringName("my-token")
+	expired, _ := json.Marshal(&StoredToken{
+		Name: "my-token",
+		TokenSet: TokenSet{
+			AccessToken:  "expired-access",
+			RefreshToken: "stale-refresh",
+			ExpiresAt:    time.Now().Add(-1 * time.Hour), // expired
+		},
+	})
+	store[key] = string(expired)
+
+	_, err := tm.GetToken("my-token")
+
+	if err == nil {
+		t.Fatal("GetToken() returned nil, want error")
+	}
+	if !errors.Is(err, ErrOAuthSessionRevoked) {
+		t.Errorf("error %q should wrap ErrOAuthSessionRevoked", err.Error())
+	}
+	if _, ok := store[key]; ok {
+		t.Error("stale OAuth cache entry still present after invalid_grant")
+	}
+}
+
+func TestTokenManager_GetToken_InvalidGrant_TokenNearExpiry(t *testing.T) {
+	// Access token within the refresh buffer but not yet expired — refresh is
+	// attempted, fails with invalid_grant; cache is evicted so the next call
+	// can fall back to the platform token rather than hitting the same error.
+	t.Parallel()
+	tm, store := newTMWithFakeKeyring(t)
+	tm.flow.httpDo = invalidGrantHTTPDo
+
+	key := tm.getKeyringName("my-token")
+	nearExpiry, _ := json.Marshal(&StoredToken{
+		Name: "my-token",
+		TokenSet: TokenSet{
+			AccessToken:  "almost-expired-access",
+			RefreshToken: "stale-refresh",
+			ExpiresAt:    time.Now().Add(1 * time.Minute), // within 5-min buffer
+		},
+	})
+	store[key] = string(nearExpiry)
+
+	_, err := tm.GetToken("my-token")
+
+	if err == nil {
+		t.Fatal("GetToken() returned nil, want error")
+	}
+	if !errors.Is(err, ErrOAuthSessionRevoked) {
+		t.Errorf("error %q should wrap ErrOAuthSessionRevoked", err.Error())
+	}
+	if _, ok := store[key]; ok {
+		t.Error("stale OAuth cache entry still present after invalid_grant")
+	}
+}
+
+func TestTokenManager_GetToken_TransientError_DoesNotEvict(t *testing.T) {
+	// A network/5xx failure must NOT evict the cache — the token may still be
+	// usable if the access token hasn't expired yet.
+	t.Parallel()
+	tm, store := newTMWithFakeKeyring(t)
+	tm.flow.httpDo = func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+		}, nil
+	}
+
+	key := tm.getKeyringName("my-token")
+	stillValid, _ := json.Marshal(&StoredToken{
+		Name: "my-token",
+		TokenSet: TokenSet{
+			AccessToken:  "still-valid-access",
+			RefreshToken: "refresh",
+			ExpiresAt:    time.Now().Add(1 * time.Minute), // within buffer but not expired
+		},
+	})
+	store[key] = string(stillValid)
+
+	got, err := tm.GetToken("my-token")
+
+	// Should return the still-valid access token, not an error.
+	if err != nil {
+		t.Fatalf("GetToken() error = %v, want nil (should use cached access token)", err)
+	}
+	if got != "still-valid-access" {
+		t.Errorf("GetToken() = %q, want %q", got, "still-valid-access")
+	}
+	// Cache entry must NOT have been evicted.
+	if _, ok := store[key]; !ok {
+		t.Error("cache entry was incorrectly evicted on transient error")
 	}
 }

--- a/pkg/client/oauth_support.go
+++ b/pkg/client/oauth_support.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/dynatrace-oss/dtctl/pkg/auth"
@@ -27,8 +28,11 @@ func GetTokenWithOAuthSupport(cfg *config.Config, tokenRef string) (string, erro
 				return token, nil
 			}
 
-			// Only "not found" errors should fall back to regular API token lookup.
-			if !isOAuthTokenNotFoundError(err) {
+			// Fall back to regular API token lookup when:
+			//   - the OAuth entry does not exist, or
+			//   - the cached OAuth session was revoked server-side (invalid_grant);
+			//     the auth layer has already evicted the stale cache entry.
+			if !isOAuthTokenNotFoundError(err) && !errors.Is(err, auth.ErrOAuthSessionRevoked) {
 				return "", err
 			}
 		}

--- a/pkg/client/oauth_support_test.go
+++ b/pkg/client/oauth_support_test.go
@@ -2,10 +2,23 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/dynatrace-oss/dtctl/pkg/auth"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 )
+
+func TestErrOAuthSessionRevoked_IsRecognised(t *testing.T) {
+	wrapped := fmt.Errorf("token %q: %w; re-authenticate", "my-token", auth.ErrOAuthSessionRevoked)
+	if !errors.Is(wrapped, auth.ErrOAuthSessionRevoked) {
+		t.Fatal("errors.Is should match wrapped ErrOAuthSessionRevoked")
+	}
+	// And it should NOT match isOAuthTokenNotFoundError (the message no longer says "not found").
+	if isOAuthTokenNotFoundError(wrapped) {
+		t.Error("isOAuthTokenNotFoundError should not match a session-revoked error")
+	}
+}
 
 func TestIsOAuthTokenNotFoundError(t *testing.T) {
 	tests := []struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -606,15 +606,44 @@ func (c *Config) DeleteContext(name string) error {
 // SetToken creates or updates a token.
 // If keyring is available, the token is stored securely in the OS keyring
 // and only a reference is kept in the config file.
+// Any cached OAuth tokens for this credential name are invalidated so that
+// a rotated platform token does not keep using a stale refresh token.
 func (c *Config) SetToken(name, token string) error {
-	// Try to store in keyring first
-	if IsKeyringAvailable() {
-		ts := NewTokenStore()
-		if err := ts.SetToken(name, token); err != nil {
+	return c.setTokenWithKeyring(name, token, nil, nil)
+}
+
+// setTokenWithKeyring is the testable core of SetToken; accepts an explicit
+// keyringBackend and OAuthFileStore so tests avoid the OS keyring.
+func (c *Config) setTokenWithKeyring(name, token string, kr keyringBackend, fileStore *OAuthFileStore) error {
+	if kr == nil {
+		kr = newOSKeyring()
+	}
+	if fileStore == nil {
+		fileStore = NewOAuthFileStore()
+	}
+
+	keyringAvailable := kr.Available()
+	if keyringAvailable {
+		if err := kr.Set(name, token); err != nil {
 			return fmt.Errorf("failed to store token in keyring: %w", err)
 		}
 		// Store empty token in config (reference only)
 		token = ""
+	}
+
+	// Invalidate cached OAuth tokens for all known environments.
+	// When a platform token is rotated, the old OAuth refresh token
+	// is no longer valid and must not be reused.
+	// Both keyring and file-based caches are cleared, because GetToken
+	// checks both backends.
+	// Deletion is best-effort: a failure here means the user will get
+	// an invalid_grant error on the next request and must re-authenticate,
+	// which is acceptable.
+	for _, key := range c.oauthKeyringNames(name) {
+		if keyringAvailable {
+			_ = kr.Delete(key)
+		}
+		_ = fileStore.DeleteToken(key)
 	}
 
 	// Update or add token entry in config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,6 +10,31 @@ import (
 
 	"github.com/adrg/xdg"
 )
+
+// mockKeyring is an in-memory keyringBackend for tests that need no OS keyring.
+type mockKeyring struct{ data map[string]string }
+
+func newMockKeyring() *mockKeyring           { return &mockKeyring{data: make(map[string]string)} }
+func (m *mockKeyring) Available() bool       { return true }
+func (m *mockKeyring) Set(n, v string) error { m.data[n] = v; return nil }
+func (m *mockKeyring) Delete(n string) error { delete(m.data, n); return nil }
+func (m *mockKeyring) Get(n string) (string, error) {
+	v, ok := m.data[n]
+	if !ok {
+		return "", fmt.Errorf("token %q not found in keyring", n)
+	}
+	return v, nil
+}
+
+// unavailableKeyring simulates an environment without OS keyring (headless/WSL).
+type unavailableKeyring struct{}
+
+func (u *unavailableKeyring) Available() bool { return false }
+func (u *unavailableKeyring) Get(string) (string, error) {
+	return "", fmt.Errorf("keyring unavailable")
+}
+func (u *unavailableKeyring) Set(string, string) error { return fmt.Errorf("keyring unavailable") }
+func (u *unavailableKeyring) Delete(string) error      { return fmt.Errorf("keyring unavailable") }
 
 func TestNewConfig(t *testing.T) {
 	cfg := NewConfig()
@@ -1095,6 +1121,131 @@ func TestConfig_SetToken_UpdateExisting(t *testing.T) {
 
 	if !found {
 		t.Error("Updated token not found in config")
+	}
+}
+
+func TestConfig_SetToken_InvalidatesOAuthCache(t *testing.T) {
+	t.Parallel()
+
+	kr := newMockKeyring()
+	// Seed cached OAuth tokens for three environments.
+	kr.data["oauth:prod:rotated-token"] = `{"access_token":"old-access","refresh_token":"stale-refresh"}`
+	kr.data["oauth:dev:rotated-token"] = `{"access_token":"old-dev","refresh_token":"stale-dev"}`
+	kr.data["oauth:hard:rotated-token"] = `{"access_token":"old-hard","refresh_token":"stale-hard"}`
+
+	cfg := NewConfig()
+	if err := cfg.setTokenWithKeyring("rotated-token", "brand-new-platform-token", kr, nil); err != nil {
+		t.Fatalf("setTokenWithKeyring() error = %v", err)
+	}
+
+	// All cached OAuth entries must be gone.
+	for _, key := range []string{"oauth:prod:rotated-token", "oauth:dev:rotated-token", "oauth:hard:rotated-token"} {
+		if _, ok := kr.data[key]; ok {
+			t.Errorf("OAuth cache entry %q still exists after setTokenWithKeyring", key)
+		}
+	}
+
+	// The new platform token must be stored.
+	if got := kr.data["rotated-token"]; got != "brand-new-platform-token" {
+		t.Errorf("platform token = %q, want %q", got, "brand-new-platform-token")
+	}
+
+	// Config entry should be empty (reference only, value lives in keyring).
+	if len(cfg.Tokens) != 1 || cfg.Tokens[0].Token != "" {
+		t.Errorf("config token should be empty reference, got %+v", cfg.Tokens)
+	}
+}
+
+func TestConfig_SetToken_InvalidatesOAuthCache_DynamicEnv(t *testing.T) {
+	t.Parallel()
+
+	kr := newMockKeyring()
+	// Seed a cached OAuth token for the "prod" environment.
+	kr.data["oauth:prod:dyn-token"] = `{"refresh_token":"stale"}`
+
+	cfg := NewConfig()
+	// Add a context whose URL maps to "prod" so oauthKeyringNames discovers it dynamically.
+	cfg.Contexts = []NamedContext{
+		{Name: "my-env", Context: Context{
+			Environment: "https://abc12345.apps.dynatrace.com",
+			TokenRef:    "dyn-token",
+		}},
+	}
+
+	if err := cfg.setTokenWithKeyring("dyn-token", "new-value", kr, nil); err != nil {
+		t.Fatalf("setTokenWithKeyring() error = %v", err)
+	}
+
+	if _, ok := kr.data["oauth:prod:dyn-token"]; ok {
+		t.Error("dynamically-discovered OAuth cache entry still exists after setTokenWithKeyring")
+	}
+}
+
+func TestConfig_SetToken_InvalidatesOAuthFileCache(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	fileStore := NewOAuthFileStoreWithDir(dir)
+
+	// Seed file-based OAuth cache entries.
+	for _, key := range []string{"oauth:prod:file-tok", "oauth:dev:file-tok", "oauth:hard:file-tok"} {
+		if err := fileStore.SetToken(key, `{"refresh_token":"stale"}`); err != nil {
+			t.Fatalf("seed file store %s: %v", key, err)
+		}
+	}
+
+	// Use a mock keyring that reports unavailable so the file-store path is
+	// the only cache backend (simulates headless/WSL).
+	kr := &unavailableKeyring{}
+
+	cfg := NewConfig()
+	if err := cfg.setTokenWithKeyring("file-tok", "new-platform-token", kr, fileStore); err != nil {
+		t.Fatalf("setTokenWithKeyring() error = %v", err)
+	}
+
+	// All file-based OAuth entries must be gone.
+	for _, key := range []string{"oauth:prod:file-tok", "oauth:dev:file-tok", "oauth:hard:file-tok"} {
+		if tok, err := fileStore.GetToken(key); err == nil {
+			t.Errorf("file OAuth cache entry %q still exists: %s", key, tok)
+		}
+	}
+
+	// Token should be stored in config (keyring unavailable).
+	if len(cfg.Tokens) != 1 || cfg.Tokens[0].Token != "new-platform-token" {
+		t.Errorf("config token = %+v, want token in config (keyring unavailable)", cfg.Tokens)
+	}
+}
+
+func TestConfig_SetToken_InvalidatesBothKeyringAndFileCache(t *testing.T) {
+	t.Parallel()
+
+	kr := newMockKeyring()
+	kr.data["oauth:prod:both-tok"] = `{"refresh_token":"kr-stale"}`
+
+	dir := t.TempDir()
+	fileStore := NewOAuthFileStoreWithDir(dir)
+	if err := fileStore.SetToken("oauth:prod:both-tok", `{"refresh_token":"file-stale"}`); err != nil {
+		t.Fatalf("seed file store: %v", err)
+	}
+
+	cfg := NewConfig()
+	if err := cfg.setTokenWithKeyring("both-tok", "fresh-token", kr, fileStore); err != nil {
+		t.Fatalf("setTokenWithKeyring() error = %v", err)
+	}
+
+	// Keyring OAuth cache must be cleared.
+	if _, ok := kr.data["oauth:prod:both-tok"]; ok {
+		t.Error("keyring OAuth cache entry still exists")
+	}
+
+	// File OAuth cache must be cleared.
+	if tok, err := fileStore.GetToken("oauth:prod:both-tok"); err == nil {
+		t.Errorf("file OAuth cache entry still exists: %s", tok)
+	}
+
+	// Platform token stored in keyring.
+	if got := kr.data["both-tok"]; got != "fresh-token" {
+		t.Errorf("keyring platform token = %q, want %q", got, "fresh-token")
 	}
 }
 

--- a/pkg/config/keyring.go
+++ b/pkg/config/keyring.go
@@ -31,6 +31,24 @@ const (
 	ErrMsgCollectionUnlock = "failed to unlock correct collection"
 )
 
+// keyringBackend abstracts secure credential storage so callers can be tested
+// without a live OS keyring.
+type keyringBackend interface {
+	Available() bool
+	Get(name string) (string, error)
+	Set(name, value string) error
+	Delete(name string) error
+}
+
+// osKeyring is the production implementation backed by the OS keyring.
+type osKeyring struct{ store *TokenStore }
+
+func newOSKeyring() *osKeyring                       { return &osKeyring{store: NewTokenStore()} }
+func (k *osKeyring) Available() bool                 { return IsKeyringAvailable() }
+func (k *osKeyring) Get(name string) (string, error) { return k.store.GetToken(name) }
+func (k *osKeyring) Set(name, value string) error    { return k.store.SetToken(name, value) }
+func (k *osKeyring) Delete(name string) error        { return k.store.DeleteToken(name) }
+
 // TokenStore provides secure token storage using the OS keyring
 type TokenStore struct {
 	// fallbackToFile indicates whether to fall back to file-based storage

--- a/pkg/config/keyring_test.go
+++ b/pkg/config/keyring_test.go
@@ -147,3 +147,11 @@ func TestMigrateTokensToKeyring_NoKeyring(t *testing.T) {
 		}
 	}
 }
+
+func TestTokenStore_DeleteToken_KeyringUnavailableIsNoop(t *testing.T) {
+	t.Setenv(EnvDisableKeyring, "1")
+	ts := NewTokenStore()
+	if err := ts.DeleteToken("definitely-missing-token"); err != nil {
+		t.Fatalf("DeleteToken() error = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Description

  When a platform token is rotated and re-added under the same name,
  the cached OAuth refresh token from the previous credential is now
  deleted from both the OS keyring and the file-based token store.
  Previously the stale refresh token was reused, causing
  `invalid_grant` errors even after supplying a fresh platform token.

  Additionally, GetToken now evicts the cache and returns
  ErrOAuthSessionRevoked on invalid_grant, letting the caller fall
  back to the underlying platform token instead of surfacing the
  cryptic 400 error directly.

## Related Issues

None

## Testing

Don't have the issue at the moment, so couldn't test the fix locally.
I ran some smoke tests with the local build `auth login`. `doctor`, `config set-credentials`,  `config use-context`, ` describe dashboard` etc.

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
