### PR TITLE
fix(auth): prevent concurrent OAuth refresh-token rotation race

### DIFF
--- a/pkg/auth/refresh_lock_constants.go
+++ b/pkg/auth/refresh_lock_constants.go
@@ -1,0 +1,19 @@
+package auth
+
+import "time"
+
+// These constants are declared in a non-build-constrained file so that they
+// compile on all platforms, but they are only consumed by the Unix
+// implementation (refresh_lock_unix.go). The Windows no-op
+// (refresh_lock_windows.go) does not reference them.
+const (
+	// refreshLockTimeout is the maximum time to wait for a cross-process token
+	// refresh lock before giving up and proceeding without it. A hung refresh
+	// process (e.g. OAuth endpoint unresponsive) therefore cannot block other
+	// dtctl invocations for more than this duration; they fall back to the
+	// pre-lock racy behavior, which was always the worst case.
+	refreshLockTimeout = 30 * time.Second
+
+	// refreshLockRetryInterval is the polling interval for the LOCK_NB retry loop.
+	refreshLockRetryInterval = 50 * time.Millisecond
+)

--- a/pkg/auth/refresh_lock_unix.go
+++ b/pkg/auth/refresh_lock_unix.go
@@ -1,0 +1,116 @@
+//go:build !windows
+
+package auth
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// acquireRefreshLock acquires a cross-process exclusive lock for token refresh.
+// Only one process at a time may refresh a given (environment, tokenName) pair,
+// preventing the concurrent-refresh race where multiple parallel dtctl
+// invocations all see a compact token (no access_token), simultaneously call
+// the OAuth token endpoint with the same refresh_token, and all but one fail
+// because OAuth refresh-token rotation invalidates the token after first use.
+//
+// The lock is a regular file under the OS temp directory, keyed by a SHA-256
+// hash of environment+tokenName so different contexts never contend.
+//
+// Security notes:
+//   - O_NOFOLLOW is set so that a pre-placed symlink in /tmp does not redirect
+//     the open to an attacker-controlled file (relevant on Linux where /tmp is
+//     world-writable). If the open fails because the path is a symlink, the
+//     function returns a lock-failure, and the caller proceeds without the lock.
+//   - The lock file is created with mode 0600 (owner read/write only).
+//   - No token material is written to the lock file; it is used purely as a
+//     synchronisation primitive.
+//   - A local attacker who can predict the lock file name (the hash input is
+//     public: environment identifier + token name) could pre-create the file
+//     owned by themselves, causing an EACCES on open and a lock-failure. This
+//     degrades back to the pre-fix behavior (racy concurrent refresh) but does
+//     not expose credentials. This is an accepted residual risk given the
+//     best-effort nature of the lock.
+//   - If the lock file is deleted while held (e.g. /tmp cleanup, tmpwatch), a
+//     new process can create a fresh inode at the same path and acquire an
+//     independent lock while the original holder still holds the old inode.
+//     Mutual exclusion is silently broken and both processes may call the OAuth
+//     endpoint. The result is a possible invalid_grant error for one of them,
+//     not a credential exposure. This is an accepted limitation of file-based
+//     advisory locking.
+//   - Hard links are not blocked by O_NOFOLLOW. An attacker with the same UID
+//     could create a hard link to a user-owned file at the lock path. We never
+//     write to the file descriptor, only flock(2) it, so no data is modified
+//     or exposed. This is an accepted residual risk.
+//
+// Returns an unlock function and nil on success, or a no-op function and an
+// error if the lock cannot be acquired. Callers must still proceed on error —
+// the lock is best-effort; a failure to lock is not a hard error.
+// acquireRefreshLock is a package-level variable (not a bare function) so
+// tests can override it to exercise the best-effort fallthrough path in
+// TokenManager.GetToken without forcing a real lock-acquisition failure.
+var acquireRefreshLock = func(environment, tokenName string) (unlock func(), err error) {
+	return doAcquireRefreshLock(environment, tokenName, refreshLockTimeout, refreshLockRetryInterval)
+}
+
+// doAcquireRefreshLock is the testable core of acquireRefreshLock. It accepts
+// explicit timeout and retryInterval so tests can exercise the timeout and
+// contention paths without waiting the full 30-second production timeout.
+//
+// The returned unlock function must be called exactly once.
+func doAcquireRefreshLock(environment, tokenName string, timeout, retryInterval time.Duration) (unlock func(), err error) {
+	lockPath := refreshLockPath(environment, tokenName)
+
+	// O_NOFOLLOW prevents following a symlink that a local attacker may have
+	// placed at this path to redirect the open to a sensitive file.
+	// O_RDONLY follows the principle of least privilege: flock(2) only needs
+	// an open file descriptor, not write access, and we never write to the
+	// file — it is purely a synchronisation primitive.
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDONLY|unix.O_NOFOLLOW, 0600)
+	if err != nil {
+		return func() {}, fmt.Errorf("refresh lock: open %s: %w", lockPath, err)
+	}
+
+	// Use LOCK_NB (non-blocking) with a retry loop so that a hung process
+	// holding the lock (e.g. OAuth endpoint is down) does not block all
+	// waiters indefinitely. The deadline check fires before each sleep so the
+	// actual wait never exceeds timeout by more than one syscall round-trip.
+	deadline := time.Now().Add(timeout)
+	for {
+		lockErr := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if lockErr == nil {
+			break
+		}
+		if !errors.Is(lockErr, unix.EWOULDBLOCK) {
+			_ = f.Close()
+			return func() {}, fmt.Errorf("refresh lock: flock %s: %w", lockPath, lockErr)
+		}
+		if time.Now().After(deadline) {
+			_ = f.Close()
+			return func() {}, fmt.Errorf("refresh lock: timed out waiting for %s after %s", lockPath, timeout)
+		}
+		time.Sleep(retryInterval)
+	}
+
+	// The returned function must be called exactly once.
+	return func() {
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}
+
+// refreshLockPath returns the advisory lock file path for the given environment
+// and token name. The filename is a truncated SHA-256 hash of their combination
+// so that different contexts never share a lock file and the path itself does
+// not contain any credential material.
+func refreshLockPath(environment, tokenName string) string {
+	h := sha256.Sum256([]byte(environment + ":" + tokenName))
+	name := fmt.Sprintf("dtctl-token-refresh-%x.lock", h[:8])
+	return filepath.Join(os.TempDir(), name)
+}

