### PR TITLE
fix(ctx): ctx set always activates the configured context

### DIFF
--- a/cmd/ctx.go
+++ b/cmd/ctx.go
@@ -35,7 +35,7 @@ Examples:
   # Describe a context
   dtctl ctx describe production
 
-  # Create or update a context
+  # Create or update a context (also switches to it)
   dtctl ctx set staging --environment https://staging.example.com
 
   # Delete a context
@@ -105,11 +105,14 @@ var ctxDescribeCmd = &cobra.Command{
 	},
 }
 
-// ctxSetCmd creates or updates a context
+// ctxSetCmd creates or updates a context and activates it
 var ctxSetCmd = &cobra.Command{
 	Use:   "set <context-name>",
-	Short: "Create or update a context",
+	Short: "Create or update a context and set it as current",
 	Long: `Create or update a context with connection and safety settings.
+
+The context is always set as the current context after being created or updated.
+To switch to an existing context without changing its settings, use: dtctl ctx <name>
 
 Safety Levels (from safest to most permissive):
   readonly                  - No modifications allowed
@@ -311,15 +314,20 @@ func setContext(name, environment, tokenRef, safetyLevel, description string) er
 
 	cfg.SetContextWithOptions(name, environment, tokenRef, opts)
 
-	if len(cfg.Contexts) == 1 || cfg.CurrentContext == "" {
-		cfg.CurrentContext = name
-	}
+	// Always activate the context that was just created or updated.
+	// "ctx set" is the canonical way to configure a context, so the natural
+	// expectation is that the named context becomes current afterward.
+	cfg.CurrentContext = name
 
 	if err := saveConfig(cfg); err != nil {
 		return err
 	}
 
-	output.PrintSuccess("Context %q set", name)
+	if isUpdate {
+		output.PrintSuccess("Context %q updated and set as current", name)
+	} else {
+		output.PrintSuccess("Context %q created and set as current", name)
+	}
 	return nil
 }
 

--- a/cmd/ctx_test.go
+++ b/cmd/ctx_test.go
@@ -148,7 +148,7 @@ func TestCtxSetCmd(t *testing.T) {
 			t.Fatalf("ctx set staging failed: %v", err)
 		}
 
-		// Verify context was created
+		// Verify context was created and is now current
 		cfg, err := config.LoadFrom(configPath)
 		if err != nil {
 			t.Fatalf("failed to load config: %v", err)
@@ -165,9 +165,36 @@ func TestCtxSetCmd(t *testing.T) {
 		if cfg.Contexts[0].Context.SafetyLevel != config.SafetyLevelReadOnly {
 			t.Errorf("expected safety level 'readonly', got %q", cfg.Contexts[0].Context.SafetyLevel)
 		}
-		// First context should be set as current
 		if cfg.CurrentContext != "staging" {
 			t.Errorf("expected current context 'staging', got %q", cfg.CurrentContext)
+		}
+	})
+
+	t.Run("update existing context activates it", func(t *testing.T) {
+		// Create two contexts with staging as current
+		initCfg := config.NewConfig()
+		initCfg.SetContext("staging", "https://staging.example.com", "staging-token")
+		initCfg.SetContext("prod", "https://prod.example.com", "prod-token")
+		initCfg.CurrentContext = "staging"
+		if err := initCfg.SaveTo(configPath); err != nil {
+			t.Fatalf("failed to save initial config: %v", err)
+		}
+
+		// Update prod (not the current context) — this should switch to it
+		_ = ctxSetCmd.Flags().Set("environment", "https://prod.example.com")
+		defer func() { _ = ctxSetCmd.Flags().Set("environment", "") }()
+
+		err := ctxSetCmd.RunE(ctxSetCmd, []string{"prod"})
+		if err != nil {
+			t.Fatalf("ctx set prod failed: %v", err)
+		}
+
+		cfg, err := config.LoadFrom(configPath)
+		if err != nil {
+			t.Fatalf("failed to load config: %v", err)
+		}
+		if cfg.CurrentContext != "prod" {
+			t.Errorf("expected current context 'prod' after update, got %q", cfg.CurrentContext)
 		}
 	})
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -101,7 +101,7 @@ func runDoctorChecksWithClient(httpClient *http.Client) []checkResult {
 		results = append(results, checkResult{
 			Name:   "Current context",
 			Status: "fail",
-			Detail: "no current context set (use 'dtctl ctx set <name>' or 'dtctl config set-context')",
+			Detail: "no current context set (use 'dtctl ctx <name>' to switch, or 'dtctl ctx set <name> --environment <url>' to create one)",
 		})
 		return results
 	}

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -1550,7 +1550,7 @@ dtctl ctx prod               # Switch to 'prod' context
 dtctl ctx current            # Show current context name
 dtctl ctx describe           # Describe current context
 dtctl ctx describe prod      # Describe specific context
-dtctl ctx set                # Create or update a context (interactive)
+dtctl ctx set <name> --environment <url>  # Create or update a context (also activates it)
 dtctl ctx delete old-env     # Delete a context
 dtctl ctx rm old-env         # Alias for delete
 ```


### PR DESCRIPTION
## Problem

`dtctl ctx set <name>` reported `OK Context "<name>" set` but left the current context unchanged when multiple contexts already existed. Users running `ctx set` on an existing context reasonably expected it to switch — the ambiguous message made the bug invisible.

Root cause: the activation guard `if len(cfg.Contexts) == 1 || cfg.CurrentContext == ""` only auto-selected a context for the very first entry or when no current was set.

## Fix

- **Always** set `cfg.CurrentContext = name` after a successful create or update.
- Split the success message into unambiguous variants:
  - `Context %q created and set as current`
  - `Context %q updated and set as current`
- Added a test case: *update existing context activates it* — starts with `staging` as current, updates `prod`, asserts `CurrentContext` flips to `prod`.

## Before / After

```
# Before
$ dtctl ctx set vuc82901
OK Context "vuc82901" set      ← sounds like it switched, but it didn't

$ dtctl ctx
CURRENT   NAME       ...
          vuc82901
*         wnf1395d   ← still the old context

# After
$ dtctl ctx set vuc82901
OK Context "vuc82901" updated and set as current

$ dtctl ctx
CURRENT   NAME       ...
*         vuc82901   ← correctly active
          wnf1395d
```