### PR TITLE
fix(workflow): monitor waited executions

### DIFF
--- a/cmd/exec_workflows.go
+++ b/cmd/exec_workflows.go
@@ -104,6 +104,10 @@ var execWorkflowCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		wait, _ := cmd.Flags().GetBool("wait")
+		// Simple workflow execution details are only available from the API for monitored
+		// runs. The --wait path polls that API surface, so it must opt into monitor=true.
+		request.Monitor = wait
 
 		result, err := executor.Execute(workflowID, request)
 		if err != nil {
@@ -123,7 +127,6 @@ var execWorkflowCmd = &cobra.Command{
 		fmt.Printf("State: %s\n", result.State)
 
 		// Handle --wait flag
-		wait, _ := cmd.Flags().GetBool("wait")
 		if wait {
 			fmt.Printf("\nWaiting for execution to complete...\n")
 

--- a/cmd/exec_workflows_test.go
+++ b/cmd/exec_workflows_test.go
@@ -39,6 +39,9 @@ func TestExecWorkflowRunE_SendsWorkflowInputRequest(t *testing.T) {
 			if r.Method != http.MethodPost {
 				t.Fatalf("unexpected method: %s", r.Method)
 			}
+			if got := r.URL.Query().Get("monitor"); got != "" {
+				t.Fatalf("expected monitor query param to be omitted without --wait, got %q", got)
+			}
 
 			requestBody := decodeWorkflowRunRequestBody(t, r.Body)
 			input, ok := requestBody["input"].(map[string]any)
@@ -79,6 +82,47 @@ func TestExecWorkflowRunE_SendsWorkflowInputRequest(t *testing.T) {
 	}
 	if ms.RequestCount != 1 {
 		t.Fatalf("expected 1 request, got %d", ms.RequestCount)
+	}
+}
+
+func TestExecWorkflowRunE_SetsMonitorQueryParamWhenWaiting(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/workflows/wf-123/run": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method: %s", r.Method)
+			}
+			if got := r.URL.Query().Get("monitor"); got != "true" {
+				t.Fatalf("expected monitor=true query param when waiting, got %q", got)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"exec-123","workflow":"wf-123","state":"RUNNING"}`))
+		},
+		"/platform/automation/v1/executions/exec-123": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"exec-123","workflow":"wf-123","state":"SUCCESS","runtime":0}`))
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	defer func() {
+		cfgFile = origCfgFile
+	}()
+	cfgFile = configPath
+
+	cmd := newExecWorkflowRunCmdForTest()
+	_ = cmd.Flags().Set("wait", "true")
+
+	err := cmd.RunE(cmd, []string{"wf-123"})
+	if err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+	if ms.RequestCount != 2 {
+		t.Fatalf("expected 2 requests (run + poll), got %d", ms.RequestCount)
 	}
 }
 

