### PR TITLE
fix(workflow): preserve definition fields in get output

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -100,30 +100,6 @@ func formatBytes(bytes int64) string {
 	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }
 
-// printTriggerInfo prints trigger configuration
-func printTriggerInfo(trigger map[string]interface{}) {
-	if triggerType, ok := trigger["type"].(string); ok {
-		fmt.Printf("  Type: %s\n", triggerType)
-	}
-
-	if schedule, ok := trigger["schedule"].(map[string]interface{}); ok {
-		if rule, exists := schedule["rule"]; exists {
-			fmt.Printf("  Schedule: %v\n", rule)
-		}
-		if tz, exists := schedule["timezone"]; exists {
-			fmt.Printf("  Timezone: %v\n", tz)
-		}
-	}
-
-	if eventTrigger, ok := trigger["eventTrigger"].(map[string]interface{}); ok {
-		if triggerConfig, exists := eventTrigger["triggerConfiguration"].(map[string]interface{}); exists {
-			if eventType, exists := triggerConfig["type"]; exists {
-				fmt.Printf("  Event Type: %v\n", eventType)
-			}
-		}
-	}
-}
-
 // describeAzureConnectionCmd shows details of an Azure connection (credential)
 var describeAzureConnectionCmd = &cobra.Command{
 	Use:     "connection <id>",

--- a/cmd/describe_helpers_test.go
+++ b/cmd/describe_helpers_test.go
@@ -61,6 +61,7 @@ func TestStringFromRecord(t *testing.T) {
 		"name":   "server-01",
 		"count":  42.0,
 		"active": true,
+		"empty":  nil,
 	}
 	cases := []struct {
 		key  string
@@ -68,6 +69,7 @@ func TestStringFromRecord(t *testing.T) {
 	}{
 		{"name", "server-01"},
 		{"missing", ""},
+		{"empty", ""},
 		{"count", "42"},    // non-string → fmt.Sprintf("%v", ...)
 		{"active", "true"}, // non-string → fmt.Sprintf("%v", ...)
 	}
@@ -76,5 +78,11 @@ func TestStringFromRecord(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("stringFromRecord(record, %q) = %q, want %q", tc.key, got, tc.want)
 		}
+	}
+}
+
+func TestStringFromRecordNilRecord(t *testing.T) {
+	if got := stringFromRecord(nil, "name"); got != "" {
+		t.Fatalf("stringFromRecord(nil, %q) = %q, want empty", "name", got)
 	}
 }

--- a/cmd/describe_workflows.go
+++ b/cmd/describe_workflows.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -41,70 +45,11 @@ Examples:
 
 		// For table output, show detailed human-readable information
 		if outputFormat == "table" {
-			const w = 13
-			output.DescribeKV("ID:", w, "%s", wf.ID)
-			output.DescribeKV("Title:", w, "%s", wf.Title)
-			if wf.Description != "" {
-				output.DescribeKV("Description:", w, "%s", wf.Description)
-			}
-			output.DescribeKV("Owner:", w, "%s (%s)", wf.Owner, wf.OwnerType)
-			output.DescribeKV("Private:", w, "%v", wf.Private)
-			output.DescribeKV("Deployed:", w, "%v", wf.IsDeployed)
-
-			// Print trigger info
-			if wf.Trigger != nil {
-				fmt.Println()
-				output.DescribeSection("Trigger:")
-				printTriggerInfo(wf.Trigger)
-			}
-
-			// Print tasks
-			if len(wf.Tasks) > 0 {
-				fmt.Println()
-				output.DescribeSection("Tasks:")
-				for name, task := range wf.Tasks {
-					taskMap, ok := task.(map[string]interface{})
-					if ok {
-						action := ""
-						if a, exists := taskMap["action"]; exists {
-							action = fmt.Sprintf("%v", a)
-						}
-						fmt.Printf("  - %s", name)
-						if action != "" {
-							fmt.Printf(" (%s)", action)
-						}
-						fmt.Println()
-					} else {
-						fmt.Printf("  - %s\n", name)
-					}
-				}
-			}
-
-			// Get recent executions
 			execList, err := execHandler.List(workflowID)
-			if err == nil && execList.Count > 0 {
-				fmt.Println()
-				output.DescribeSection("Recent Executions:")
-
-				// Show up to 5 recent executions
-				limit := 5
-				if execList.Count < limit {
-					limit = execList.Count
-				}
-
-				for i := 0; i < limit; i++ {
-					exec := execList.Results[i]
-					fmt.Printf("  - %s  %-10s  %s  %s\n",
-						exec.ID[:8]+"...",
-						exec.State,
-						exec.StartedAt.Format("2006-01-02 15:04"),
-						formatDuration(exec.Runtime))
-				}
-
-				if execList.Count > limit {
-					fmt.Printf("  ... and %d more\n", execList.Count-limit)
-				}
+			if err != nil {
+				execList = nil
 			}
+			printWorkflowDescribeTable(os.Stdout, wf, execList)
 
 			return nil
 		}
@@ -113,6 +58,132 @@ Examples:
 		enrichAgent(printer, "describe", "workflow")
 		return printer.Print(wf)
 	},
+}
+
+func printWorkflowDescribeTable(w io.Writer, wf *workflow.Workflow, execList *workflow.ExecutionList) {
+	const kw = 13
+	output.FprintDescribeKV(w, "ID:", kw, "%s", wf.ID)
+	output.FprintDescribeKV(w, "Title:", kw, "%s", wf.Title)
+	if wf.Description != "" {
+		output.FprintDescribeKV(w, "Description:", kw, "%s", wf.Description)
+	}
+	output.FprintDescribeKV(w, "Owner:", kw, "%s (%s)", wf.Owner, wf.OwnerType)
+	output.FprintDescribeKV(w, "Private:", kw, "%v", wf.Private)
+	output.FprintDescribeKV(w, "Deployed:", kw, "%v", wf.IsDeployed)
+	output.FprintDescribeKV(w, "Type:", kw, "%s", wf.Type)
+
+	if summary := triggerSummary(wf.Trigger); summary != "" {
+		output.FprintDescribeKV(w, "Trigger:", kw, "%s", summary)
+	}
+
+	printWorkflowDefinitionFields(w, kw, wf)
+
+	if len(wf.Tasks) > 0 {
+		fmt.Fprintln(w)
+		output.FprintDescribeSection(w, "Tasks:")
+		for name, task := range wf.Tasks {
+			taskMap, ok := task.(map[string]interface{})
+			if ok {
+				action := ""
+				if a, exists := taskMap["action"]; exists {
+					action = fmt.Sprintf("%v", a)
+				}
+				fmt.Fprintf(w, "  - %s", name)
+				if action != "" {
+					fmt.Fprintf(w, " (%s)", action)
+				}
+				fmt.Fprintln(w)
+			} else {
+				fmt.Fprintf(w, "  - %s\n", name)
+			}
+		}
+	}
+
+	if execList == nil || execList.Count == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	output.FprintDescribeSection(w, "Recent Executions:")
+
+	limit := 5
+	if execList.Count < limit {
+		limit = execList.Count
+	}
+
+	for i := 0; i < limit; i++ {
+		exec := execList.Results[i]
+		fmt.Fprintf(w, "  - %s  %-10s  %s  %s\n",
+			exec.ID[:8]+"...",
+			exec.State,
+			exec.StartedAt.Format("2006-01-02 15:04"),
+			formatDuration(exec.Runtime))
+	}
+
+	if execList.Count > limit {
+		fmt.Fprintf(w, "  ... and %d more\n", execList.Count-limit)
+	}
+}
+
+func printWorkflowDefinitionFields(w io.Writer, width int, wf *workflow.Workflow) {
+	if wf.Result != nil && *wf.Result != "" {
+		fmt.Fprintln(w)
+		output.FprintDescribeKV(w, "Result:", width, "%s", *wf.Result)
+	}
+
+	if len(wf.Input) == 0 {
+		return
+	}
+
+	inputJSON, err := json.MarshalIndent(wf.Input, "  ", "  ")
+	if err != nil {
+		return
+	}
+
+	fmt.Fprintln(w)
+	output.FprintDescribeSection(w, "Input:")
+	fmt.Fprintf(w, "  %s\n", string(inputJSON))
+}
+
+func triggerSummary(trigger map[string]interface{}) string {
+	if _, ok := trigger["schedule"]; ok {
+		return formatTriggerSummary("schedule", nestedTriggerString(trigger, "schedule", "trigger", "type"))
+	}
+	if _, ok := trigger["eventTrigger"]; ok {
+		return formatTriggerSummary("eventTrigger", nestedTriggerString(trigger, "eventTrigger", "triggerConfiguration", "type"))
+	}
+	return ""
+}
+
+func formatTriggerSummary(familyKey, subtype string) string {
+	family := strings.TrimSuffix(familyKey, "Trigger")
+	if family == "" {
+		return ""
+	}
+	family = strings.ToUpper(family[:1]) + family[1:]
+	if subtype == "" {
+		return family
+	}
+	return fmt.Sprintf("%s (%s)", family, subtype)
+}
+
+func nestedTriggerString(root map[string]interface{}, path ...string) string {
+	current := any(root)
+	for _, part := range path {
+		currentMap, ok := current.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current, ok = currentMap[part]
+		if !ok || current == nil {
+			return ""
+		}
+	}
+	value, ok := current.(string)
+	if !ok {
+		return ""
+	}
+	return value
 }
 
 // describeWorkflowExecutionCmd shows detailed info about a workflow execution

