### PR TITLE
fix: --mine no longer crashes on platform tokens (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`--mine` filter no longer crashes on platform tokens** — `dtctl get dashboards --mine` (and `get documents`/`get workflows --mine`) failed with `failed to parse JWT claims: invalid character '#' looking for beginning of value` when the configured token was a Dynatrace platform token (`dt0s16.*`) and `/platform/metadata/v1/user` returned 403; the JWT fallback in `Client.CurrentUserID` blindly base64-decoded the middle segment of the platform token, which is not a JWT payload, producing the misleading parse error; `ExtractUserIDFromToken` now rejects platform tokens up front, and `CurrentUserID` returns an actionable message pointing at the missing `app-engine:apps:run` scope; fixes [#210](https://github.com/dynatrace-oss/dtctl/issues/210)
+
+### Changed
+- **`dtctl doctor` warning text for platform tokens now identifies the correct scope** — the previous message blamed `iam:users:read`, but `/platform/metadata/v1/user` actually requires `app-engine:apps:run` (which *is* grantable to platform tokens); the warning now reads `platform token: user identity unavailable via metadata API (token likely lacks 'app-engine:apps:run' scope; platform tokens are not JWTs, so no fallback)`, which correctly tells users how to fix it
+
 ## [0.27.0] - 2026-05-05
 
 ### Added

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -257,16 +257,18 @@ func runDoctorChecksWithClient(httpClient *http.Client) []checkResult {
 
 	userInfo, authErr := c.CurrentUser()
 	if authErr != nil {
-		// Platform tokens cannot be granted iam:users:read, so the metadata API
-		// returns 403 by design — surface this as a known limitation, not a
-		// failure. For other (OAuth/JWT) tokens, fall back to decoding the user
-		// ID directly out of the token; CurrentUserID would re-issue the same
-		// metadata call we already failed, so go straight to the JWT path.
+		// /platform/metadata/v1/user requires the 'app-engine:apps:run' scope.
+		// Platform tokens that lack it return 403, and unlike OAuth/JWT tokens
+		// they can't be JWT-decoded as a fallback (they aren't JWTs). Surface
+		// this as a known limitation, not a failure. For OAuth/JWT tokens we
+		// fall back to decoding the user ID directly out of the token;
+		// CurrentUserID would re-issue the same metadata call we already
+		// failed, so go straight to the JWT path.
 		if client.IsPlatformToken(token) {
 			results = append(results, checkResult{
 				Name:   "Authentication",
 				Status: "warn",
-				Detail: "platform token: user identity unavailable via metadata API (requires iam:users:read scope, not grantable to platform tokens)",
+				Detail: "platform token: user identity unavailable via metadata API (token likely lacks 'app-engine:apps:run' scope; platform tokens are not JWTs, so no fallback)",
 			})
 		} else if userID, jwtErr := client.ExtractUserIDFromToken(token); jwtErr == nil {
 			results = append(results, checkResult{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -306,13 +306,25 @@ func (c *Client) CurrentUserID() (string, error) {
 		return userInfo.UserID, nil
 	}
 
+	// Platform tokens are not JWTs, so the JWT fallback below would parse
+	// garbage and fail with a confusing decode error (see issue #210). Surface
+	// an actionable message instead.
+	if IsPlatformToken(c.token) {
+		if err == nil {
+			err = fmt.Errorf("metadata API returned no user ID")
+		}
+		return "", fmt.Errorf("cannot determine current user ID for a platform token: %w "+
+			"(ensure the token has the 'app-engine:apps:run' scope so /platform/metadata/v1/user can return the user identity)", err)
+	}
+
 	// Fallback to JWT decoding
 	return ExtractUserIDFromToken(c.token)
 }
 
 // platformTokenPrefix identifies Dynatrace platform tokens — opaque bearer
-// tokens (not JWTs) that cannot be granted iam:users:read / iam:groups:read,
-// so /platform/metadata/v1/user returns 403 when authenticated with one.
+// tokens (not JWTs). The /platform/metadata/v1/user endpoint requires the
+// 'app-engine:apps:run' scope; platform tokens that lack it get a 403, and
+// the token itself cannot be JWT-decoded as a user-ID fallback.
 const platformTokenPrefix = "dt0s16."
 
 // IsPlatformToken reports whether token is a Dynatrace platform token.
@@ -321,7 +333,13 @@ func IsPlatformToken(token string) bool {
 }
 
 // ExtractUserIDFromToken extracts the user ID (sub claim) from a JWT token.
+// Platform tokens (dt0s16.*) are not JWTs even though they have three
+// dot-separated parts, so they're rejected up front rather than producing
+// a misleading base64/JSON decode error.
 func ExtractUserIDFromToken(token string) (string, error) {
+	if IsPlatformToken(token) {
+		return "", fmt.Errorf("cannot extract user ID: token is a Dynatrace platform token, not a JWT")
+	}
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
 		return "", fmt.Errorf("invalid JWT token format")

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -270,6 +270,17 @@ func TestExtractUserIDFromToken(t *testing.T) {
 			want:    "",
 			wantErr: true,
 		},
+		{
+			// Regression for #210: platform tokens have three dot-separated
+			// parts but are not JWTs. Without the IsPlatformToken guard,
+			// base64-decoding the middle segment yields random bytes and
+			// json.Unmarshal reports e.g. "invalid character '#' looking for
+			// beginning of value", which is what the bug report shows.
+			name:    "platform token rejected (not a JWT)",
+			token:   "dt0s16.ABCDEFGHIJKLMNOPQRSTUVWX.YZ0123456789abcdefghijkl",
+			want:    "",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -628,6 +639,20 @@ func TestClient_CurrentUserID(t *testing.T) {
 			token:       "invalid-token",
 			wantErr:     true,
 			errContains: "invalid JWT token format",
+		},
+		{
+			// Regression for #210: when /platform/metadata/v1/user fails
+			// (e.g. 403 because the token lacks app-engine:apps:run) and the
+			// token is a platform token, we must not silently fall through to
+			// the JWT decoder — that produces a confusing "invalid character
+			// '#' looking for beginning of value" error. Surface an actionable
+			// message instead.
+			name:        "platform token + metadata 403 returns actionable error",
+			apiSuccess:  false,
+			apiStatus:   http.StatusForbidden,
+			token:       "dt0s16.ABCDEFGHIJKLMNOPQRSTUVWX.YZ0123456789abcdefghijkl",
+			wantErr:     true,
+			errContains: "platform token",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `dtctl get dashboards --mine` (and `get documents`/`get workflows --mine`) failed with `failed to parse JWT claims: invalid character '#' looking for beginning of value` when authenticated with a Dynatrace platform token (`dt0s16.*`). Root cause: `Client.CurrentUserID`'s JWT fallback blindly base64-decoded the middle segment of the platform token. Platform tokens have three dot-separated parts but are not JWTs, so decoding produced random bytes and `json.Unmarshal` reported the first non-JSON byte. `ExtractUserIDFromToken` now rejects platform tokens up front, and `CurrentUserID` returns an actionable message pointing at the `app-engine:apps:run` scope.
- **Doc/UX cleanup**: The `dtctl doctor` warning text for platform tokens was attributing the 403 to `iam:users:read`, but `/platform/metadata/v1/user` actually requires `app-engine:apps:run` (per `pkg/client/client.go:285`, `docs/dev/API_DESIGN.md:1617`, `docs/TOKEN_SCOPES.md:417`) — and that scope **is** grantable to platform tokens. Corrected the warning so users see the right fix.
- **Tests**: Added regression cases for both the `ExtractUserIDFromToken` guard and the `CurrentUserID` actionable-error path. Existing `doctor_test.go` assertion (`Contains "platform token"`) still holds.

Why integration tests didn't catch it: `TestExtractUserIDFromToken` and `TestClient_CurrentUserID` only covered valid JWTs and trivially malformed (1-part) tokens. There was no case for a 3-part non-JWT (`dt0s16.x.y`) — exactly the failing input. The new test cases close that gap.

Fixes #210.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] On a real env with a platform token that lacks `app-engine:apps:run`: `dtctl get dashboards --mine` now produces an actionable error instead of the JWT-parse error
- [ ] On a real env with a platform token that has `app-engine:apps:run`: `dtctl get dashboards --mine` still works (metadata API path unchanged)
- [ ] `dtctl doctor` against a platform token shows the corrected scope name in the warning detail