--- a/pkg/exec/workflow.go
+++ b/pkg/exec/workflow.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -21,8 +22,9 @@ func NewWorkflowExecutor(c *client.Client) *WorkflowExecutor {
 
 // WorkflowExecutionRequest represents a workflow execution request
 type WorkflowExecutionRequest struct {
-	Input  map[string]any         `json:"input,omitempty"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	Input   map[string]any         `json:"input,omitempty"`
+	Params  map[string]interface{} `json:"params,omitempty"`
+	Monitor bool                   `json:"-"`
 }
 
 // WorkflowExecutionResponse represents a workflow execution response
@@ -32,14 +34,26 @@ type WorkflowExecutionResponse struct {
 	State    string `json:"state"`
 }
 
+type apiErrorEnvelope struct {
+	Error struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
 // Execute executes a workflow
 func (e *WorkflowExecutor) Execute(workflowID string, req WorkflowExecutionRequest) (*WorkflowExecutionResponse, error) {
 	var result WorkflowExecutionResponse
 
-	resp, err := e.client.HTTP().R().
+	httpReq := e.client.HTTP().R().
 		SetHeader("Content-Type", "application/json").
 		SetBody(req).
-		SetResult(&result).
+		SetResult(&result)
+
+	if req.Monitor {
+		httpReq.SetQueryParam("monitor", "true")
+	}
+
+	resp, err := httpReq.
 		Post(fmt.Sprintf("/platform/automation/v1/workflows/%s/run", workflowID))
 
 	if err != nil {
@@ -47,7 +61,7 @@ func (e *WorkflowExecutor) Execute(workflowID string, req WorkflowExecutionReque
 	}
 
 	if resp.IsError() {
-		return nil, fmt.Errorf("workflow execution failed with status %d: %s", resp.StatusCode(), resp.String())
+		return nil, formatWorkflowAPIError("workflow execution failed", resp.StatusCode(), resp.String())
 	}
 
 	return &result, nil
@@ -103,10 +117,19 @@ func (e *WorkflowExecutor) GetStatus(executionID string) (*ExecutionStatus, erro
 	}
 
 	if resp.IsError() {
-		return nil, fmt.Errorf("failed to get execution status: status %d: %s", resp.StatusCode(), resp.String())
+		return nil, formatWorkflowAPIError("failed to get execution status", resp.StatusCode(), resp.String())
 	}
 
 	return &result, nil
+}
+
+func formatWorkflowAPIError(prefix string, statusCode int, body string) error {
+	var envelope apiErrorEnvelope
+	if err := json.Unmarshal([]byte(body), &envelope); err == nil && envelope.Error.Message != "" {
+		return fmt.Errorf("%s: status %d: %s", prefix, statusCode, envelope.Error.Message)
+	}
+
+	return fmt.Errorf("%s: status %d: %s", prefix, statusCode, body)
 }
 
 // WaitOptions configures the wait behavior

--- a/pkg/exec/workflow_test.go
+++ b/pkg/exec/workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
@@ -124,5 +125,100 @@ func TestWorkflowExecutor_Execute_SendsWorkflowInputRequest(t *testing.T) {
 	}
 	if result.ID != "exec-456" {
 		t.Fatalf("expected execution id exec-456, got %s", result.ID)
+	}
+}
+
+func TestWorkflowExecutor_Execute_SendsMonitorQueryParamWhenRequested(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("monitor"); got != "true" {
+			t.Fatalf("expected monitor=true query param, got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"exec-monitor","workflow":"wf-123","state":"RUNNING"}`))
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewWorkflowExecutor(c)
+	_, err = executor.Execute("wf-123", WorkflowExecutionRequest{Monitor: true})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestWorkflowExecutor_Execute_UsesAPIErrorMessageForRateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Too many requests. Please wait for 17 seconds before making another request."}}`))
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewWorkflowExecutor(c)
+	_, err = executor.Execute("wf-123", WorkflowExecutionRequest{})
+	if err == nil {
+		t.Fatal("Execute() expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "Too many requests. Please wait for 17 seconds before making another request.") {
+		t.Fatalf("Execute() error = %q, want server error message", err.Error())
+	}
+}
+
+func TestWorkflowExecutor_GetStatus_UsesAPIErrorMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Too many requests. Please wait for 9 seconds before making another request."}}`))
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewWorkflowExecutor(c)
+	_, err = executor.GetStatus("exec-123")
+	if err == nil {
+		t.Fatal("GetStatus() expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "Too many requests. Please wait for 9 seconds before making another request.") {
+		t.Fatalf("GetStatus() error = %q, want server error message", err.Error())
+	}
+}
+
+func TestWorkflowExecutor_Execute_FallsBackToRawErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream gateway timeout"))
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	executor := NewWorkflowExecutor(c)
+	_, err = executor.Execute("wf-123", WorkflowExecutionRequest{})
+	if err == nil {
+		t.Fatal("Execute() expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "status 502: upstream gateway timeout") {
+		t.Fatalf("Execute() error = %q, want raw response body fallback", err.Error())
 	}
 }


### PR DESCRIPTION
This change fixes `dtctl exec workflow --wait` for simple workflows.

Simple workflows need the monitoring parameter for execution information to be available through the API. Since `--wait` works by starting a workflow and then polling that API for status, it needs to send that parameter. For standard workflows, sending it does not hurt, so the CLI now does this whenever `--wait` is used instead of trying to special-case workflow types.

While working through this, we also improved the error handling around workflow execution and polling. When the API returns a structured error such as a rate limit response, dtctl now surfaces the actual message from the response instead of printing raw JSON. The change is covered with focused tests for the `--wait` behavior, the emitted query parameter, and the improved API error reporting.