--- a/cmd/describe_workflows_test.go
+++ b/cmd/describe_workflows_test.go
@@ -1,0 +1,332 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
+)
+
+func TestPrintWorkflowDescribeTableGolden(t *testing.T) {
+	result := "{{ result('deploy') }}"
+	wf := &workflow.Workflow{
+		ID:         "wf-123",
+		Title:      "Deploy to Production",
+		Owner:      "user-123",
+		OwnerType:  "USER",
+		Private:    false,
+		Type:       "STANDARD",
+		IsDeployed: true,
+		Result:     &result,
+		Input: map[string]interface{}{
+			"environment": map[string]interface{}{"type": "string"},
+		},
+		Tasks: map[string]interface{}{
+			"deploy": map[string]interface{}{"action": "dynatrace.automations:run-javascript"},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkflowDescribeTable(&buf, wf, nil)
+
+	want := "ID:          wf-123\nTitle:       Deploy to Production\nOwner:       user-123 (USER)\nPrivate:     false\nDeployed:    true\nType:        STANDARD\n\nResult:      {{ result('deploy') }}\n\nInput:\n  {\n    \"environment\": {\n      \"type\": \"string\"\n    }\n  }\n\nTasks:\n  - deploy (dynatrace.automations:run-javascript)\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("printWorkflowDescribeTable() = %q, want %q", got, want)
+	}
+}
+
+func TestPrintWorkflowDefinitionFields(t *testing.T) {
+	result := "{{ result('deploy') }}"
+	wf := &workflow.Workflow{
+		Result: &result,
+		Input: map[string]interface{}{
+			"environment": map[string]interface{}{"type": "string"},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkflowDefinitionFields(&buf, 13, wf)
+
+	want := "\nResult:      {{ result('deploy') }}\n\nInput:\n  {\n    \"environment\": {\n      \"type\": \"string\"\n    }\n  }\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("printWorkflowDefinitionFields() = %q, want %q", got, want)
+	}
+}
+
+func TestPrintWorkflowDefinitionFieldsSkipsInvalidInputJSON(t *testing.T) {
+	result := "{{ result('deploy') }}"
+	wf := &workflow.Workflow{
+		Result: &result,
+		Input: map[string]interface{}{
+			"invalid": func() {},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkflowDefinitionFields(&buf, 13, wf)
+
+	got := buf.String()
+	if !strings.Contains(got, "Result:      {{ result('deploy') }}") {
+		t.Fatalf("expected result to be printed before invalid input is skipped, got %q", got)
+	}
+	if strings.Contains(got, "Input:") {
+		t.Fatalf("expected invalid input JSON to be skipped, got %q", got)
+	}
+}
+
+func TestPrintWorkflowDescribeTableIncludesTriggerAndRecentExecutions(t *testing.T) {
+	startedAt := time.Date(2026, 5, 18, 12, 30, 0, 0, time.UTC)
+	wf := &workflow.Workflow{
+		ID:          "wf-456",
+		Title:       "Incident Response",
+		Description: "Handles incident workflows",
+		Owner:       "user-456",
+		OwnerType:   "USER",
+		Private:     true,
+		Type:        "STANDARD",
+		IsDeployed:  false,
+		Trigger: map[string]interface{}{
+			"type": "event",
+			"schedule": map[string]interface{}{
+				"rule":     "0 9 * * 1-5",
+				"timezone": "UTC",
+			},
+		},
+		Tasks: map[string]interface{}{
+			"notify": "plain-task",
+		},
+	}
+	execList := &workflow.ExecutionList{
+		Count: 1,
+		Results: []workflow.Execution{
+			{ID: "12345678-aaaa-bbbb-cccc-1234567890ab", State: "SUCCEEDED", StartedAt: startedAt, Runtime: 61},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkflowDescribeTable(&buf, wf, execList)
+
+	got := buf.String()
+	checks := []string{
+		"Description: Handles incident workflows",
+		"Trigger:     Schedule",
+		"Tasks:\n  - notify",
+		"Recent Executions:\n  - 12345678...  SUCCEEDED",
+	}
+	for _, want := range checks {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected output to contain %q, got %q", want, got)
+		}
+	}
+}
+
+func TestPrintWorkflowDescribeTableSkipsNilScheduleRuleAndUsesNestedTrigger(t *testing.T) {
+	wf := &workflow.Workflow{
+		ID:         "wf-789",
+		Title:      "Daily Cleanup",
+		Owner:      "user-789",
+		OwnerType:  "USER",
+		Private:    false,
+		Type:       "STANDARD",
+		IsDeployed: true,
+		Trigger: map[string]interface{}{
+			"schedule": map[string]interface{}{
+				"rule": nil,
+				"trigger": map[string]interface{}{
+					"type": "cron",
+					"cron": "0 9 * * 1-5",
+				},
+				"timezone": "UTC",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkflowDescribeTable(&buf, wf, nil)
+
+	got := buf.String()
+	if strings.Contains(got, "<nil>") {
+		t.Fatalf("expected output to skip nil trigger values, got %q", got)
+	}
+	if !strings.Contains(got, "Trigger:     Schedule (cron)") {
+		t.Fatalf("expected schedule subtype summary to be rendered, got %q", got)
+	}
+}
+
+func TestPrintWorkflowDescribeTableShowsTimeBasedNestedScheduleTrigger(t *testing.T) {
+	wf := &workflow.Workflow{
+		ID:         "wf-999",
+		Title:      "Morning Run",
+		Owner:      "user-999",
+		OwnerType:  "USER",
+		Private:    false,
+		Type:       "STANDARD",
+		IsDeployed: true,
+		Trigger: map[string]interface{}{
+			"schedule": map[string]interface{}{
+				"rule":     nil,
+				"timezone": "UTC",
+				"trigger": map[string]interface{}{
+					"type": "time",
+					"time": "10:00",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkflowDescribeTable(&buf, wf, nil)
+
+	got := buf.String()
+	for _, want := range []string{"Type:        STANDARD", "Trigger:     Schedule (time)"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected output to contain %q, got %q", want, got)
+		}
+	}
+	if strings.Contains(got, "<nil>") {
+		t.Fatalf("expected output to skip nil trigger values, got %q", got)
+	}
+}
+
+func TestPrintWorkflowDescribeTableShowsGenericEventTriggerSummary(t *testing.T) {
+	wf := &workflow.Workflow{
+		ID:         "wf-event",
+		Title:      "Generic Event Workflow",
+		Owner:      "user-event",
+		OwnerType:  "USER",
+		Private:    false,
+		Type:       "STANDARD",
+		IsDeployed: true,
+		Trigger: map[string]interface{}{
+			"eventTrigger": map[string]interface{}{
+				"triggerConfiguration": map[string]interface{}{
+					"type": "event",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkflowDescribeTable(&buf, wf, nil)
+
+	if got := buf.String(); !strings.Contains(got, "Trigger:     Event (event)") {
+		t.Fatalf("expected generic event trigger summary, got %q", got)
+	}
+}
+
+func TestPrintWorkflowDescribeTableShowsDavisProblemTriggerSummary(t *testing.T) {
+	wf := &workflow.Workflow{
+		ID:         "wf-davis-problem",
+		Title:      "Davis Problem Workflow",
+		Owner:      "user-davis",
+		OwnerType:  "USER",
+		Private:    false,
+		Type:       "STANDARD",
+		IsDeployed: true,
+		Trigger: map[string]interface{}{
+			"eventTrigger": map[string]interface{}{
+				"triggerConfiguration": map[string]interface{}{
+					"type": "davis-problem",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkflowDescribeTable(&buf, wf, nil)
+
+	if got := buf.String(); !strings.Contains(got, "Trigger:     Event (davis-problem)") {
+		t.Fatalf("expected davis problem trigger summary, got %q", got)
+	}
+}
+
+func TestPrintWorkflowDescribeTableShowsMoreRecentExecutionsNotice(t *testing.T) {
+	startedAt := time.Date(2026, 5, 18, 12, 30, 0, 0, time.UTC)
+	execs := make([]workflow.Execution, 6)
+	for i := range execs {
+		execs[i] = workflow.Execution{
+			ID:        "12345678-aaaa-bbbb-cccc-1234567890ab",
+			State:     "SUCCEEDED",
+			StartedAt: startedAt,
+			Runtime:   61,
+		}
+	}
+
+	var buf bytes.Buffer
+	printWorkflowDescribeTable(&buf, &workflow.Workflow{}, &workflow.ExecutionList{Count: 6, Results: execs})
+
+	got := buf.String()
+	if !strings.Contains(got, "... and 1 more") {
+		t.Fatalf("expected overflow notice in output, got %q", got)
+	}
+	if strings.Count(got, "12345678...") != 5 {
+		t.Fatalf("expected only 5 recent executions to be printed, got %q", got)
+	}
+}
+
+func TestPrintWorkflowDefinitionFieldsSkipsEmptyValues(t *testing.T) {
+	wf := &workflow.Workflow{
+		Input: map[string]interface{}{},
+	}
+
+	var buf bytes.Buffer
+	printWorkflowDefinitionFields(&buf, 13, wf)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("printWorkflowDefinitionFields() = %q, want empty output", got)
+	}
+}
+
+func TestFormatTriggerSummaryWithoutSubtype(t *testing.T) {
+	if got := formatTriggerSummary("schedule", ""); got != "Schedule" {
+		t.Fatalf("formatTriggerSummary() = %q, want %q", got, "Schedule")
+	}
+}
+
+func TestFormatTriggerSummaryEmptyFamily(t *testing.T) {
+	if got := formatTriggerSummary("Trigger", "cron"); got != "" {
+		t.Fatalf("formatTriggerSummary() = %q, want empty", got)
+	}
+}
+
+func TestNestedTriggerStringEdgeCases(t *testing.T) {
+	trigger := map[string]interface{}{
+		"schedule": map[string]interface{}{
+			"trigger": map[string]interface{}{
+				"type": "cron",
+			},
+			"nonStringType": map[string]interface{}{
+				"type": 42,
+			},
+			"invalid": "not-a-map",
+		},
+	}
+
+	if got := nestedTriggerString(trigger, "schedule", "trigger", "type"); got != "cron" {
+		t.Fatalf("nestedTriggerString() = %q, want %q", got, "cron")
+	}
+	if got := nestedTriggerString(trigger, "schedule", "missing", "type"); got != "" {
+		t.Fatalf("nestedTriggerString() missing path = %q, want empty", got)
+	}
+	if got := nestedTriggerString(trigger, "schedule", "invalid", "type"); got != "" {
+		t.Fatalf("nestedTriggerString() non-map path = %q, want empty", got)
+	}
+	if got := nestedTriggerString(trigger, "schedule", "nonStringType", "type"); got != "" {
+		t.Fatalf("nestedTriggerString() non-string leaf = %q, want empty", got)
+	}
+}
+
+func TestTriggerSummaryUnknownTrigger(t *testing.T) {
+	if got := triggerSummary(map[string]interface{}{"manual": true}); got != "" {
+		t.Fatalf("triggerSummary() = %q, want empty", got)
+	}
+}
+
+func TestTriggerSummaryNilTrigger(t *testing.T) {
+	var trigger map[string]interface{}
+	if got := triggerSummary(trigger); got != "" {
+		t.Fatalf("triggerSummary(nil) = %q, want empty", got)
+	}
+}

--- a/pkg/apply/apply_integration_test.go
+++ b/pkg/apply/apply_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -144,7 +145,7 @@ func TestApply_WorkflowCreate_NoID(t *testing.T) {
 			}
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"id":    "wf-new-123",
+				"id":    "11111111-1111-4111-8111-111111111111",
 				"title": "My Workflow",
 			})
 		},
@@ -172,20 +173,22 @@ func TestApply_WorkflowCreate_NoID(t *testing.T) {
 // --- Apply: workflow update (has id, exists) ---
 
 func TestApply_WorkflowUpdate_Exists(t *testing.T) {
+	const workflowID = "22222222-2222-4222-8222-222222222222"
+
 	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
-		"/platform/automation/v1/workflows/wf-existing": func(w http.ResponseWriter, r *http.Request) {
+		"/platform/automation/v1/workflows/22222222-2222-4222-8222-222222222222": func(w http.ResponseWriter, r *http.Request) {
 			switch r.Method {
 			case http.MethodGet:
 				w.WriteHeader(http.StatusOK)
 				json.NewEncoder(w).Encode(map[string]interface{}{
-					"id":    "wf-existing",
+					"id":    workflowID,
 					"title": "Old Title",
 					"owner": "user-xyz",
 				})
 			case http.MethodPut:
 				w.WriteHeader(http.StatusOK)
 				json.NewEncoder(w).Encode(map[string]interface{}{
-					"id":    "wf-existing",
+					"id":    workflowID,
 					"title": "New Title",
 				})
 			}
@@ -197,7 +200,7 @@ func TestApply_WorkflowUpdate_Exists(t *testing.T) {
 	defer srv.Close()
 	a := NewApplier(c)
 
-	wfJSON := `{"id":"wf-existing","title":"New Title","tasks":{},"trigger":{}}`
+	wfJSON := `{"id":"22222222-2222-4222-8222-222222222222","title":"New Title","tasks":{},"trigger":{}}`
 	results, err := a.Apply([]byte(wfJSON), ApplyOptions{})
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)
@@ -211,17 +214,128 @@ func TestApply_WorkflowUpdate_Exists(t *testing.T) {
 	}
 }
 
+func TestApply_WorkflowUpdate_BackwardsCompatibility_OldGetYAMLForwardsOnlyAvailableFields(t *testing.T) {
+	const workflowID = "33333333-3333-4333-8333-333333333333"
+
+	var putBody map[string]interface{}
+
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/workflows/33333333-3333-4333-8333-333333333333": func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    workflowID,
+					"title": "Old Title",
+					"owner": "user-xyz",
+				})
+			case http.MethodPut:
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("ReadAll(r.Body): %v", err)
+				}
+				if err := json.Unmarshal(body, &putBody); err != nil {
+					t.Fatalf("json.Unmarshal(body): %v\nbody was:\n%s", err, body)
+				}
+
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    workflowID,
+					"title": "Deploy to Production",
+				})
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	// workflow without newly added attributes
+	oldGetYAML := `id: 33333333-3333-4333-8333-333333333333
+title: Deploy to Production
+owner: user-xyz
+ownerType: USER
+description: Deploys latest build to prod environment
+isPrivate: false
+isDeployed: true
+tasks:
+  deploy:
+    action: dynatrace.automations:run-javascript
+    input:
+      script: // deploy logic
+trigger:
+  schedule:
+    trigger:
+      cron: 0 9 * * 1-5
+      type: cron
+`
+
+	results, err := a.Apply([]byte(oldGetYAML), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	base := results[0].(*WorkflowApplyResult).ApplyResultBase
+	if base.Action != ActionUpdated {
+		t.Errorf("expected action 'updated', got %q", base.Action)
+	}
+
+	expectedPutBody := map[string]interface{}{
+		"id":          workflowID,
+		"title":       "Deploy to Production",
+		"owner":       "user-xyz",
+		"ownerType":   "USER",
+		"description": "Deploys latest build to prod environment",
+		"isPrivate":   false,
+		"isDeployed":  true,
+		"tasks": map[string]interface{}{
+			"deploy": map[string]interface{}{
+				"action": "dynatrace.automations:run-javascript",
+				"input": map[string]interface{}{
+					"script": "// deploy logic",
+				},
+			},
+		},
+		"trigger": map[string]interface{}{
+			"schedule": map[string]interface{}{
+				"trigger": map[string]interface{}{
+					"cron": "0 9 * * 1-5",
+					"type": "cron",
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(putBody, expectedPutBody) {
+		t.Errorf("PUT body mismatch\n got: %#v\nwant: %#v", putBody, expectedPutBody)
+	}
+
+	for _, field := range []string{"schemaVersion", "type", "result", "input", "hourlyExecutionLimit", "guide"} {
+		if _, exists := putBody[field]; exists {
+			t.Errorf("PUT body should not synthesize %q from old get payload", field)
+		}
+	}
+}
+
 // --- Apply: workflow with id but not found → create ---
 
 func TestApply_WorkflowCreate_IDNotFound(t *testing.T) {
+	const workflowID = "44444444-4444-4444-8444-444444444444"
+
 	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
-		"/platform/automation/v1/workflows/wf-missing": func(w http.ResponseWriter, r *http.Request) {
+		"/platform/automation/v1/workflows/44444444-4444-4444-8444-444444444444": func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 		},
 		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"id":    "wf-missing",
+				"id":    workflowID,
 				"title": "New Workflow",
 			})
 		},
@@ -232,7 +346,7 @@ func TestApply_WorkflowCreate_IDNotFound(t *testing.T) {
 	defer srv.Close()
 	a := NewApplier(c)
 
-	wfJSON := `{"id":"wf-missing","title":"New Workflow","tasks":{},"trigger":{}}`
+	wfJSON := `{"id":"44444444-4444-4444-8444-444444444444","title":"New Workflow","tasks":{},"trigger":{}}`
 	results, err := a.Apply([]byte(wfJSON), ApplyOptions{})
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)

--- a/pkg/output/golden_test.go
+++ b/pkg/output/golden_test.go
@@ -77,42 +77,53 @@ var fixedTime = time.Date(2025, 3, 15, 10, 30, 0, 0, time.UTC)
 func workflowFixtures() []workflow.Workflow {
 	return []workflow.Workflow{
 		{
-			ID:          "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
-			Title:       "Deploy to Production",
-			Owner:       "7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d",
-			OwnerType:   "USER",
-			Description: "Deploys latest build to prod environment",
-			Private:     false,
-			IsDeployed:  true,
+			ID:            "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+			Title:         "Deploy to Production",
+			IsDeployed:    true,
+			Description:   "Deploys latest build to prod environment",
+			Actor:         "7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d",
+			Owner:         "7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d",
+			OwnerType:     "USER",
+			Private:       false,
+			SchemaVersion: 4,
+			Trigger: map[string]interface{}{
+				"schedule": map[string]interface{}{
+					"trigger": map[string]interface{}{"type": "cron", "cron": "0 9 * * 1-5"},
+				},
+			},
+			Result:               stringPtr("{{ result('deploy') }}"),
+			Type:                 "STANDARD",
+			Input:                map[string]interface{}{"environment": map[string]interface{}{"type": "string"}},
+			HourlyExecutionLimit: intPtr(1000),
+			Guide:                stringPtr("# Deploy to Production\n\nRun this workflow after validating the release candidate."),
 			Tasks: map[string]interface{}{
 				"deploy": map[string]interface{}{
 					"action": "dynatrace.automations:run-javascript",
 					"input":  map[string]interface{}{"script": "// deploy logic"},
 				},
 			},
-			Trigger: map[string]interface{}{
-				"schedule": map[string]interface{}{
-					"trigger": map[string]interface{}{"type": "cron", "cron": "0 9 * * 1-5"},
-				},
-			},
 		},
 		{
 			ID:          "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
 			Title:       "Daily Cleanup",
+			IsDeployed:  true,
+			Description: "Removes stale resources older than 30 days",
+			Type:        "STANDARD",
 			Owner:       "00000000-0000-0000-0000-000000000000",
 			OwnerType:   "USER",
-			Description: "Removes stale resources older than 30 days",
 			Private:     false,
-			IsDeployed:  true,
+			Tasks:       map[string]interface{}{},
 		},
 		{
 			ID:          "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
 			Title:       "Incident Response",
+			IsDeployed:  false,
+			Description: "",
+			Type:        "STANDARD",
 			Owner:       "8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e",
 			OwnerType:   "USER",
-			Description: "",
 			Private:     true,
-			IsDeployed:  false,
+			Tasks:       map[string]interface{}{},
 		},
 	}
 }
@@ -150,6 +161,8 @@ func sloFixtures() []slo.SLO {
 
 func float64Ptr(v float64) *float64 { return &v }
 func int64Ptr(v int64) *int64       { return &v }
+func intPtr(v int) *int             { return &v }
+func stringPtr(v string) *string    { return &v }
 
 func bucketFixtures() []bucket.Bucket {
 	return []bucket.Bucket{

--- a/pkg/output/testdata/golden/describe/workflow-json.golden
+++ b/pkg/output/testdata/golden/describe/workflow-json.golden
@@ -1,24 +1,35 @@
 {
   "id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
   "title": "Deploy to Production",
+  "isDeployed": true,
+  "description": "Deploys latest build to prod environment",
+  "actor": "7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d",
   "owner": "7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d",
   "ownerType": "USER",
-  "description": "Deploys latest build to prod environment",
   "isPrivate": false,
-  "isDeployed": true,
-  "tasks": {
-    "deploy": {
-      "action": "dynatrace.automations:run-javascript",
-      "input": {
-        "script": "// deploy logic"
-      }
-    }
-  },
+  "schemaVersion": 4,
   "trigger": {
     "schedule": {
       "trigger": {
         "cron": "0 9 * * 1-5",
         "type": "cron"
+      }
+    }
+  },
+  "result": "{{ result('deploy') }}",
+  "type": "STANDARD",
+  "input": {
+    "environment": {
+      "type": "string"
+    }
+  },
+  "hourlyExecutionLimit": 1000,
+  "guide": "# Deploy to Production\n\nRun this workflow after validating the release candidate.",
+  "tasks": {
+    "deploy": {
+      "action": "dynatrace.automations:run-javascript",
+      "input": {
+        "script": "// deploy logic"
       }
     }
   }

--- a/pkg/output/testdata/golden/describe/workflow-table.golden
+++ b/pkg/output/testdata/golden/describe/workflow-table.golden
@@ -1,2 +1,2 @@
-ID                                     TITLE                  DEPLOYED   
-a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true       
+ID                                     TITLE                  DEPLOYED   TYPE       
+a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true       STANDARD   

--- a/pkg/output/testdata/golden/describe/workflow-toon.golden
+++ b/pkg/output/testdata/golden/describe/workflow-toon.golden
@@ -1,9 +1,17 @@
+actor: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
 description: Deploys latest build to prod environment
+guide: "# Deploy to Production\n\nRun this workflow after validating the release candidate."
+hourlyExecutionLimit: 1000
 id: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
+input:
+  environment:
+    type: string
 isDeployed: true
 isPrivate: false
 owner: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
 ownerType: USER
+result: "{{ result('deploy') }}"
+schemaVersion: 4
 tasks:
   deploy:
     action: "dynatrace.automations:run-javascript"
@@ -15,3 +23,4 @@ trigger:
     trigger:
       cron: 0 9 * * 1-5
       type: cron
+type: STANDARD

--- a/pkg/output/testdata/golden/describe/workflow-yaml.golden
+++ b/pkg/output/testdata/golden/describe/workflow-yaml.golden
@@ -1,18 +1,29 @@
 id: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
 title: Deploy to Production
-owner: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
-ownertype: USER
+isDeployed: true
 description: Deploys latest build to prod environment
-private: false
-isdeployed: true
-tasks:
-  deploy:
-    action: dynatrace.automations:run-javascript
-    input:
-      script: // deploy logic
+actor: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
+owner: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
+ownerType: USER
+isPrivate: false
+schemaVersion: 4
 trigger:
   schedule:
     trigger:
       cron: 0 9 * * 1-5
       type: cron
-actor: ""
+result: '{{ result(''deploy'') }}'
+type: STANDARD
+input:
+  environment:
+    type: string
+hourlyExecutionLimit: 1000
+guide: |-
+  # Deploy to Production
+
+  Run this workflow after validating the release candidate.
+tasks:
+  deploy:
+    action: dynatrace.automations:run-javascript
+    input:
+      script: // deploy logic

--- a/pkg/output/testdata/golden/get/workflows-agent.golden
+++ b/pkg/output/testdata/golden/get/workflows-agent.golden
@@ -4,19 +4,13 @@
     {
       "id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
       "title": "Deploy to Production",
+      "isDeployed": true,
+      "description": "Deploys latest build to prod environment",
+      "actor": "7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d",
       "owner": "7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d",
       "ownerType": "USER",
-      "description": "Deploys latest build to prod environment",
       "isPrivate": false,
-      "isDeployed": true,
-      "tasks": {
-        "deploy": {
-          "action": "dynatrace.automations:run-javascript",
-          "input": {
-            "script": "// deploy logic"
-          }
-        }
-      },
+      "schemaVersion": 4,
       "trigger": {
         "schedule": {
           "trigger": {
@@ -24,23 +18,45 @@
             "type": "cron"
           }
         }
+      },
+      "result": "{{ result('deploy') }}",
+      "type": "STANDARD",
+      "input": {
+        "environment": {
+          "type": "string"
+        }
+      },
+      "hourlyExecutionLimit": 1000,
+      "guide": "# Deploy to Production\n\nRun this workflow after validating the release candidate.",
+      "tasks": {
+        "deploy": {
+          "action": "dynatrace.automations:run-javascript",
+          "input": {
+            "script": "// deploy logic"
+          }
+        }
       }
     },
     {
       "id": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
       "title": "Daily Cleanup",
+      "isDeployed": true,
+      "description": "Removes stale resources older than 30 days",
       "owner": "00000000-0000-0000-0000-000000000000",
       "ownerType": "USER",
-      "description": "Removes stale resources older than 30 days",
       "isPrivate": false,
-      "isDeployed": true
+      "type": "STANDARD",
+      "tasks": {}
     },
     {
       "id": "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
       "title": "Incident Response",
+      "isDeployed": false,
       "owner": "8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e",
       "ownerType": "USER",
-      "isPrivate": true
+      "isPrivate": true,
+      "type": "STANDARD",
+      "tasks": {}
     }
   ],
   "context": {

--- a/pkg/output/testdata/golden/get/workflows-csv.golden
+++ b/pkg/output/testdata/golden/get/workflows-csv.golden
@@ -1,4 +1,4 @@
-ID,TITLE,DESCRIPTION,DEPLOYED
-a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d,Deploy to Production,Deploys latest build to prod environment,true
-b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e,Daily Cleanup,Removes stale resources older than 30 days,true
-c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f,Incident Response,,false
+ID,TITLE,DEPLOYED,DESCRIPTION,TYPE
+a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d,Deploy to Production,true,Deploys latest build to prod environment,STANDARD
+b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e,Daily Cleanup,true,Removes stale resources older than 30 days,STANDARD
+c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f,Incident Response,false,,STANDARD

--- a/pkg/output/testdata/golden/get/workflows-json.golden
+++ b/pkg/output/testdata/golden/get/workflows-json.golden
@@ -2,19 +2,13 @@
   {
     "id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
     "title": "Deploy to Production",
+    "isDeployed": true,
+    "description": "Deploys latest build to prod environment",
+    "actor": "7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d",
     "owner": "7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d",
     "ownerType": "USER",
-    "description": "Deploys latest build to prod environment",
     "isPrivate": false,
-    "isDeployed": true,
-    "tasks": {
-      "deploy": {
-        "action": "dynatrace.automations:run-javascript",
-        "input": {
-          "script": "// deploy logic"
-        }
-      }
-    },
+    "schemaVersion": 4,
     "trigger": {
       "schedule": {
         "trigger": {
@@ -22,22 +16,44 @@
           "type": "cron"
         }
       }
+    },
+    "result": "{{ result('deploy') }}",
+    "type": "STANDARD",
+    "input": {
+      "environment": {
+        "type": "string"
+      }
+    },
+    "hourlyExecutionLimit": 1000,
+    "guide": "# Deploy to Production\n\nRun this workflow after validating the release candidate.",
+    "tasks": {
+      "deploy": {
+        "action": "dynatrace.automations:run-javascript",
+        "input": {
+          "script": "// deploy logic"
+        }
+      }
     }
   },
   {
     "id": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
     "title": "Daily Cleanup",
+    "isDeployed": true,
+    "description": "Removes stale resources older than 30 days",
     "owner": "00000000-0000-0000-0000-000000000000",
     "ownerType": "USER",
-    "description": "Removes stale resources older than 30 days",
     "isPrivate": false,
-    "isDeployed": true
+    "type": "STANDARD",
+    "tasks": {}
   },
   {
     "id": "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
     "title": "Incident Response",
+    "isDeployed": false,
     "owner": "8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e",
     "ownerType": "USER",
-    "isPrivate": true
+    "isPrivate": true,
+    "type": "STANDARD",
+    "tasks": {}
   }
 ]

--- a/pkg/output/testdata/golden/get/workflows-table.golden
+++ b/pkg/output/testdata/golden/get/workflows-table.golden
@@ -1,4 +1,4 @@
-ID                                     TITLE                  DEPLOYED   
-a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true       
-b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup          true       
-c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response      false      
+ID                                     TITLE                  DEPLOYED   TYPE       
+a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true       STANDARD   
+b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup          true       STANDARD   
+c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response      false      STANDARD   

--- a/pkg/output/testdata/golden/get/workflows-toon.golden
+++ b/pkg/output/testdata/golden/get/workflows-toon.golden
@@ -1,10 +1,18 @@
 [#3]:
-  - description: Deploys latest build to prod environment
+  - actor: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
+    description: Deploys latest build to prod environment
+    guide: "# Deploy to Production\n\nRun this workflow after validating the release candidate."
+    hourlyExecutionLimit: 1000
     id: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
+    input:
+      environment:
+        type: string
     isDeployed: true
     isPrivate: false
     owner: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
     ownerType: USER
+    result: "{{ result('deploy') }}"
+    schemaVersion: 4
     tasks:
       deploy:
         action: "dynatrace.automations:run-javascript"
@@ -16,15 +24,21 @@
         trigger:
           cron: 0 9 * * 1-5
           type: cron
+    type: STANDARD
   - description: Removes stale resources older than 30 days
     id: b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e
     isDeployed: true
     isPrivate: false
     owner: "00000000-0000-0000-0000-000000000000"
     ownerType: USER
+    tasks:
     title: Daily Cleanup
+    type: STANDARD
   - id: c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
+    isDeployed: false
     isPrivate: true
     owner: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
     ownerType: USER
+    tasks:
     title: Incident Response
+    type: STANDARD

--- a/pkg/output/testdata/golden/get/workflows-watch-changes.golden
+++ b/pkg/output/testdata/golden/get/workflows-watch-changes.golden
@@ -1,3 +1,3 @@
-+ a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true
-~ b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup   true
-- c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response   false
++ a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true   STANDARD
+~ b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup   true   STANDARD
+- c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response   false   STANDARD

--- a/pkg/output/testdata/golden/get/workflows-wide.golden
+++ b/pkg/output/testdata/golden/get/workflows-wide.golden
@@ -1,4 +1,4 @@
-ID                                     TITLE                  DESCRIPTION                                  DEPLOYED   
-a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   Deploys latest build to prod environment     true       
-b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup          Removes stale resources older than 30 days   true       
-c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response                                                   false      
+ID                                     TITLE                  DEPLOYED   DESCRIPTION                                  TYPE       
+a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true       Deploys latest build to prod environment     STANDARD   
+b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup          true       Removes stale resources older than 30 days   STANDARD   
+c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response      false                                                   STANDARD   

--- a/pkg/output/testdata/golden/get/workflows-yaml.golden
+++ b/pkg/output/testdata/golden/get/workflows-yaml.golden
@@ -1,38 +1,46 @@
 - id: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
   title: Deploy to Production
-  owner: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
-  ownertype: USER
+  isDeployed: true
   description: Deploys latest build to prod environment
-  private: false
-  isdeployed: true
-  tasks:
-    deploy:
-      action: dynatrace.automations:run-javascript
-      input:
-        script: // deploy logic
+  actor: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
+  owner: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
+  ownerType: USER
+  isPrivate: false
+  schemaVersion: 4
   trigger:
     schedule:
       trigger:
         cron: 0 9 * * 1-5
         type: cron
-  actor: ""
+  result: '{{ result(''deploy'') }}'
+  type: STANDARD
+  input:
+    environment:
+      type: string
+  hourlyExecutionLimit: 1000
+  guide: |-
+    # Deploy to Production
+
+    Run this workflow after validating the release candidate.
+  tasks:
+    deploy:
+      action: dynatrace.automations:run-javascript
+      input:
+        script: // deploy logic
 - id: b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e
   title: Daily Cleanup
-  owner: 00000000-0000-0000-0000-000000000000
-  ownertype: USER
+  isDeployed: true
   description: Removes stale resources older than 30 days
-  private: false
-  isdeployed: true
+  owner: 00000000-0000-0000-0000-000000000000
+  ownerType: USER
+  isPrivate: false
+  type: STANDARD
   tasks: {}
-  trigger: {}
-  actor: ""
 - id: c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
   title: Incident Response
+  isDeployed: false
   owner: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
-  ownertype: USER
-  description: ""
-  private: true
-  isdeployed: false
+  ownerType: USER
+  isPrivate: true
+  type: STANDARD
   tasks: {}
-  trigger: {}
-  actor: ""

--- a/pkg/resources/workflow/workflow.go
+++ b/pkg/resources/workflow/workflow.go
@@ -13,16 +13,22 @@ type WorkflowFilters = sdkworkflow.WorkflowFilters
 
 // Workflow represents a workflow resource (CLI version with table tags).
 type Workflow struct {
-	ID          string                 `json:"id" table:"ID"`
-	Title       string                 `json:"title" table:"TITLE"`
-	Owner       string                 `json:"owner,omitempty" table:"-"`
-	OwnerType   string                 `json:"ownerType,omitempty" table:"-"`
-	Description string                 `json:"description,omitempty" table:"DESCRIPTION,wide"`
-	Private     bool                   `json:"isPrivate" table:"-"`
-	IsDeployed  bool                   `json:"isDeployed,omitempty" table:"DEPLOYED"`
-	Tasks       map[string]interface{} `json:"tasks,omitempty" table:"-"`
-	Trigger     map[string]interface{} `json:"trigger,omitempty" table:"-"`
-	Actor       string                 `json:"actor,omitempty" table:"-"`
+	ID                   string                 `json:"id" yaml:"id" table:"ID"`
+	Title                string                 `json:"title" yaml:"title" table:"TITLE"`
+	IsDeployed           bool                   `json:"isDeployed" yaml:"isDeployed" table:"DEPLOYED"`
+	Description          string                 `json:"description,omitempty" yaml:"description,omitempty" table:"DESCRIPTION,wide"`
+	Actor                string                 `json:"actor,omitempty" yaml:"actor,omitempty" table:"-"`
+	Owner                string                 `json:"owner,omitempty" yaml:"owner,omitempty" table:"-"`
+	OwnerType            string                 `json:"ownerType,omitempty" yaml:"ownerType,omitempty" table:"-"`
+	Private              bool                   `json:"isPrivate" yaml:"isPrivate" table:"-"`
+	SchemaVersion        int                    `json:"schemaVersion,omitempty" yaml:"schemaVersion,omitempty" table:"-"`
+	Trigger              map[string]interface{} `json:"trigger,omitempty" yaml:"trigger,omitempty" table:"-"`
+	Result               *string                `json:"result,omitempty" yaml:"result,omitempty" table:"-"`
+	Type                 string                 `json:"type,omitempty" yaml:"type,omitempty" table:"TYPE"`
+	Input                map[string]interface{} `json:"input,omitempty" yaml:"input,omitempty" table:"-"`
+	HourlyExecutionLimit *int                   `json:"hourlyExecutionLimit,omitempty" yaml:"hourlyExecutionLimit,omitempty" table:"-"`
+	Guide                *string                `json:"guide,omitempty" yaml:"guide,omitempty" table:"-"`
+	Tasks                map[string]interface{} `json:"tasks" yaml:"tasks" table:"-"`
 }
 
 // WorkflowList represents a list of workflows.
@@ -47,16 +53,22 @@ type HistoryList struct {
 // fromSDKWorkflow converts an SDK Workflow to a CLI Workflow.
 func fromSDKWorkflow(s *sdkworkflow.Workflow) Workflow {
 	return Workflow{
-		ID:          s.ID,
-		Title:       s.Title,
-		Owner:       s.Owner,
-		OwnerType:   s.OwnerType,
-		Description: s.Description,
-		Private:     s.Private,
-		IsDeployed:  s.IsDeployed,
-		Tasks:       s.Tasks,
-		Trigger:     s.Trigger,
-		Actor:       s.Actor,
+		ID:                   s.ID,
+		Title:                s.Title,
+		IsDeployed:           s.IsDeployed,
+		Description:          s.Description,
+		Actor:                s.Actor,
+		Owner:                s.Owner,
+		OwnerType:            s.OwnerType,
+		Private:              s.Private,
+		SchemaVersion:        s.SchemaVersion,
+		Trigger:              s.Trigger,
+		Result:               s.Result,
+		Type:                 s.Type,
+		Input:                s.Input,
+		HourlyExecutionLimit: s.HourlyExecutionLimit,
+		Guide:                s.Guide,
+		Tasks:                s.Tasks,
 	}
 }
 

--- a/pkg/resources/workflow/workflow_test.go
+++ b/pkg/resources/workflow/workflow_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 )
 
+func stringPtr(v string) *string { return &v }
+
+func intPtr(v int) *int { return &v }
+
 func TestHandler_List(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -116,10 +120,21 @@ func TestHandler_Get(t *testing.T) {
 			id:         "wf-123",
 			statusCode: http.StatusOK,
 			response: Workflow{
-				ID:          "wf-123",
-				Title:       "Test Workflow",
-				Owner:       "user-123",
-				Description: "A test workflow",
+				ID:                   "wf-123",
+				Title:                "Test Workflow",
+				IsDeployed:           true,
+				Description:          "A test workflow",
+				Actor:                "user-123",
+				Owner:                "user-123",
+				OwnerType:            "USER",
+				Private:              false,
+				SchemaVersion:        4,
+				Trigger:              map[string]interface{}{"manual": true},
+				Result:               stringPtr("{{ result('task1') }}"),
+				Type:                 "STANDARD",
+				Input:                map[string]interface{}{"env": "prod"},
+				HourlyExecutionLimit: intPtr(1000),
+				Guide:                stringPtr("# Workflow Guide\n\nUse this workflow for testing."),
 			},
 			wantErr: false,
 		},
@@ -170,8 +185,97 @@ func TestHandler_Get(t *testing.T) {
 				if wf.Title != tt.response.Title {
 					t.Errorf("Get() Title = %v, want %v", wf.Title, tt.response.Title)
 				}
+				if wf.IsDeployed != tt.response.IsDeployed {
+					t.Errorf("Get() IsDeployed = %v, want %v", wf.IsDeployed, tt.response.IsDeployed)
+				}
+				if wf.Description != tt.response.Description {
+					t.Errorf("Get() Description = %v, want %v", wf.Description, tt.response.Description)
+				}
+				if wf.Actor != tt.response.Actor {
+					t.Errorf("Get() Actor = %v, want %v", wf.Actor, tt.response.Actor)
+				}
+				if wf.OwnerType != tt.response.OwnerType {
+					t.Errorf("Get() OwnerType = %v, want %v", wf.OwnerType, tt.response.OwnerType)
+				}
+				if wf.Private != tt.response.Private {
+					t.Errorf("Get() Private = %v, want %v", wf.Private, tt.response.Private)
+				}
+				if wf.SchemaVersion != tt.response.SchemaVersion {
+					t.Errorf("Get() SchemaVersion = %v, want %v", wf.SchemaVersion, tt.response.SchemaVersion)
+				}
+				if got := wf.Trigger["manual"]; got != tt.response.Trigger["manual"] {
+					t.Errorf("Get() Trigger[manual] = %v, want %v", got, tt.response.Trigger["manual"])
+				}
+				if wf.Type != tt.response.Type {
+					t.Errorf("Get() Type = %v, want %v", wf.Type, tt.response.Type)
+				}
+				if got := wf.Input["env"]; got != tt.response.Input["env"] {
+					t.Errorf("Get() Input[env] = %v, want %v", got, tt.response.Input["env"])
+				}
+				if wf.Result == nil || tt.response.Result == nil || *wf.Result != *tt.response.Result {
+					t.Errorf("Get() Result = %v, want %v", wf.Result, tt.response.Result)
+				}
+				if wf.HourlyExecutionLimit == nil || tt.response.HourlyExecutionLimit == nil || *wf.HourlyExecutionLimit != *tt.response.HourlyExecutionLimit {
+					t.Errorf("Get() HourlyExecutionLimit = %v, want %v", wf.HourlyExecutionLimit, tt.response.HourlyExecutionLimit)
+				}
+				if wf.Guide == nil || tt.response.Guide == nil || *wf.Guide != *tt.response.Guide {
+					t.Errorf("Get() Guide = %v, want %v", wf.Guide, tt.response.Guide)
+				}
 			}
 		})
+	}
+}
+
+func TestWorkflowJSONRoundTripPreservesDefinitionFields(t *testing.T) {
+	wf := Workflow{
+		ID:                   "wf-123",
+		Title:                "Test Workflow",
+		IsDeployed:           true,
+		Description:          "A test workflow",
+		Actor:                "user-123",
+		Owner:                "user-123",
+		OwnerType:            "USER",
+		Private:              false,
+		SchemaVersion:        4,
+		Trigger:              map[string]interface{}{"manual": true},
+		Result:               stringPtr("{{ result('task1') }}"),
+		Type:                 "STANDARD",
+		Input:                map[string]interface{}{"env": map[string]interface{}{"type": "string"}},
+		HourlyExecutionLimit: intPtr(1000),
+		Guide:                stringPtr("# Workflow Guide\n\nUse this workflow for testing."),
+	}
+
+	data, err := json.Marshal(wf)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var roundTrip Workflow
+	if err := json.Unmarshal(data, &roundTrip); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if roundTrip.SchemaVersion != wf.SchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", roundTrip.SchemaVersion, wf.SchemaVersion)
+	}
+	if roundTrip.Type != wf.Type {
+		t.Errorf("Type = %q, want %q", roundTrip.Type, wf.Type)
+	}
+	inputField, ok := roundTrip.Input["env"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Input[env] type = %T, want map[string]interface{}", roundTrip.Input["env"])
+	}
+	if inputField["type"] != "string" {
+		t.Errorf("Input[env][type] = %#v, want %q", inputField["type"], "string")
+	}
+	if roundTrip.Result == nil || *roundTrip.Result != *wf.Result {
+		t.Errorf("Result = %v, want %v", roundTrip.Result, wf.Result)
+	}
+	if roundTrip.HourlyExecutionLimit == nil || *roundTrip.HourlyExecutionLimit != *wf.HourlyExecutionLimit {
+		t.Errorf("HourlyExecutionLimit = %v, want %v", roundTrip.HourlyExecutionLimit, wf.HourlyExecutionLimit)
+	}
+	if roundTrip.Guide == nil || *roundTrip.Guide != *wf.Guide {
+		t.Errorf("Guide = %v, want %v", roundTrip.Guide, wf.Guide)
 	}
 }
 

--- a/sdk/api/workflow/workflow.go
+++ b/sdk/api/workflow/workflow.go
@@ -21,16 +21,22 @@ func NewHandler(c *httpclient.Client) *Handler {
 
 // Workflow represents a workflow resource.
 type Workflow struct {
-	ID          string                 `json:"id"`
-	Title       string                 `json:"title"`
-	Owner       string                 `json:"owner,omitempty"`
-	OwnerType   string                 `json:"ownerType,omitempty"`
-	Description string                 `json:"description,omitempty"`
-	Private     bool                   `json:"isPrivate"`
-	IsDeployed  bool                   `json:"isDeployed,omitempty"`
-	Tasks       map[string]interface{} `json:"tasks,omitempty"`
-	Trigger     map[string]interface{} `json:"trigger,omitempty"`
-	Actor       string                 `json:"actor,omitempty"`
+	ID                   string                 `json:"id"`
+	Title                string                 `json:"title"`
+	IsDeployed           bool                   `json:"isDeployed"`
+	Description          string                 `json:"description,omitempty"`
+	Actor                string                 `json:"actor,omitempty"`
+	Owner                string                 `json:"owner,omitempty"`
+	OwnerType            string                 `json:"ownerType,omitempty"`
+	Private              bool                   `json:"isPrivate"`
+	SchemaVersion        int                    `json:"schemaVersion,omitempty"`
+	Trigger              map[string]interface{} `json:"trigger,omitempty"`
+	Result               *string                `json:"result,omitempty"`
+	Type                 string                 `json:"type,omitempty"`
+	Input                map[string]interface{} `json:"input,omitempty"`
+	HourlyExecutionLimit *int                   `json:"hourlyExecutionLimit,omitempty"`
+	Guide                *string                `json:"guide,omitempty"`
+	Tasks                map[string]interface{} `json:"tasks"`
 }
 
 // WorkflowList represents a list of workflows.

--- a/sdk/api/workflow/workflow_test.go
+++ b/sdk/api/workflow/workflow_test.go
@@ -22,6 +22,10 @@ func newTestClient(t *testing.T, handler http.Handler) *httpclient.Client {
 	return c
 }
 
+func stringPtr(v string) *string { return &v }
+
+func intPtr(v int) *int { return &v }
+
 func TestList(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/platform/automation/v1/workflows", func(w http.ResponseWriter, r *http.Request) {
@@ -53,6 +57,37 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestList_WithOwnerFilter(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("owner"); got != "user-1" {
+			t.Fatalf("owner query = %q, want %q", got, "user-1")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"count":0,"results":[]}`)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.List(context.Background(), WorkflowFilters{Owner: "user-1"})
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+}
+
+func TestList_ParseError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{invalid-json`)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.List(context.Background(), WorkflowFilters{})
+	if err == nil {
+		t.Fatal("List() expected parse error")
+	}
+}
+
 func TestGet(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/platform/automation/v1/workflows/wf-1", func(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +95,23 @@ func TestGet(t *testing.T) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		resp := Workflow{ID: "wf-1", Title: "Deploy", Owner: "user-1"}
+		resp := Workflow{
+			ID:                   "wf-1",
+			Title:                "Deploy",
+			IsDeployed:           true,
+			Description:          "Workflow description",
+			Actor:                "user-1",
+			Owner:                "user-1",
+			OwnerType:            "USER",
+			Private:              false,
+			SchemaVersion:        4,
+			Trigger:              map[string]interface{}{"manual": true},
+			Result:               stringPtr("{{ result('deploy') }}"),
+			Type:                 "STANDARD",
+			Input:                map[string]interface{}{"env": "prod"},
+			HourlyExecutionLimit: intPtr(1000),
+			Guide:                stringPtr("# Deploy\n\nRun after validation."),
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
 	})
@@ -75,6 +126,42 @@ func TestGet(t *testing.T) {
 	}
 	if result.Title != "Deploy" {
 		t.Errorf("Title = %q, want %q", result.Title, "Deploy")
+	}
+	if !result.IsDeployed {
+		t.Errorf("IsDeployed = %v, want true", result.IsDeployed)
+	}
+	if result.Description != "Workflow description" {
+		t.Errorf("Description = %q, want %q", result.Description, "Workflow description")
+	}
+	if result.Actor != "user-1" {
+		t.Errorf("Actor = %q, want %q", result.Actor, "user-1")
+	}
+	if result.OwnerType != "USER" {
+		t.Errorf("OwnerType = %q, want %q", result.OwnerType, "USER")
+	}
+	if result.Private {
+		t.Errorf("Private = %v, want false", result.Private)
+	}
+	if result.SchemaVersion != 4 {
+		t.Errorf("SchemaVersion = %d, want 4", result.SchemaVersion)
+	}
+	if got := result.Trigger["manual"]; got != true {
+		t.Errorf("Trigger[manual] = %#v, want true", got)
+	}
+	if result.Type != "STANDARD" {
+		t.Errorf("Type = %q, want %q", result.Type, "STANDARD")
+	}
+	if got := result.Input["env"]; got != "prod" {
+		t.Errorf("Input[env] = %#v, want %q", got, "prod")
+	}
+	if result.Result == nil || *result.Result != "{{ result('deploy') }}" {
+		t.Fatalf("Result = %#v, want %q", result.Result, "{{ result('deploy') }}")
+	}
+	if result.HourlyExecutionLimit == nil || *result.HourlyExecutionLimit != 1000 {
+		t.Fatalf("HourlyExecutionLimit = %#v, want %d", result.HourlyExecutionLimit, 1000)
+	}
+	if result.Guide == nil || *result.Guide != "# Deploy\n\nRun after validation." {
+		t.Fatalf("Guide = %#v, want %q", result.Guide, "# Deploy\n\nRun after validation.")
 	}
 }
 
@@ -115,6 +202,24 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestCreate_ParseError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{invalid-json`)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.Create(context.Background(), []byte(`{"title":"New Workflow"}`))
+	if err == nil {
+		t.Fatal("Create() expected parse error")
+	}
+}
+
 func TestDelete(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/platform/automation/v1/workflows/wf-1", func(w http.ResponseWriter, r *http.Request) {
@@ -129,6 +234,210 @@ func TestDelete(t *testing.T) {
 	err := h.Delete(context.Background(), "wf-1")
 	if err != nil {
 		t.Fatalf("Delete() error: %v", err)
+	}
+}
+
+func TestDelete_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows/wf-1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"error":{"message":"internal error"}}`)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	err := h.Delete(context.Background(), "wf-1")
+	if err == nil {
+		t.Fatal("Delete() expected error for 500")
+	}
+}
+
+func TestGetRaw(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows/wf-raw", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"wf-raw","title":"Raw"}`)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	body, err := h.GetRaw(context.Background(), "wf-raw")
+	if err != nil {
+		t.Fatalf("GetRaw() error: %v", err)
+	}
+	if got := string(body); got != `{"id":"wf-raw","title":"Raw"}` {
+		t.Fatalf("GetRaw() = %q, want %q", got, `{"id":"wf-raw","title":"Raw"}`)
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows/wf-1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", ct)
+		}
+		resp := Workflow{ID: "wf-1", Title: "Updated Workflow", Owner: "user-1"}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.Update(context.Background(), "wf-1", []byte(`{"title":"Updated Workflow"}`))
+	if err != nil {
+		t.Fatalf("Update() error: %v", err)
+	}
+	if result.Title != "Updated Workflow" {
+		t.Fatalf("Title = %q, want %q", result.Title, "Updated Workflow")
+	}
+}
+
+func TestUpdate_ParseError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows/wf-1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{invalid-json`)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.Update(context.Background(), "wf-1", []byte(`{"title":"Updated Workflow"}`))
+	if err == nil {
+		t.Fatal("Update() expected parse error")
+	}
+}
+
+func TestListHistory(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows/wf-1/history", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		resp := HistoryList{
+			Count: 2,
+			Results: []HistoryRecord{
+				{Version: 1, User: "user-1", DateCreated: "2026-05-19T10:00:00Z"},
+				{Version: 2, User: "user-1", DateCreated: "2026-05-19T11:00:00Z"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.ListHistory(context.Background(), "wf-1")
+	if err != nil {
+		t.Fatalf("ListHistory() error: %v", err)
+	}
+	if result.Count != 2 || len(result.Results) != 2 {
+		t.Fatalf("ListHistory() = %#v, want count=2 and two results", result)
+	}
+}
+
+func TestListHistory_ParseError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows/wf-1/history", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{invalid-json`)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.ListHistory(context.Background(), "wf-1")
+	if err == nil {
+		t.Fatal("ListHistory() expected parse error")
+	}
+}
+
+func TestGetHistoryRecord(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows/wf-1/history/2", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		resp := Workflow{ID: "wf-1", Title: "Version 2", Owner: "user-1"}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.GetHistoryRecord(context.Background(), "wf-1", 2)
+	if err != nil {
+		t.Fatalf("GetHistoryRecord() error: %v", err)
+	}
+	if result.Title != "Version 2" {
+		t.Fatalf("Title = %q, want %q", result.Title, "Version 2")
+	}
+}
+
+func TestGetHistoryRecord_ParseError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows/wf-1/history/2", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{invalid-json`)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.GetHistoryRecord(context.Background(), "wf-1", 2)
+	if err == nil {
+		t.Fatal("GetHistoryRecord() expected parse error")
+	}
+}
+
+func TestRestoreHistory(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows/wf-1/history/2/restore", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		resp := Workflow{ID: "wf-1", Title: "Restored", Owner: "user-1"}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.RestoreHistory(context.Background(), "wf-1", 2)
+	if err != nil {
+		t.Fatalf("RestoreHistory() error: %v", err)
+	}
+	if result.Title != "Restored" {
+		t.Fatalf("Title = %q, want %q", result.Title, "Restored")
+	}
+}
+
+func TestRestoreHistory_ParseError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows/wf-1/history/2/restore", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{invalid-json`)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.RestoreHistory(context.Background(), "wf-1", 2)
+	if err == nil {
+		t.Fatal("RestoreHistory() expected parse error")
 	}
 }
 


### PR DESCRIPTION
This change ensures that essential workflow fields are no longer lost or silently altered in CLI output, especially in YAML/JSON round-trips. It also fixes `describe` display issues by showing important attributes such as workflow type and by rendering triggers as concise semantic summaries instead of noisy nested structures.

A related part of the fix is serialization correctness: values like isDeployed: false and empty tasks: {} are now preserved instead of being dropped from output, which prevents reapply drift and avoids fields being ignored on subsequent apply operations.

The implementation was grounded in AutomationEngine's actual source and schema behavior, so dtctl now mirrors the API's real workflow semantics more closely instead of relying only on its prior local model assumptions.