### PR TITLE
fix: accept both 'not found' and 'does not exist' in Settings invalid-schema test

### DIFF
--- a/test/e2e/settings_test.go
+++ b/test/e2e/settings_test.go
@@ -392,8 +392,14 @@ func TestSettingsListObjectsInvalidSchema(t *testing.T) {
 		t.Fatal("Expected error for non-existent schema, got nil")
 	}
 
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("Expected 'not found' error, got: %v", err)
+	// Accept either the legacy "not found" wording or the current
+	// "does not exist" wording — both ride on top of an HTTP 404 from the
+	// Settings API, and the exact phrasing has drifted over time.
+	msg := err.Error()
+	if !strings.Contains(msg, "404") &&
+		!strings.Contains(msg, "not found") &&
+		!strings.Contains(msg, "does not exist") {
+		t.Errorf("Expected 404 / 'not found' / 'does not exist' error, got: %v", err)
 	}
 
 	t.Logf("✓ Got expected error: %v", err)


### PR DESCRIPTION
## Summary
- `TestSettingsListObjectsInvalidSchema` failed because the Dynatrace Settings API now answers a missing schema with `Configuration schema ... does not exist` instead of the older `not found` wording (still HTTP 404).
- Loosen the assertion to accept either phrasing, plus the `404` status string, so upstream message drift no longer fails the integration suite.
- Same class of test-only fix as #238.

## Test plan
- [x] `go test -tags integration -count=1 -run TestSettingsListObjectsInvalidSchema ./test/e2e/...` (passes)
- [ ] Wait for CI green on this PR before merging