### PR TITLE
fix(apply/settings): --id flag and --write-id --id now trigger UPDATE

### DIFF
--- a/pkg/apply/apply_integration_test.go
+++ b/pkg/apply/apply_integration_test.go
@@ -2304,3 +2304,60 @@ func TestApply_SettingsArray_YAML_RoundTrip(t *testing.T) {
 		t.Fatalf("expected 2 results, got %d", len(results))
 	}
 }
+
+// TestApply_Settings_OverrideID_TriggersUpdate is a regression test for
+// https://github.com/dynatrace-oss/dtctl/issues/255
+//
+// When --id <objectId> is provided for a settings object that has no
+// objectId/objectid field, apply must issue a PUT (UPDATE) rather than a
+// POST (CREATE).
+func TestApply_Settings_OverrideID_TriggersUpdate(t *testing.T) {
+	putCalled := false
+	// handler.Update internally does: GET (schemaVersion) → PUT → GET (re-fetch).
+	// applySettings itself also does a GET first to confirm existence.
+	// All three GET and the PUT land on the same path.
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/classic/environment-api/v2/settings/objects/urn:settings:obj-255": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.Method {
+			case http.MethodGet:
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"objectId":      "urn:settings:obj-255",
+					"schemaId":      "builtin:alerting.profile",
+					"schemaVersion": "1",
+					"scope":         "environment",
+					"value":         map[string]interface{}{"name": "Updated"},
+					"summary":       "Updated",
+				})
+			case http.MethodPut:
+				putCalled = true
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				t.Errorf("unexpected method %s on settings object path", r.Method)
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	// File has no objectId — the caller provides it via --id (OverrideID).
+	settingsJSON := `{"schemaId":"builtin:alerting.profile","scope":"environment","value":{"name":"Updated"}}`
+	results, err := a.Apply([]byte(settingsJSON), ApplyOptions{OverrideID: "urn:settings:obj-255"})
+	if err != nil {
+		t.Fatalf("Apply() with --id for settings error = %v", err)
+	}
+	if !putCalled {
+		t.Error("expected a PUT request, but none was made (bug #255: --id flag ignored for settings)")
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	base := results[0].(*SettingsApplyResult).ApplyResultBase
+	if base.Action != ActionUpdated {
+		t.Errorf("expected action 'updated', got %q", base.Action)
+	}
+}

--- a/pkg/apply/apply_settings.go
+++ b/pkg/apply/apply_settings.go
@@ -17,10 +17,16 @@ func (a *Applier) applySettings(data []byte) (ApplyResult, error) {
 
 	handler := settings.NewHandler(a.client)
 
-	// Extract fields - handle both camelCase (API format) and lowercase (YAML keys)
+	// Extract fields - handle both camelCase (API format) and lowercase (YAML keys).
+	// Also accept "id" as a final fallback so that the --id CLI flag (which injects
+	// doc["id"] via injectID) works for settings objects the same way it does for
+	// other resource types. See https://github.com/dynatrace-oss/dtctl/issues/255
 	objectID, _ := setting["objectId"].(string)
 	if objectID == "" {
 		objectID, _ = setting["objectid"].(string)
+	}
+	if objectID == "" {
+		objectID, _ = setting["id"].(string)
 	}
 
 	schemaID, _ := setting["schemaId"].(string)


### PR DESCRIPTION
## Summary

Fixes #255

`dtctl apply -f file.yaml --id <objectId>` was always issuing a POST (CREATE) for settings objects, ignoring the provided ID. This caused HTTP 400 (duplicate identifier) from the DT Settings API when the object already existed.

## Root cause

`injectID()` (`pkg/apply/applier.go:678`) injects the provided value into `doc["id"]`. However, `applySettings` (`pkg/apply/apply_settings.go:21-24`) only read `objectId` (camelCase) and `objectid` (lowercase) — it never checked `id`. So the value injected by `--id` was silently discarded for settings objects.

## Fix

Add `doc["id"]` as a final fallback in the objectID resolution chain inside `applySettings`. No changes to other resource types.

```go
// Before
objectID, _ := setting["objectId"].(string)
if objectID == "" {
    objectID, _ = setting["objectid"].(string)
}

// After
objectID, _ := setting["objectId"].(string)
if objectID == "" {
    objectID, _ = setting["objectid"].(string)
}
if objectID == "" {
    objectID, _ = setting["id"].(string)  // injected by --id flag
}
```

## Testing

Added regression test `TestApply_Settings_OverrideID_TriggersUpdate` that:
- Provides a settings YAML with no `objectId` field
- Passes the ID via `ApplyOptions.OverrideID` (equivalent to `--id` flag)
- Asserts that a PUT request is made (not POST)
- Asserts that the result action is `updated`

All existing tests pass.