### PR TITLE
fix(urls): detect missing https:// scheme in environment URL

### DIFF
--- a/sdk/urls/urls.go
+++ b/sdk/urls/urls.go
@@ -26,6 +26,16 @@ func Check(environmentURL string) []Problem {
 
 	lower := strings.ToLower(environmentURL)
 
+	// Missing scheme: URL without https:// causes Go's HTTP client to return
+	// "unsupported protocol scheme" at runtime. Detect early and suggest the fix.
+	if !strings.HasPrefix(lower, "https://") && !strings.HasPrefix(lower, "http://") {
+		problems = append(problems, Problem{
+			Message:      "environment URL is missing the https:// scheme",
+			SuggestedURL: "https://" + environmentURL,
+		})
+		return problems
+	}
+
 	// SaaS production: <tenant>.live.dynatrace.com instead of <tenant>.apps.dynatrace.com
 	if strings.Contains(lower, ".live.dynatrace.com") {
 		suggested := fixDomain(environmentURL, ".live.dynatrace.com", ".apps.dynatrace.com")

--- a/sdk/urls/urls_test.go
+++ b/sdk/urls/urls_test.go
@@ -23,6 +23,20 @@ func TestCheck(t *testing.T) {
 			wantProblems: 0,
 		},
 		{
+			name:          "missing scheme - apps domain",
+			url:           "abc12345.apps.dynatrace.com",
+			wantProblems:  1,
+			wantMessage:   "missing the https:// scheme",
+			wantSuggested: "https://abc12345.apps.dynatrace.com",
+		},
+		{
+			name:          "missing scheme - dev domain",
+			url:           "abc12345.dev.apps.dynatracelabs.com",
+			wantProblems:  1,
+			wantMessage:   "missing the https:// scheme",
+			wantSuggested: "https://abc12345.dev.apps.dynatracelabs.com",
+		},
+		{
 			name:          "live domain",
 			url:           "https://abc12345.live.dynatrace.com",
 			wantProblems:  1,


### PR DESCRIPTION
## Problem

`dtctl doctor` reported `[OK] URL pattern looks correct` for environment URLs configured without an `https://` scheme (e.g. `abc12345.apps.dynatrace.com` instead of `https://abc12345.apps.dynatrace.com`), then immediately failed the connectivity check with:

```
[FAIL] Connectivity  cannot reach abc12345.apps.dynatrace.com: Head "abc12345.apps.dynatrace.com": unsupported protocol scheme ""
```

The URL pattern checker in `urls.Check()` only validated domain patterns (e.g. `.live.` vs `.apps.`) but never verified that an `https://` scheme was present. Go's `net/http` client requires a scheme to make any request.

## Fix

Add an early-exit check at the top of `urls.Check()`: if the URL has no `http(s)://` prefix, immediately return a `Problem` with the corrected URL as a suggestion.

**Before:**
```
[OK]   Environment URL  URL pattern looks correct
[FAIL] Connectivity     cannot reach abc12345.apps.dynatrace.com: Head "abc12345.apps.dynatrace.com": unsupported protocol scheme ""
```

**After:**
```
[WARN] Environment URL  environment URL is missing the https:// scheme.
                        Suggested fix: dtctl ctx set my-env --environment https://abc12345.apps.dynatrace.com
```

## Changes

- `sdk/urls/urls.go`: scheme presence check with early return
- `sdk/urls/urls_test.go`: two new test cases (bare apps domain, bare dev domain)