### PR TITLE
fix: use workflow input for exec workflow (#221)

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -22,8 +22,8 @@ Available operations:
 	Example: `  # Execute a workflow and wait for completion
   dtctl exec workflow <workflow-id>
 
-  # Execute a workflow with input parameters
-  dtctl exec workflow <workflow-id> --set key=value
+  # Execute a workflow with JSON input
+  dtctl exec workflow <workflow-id> --input '{"foo":"bar", "baz":3}'
 
   # Invoke a serverless function
   dtctl exec function <app-id>/<function-name>

--- a/cmd/exec_workflows.go
+++ b/cmd/exec_workflows.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -30,26 +32,53 @@ type execWorkflowTaskResult struct {
 	Result any    `json:"result,omitempty"`
 }
 
+type singleUseStringValue struct {
+	value *string
+	set   bool
+}
+
+func (v *singleUseStringValue) Set(value string) error {
+	if v.set {
+		return fmt.Errorf("flag can only be provided once")
+	}
+	v.set = true
+	*v.value = value
+	return nil
+}
+
+func (v *singleUseStringValue) String() string {
+	if v.value == nil {
+		return ""
+	}
+	return *v.value
+}
+
+func (v *singleUseStringValue) Type() string {
+	return "string"
+}
+
 // execWorkflowCmd executes a workflow
 var execWorkflowCmd = &cobra.Command{
 	Use:     "workflow <workflow-id>",
 	Aliases: []string{"wf"},
 	Short:   "Execute a workflow",
-	Long:    `Execute an automation workflow.`,
-	Example: `  # Execute workflow
-  dtctl exec workflow my-workflow-id
-
-  # Execute with parameters
-  dtctl exec workflow my-workflow-id --params severity=high --params env=prod
-
-  # Execute and wait for completion
-  dtctl exec workflow my-workflow-id --wait
-
-  # Execute with custom timeout
-  dtctl exec workflow my-workflow-id --wait --timeout 10m
-
-  # Execute, wait, and print each task's return value when done
-  dtctl exec workflow my-workflow-id --wait --show-results`,
+	Long:    "Execute an automation workflow. Workflow input must be provided as a JSON object via --input.",
+	Example: strings.Join([]string{
+		"  # Execute workflow",
+		"  dtctl exec workflow my-workflow-id",
+		"",
+		"  # Execute with workflow input",
+		"  dtctl exec workflow my-workflow-id --input '{\"foo\":\"bar\", \"baz\":3}'",
+		"",
+		"  # Execute and wait for completion",
+		"  dtctl exec workflow my-workflow-id --wait",
+		"",
+		"  # Execute with custom timeout",
+		"  dtctl exec workflow my-workflow-id --wait --timeout 10m",
+		"",
+		"  # Execute, wait, and print each task's return value when done",
+		"  dtctl exec workflow my-workflow-id --wait --show-results",
+	}, "\n"),
 	Args: cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		showResults, _ := cmd.Flags().GetBool("show-results")
@@ -57,7 +86,9 @@ var execWorkflowCmd = &cobra.Command{
 		if showResults && !wait {
 			return fmt.Errorf("--show-results requires --wait")
 		}
-		return nil
+
+		_, err := buildWorkflowExecutionRequest(cmd)
+		return err
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		workflowID := args[0]
@@ -69,13 +100,12 @@ var execWorkflowCmd = &cobra.Command{
 
 		executor := exec.NewWorkflowExecutor(c)
 
-		paramStrings, _ := cmd.Flags().GetStringSlice("params")
-		params, err := exec.ParseParams(paramStrings)
+		request, err := buildWorkflowExecutionRequest(cmd)
 		if err != nil {
 			return err
 		}
 
-		result, err := executor.Execute(workflowID, params)
+		result, err := executor.Execute(workflowID, request)
 		if err != nil {
 			return err
 		}
@@ -241,10 +271,74 @@ func formatExecutionDuration(seconds int) string {
 	return fmt.Sprintf("%dh%dm", h, m)
 }
 
+func buildWorkflowExecutionRequest(cmd *cobra.Command) (exec.WorkflowExecutionRequest, error) {
+	inputJSONValue, _ := cmd.Flags().GetString("input")
+	inputJSONValues := []string{}
+	if cmd.Flags().Lookup("input").Changed {
+		inputJSONValues = append(inputJSONValues, inputJSONValue)
+	}
+	paramStrings, _ := cmd.Flags().GetStringSlice("params")
+
+	return buildWorkflowExecutionRequestFromValues(inputJSONValues, paramStrings)
+}
+
+func buildWorkflowExecutionRequestFromValues(inputJSONValues []string, paramStrings []string) (exec.WorkflowExecutionRequest, error) {
+	request := exec.WorkflowExecutionRequest{}
+
+	if len(inputJSONValues) > 1 {
+		return request, fmt.Errorf("--input may only be provided once")
+	}
+	if len(inputJSONValues) == 1 {
+		input, err := parseWorkflowInputJSON(inputJSONValues[0])
+		if err != nil {
+			return request, err
+		}
+		request.Input = input
+	}
+
+	params, err := exec.ParseParams(paramStrings)
+	if err != nil {
+		return request, err
+	}
+	if len(params) > 0 {
+		request.Params = make(map[string]any, len(params))
+		for key, value := range params {
+			request.Params[key] = value
+		}
+	}
+
+	return request, nil
+}
+
+func parseWorkflowInputJSON(raw string) (map[string]any, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("--input must not be empty")
+	}
+
+	var parsed any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("invalid value for --input: %w", err)
+	}
+
+	input, ok := parsed.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("--input must be a JSON object")
+	}
+
+	return input, nil
+}
+
+func registerWorkflowExecFlags(cmd *cobra.Command) {
+	var inputJSON string
+	cmd.Flags().Var(&singleUseStringValue{value: &inputJSON}, "input", "workflow input as a JSON object")
+	cmd.Flags().StringSlice("params", []string{}, "workflow parameters (key=value)")
+	cmd.Flags().Bool("wait", false, "wait for workflow execution to complete")
+	cmd.Flags().Duration("timeout", 30*time.Minute, "timeout when waiting for completion")
+	cmd.Flags().Bool("show-results", false, "print the result of each task after execution completes (requires --wait)")
+	_ = cmd.Flags().MarkDeprecated("params", "It targets legacy execution metadata. Workflow input must be provided as a JSON object via --input.")
+	_ = cmd.Flags().MarkHidden("params")
+}
+
 func init() {
-	// Workflow flags
-	execWorkflowCmd.Flags().StringSlice("params", []string{}, "workflow parameters (key=value)")
-	execWorkflowCmd.Flags().Bool("wait", false, "wait for workflow execution to complete")
-	execWorkflowCmd.Flags().Duration("timeout", 30*time.Minute, "timeout when waiting for completion")
-	execWorkflowCmd.Flags().Bool("show-results", false, "print the result of each task after execution completes (requires --wait)")
+	registerWorkflowExecFlags(execWorkflowCmd)
 }

--- a/cmd/exec_workflows_test.go
+++ b/cmd/exec_workflows_test.go
@@ -1,0 +1,249 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
+)
+
+func newExecWorkflowRunCmdForTest() *cobra.Command {
+	cmd := &cobra.Command{
+		PreRunE: execWorkflowCmd.PreRunE,
+		RunE:    execWorkflowCmd.RunE,
+	}
+	registerWorkflowExecFlags(cmd)
+	return cmd
+}
+
+func decodeWorkflowRunRequestBody(t *testing.T, body io.Reader) map[string]any {
+	t.Helper()
+
+	var requestBody map[string]any
+	if err := json.NewDecoder(body).Decode(&requestBody); err != nil {
+		t.Fatalf("failed to decode workflow run request body: %v", err)
+	}
+
+	return requestBody
+}
+
+func TestExecWorkflowRunE_SendsWorkflowInputRequest(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/workflows/wf-123/run": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method: %s", r.Method)
+			}
+
+			requestBody := decodeWorkflowRunRequestBody(t, r.Body)
+			input, ok := requestBody["input"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected request body to contain workflow input, got %#v", requestBody["input"])
+			}
+			if input["enabled"] != true {
+				t.Fatalf("expected enabled=true, got %#v", input["enabled"])
+			}
+			if input["count"] != float64(2) {
+				t.Fatalf("expected count=2, got %#v", input["count"])
+			}
+			if _, exists := requestBody["params"]; exists {
+				t.Fatalf("expected workflow input request to omit legacy params, got %#v", requestBody)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"exec-123","workflow":"wf-123","state":"RUNNING"}`))
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	defer func() {
+		cfgFile = origCfgFile
+	}()
+	cfgFile = configPath
+
+	cmd := newExecWorkflowRunCmdForTest()
+	_ = cmd.Flags().Set("input", `{"enabled":true,"count":2}`)
+
+	err := cmd.RunE(cmd, []string{"wf-123"})
+	if err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+	if ms.RequestCount != 1 {
+		t.Fatalf("expected 1 request, got %d", ms.RequestCount)
+	}
+}
+
+func TestExecWorkflowRunE_SendsLegacyParamsCompatibilityRequestAndWarning(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/workflows/wf-123/run": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method: %s", r.Method)
+			}
+
+			requestBody := decodeWorkflowRunRequestBody(t, r.Body)
+			params, ok := requestBody["params"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected request body to contain legacy params, got %#v", requestBody["params"])
+			}
+			if params["severity"] != "high" {
+				t.Fatalf("expected severity=high, got %#v", params["severity"])
+			}
+			if _, exists := requestBody["input"]; exists {
+				t.Fatalf("expected legacy params compatibility request to omit workflow input, got %#v", requestBody)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"exec-456","workflow":"wf-123","state":"RUNNING"}`))
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	defer func() {
+		cfgFile = origCfgFile
+	}()
+	cfgFile = configPath
+
+	cmd := newExecWorkflowRunCmdForTest()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.Flags().SetOutput(&stderr)
+
+	err := cmd.ParseFlags([]string{"--params", "severity=high"})
+	if err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+	if !strings.Contains(stderr.String(), "deprecated") {
+		t.Fatalf("expected deprecation warning, got %q", stderr.String())
+	}
+
+	err = cmd.RunE(cmd, []string{"wf-123"})
+	if err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+	if ms.RequestCount != 1 {
+		t.Fatalf("expected 1 request, got %d", ms.RequestCount)
+	}
+}
+
+func TestBuildWorkflowExecutionRequest_BuildsWorkflowInputFromFlagValue(t *testing.T) {
+	request, err := buildWorkflowExecutionRequestFromValues(
+		[]string{`{"severity":"high","count":3,"options":{"dryRun":true},"items":["a",false,null]}`},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildWorkflowExecutionRequest() error = %v", err)
+	}
+	if request.Input["severity"] != "high" {
+		t.Fatalf("expected severity=high, got %#v", request.Input["severity"])
+	}
+	if request.Input["count"] != float64(3) {
+		t.Fatalf("expected count=3, got %#v", request.Input["count"])
+	}
+	options, ok := request.Input["options"].(map[string]any)
+	if !ok || options["dryRun"] != true {
+		t.Fatalf("expected options.dryRun=true, got %#v", request.Input["options"])
+	}
+	items, ok := request.Input["items"].([]any)
+	if !ok || len(items) != 3 || items[2] != nil {
+		t.Fatalf("expected items to preserve JSON array semantics, got %#v", request.Input["items"])
+	}
+	if request.Params != nil {
+		t.Fatalf("did not expect params in input request, got %#v", request.Params)
+	}
+}
+
+func TestBuildWorkflowExecutionRequest_RejectsInvalidWorkflowInput(t *testing.T) {
+	tests := []struct {
+		name            string
+		inputValues     []string
+		wantErrContains string
+	}{
+		{
+			name:            "empty input",
+			inputValues:     []string{""},
+			wantErrContains: "--input must not be empty",
+		},
+		{
+			name:            "invalid json",
+			inputValues:     []string{`{"severity":`},
+			wantErrContains: "invalid value for --input",
+		},
+		{
+			name:            "non-object json",
+			inputValues:     []string{`[1,2,3]`},
+			wantErrContains: "--input must be a JSON object",
+		},
+		{
+			name:            "repeated input flag",
+			inputValues:     []string{`{"first":true}`, `{"second":true}`},
+			wantErrContains: "--input may only be provided once",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildWorkflowExecutionRequestFromValues(tt.inputValues, nil)
+			if err == nil {
+				t.Fatal("expected invalid workflow input to be rejected")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErrContains, err)
+			}
+		})
+	}
+}
+
+func TestExecWorkflowParamsFlagHiddenFromUsage(t *testing.T) {
+	usage := newExecWorkflowRunCmdForTest().UsageString()
+	if strings.Contains(usage, "--params") {
+		t.Fatalf("expected --params to be hidden from usage, got: %s", usage)
+	}
+}
+
+func TestExecWorkflowParamsFlagEmitsDeprecationWarning(t *testing.T) {
+	var stderr bytes.Buffer
+	cmd := newExecWorkflowRunCmdForTest()
+	cmd.SetErr(&stderr)
+	cmd.Flags().SetOutput(&stderr)
+
+	err := cmd.ParseFlags([]string{"--params", "env=prod"})
+	if err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+
+	output := stderr.String()
+	if !strings.Contains(output, "deprecated") {
+		t.Fatalf("expected deprecation warning, got: %q", output)
+	}
+	if !strings.Contains(output, "--input") {
+		t.Fatalf("expected migration guidance in warning, got: %q", output)
+	}
+}
+
+func TestExecWorkflowInputHelpType(t *testing.T) {
+	usage := newExecWorkflowRunCmdForTest().UsageString()
+	if !strings.Contains(usage, "--input string") {
+		t.Fatalf("expected --input help to show string type, got: %s", usage)
+	}
+}
+
+func TestExecWorkflowExampleFormatting(t *testing.T) {
+	help := execWorkflowCmd.HelpTemplate()
+	_ = help
+	if strings.Contains(execWorkflowCmd.Example, "\n\t# Execute with workflow input") {
+		t.Fatalf("expected workflow example to avoid tab indentation, got: %q", execWorkflowCmd.Example)
+	}
+}

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -136,9 +136,10 @@ func TestExecFlags(t *testing.T) {
 		flagName     string
 		defaultValue string
 	}{
-		{"params", "[]"},
+		{"input", ""},
 		{"wait", "false"},
 		{"timeout", "30m0s"},
+		{"show-results", "false"},
 	}
 
 	for _, tt := range workflowFlags {

--- a/cmd/get_wfe_task_result_test.go
+++ b/cmd/get_wfe_task_result_test.go
@@ -6,12 +6,20 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/dynatrace-oss/dtctl/cmd/testutil"
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	workflowpkg "github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
 )
+
+func newExecWorkflowCmdForTest() *cobra.Command {
+	cmd := &cobra.Command{PreRunE: execWorkflowCmd.PreRunE}
+	registerWorkflowExecFlags(cmd)
+	return cmd
+}
 
 func TestGetWfeTaskResult_RunE(t *testing.T) {
 	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
@@ -177,8 +185,7 @@ func TestExecWorkflowAgent_Success(t *testing.T) {
 	}
 
 	// Set up a command with --wait and --show-results flags
-	cmd := *execWorkflowCmd // shallow copy to avoid mutating the global
-	testutil.ResetCommandFlags(&cmd)
+	cmd := newExecWorkflowCmdForTest()
 	_ = cmd.Flags().Set("wait", "true")
 	_ = cmd.Flags().Set("show-results", "true")
 
@@ -186,7 +193,7 @@ func TestExecWorkflowAgent_Success(t *testing.T) {
 	ctx := &output.ResponseContext{}
 	ap := output.NewAgentPrinter(&buf, ctx)
 
-	err = execWorkflowAgent(&cmd, c, executor, execResult, ap)
+	err = execWorkflowAgent(cmd, c, executor, execResult, ap)
 	if err != nil {
 		t.Fatalf("execWorkflowAgent: %v", err)
 	}
@@ -248,8 +255,7 @@ func TestExecWorkflowAgent_NoWait(t *testing.T) {
 		State:    "RUNNING",
 	}
 
-	cmd := *execWorkflowCmd
-	testutil.ResetCommandFlags(&cmd)
+	cmd := newExecWorkflowCmdForTest()
 	// --wait defaults to false
 
 	var buf bytes.Buffer
@@ -257,7 +263,7 @@ func TestExecWorkflowAgent_NoWait(t *testing.T) {
 	ap := output.NewAgentPrinter(&buf, ctx)
 
 	// No mock server needed — without --wait we don't poll
-	err := execWorkflowAgent(&cmd, nil, nil, execResult, ap)
+	err := execWorkflowAgent(cmd, nil, nil, execResult, ap)
 	if err != nil {
 		t.Fatalf("execWorkflowAgent: %v", err)
 	}
@@ -304,15 +310,14 @@ func TestExecWorkflowAgent_ErrorState(t *testing.T) {
 		State:    "RUNNING",
 	}
 
-	cmd := *execWorkflowCmd
-	testutil.ResetCommandFlags(&cmd)
+	cmd := newExecWorkflowCmdForTest()
 	_ = cmd.Flags().Set("wait", "true")
 
 	var buf bytes.Buffer
 	ctx := &output.ResponseContext{}
 	ap := output.NewAgentPrinter(&buf, ctx)
 
-	err = execWorkflowAgent(&cmd, c, executor, execResult, ap)
+	err = execWorkflowAgent(cmd, c, executor, execResult, ap)
 	if err != nil {
 		t.Fatalf("execWorkflowAgent should not return error (it sets warnings): %v", err)
 	}
@@ -337,11 +342,10 @@ func TestExecWorkflowAgent_ErrorState(t *testing.T) {
 
 func TestExecWorkflowShowResults_PreRunE(t *testing.T) {
 	// --show-results without --wait should fail
-	cmd := *execWorkflowCmd
-	testutil.ResetCommandFlags(&cmd)
+	cmd := newExecWorkflowCmdForTest()
 	_ = cmd.Flags().Set("show-results", "true")
 
-	err := cmd.PreRunE(&cmd, []string{"wf-123"})
+	err := cmd.PreRunE(cmd, []string{"wf-123"})
 	if err == nil {
 		t.Fatal("expected error when --show-results used without --wait")
 	}
@@ -351,7 +355,7 @@ func TestExecWorkflowShowResults_PreRunE(t *testing.T) {
 
 	// --show-results with --wait should pass
 	_ = cmd.Flags().Set("wait", "true")
-	err = cmd.PreRunE(&cmd, []string{"wf-123"})
+	err = cmd.PreRunE(cmd, []string{"wf-123"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/exec/workflow.go
+++ b/pkg/exec/workflow.go
@@ -21,6 +21,7 @@ func NewWorkflowExecutor(c *client.Client) *WorkflowExecutor {
 
 // WorkflowExecutionRequest represents a workflow execution request
 type WorkflowExecutionRequest struct {
+	Input  map[string]any         `json:"input,omitempty"`
 	Params map[string]interface{} `json:"params,omitempty"`
 }
 
@@ -32,16 +33,7 @@ type WorkflowExecutionResponse struct {
 }
 
 // Execute executes a workflow
-func (e *WorkflowExecutor) Execute(workflowID string, params map[string]string) (*WorkflowExecutionResponse, error) {
-	req := WorkflowExecutionRequest{
-		Params: make(map[string]interface{}),
-	}
-
-	// Convert string params to interface map
-	for k, v := range params {
-		req.Params[k] = v
-	}
-
+func (e *WorkflowExecutor) Execute(workflowID string, req WorkflowExecutionRequest) (*WorkflowExecutionResponse, error) {
 	var result WorkflowExecutionResponse
 
 	resp, err := e.client.HTTP().R().

--- a/pkg/exec/workflow_test.go
+++ b/pkg/exec/workflow_test.go
@@ -1,0 +1,128 @@
+package exec
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+)
+
+func TestWorkflowExecutor_Execute_SendsLegacyParamsCompatibilityRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/platform/automation/v1/workflows/wf-123/run" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		params, ok := body["params"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected request body to contain legacy params, got %#v", body["params"])
+		}
+		if params["severity"] != "high" {
+			t.Fatalf("expected params.severity=high, got %#v", params["severity"])
+		}
+		if params["env"] != "prod" {
+			t.Fatalf("expected params.env=prod, got %#v", params["env"])
+		}
+		if _, exists := body["input"]; exists {
+			t.Fatalf("expected legacy params compatibility request to omit workflow input, got %#v", body)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"exec-123","workflow":"wf-123","state":"RUNNING"}`))
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewWorkflowExecutor(c)
+	result, err := executor.Execute("wf-123", WorkflowExecutionRequest{
+		Params: map[string]any{"severity": "high", "env": "prod"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result.ID != "exec-123" {
+		t.Fatalf("expected execution id exec-123, got %s", result.ID)
+	}
+}
+
+func TestWorkflowExecutor_Execute_SendsWorkflowInputRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/platform/automation/v1/workflows/wf-123/run" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		input, ok := body["input"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected request body to contain workflow input, got %#v", body["input"])
+		}
+		if input["severity"] != "high" {
+			t.Fatalf("expected input.severity=high, got %#v", input["severity"])
+		}
+		if input["count"] != float64(3) {
+			t.Fatalf("expected input.count=3, got %#v", input["count"])
+		}
+		options, ok := input["options"].(map[string]any)
+		if !ok || options["dryRun"] != true {
+			t.Fatalf("expected nested options.dryRun=true, got %#v", input["options"])
+		}
+		items, ok := input["items"].([]any)
+		if !ok || len(items) != 3 {
+			t.Fatalf("expected items array, got %#v", input["items"])
+		}
+		if items[2] != nil {
+			t.Fatalf("expected items[2]=nil, got %#v", items[2])
+		}
+		if _, exists := body["params"]; exists {
+			t.Fatalf("expected workflow input request to omit legacy params, got %#v", body)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"exec-456","workflow":"wf-123","state":"RUNNING"}`))
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewWorkflowExecutor(c)
+	result, err := executor.Execute("wf-123", WorkflowExecutionRequest{
+		Input: map[string]any{
+			"severity": "high",
+			"count":    3,
+			"options": map[string]any{
+				"dryRun": true,
+			},
+			"items": []any{"a", false, nil},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result.ID != "exec-456" {
+		t.Fatalf("expected execution id exec-456, got %s", result.ID)
+	}
+}

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -20,6 +20,7 @@ func TestWorkflowLifecycle(t *testing.T) {
 
 	handler := workflow.NewHandler(env.Client)
 	execHandler := exec.NewWorkflowExecutor(env.Client)
+	executionHandler := workflow.NewExecutionHandler(env.Client)
 
 	tests := []struct {
 		name    string
@@ -121,10 +122,10 @@ func TestWorkflowLifecycle(t *testing.T) {
 
 			// Step 7: Execute workflow
 			t.Log("Step 7: Executing workflow...")
-			params := map[string]string{
-				"testParam": "testValue",
-			}
-			execution, err := execHandler.Execute(created.ID, params)
+			input := integration.WorkflowExecutionInput()
+			execution, err := execHandler.Execute(created.ID, exec.WorkflowExecutionRequest{
+				Input: input,
+			})
 			if err != nil {
 				t.Fatalf("Failed to execute workflow: %v", err)
 			}
@@ -152,6 +153,24 @@ func TestWorkflowLifecycle(t *testing.T) {
 				if finalStatus.State == "ERROR" && finalStatus.StateInfo != nil {
 					t.Logf("  Execution error info: %s", *finalStatus.StateInfo)
 				}
+			}
+
+			// Step 8b: Fetch the execution and verify persisted workflow input.
+			t.Log("Step 8b: Verifying execution input...")
+			executionDetails, err := executionHandler.Get(execution.ID)
+			if err != nil {
+				t.Fatalf("Failed to get execution details: %v", err)
+			}
+			gotInput, err := json.Marshal(executionDetails.Input)
+			if err != nil {
+				t.Fatalf("Failed to marshal execution input: %v", err)
+			}
+			wantInput, err := json.Marshal(input)
+			if err != nil {
+				t.Fatalf("Failed to marshal expected input: %v", err)
+			}
+			if string(gotInput) != string(wantInput) {
+				t.Fatalf("execution input mismatch: got %s want %s", gotInput, wantInput)
 			}
 
 			// Step 9: Restore to previous version

--- a/test/integration/fixtures.go
+++ b/test/integration/fixtures.go
@@ -23,7 +23,7 @@ func WorkflowFixture(prefix string) []byte {
 				"name":   "test_task",
 				"action": "dynatrace.automations:run-javascript",
 				"input": map[string]interface{}{
-					"script": "export default async function() { return { result: 'Integration test success' }; }",
+					"script": "import { execution } from '@dynatrace-sdk/automation-utils';\nexport default async function() { const ex = await execution(); return { result: ex.input }; }",
 				},
 			},
 		},
@@ -236,6 +236,17 @@ func BucketUpdateRequest(prefix string) map[string]interface{} {
 func WorkflowExecutionParams() map[string]interface{} {
 	return map[string]interface{}{
 		"testParam": "testValue",
+	}
+}
+
+// WorkflowExecutionInput returns sample workflow input for integration testing.
+func WorkflowExecutionInput() map[string]interface{} {
+	return map[string]interface{}{
+		"message": "hello from dtctl",
+		"count":   3,
+		"options": map[string]interface{}{
+			"dryRun": true,
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
- use workflow input via --input-json for workflow execution
- keep --params hidden and deprecated as a compatibility path
- add focused request, command, and workflow integration coverage

Closes #221