### PR TITLE
feat(dev): harden markdownlint docker container usage

### DIFF
--- a/makefile
+++ b/makefile
@@ -148,10 +148,14 @@ fmt:
 
 # Markdown linting
 markdownlint:
-	docker run -v $(CURDIR):/workdir --rm $(MD_LINT_CLI_IMAGE) "**/*.md"
+	docker run -v $(CURDIR):/workdir:ro --rm \
+		--network=none --read-only --security-opt=no-new-privileges --cap-drop ALL \
+		$(MD_LINT_CLI_IMAGE) "**/*.md"
 
 markdownlint-fix:
-	docker run -v $(CURDIR):/workdir --rm $(MD_LINT_CLI_IMAGE) "**/*.md" --fix
+	docker run -v $(CURDIR):/workdir --rm \
+		--network=none --security-opt=no-new-privileges --cap-drop ALL --cap-add DAC_OVERRIDE \
+		$(MD_LINT_CLI_IMAGE) "**/*.md" --fix
 
 # Release (using goreleaser)
 release:


### PR DESCRIPTION
## Description

Minor security improvement. Do not give containers more permissions than necessary.

  Restrict surface area against supply chain attacks:
  - Drop all Linux capabilities; re-add only CAP_DAC_OVERRIDE for the fix variant (needed for file writes across UID boundaries)
  - do not permit network access via --network=none
  - Add --read-only root FS to the lint-only target
  - Enforce --no-new-privileges to block setuid/setgid escalation

  No --user flag: host UID varies across environments and breaks
  volumewrite permissions. Seccomp profiles would add more
  isolation but are overkill for a local dev tooling target.

## Related Issues

None

## Testing

Running `make markdownlint`  and `make markdownlint-fix` with markdown files that needed fixing.

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