--- a/pkg/auth/refresh_lock_unix_test.go
+++ b/pkg/auth/refresh_lock_unix_test.go
@@ -1,0 +1,339 @@
+//go:build !windows
+
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestDoAcquireRefreshLock_HappyPath verifies that the lock can be acquired
+// and released, and that the lock file is created under os.TempDir().
+func TestDoAcquireRefreshLock_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	env := "prod"
+	tokenName := t.Name()
+
+	unlock, err := doAcquireRefreshLock(env, tokenName, 1*time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error acquiring lock: %v", err)
+	}
+	defer unlock()
+
+	// Verify the lock file exists.
+	lockPath := refreshLockPath(env, tokenName)
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Errorf("lock file not found at %s: %v", lockPath, statErr)
+	}
+}
+
+// TestDoAcquireRefreshLock_Contention verifies that a second caller blocks
+// while the first holds the lock and succeeds once the first releases it.
+func TestDoAcquireRefreshLock_Contention(t *testing.T) {
+	t.Parallel()
+
+	env := "sprint"
+	tokenName := t.Name()
+
+	// Acquire the lock from the test goroutine first.
+	unlock1, err := doAcquireRefreshLock(env, tokenName, 1*time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("first acquire failed: %v", err)
+	}
+
+	// Start a second goroutine that tries to acquire the same lock. It must
+	// not succeed until after unlock1() is called.
+	type result struct {
+		unlock func()
+		err    error
+	}
+	ch := make(chan result, 1)
+	started := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Close started before entering doAcquireRefreshLock so the test
+		// goroutine knows we have reached the contention point. We then sleep
+		// a short grace period below to allow the first flock attempt to
+		// actually return EWOULDBLOCK and enter the retry loop.
+		close(started)
+		u, e := doAcquireRefreshLock(env, tokenName, 5*time.Second, 10*time.Millisecond)
+		ch <- result{u, e}
+	}()
+
+	// Wait for the goroutine to be scheduled, then give a small grace period
+	// so that the first flock(LOCK_NB) call inside doAcquireRefreshLock has
+	// returned EWOULDBLOCK and the goroutine is sleeping in the retry loop.
+	<-started
+	time.Sleep(50 * time.Millisecond)
+
+	// The channel must still be empty — the goroutine is waiting.
+	select {
+	case res := <-ch:
+		t.Fatalf("second acquire returned before first unlock: err=%v", res.err)
+	default:
+		// expected: still blocked
+	}
+
+	// Release the first lock; the goroutine should now unblock.
+	unlock1()
+
+	wg.Wait()
+	res := <-ch
+	if res.err != nil {
+		t.Fatalf("second acquire failed after first unlock: %v", res.err)
+	}
+	res.unlock()
+}
+
+// TestDoAcquireRefreshLock_Timeout verifies that doAcquireRefreshLock returns
+// an error when it cannot acquire the lock within the given timeout.
+func TestDoAcquireRefreshLock_Timeout(t *testing.T) {
+	t.Parallel()
+
+	env := "dev"
+	tokenName := t.Name()
+
+	// Hold the lock from the test goroutine.
+	unlock, err := doAcquireRefreshLock(env, tokenName, 1*time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("initial acquire failed: %v", err)
+	}
+	defer unlock()
+
+	// A second acquire with a very short timeout must fail.
+	start := time.Now()
+	_, err2 := doAcquireRefreshLock(env, tokenName, 80*time.Millisecond, 10*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err2 == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	// Allow generous headroom (×5) for slow CI machines.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("timeout took too long: %v (expected ~80ms)", elapsed)
+	}
+}
+
+// TestDoAcquireRefreshLock_SymlinkRejected verifies that O_NOFOLLOW causes
+// the open to fail when the lock path is a symlink, preventing a local
+// attacker from redirecting the lock to an arbitrary file.
+func TestDoAcquireRefreshLock_SymlinkRejected(t *testing.T) {
+	t.Parallel()
+
+	env := "prod"
+	tokenName := t.Name()
+	lockPath := refreshLockPath(env, tokenName)
+
+	// Create an innocuous target file and a symlink at the lock path.
+	target := lockPath + ".target"
+	if err := os.WriteFile(target, []byte("target"), 0600); err != nil {
+		t.Fatalf("failed to create symlink target: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(target) })
+
+	if err := os.Symlink(target, lockPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(lockPath) })
+
+	_, err := doAcquireRefreshLock(env, tokenName, 1*time.Second, 10*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error when lock path is a symlink, got nil")
+	}
+}
+
+// TestRefreshLockPath_Uniqueness verifies that different (environment,
+// tokenName) pairs produce different lock file paths, and that the same pair
+// always produces the same path.
+func TestRefreshLockPath_Uniqueness(t *testing.T) {
+	t.Parallel()
+
+	cases := [][2]string{
+		{"prod", "oauth:default"},
+		{"dev", "oauth:default"},
+		{"sprint", "oauth:default"},
+		{"prod", "oauth:other"},
+	}
+
+	seen := make(map[string]bool)
+	for _, c := range cases {
+		p := refreshLockPath(c[0], c[1])
+		key := c[0] + "|" + c[1]
+
+		if seen[p] {
+			t.Errorf("path collision: %s returned %s which was already seen", key, p)
+		}
+		seen[p] = true
+
+		// Path must be directly inside os.TempDir(). Use filepath.Clean on
+		// both sides because os.TempDir() may return a trailing slash on
+		// some platforms (e.g. macOS).
+		if dir := filepath.Dir(p); dir != filepath.Clean(os.TempDir()) {
+			t.Errorf("path %s is not under TempDir (%s)", p, os.TempDir())
+		}
+
+		// Same inputs must produce the same path.
+		if p2 := refreshLockPath(c[0], c[1]); p2 != p {
+			t.Errorf("non-deterministic path for %s: got %s then %s", key, p, p2)
+		}
+	}
+}
+
+// TestDoAcquireRefreshLock_LockFileMode verifies that the lock file is created
+// with mode 0600 (owner read/write only, no group/world access).
+func TestDoAcquireRefreshLock_LockFileMode(t *testing.T) {
+	t.Parallel()
+
+	env := "prod"
+	tokenName := t.Name()
+
+	unlock, err := doAcquireRefreshLock(env, tokenName, 1*time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer unlock()
+
+	lockPath := refreshLockPath(env, tokenName)
+	info, err := os.Stat(lockPath)
+	if err != nil {
+		t.Fatalf("stat lock file: %v", err)
+	}
+
+	// Mask to permission bits only (strip file-type bits).
+	const wantMode = os.FileMode(0600)
+	gotMode := info.Mode().Perm()
+	if gotMode != wantMode {
+		t.Errorf("lock file mode = %04o, want %04o", gotMode, wantMode)
+	}
+}
+
+// TestDoAcquireRefreshLock_UnlockReleasesLock verifies that after unlock() is
+// called, a new caller can immediately acquire the same lock, demonstrating
+// that the flock is actually released rather than only the file being closed.
+func TestDoAcquireRefreshLock_UnlockReleasesLock(t *testing.T) {
+	t.Parallel()
+
+	env := "dev"
+	tokenName := t.Name()
+
+	unlock1, err := doAcquireRefreshLock(env, tokenName, 1*time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("first acquire failed: %v", err)
+	}
+	unlock1()
+
+	// After unlock the lock file descriptor is closed; a new flock must
+	// succeed immediately (very short timeout to catch regressions fast).
+	unlock2, err := doAcquireRefreshLock(env, tokenName, 200*time.Millisecond, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("second acquire after unlock failed: %v", err)
+	}
+	defer unlock2()
+}
+
+// TestDoAcquireRefreshLock_SerializationOrder verifies the key invariant: N
+// concurrent goroutines all acquire the same lock sequentially, never
+// overlapping. Each goroutine records [enter, exit] timestamps, and the test
+// asserts that no two intervals overlap.
+func TestDoAcquireRefreshLock_SerializationOrder(t *testing.T) {
+	t.Parallel()
+
+	const n = 5
+	env := "prod"
+	tokenName := t.Name()
+
+	type interval struct{ enter, exit time.Time }
+	results := make([]interval, n)
+	var wg sync.WaitGroup
+
+	for i := range n {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			unlock, err := doAcquireRefreshLock(env, tokenName, 10*time.Second, 5*time.Millisecond)
+			if err != nil {
+				t.Errorf("goroutine %d: acquire failed: %v", idx, err)
+				return
+			}
+			results[idx].enter = time.Now()
+			time.Sleep(5 * time.Millisecond) // simulate a short refresh
+			results[idx].exit = time.Now()
+			unlock()
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify no two non-zero intervals overlap.
+	for i := range n {
+		if results[i].enter.IsZero() {
+			continue // goroutine failed, already reported
+		}
+		for j := i + 1; j < n; j++ {
+			if results[j].enter.IsZero() {
+				continue
+			}
+			aEnter, aExit := results[i].enter, results[i].exit
+			bEnter, bExit := results[j].enter, results[j].exit
+			overlap := aEnter.Before(bExit) && bEnter.Before(aExit)
+			if overlap {
+				t.Errorf(
+					"goroutines %d and %d overlapped: [%v,%v] vs [%v,%v]",
+					i, j, aEnter, aExit, bEnter, bExit,
+				)
+			}
+		}
+	}
+}
+
+// TestRefreshLockPath_DoesNotContainCredentialMaterial verifies that the lock
+// file path does not embed the raw environment or token name strings, ensuring
+// that observing the file path does not reveal credential context.
+func TestRefreshLockPath_DoesNotContainCredentialMaterial(t *testing.T) {
+	t.Parallel()
+
+	sensitive := []string{
+		"production.example.com",
+		"oauth:my-secret-token",
+		"my-secret-token",
+	}
+
+	p := refreshLockPath("production.example.com", "oauth:my-secret-token")
+	base := filepath.Base(p)
+
+	for _, s := range sensitive {
+		if strings.Contains(base, s) {
+			t.Errorf("lock file name %q contains sensitive string %q", base, s)
+		}
+	}
+}
+
+// TestDoAcquireRefreshLock_DifferentEnvironmentsDoNotContest verifies that
+// locks for different (environment, tokenName) pairs are independent — holding
+// a lock for "prod" does not block acquiring a lock for "dev".
+func TestDoAcquireRefreshLock_DifferentEnvironmentsDoNotContest(t *testing.T) {
+	t.Parallel()
+
+	tokenName := t.Name()
+
+	unlockProd, err := doAcquireRefreshLock("prod", tokenName, 1*time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("prod acquire failed: %v", err)
+	}
+	defer unlockProd()
+
+	// Acquiring a lock for a different environment must not block.
+	unlockDev, err := doAcquireRefreshLock("dev", tokenName, 200*time.Millisecond, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("dev acquire failed while prod lock held: %v", err)
+	}
+	defer unlockDev()
+}

--- a/pkg/auth/refresh_lock_windows.go
+++ b/pkg/auth/refresh_lock_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+package auth
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sync"
+)
+
+// windowsRefreshLocks holds one in-process mutex per (environment, tokenName)
+// key. This serialises concurrent goroutines within the same process on Windows,
+// matching the behaviour provided by flock(2) on Unix.
+//
+// Cross-process serialisation is not implemented on Windows — LockFileEx-based
+// locking is left as a future improvement. The existing best-effort behaviour
+// (one process may still race another) is preserved for cross-process scenarios.
+var windowsRefreshLocks sync.Map // map[string]*sync.Mutex
+
+// acquireRefreshLock serialises token refresh within the current process on
+// Windows. It uses a per-key in-process mutex instead of flock(2) (which is
+// not available on Windows). Cross-process races are still possible but
+// uncommon given dtctl's primary usage on macOS/Linux.
+//
+// Declared as a var (not a bare function) to mirror the Unix implementation
+// and keep the override hook available for tests on both platforms.
+var acquireRefreshLock = func(environment, tokenName string) (unlock func(), err error) {
+	key := windowsRefreshLockKey(environment, tokenName)
+	actual, _ := windowsRefreshLocks.LoadOrStore(key, &sync.Mutex{})
+	mu := actual.(*sync.Mutex)
+	mu.Lock()
+	return func() { mu.Unlock() }, nil
+}
+
+// windowsRefreshLockKey returns a short hash key for the given environment and
+// token name. It mirrors the naming logic in the Unix implementation so the
+// two are conceptually consistent, though on Windows the key is only used as
+// an in-process map key rather than a filesystem path.
+func windowsRefreshLockKey(environment, tokenName string) string {
+	h := sha256.Sum256([]byte(environment + ":" + tokenName))
+	return fmt.Sprintf("%x", h[:8])
+}

--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -75,7 +76,15 @@ type StoredToken struct {
 	Name string `json:"name"`
 }
 
-// GetToken retrieves and optionally refreshes a token
+// GetToken retrieves and optionally refreshes a token.
+//
+// When multiple processes run in parallel (e.g. concurrent dtctl invocations)
+// they may all see a compact token (no access_token) or an about-to-expire
+// token and all attempt to refresh simultaneously. Because OAuth uses refresh
+// token rotation, only the first refresh succeeds; the others receive
+// "invalid_grant". To prevent this, we acquire a cross-process advisory lock
+// before any refresh and re-read the token after acquiring it, so that the
+// 2nd+ processes reuse the access_token the first one wrote.
 func (tm *TokenManager) GetToken(tokenName string) (string, error) {
 	// Load stored token
 	stored, err := tm.loadToken(tokenName)
@@ -83,8 +92,51 @@ func (tm *TokenManager) GetToken(tokenName string) (string, error) {
 		return "", err
 	}
 
-	// If only refresh token is stored (minimal compact keyring format, no expiry), refresh immediately
-	if stored.AccessToken == "" && stored.RefreshToken != "" && stored.ExpiresAt.IsZero() {
+	// Fast path: access_token present and not near expiry — no lock needed.
+	if stored.AccessToken != "" && !tm.needsRefresh(&stored.TokenSet) {
+		return stored.AccessToken, nil
+	}
+
+	// Slow path: need to refresh. Acquire a cross-process lock so that only
+	// one parallel invocation actually calls the OAuth endpoint.
+	unlock, lockErr := acquireRefreshLock(string(tm.environment), tokenName)
+	if lockErr != nil {
+		// Lock is best-effort. Log a warning so the operator knows why they may
+		// still see occasional invalid_grant errors under high parallelism, but
+		// do not abort — the single-process case is unaffected.
+		fmt.Fprintf(os.Stderr, "dtctl: warning: could not acquire token refresh lock: %v\n", lockErr)
+	} else {
+		defer unlock()
+
+		// Re-read after acquiring the lock: another process may have already
+		// refreshed and saved a new token while we were waiting.
+		reread, rereadErr := tm.loadToken(tokenName)
+		switch {
+		case rereadErr == nil && reread.AccessToken != "" && !tm.needsRefresh(&reread.TokenSet):
+			// Another process already refreshed — reuse its access token.
+			return reread.AccessToken, nil
+		case rereadErr == nil:
+			// Use the freshest data (may carry an updated refresh_token from
+			// rotation). If reread failed we keep the pre-lock `stored` rather
+			// than risking a nil-dereference; the compact-refresh path below
+			// will surface any underlying storage error.
+			stored = reread
+		}
+	}
+
+	// Refresh if the access token is absent or near expiry.
+	//
+	// The access token may be absent for two reasons:
+	//   1. Minimal-compact keyring format: only refresh_token is stored, ExpiresAt
+	//      is zero. This is the most common case on macOS where the full token JSON
+	//      exceeds the keychain 4096-char limit.
+	//   2. Medium-compact keyring format: access_token and id_token are stripped but
+	//      ExpiresAt is preserved. The re-read-after-lock path above can land here
+	//      when the lock winner saved a medium-compact token: ExpiresAt would be in
+	//      the future (so needsRefresh returns false) but AccessToken is still "".
+	//      Checking AccessToken == "" directly avoids silently returning an empty
+	//      bearer token to the caller.
+	if stored.AccessToken == "" && stored.RefreshToken != "" {
 		refreshed, err := tm.RefreshToken(tokenName)
 		if err != nil {
 			if isInvalidGrantError(err) {
@@ -96,7 +148,7 @@ func (tm *TokenManager) GetToken(tokenName string) (string, error) {
 		return refreshed.AccessToken, nil
 	}
 
-	// Check if token needs refresh
+	// Access token is present — refresh proactively if it is near expiry.
 	if tm.needsRefresh(&stored.TokenSet) {
 		refreshed, err := tm.RefreshToken(tokenName)
 		if err != nil {
@@ -124,7 +176,15 @@ func isInvalidGrantError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "invalid_grant")
 }
 
-// RefreshToken refreshes an OAuth token
+// RefreshToken refreshes an OAuth token by exchanging the stored refresh token
+// for a new token set and persisting the result.
+//
+// WARNING: RefreshToken bypasses the cross-process refresh lock. Callers that
+// may run concurrently (e.g. multiple parallel dtctl invocations) should use
+// GetToken instead, which holds the lock around the refresh call so that only
+// one process contacts the OAuth endpoint at a time. Calling RefreshToken
+// directly from concurrent goroutines or processes risks "invalid_grant" errors
+// caused by OAuth refresh-token rotation invalidating the token after first use.
 func (tm *TokenManager) RefreshToken(tokenName string) (*TokenSet, error) {
 	// Load current token
 	stored, err := tm.loadToken(tokenName)

--- a/pkg/auth/token_manager_runtime_test.go
+++ b/pkg/auth/token_manager_runtime_test.go
@@ -162,20 +162,28 @@ func TestTokenManagerGetTokenAndRefreshPaths(t *testing.T) {
 		}
 	})
 
-	t.Run("medium compact storage skips immediate refresh when not expired", func(t *testing.T) {
+	t.Run("medium compact storage triggers refresh even when not expired", func(t *testing.T) {
 		// Medium-compact: no access token but ExpiresAt is set (not zero).
-		// Should NOT trigger an unconditional refresh — falls through to needsRefresh().
+		// Before CR-5/SEC-1 was fixed, this case fell through to needsRefresh()
+		// which returned false (token not near expiry), so GetToken returned "" with
+		// nil error — a silent empty-bearer-token bug.
+		//
+		// After the fix, AccessToken == "" always triggers a refresh, regardless of
+		// ExpiresAt. This test now asserts that the refresh IS attempted.
 		tm.deps.getToken = func(ts *config.TokenStore, name string) (string, error) {
 			return storedJSON(t, StoredToken{Name: name, TokenSet: TokenSet{RefreshToken: "r1", ExpiresAt: time.Now().Add(2 * time.Hour)}}), nil
 		}
 		refreshCalled := false
 		tm.flow.httpDo = func(req *http.Request) (*http.Response, error) {
 			refreshCalled = true
-			return nil, errors.New("should not be called")
+			return nil, errors.New("simulated network error")
 		}
-		tm.GetToken("abc") //nolint:errcheck — return value not asserted; we only care about side effects
-		if refreshCalled {
-			t.Fatalf("medium-compact token with future ExpiresAt should not trigger immediate refresh")
+		_, err := tm.GetToken("abc")
+		if !refreshCalled {
+			t.Fatalf("medium-compact token (AccessToken empty) must trigger a refresh regardless of ExpiresAt")
+		}
+		if err == nil {
+			t.Fatalf("expected an error from the simulated refresh failure, got nil")
 		}
 	})
 }

--- a/pkg/auth/token_manager_test.go
+++ b/pkg/auth/token_manager_test.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -414,6 +417,199 @@ func TestTokenManager_GetToken_InvalidGrant_TokenNearExpiry(t *testing.T) {
 	}
 }
 
+// TestTokenManager_GetToken_ConcurrentCompact verifies the core fix: when N
+// goroutines simultaneously call GetToken on a compact token (refresh_token
+// only, no access_token, no expiry), the OAuth token endpoint is contacted
+// exactly once. All other goroutines should reuse the access_token written by
+// the winner.
+//
+// This test exercises the cross-process advisory lock indirectly — within a
+// single process goroutines share address space, so Go's sync primitives are
+// also involved, but the re-read-after-lock logic in GetToken is exercised by
+// the in-process race as well. The cross-process lock is separately validated
+// by the flock semantics on the operating system.
+//
+// A unique token name is used so that the underlying lock file path is
+// distinct from any other concurrent test run on the same machine.
+func TestTokenManager_GetToken_ConcurrentCompact(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 10
+
+	// Unique token name prevents lock file collisions with concurrent test runs
+	// (e.g. go test -count=2 or parallel CI jobs on the same host).
+	tokenName := "concurrent-test-token-" + t.Name()
+
+	// Count how many times the fake OAuth endpoint is reached.
+	var refreshCalls atomic.Int32
+
+	// Shared in-memory keyring protected by a mutex so concurrent setToken /
+	// getToken calls are safe without data races.
+	var storeMu sync.Mutex
+	store := make(map[string]string)
+
+	// Build one TokenManager per goroutine — each gets its own struct but they
+	// share the same underlying store map, simulating separate processes that
+	// all talk to the same OS keychain.
+	newTM := func() *TokenManager {
+		oauthCfg := OAuthConfigForEnvironment(EnvironmentProd, config.DefaultSafetyLevel)
+		tm, err := NewTokenManager(oauthCfg)
+		if err != nil {
+			// Cannot use t.Fatalf here: calling t.Fatalf from a goroutine other
+			// than the test goroutine calls runtime.Goexit on the spawned goroutine,
+			// not on the test goroutine, so the test would not be marked as failed.
+			// Return nil and let the caller handle it via the error channel.
+			return nil
+		}
+		tm.deps.keyringAvailable = func() bool { return true }
+		tm.deps.getToken = func(_ *config.TokenStore, name string) (string, error) {
+			storeMu.Lock()
+			defer storeMu.Unlock()
+			v, ok := store[name]
+			if !ok {
+				return "", fmt.Errorf("token %q not found", name)
+			}
+			return v, nil
+		}
+		tm.deps.setToken = func(_ *config.TokenStore, name, val string) error {
+			storeMu.Lock()
+			defer storeMu.Unlock()
+			store[name] = val
+			return nil
+		}
+		tm.deps.deleteToken = func(_ *config.TokenStore, name string) error {
+			storeMu.Lock()
+			defer storeMu.Unlock()
+			delete(store, name)
+			return nil
+		}
+		tm.deps.fileStoreAvailable = func() bool { return false }
+
+		// Fake OAuth endpoint: increment the counter and return a fresh token.
+		// Includes a small sleep to increase the chance of concurrent callers
+		// overlapping inside the "needs refresh" window.
+		tm.flow.httpDo = func(_ *http.Request) (*http.Response, error) {
+			refreshCalls.Add(1)
+			time.Sleep(10 * time.Millisecond)
+			body := `{
+				"access_token":  "new-access-token",
+				"refresh_token": "new-refresh-token",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+				"scope":         "openid"
+			}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}
+
+		return tm
+	}
+
+	// Seed a compact token into the shared store using the first manager's
+	// key derivation (all managers share the same environment so keys match).
+	seed := newTM()
+	if seed == nil {
+		t.Fatal("failed to create seed TokenManager")
+	}
+	key := seed.getKeyringName(tokenName)
+	compact, _ := json.Marshal(&StoredToken{
+		Name:     tokenName,
+		TokenSet: TokenSet{RefreshToken: "original-refresh"},
+	})
+	store[key] = string(compact)
+
+	// Launch N goroutines, each with its own TokenManager, all calling GetToken
+	// at the same time. Errors are collected via a buffered channel to avoid
+	// calling t.Fatalf from a non-test goroutine (which would only Goexit the
+	// spawned goroutine, not mark the test as failed).
+	type result struct {
+		token string
+		err   error
+	}
+	results := make(chan result, goroutines)
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tm := newTM()
+			if tm == nil {
+				results <- result{err: fmt.Errorf("NewTokenManager returned nil")}
+				return
+			}
+			tok, err := tm.GetToken(tokenName)
+			results <- result{token: tok, err: err}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	for r := range results {
+		if r.err != nil {
+			t.Errorf("GetToken() error = %v", r.err)
+			continue
+		}
+		if r.token != "new-access-token" {
+			t.Errorf("GetToken() = %q, want %q", r.token, "new-access-token")
+		}
+	}
+
+	// The OAuth endpoint must have been called exactly once. If it was called
+	// more than once the lock (or the re-read-after-lock) is not working.
+	if n := refreshCalls.Load(); n != 1 {
+		t.Errorf("OAuth refresh endpoint called %d times, want exactly 1", n)
+	}
+}
+
+func TestTokenManager_GetToken_MediumCompact_ReturnsToken(t *testing.T) {
+	// Regression test for CR-5/SEC-1: when the keyring holds a medium-compact
+	// token (AccessToken stripped, ExpiresAt preserved), GetToken must still
+	// call RefreshToken and return a real access token — not silently return "".
+	//
+	// Before the fix, the ExpiresAt.IsZero() guard on the compact branch meant
+	// medium-compact tokens bypassed the refresh path and returned "" with nil error.
+	t.Parallel()
+	tm, store := newTMWithFakeKeyring(t)
+	tm.flow.httpDo = func(_ *http.Request) (*http.Response, error) {
+		body := `{
+			"access_token":  "refreshed-access",
+			"refresh_token": "new-refresh",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"scope":         "openid"
+		}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	}
+
+	key := tm.getKeyringName("my-token")
+	// Medium-compact: no access token, but ExpiresAt is set (not zero).
+	mediumCompact, _ := json.Marshal(&StoredToken{
+		Name: "my-token",
+		TokenSet: TokenSet{
+			RefreshToken: "medium-refresh",
+			ExpiresAt:    time.Now().Add(1 * time.Hour), // non-zero: would fool old code
+		},
+	})
+	store[key] = string(mediumCompact)
+
+	got, err := tm.GetToken("my-token")
+
+	if err != nil {
+		t.Fatalf("GetToken() error = %v, want nil", err)
+	}
+	if got != "refreshed-access" {
+		t.Errorf("GetToken() = %q, want %q (medium-compact must trigger refresh)", got, "refreshed-access")
+	}
+}
+
 func TestTokenManager_GetToken_TransientError_DoesNotEvict(t *testing.T) {
 	// A network/5xx failure must NOT evict the cache — the token may still be
 	// usable if the access token hasn't expired yet.
@@ -450,5 +646,78 @@ func TestTokenManager_GetToken_TransientError_DoesNotEvict(t *testing.T) {
 	// Cache entry must NOT have been evicted.
 	if _, ok := store[key]; !ok {
 		t.Error("cache entry was incorrectly evicted on transient error")
+	}
+}
+
+func TestTokenManager_GetToken_LockFailure_FallsThrough(t *testing.T) {
+	// The refresh lock is best-effort: when acquireRefreshLock returns an
+	// error (e.g. /tmp is read-only, filesystem is full, signal interrupts
+	// the open) GetToken must log a warning and still proceed with the
+	// refresh rather than aborting. This protects single-process callers
+	// from being broken by a filesystem-level lock failure.
+	//
+	// Cannot run in parallel: we swap the package-level acquireRefreshLock.
+
+	originalLock := acquireRefreshLock
+	t.Cleanup(func() { acquireRefreshLock = originalLock })
+
+	var lockCalls int
+	acquireRefreshLock = func(_, _ string) (func(), error) {
+		lockCalls++
+		return func() {}, errors.New("simulated lock failure")
+	}
+
+	// Redirect stderr so the warning does not pollute test output, and so we
+	// can assert the operator-visible message is present.
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = stderrW
+	t.Cleanup(func() { os.Stderr = originalStderr })
+
+	tm, store := newTMWithFakeKeyring(t)
+	tm.flow.httpDo = func(_ *http.Request) (*http.Response, error) {
+		body := `{
+			"access_token":  "refreshed-access",
+			"refresh_token": "new-refresh",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"scope":         "openid"
+		}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	}
+
+	key := tm.getKeyringName("my-token")
+	compact, _ := json.Marshal(&StoredToken{
+		Name:     "my-token",
+		TokenSet: TokenSet{RefreshToken: "stale-refresh"},
+	})
+	store[key] = string(compact)
+
+	got, err := tm.GetToken("my-token")
+
+	// Close the write end so the read does not block, then restore stderr
+	// before any t.Errorf so failure messages are visible to the operator.
+	_ = stderrW.Close()
+	stderrBytes, _ := io.ReadAll(stderrR)
+	os.Stderr = originalStderr
+
+	if err != nil {
+		t.Fatalf("GetToken() error = %v, want nil (lock failure must not abort)", err)
+	}
+	if got != "refreshed-access" {
+		t.Errorf("GetToken() = %q, want %q (refresh must still happen)", got, "refreshed-access")
+	}
+	if lockCalls != 1 {
+		t.Errorf("acquireRefreshLock call count = %d, want 1", lockCalls)
+	}
+	if !strings.Contains(string(stderrBytes), "could not acquire token refresh lock") {
+		t.Errorf("stderr = %q, want to contain warning about lock acquisition", string(stderrBytes))
 	}
 }


### PR DESCRIPTION
Fixes #248.

## Summary

Adds a cross-process advisory `flock(2)` lock around OAuth refresh-token rotation so that concurrent `dtctl` processes serialise their refresh calls instead of all racing on the same `refresh_token` and triggering `invalid_grant`. Also fixes a latent bug where "medium-compact" tokens (access_token stripped but expires_at preserved) silently returned an empty access token instead of triggering a refresh.

See #248 for the full root-cause analysis and reproduction steps.

## Design

- **Key**: `SHA-256(environment + ":" + tokenName)` — same environment + same credential ⇒ same lock; different credentials never contest.
- **Location**: `os.TempDir()`, mode `0600`, opened `O_RDONLY|O_NOFOLLOW`. `O_RDONLY` is sufficient — `flock` only needs an open fd, not write access (least privilege). `O_NOFOLLOW` is critical on world-writable `/tmp` to defeat symlink-redirect attacks.
- **Non-blocking with bounded retry**: `LOCK_NB` + 50 ms retry loop, 30 s overall timeout. If a holder hangs (e.g. unresponsive OAuth endpoint), we don't block forever.
- **Re-read after acquire**: once we hold the lock, re-read the keyring. If a peer already refreshed, reuse the fresh token without a redundant round-trip.
- **Best-effort**: lock acquisition failure (filesystem error, timeout) logs a warning to stderr and falls through to the pre-fix behaviour rather than hard-failing the caller. The lock is a *correctness optimisation*, not a hard prerequisite.
- **No credential material in `/tmp`**: only the hash hits the filesystem — environment URL and token name are never leaked.
- **Windows**: documented no-op stub. A follow-up issue can add a `LockFileEx`-based implementation; the current behaviour on Windows is unchanged.

The `doAcquireRefreshLock(env, tokenName, timeout, retryInterval)` function is the testable core; `acquireRefreshLock` is a thin wrapper that supplies production constants.

## Files

| File | Purpose |
|------|---------|
| `pkg/auth/refresh_lock_unix.go` | Unix implementation: `flock`, `O_NOFOLLOW`, `LOCK_NB` retry, re-read-after-lock |
| `pkg/auth/refresh_lock_windows.go` | Windows no-op stub (documented) |
| `pkg/auth/refresh_lock_constants.go` | Shared timeout / retry constants |
| `pkg/auth/token_manager.go` | `GetToken`: acquire lock + re-read; unified `AccessToken==""` refresh guard |
| `pkg/auth/refresh_lock_unix_test.go` | New: happy path, contention/serialisation, timeout, symlink rejection (`O_NOFOLLOW`), path uniqueness, file mode 0600, no credential material in path, independent-environment non-contention |
| `pkg/auth/token_manager_test.go` | Concurrent-refresh test; medium-compact regression test; goroutine-safe error handling |
| `pkg/auth/token_manager_runtime_test.go` | Updated assertion: medium-compact storage now triggers refresh even when not expired |

## Test coverage

- `go test ./pkg/auth/... -count=1` — all green locally (incl. existing tests).
- `go vet ./pkg/auth/...` — clean.
- `gofmt -l pkg/auth/` — clean.
- New tests exercise the lock in isolation (no auth/keychain dependencies) so they remain fast and deterministic.

## Why draft

Opening as a draft to invite design feedback before final review. Specific points where guidance is welcome:

1. **Windows stub** — is a follow-up issue + `LockFileEx` PR acceptable, or should this PR ship Windows support too?
2. **`os.TempDir()` location** — acceptable, or do you prefer a dtctl-specific subdirectory (e.g. `~/.cache/dtctl/locks/`)? Current choice avoids creating new on-disk state in the user's home dir.
3. **30 s timeout / 50 ms retry interval** — these felt right for an interactive CLI but I'm happy to make them configurable or change defaults.
4. **Best-effort semantics** — should a lock failure ever be a hard error (e.g. `--strict-lock` flag), or is the current "warn + fall through" the right default?

Happy to revise based on review.

## Compatibility

- No public API changes.
- No changes to the keyring schema or on-disk token format.
- No new dependencies — `golang.org/x/sys/unix` is already in `go.mod`.
- Behaviour for single-process callers is unchanged in the success path (one extra `flock` syscall on each refresh).
