### PR TITLE
fix: update trash restore conflict test to match current API behavior

### DIFF
--- a/test/integration/trash_test.go
+++ b/test/integration/trash_test.go
@@ -329,14 +329,10 @@ func TestTrash_RestoreWithConflict(t *testing.T) {
 	require.NoError(t, err)
 	env.Cleanup.TrackDocument("dashboard", created2.ID, dashboard2Req.Name, created2.Version)
 
-	// Try to restore dashboard 1 (should fail due to name conflict)
+	// Restore dashboard 1 — the API allows restoring even when another
+	// dashboard with the same name exists (no conflict error).
 	err = trashHandler.Restore(created1.ID, document.RestoreOptions{})
-	assert.Error(t, err, "Restore should fail due to name conflict")
-	assert.Contains(t, err.Error(), "name conflict", "Error should mention name conflict")
-
-	// Restore with force flag (should succeed)
-	err = trashHandler.Restore(created1.ID, document.RestoreOptions{Force: true})
-	assert.NoError(t, err, "Restore with force should succeed")
+	assert.NoError(t, err, "Restore should succeed even with a duplicate name")
 
 	// Cleanup
 	restored1, _ := handler.Get(created1.ID)


### PR DESCRIPTION
## Summary
- The Dynatrace Document API no longer returns an error when restoring a trashed document whose name conflicts with an existing document
- `TestTrash_RestoreWithConflict` expected an error and panicked (nil pointer dereference on `err.Error()`) when none was returned
- Updated the test to assert that restore succeeds without the force flag, matching current API behavior