### PR TITLE
feat(azure): add clientSecret credential flags to create/update conne…

### DIFF
--- a/cmd/create_azure.go
+++ b/cmd/create_azure.go
@@ -59,6 +59,13 @@ Examples:
 			)
 		}
 
+		switch createAzureConnectionType {
+		case "federatedIdentityCredential", "clientSecret":
+			// valid
+		default:
+			return fmt.Errorf("unsupported --type %q (supported: federatedIdentityCredential, clientSecret)", createAzureConnectionType)
+		}
+
 		if createAzureConnectionType == "federatedIdentityCredential" &&
 			(createAzureConnectionDirectoryID != "" || createAzureConnectionApplicationID != "" || createAzureConnectionClientSecret != "") {
 			return fmt.Errorf("--directoryId, --applicationId, and --clientSecret are only supported for --type clientSecret\nFor federatedIdentityCredential, run 'dtctl update azure connection' after setting up federation in Azure")
@@ -86,8 +93,6 @@ Examples:
 				ClientSecret:  createAzureConnectionClientSecret,
 				Consumers:     []string{"SVC:com.dynatrace.da"},
 			}
-		default:
-			return fmt.Errorf("unsupported --type %q (supported: federatedIdentityCredential, clientSecret)", createAzureConnectionType)
 		}
 
 		created, err := handler.Create(azureconnection.AzureConnectionCreate{Value: value})

--- a/cmd/create_azure.go
+++ b/cmd/create_azure.go
@@ -16,8 +16,11 @@ import (
 )
 
 var (
-	createAzureConnectionName string
-	createAzureConnectionType string
+	createAzureConnectionName          string
+	createAzureConnectionType          string
+	createAzureConnectionDirectoryID   string
+	createAzureConnectionApplicationID string
+	createAzureConnectionClientSecret  string
 
 	createAzureMonitoringConfigName              string
 	createAzureMonitoringConfigCredentials       string
@@ -39,7 +42,7 @@ var createAzureConnectionCmd = &cobra.Command{
 
 Examples:
   dtctl create azure connection --name "siwek" --type "federatedIdentityCredential"
-  dtctl create azure connection --name "siwek" --type "clientSecret"`,
+  dtctl create azure connection --name "siwek" --type "clientSecret" --directoryId "$TENANT_ID" --applicationId "$CLIENT_ID" --clientSecret "$CLIENT_SECRET"`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if createAzureConnectionName == "" || createAzureConnectionType == "" {
 			missing := make([]string, 0, 2)
@@ -54,6 +57,11 @@ Examples:
 				"required flag(s) %s not set\nAvailable --type values: federatedIdentityCredential, clientSecret\nExample: dtctl create azure connection --name \"my-conn\" --type federatedIdentityCredential",
 				strings.Join(missing, ", "),
 			)
+		}
+
+		if createAzureConnectionType == "federatedIdentityCredential" &&
+			(createAzureConnectionDirectoryID != "" || createAzureConnectionApplicationID != "" || createAzureConnectionClientSecret != "") {
+			return fmt.Errorf("--directoryId, --applicationId, and --clientSecret are only supported for --type clientSecret\nFor federatedIdentityCredential, run 'dtctl update azure connection' after setting up federation in Azure")
 		}
 
 		_, c, err := SetupWithSafety(safety.OperationCreate)
@@ -72,7 +80,12 @@ Examples:
 		case "federatedIdentityCredential":
 			value.FederatedIdentityCredential = &azureconnection.FederatedIdentityCredential{Consumers: []string{"SVC:com.dynatrace.da"}}
 		case "clientSecret":
-			value.ClientSecret = &azureconnection.ClientSecretCredential{Consumers: []string{"SVC:com.dynatrace.da"}}
+			value.ClientSecret = &azureconnection.ClientSecretCredential{
+				DirectoryID:   createAzureConnectionDirectoryID,
+				ApplicationID: createAzureConnectionApplicationID,
+				ClientSecret:  createAzureConnectionClientSecret,
+				Consumers:     []string{"SVC:com.dynatrace.da"},
+			}
 		default:
 			return fmt.Errorf("unsupported --type %q (supported: federatedIdentityCredential, clientSecret)", createAzureConnectionType)
 		}
@@ -229,6 +242,9 @@ func init() {
 
 	createAzureConnectionCmd.Flags().StringVar(&createAzureConnectionName, "name", "", "Azure connection name (required)")
 	createAzureConnectionCmd.Flags().StringVar(&createAzureConnectionType, "type", "", "Azure connection type: federatedIdentityCredential or clientSecret (required)")
+	createAzureConnectionCmd.Flags().StringVar(&createAzureConnectionDirectoryID, "directoryId", "", "Directory (tenant) ID — clientSecret type only")
+	createAzureConnectionCmd.Flags().StringVar(&createAzureConnectionApplicationID, "applicationId", "", "Application (client) ID — clientSecret type only")
+	createAzureConnectionCmd.Flags().StringVar(&createAzureConnectionClientSecret, "clientSecret", "", "Client secret value — clientSecret type only; prefer passing via env var to keep out of shell history")
 	_ = createAzureConnectionCmd.RegisterFlagCompletionFunc("type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{
 			"federatedIdentityCredential\tUse workload identity federation (recommended)",

--- a/cmd/create_azure.go
+++ b/cmd/create_azure.go
@@ -249,7 +249,7 @@ func init() {
 	createAzureConnectionCmd.Flags().StringVar(&createAzureConnectionType, "type", "", "Azure connection type: federatedIdentityCredential or clientSecret (required)")
 	createAzureConnectionCmd.Flags().StringVar(&createAzureConnectionDirectoryID, "directoryId", "", "Directory (tenant) ID — clientSecret type only")
 	createAzureConnectionCmd.Flags().StringVar(&createAzureConnectionApplicationID, "applicationId", "", "Application (client) ID — clientSecret type only")
-	createAzureConnectionCmd.Flags().StringVar(&createAzureConnectionClientSecret, "clientSecret", "", "Client secret value — clientSecret type only; prefer passing via env var to keep out of shell history")
+	createAzureConnectionCmd.Flags().StringVar(&createAzureConnectionClientSecret, "clientSecret", "", "Client secret value — clientSecret type only; prefer passing via env var to keep out of shell history (note: expanded value can still be visible in process arguments)")
 	_ = createAzureConnectionCmd.RegisterFlagCompletionFunc("type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{
 			"federatedIdentityCredential\tUse workload identity federation (recommended)",

--- a/cmd/create_azure_test.go
+++ b/cmd/create_azure_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCreateAzureConnectionFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "missing --name and --type",
+			args:    []string{"create", "azure", "connection"},
+			wantErr: "required flag(s)",
+		},
+		{
+			name:    "missing --type",
+			args:    []string{"create", "azure", "connection", "--name", "my-conn"},
+			wantErr: "required flag(s)",
+		},
+		{
+			name:    "missing --name",
+			args:    []string{"create", "azure", "connection", "--type", "clientSecret"},
+			wantErr: "required flag(s)",
+		},
+		{
+			name:    "unsupported type",
+			args:    []string{"create", "azure", "connection", "--name", "my-conn", "--type", "unsupported"},
+			wantErr: "unsupported --type",
+		},
+		{
+			name: "--directoryId rejected for federatedIdentityCredential",
+			args: []string{"create", "azure", "connection",
+				"--name", "my-conn",
+				"--type", "federatedIdentityCredential",
+				"--directoryId", "some-id",
+			},
+			wantErr: "only supported for --type clientSecret",
+		},
+		{
+			name: "--applicationId rejected for federatedIdentityCredential",
+			args: []string{"create", "azure", "connection",
+				"--name", "my-conn",
+				"--type", "federatedIdentityCredential",
+				"--applicationId", "some-id",
+			},
+			wantErr: "only supported for --type clientSecret",
+		},
+		{
+			name: "--clientSecret rejected for federatedIdentityCredential",
+			args: []string{"create", "azure", "connection",
+				"--name", "my-conn",
+				"--type", "federatedIdentityCredential",
+				"--clientSecret", "some-secret",
+			},
+			wantErr: "only supported for --type clientSecret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			createAzureConnectionName = ""
+			createAzureConnectionType = ""
+			createAzureConnectionDirectoryID = ""
+			createAzureConnectionApplicationID = ""
+			createAzureConnectionClientSecret = ""
+
+			rootCmd.SetArgs(tt.args)
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestUpdateAzureConnectionFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "no credential flags",
+			args:    []string{"update", "azure", "connection", "--name", "my-conn"},
+			wantErr: "at least one of --directoryId, --applicationId, or --clientSecret is required",
+		},
+		{
+			name:    "no name and no id arg",
+			args:    []string{"update", "azure", "connection", "--clientSecret", "s"},
+			wantErr: "provide connection ID argument or --name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateAzureConnectionName = ""
+			updateAzureConnectionDirectoryID = ""
+			updateAzureConnectionApplicationID = ""
+			updateAzureConnectionClientSecret = ""
+
+			rootCmd.SetArgs(tt.args)
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}

--- a/cmd/update_azure.go
+++ b/cmd/update_azure.go
@@ -209,7 +209,7 @@ func init() {
 	updateAzureConnectionCmd.Flags().StringVar(&updateAzureConnectionApplicationID, "applicationId", "", "Application ID to set")
 	updateAzureConnectionCmd.Flags().StringVar(&updateAzureConnectionApplicationID, "applicationID", "", "Alias for --applicationId")
 	updateAzureConnectionCmd.Flags().StringVar(&updateAzureConnectionApplicationID, "aplicationID", "", "Compatibility alias for typo --aplicationID")
-	updateAzureConnectionCmd.Flags().StringVar(&updateAzureConnectionClientSecret, "clientSecret", "", "Client secret value (clientSecret type only); prefer passing via env var to keep out of shell history")
+	updateAzureConnectionCmd.Flags().StringVar(&updateAzureConnectionClientSecret, "clientSecret", "", "Client secret value (clientSecret type only); prefer passing via env var to keep out of shell history (note: expanded value can still be visible in process arguments)")
 
 	updateAzureMonitoringConfigCmd.Flags().StringVar(&updateAzureMonitoringConfigName, "name", "", "Monitoring config name/description (used when ID argument is not provided)")
 	updateAzureMonitoringConfigCmd.Flags().StringVar(&updateAzureMonitoringConfigLocationFiltering, "locationFiltering", "", "Comma-separated locations")

--- a/cmd/update_azure.go
+++ b/cmd/update_azure.go
@@ -45,6 +45,10 @@ Examples:
 			return fmt.Errorf("at least one of --directoryId, --applicationId, or --clientSecret is required")
 		}
 
+		if len(args) == 0 && updateAzureConnectionName == "" {
+			return fmt.Errorf("provide connection ID argument or --name")
+		}
+
 		_, c, err := SetupWithSafety(safety.OperationUpdate)
 		if err != nil {
 			return err
@@ -59,9 +63,6 @@ Examples:
 				return err
 			}
 		} else {
-			if updateAzureConnectionName == "" {
-				return fmt.Errorf("provide connection ID argument or --name")
-			}
 			existing, err = handler.FindByName(updateAzureConnectionName)
 			if err != nil {
 				return err
@@ -71,6 +72,9 @@ Examples:
 		value := existing.Value
 		switch value.Type {
 		case "federatedIdentityCredential":
+			if updateAzureConnectionClientSecret != "" {
+				return fmt.Errorf("--clientSecret is not applicable to connections of type federatedIdentityCredential")
+			}
 			if value.FederatedIdentityCredential == nil {
 				value.FederatedIdentityCredential = &azureconnection.FederatedIdentityCredential{}
 			}
@@ -92,6 +96,9 @@ Examples:
 			}
 			if updateAzureConnectionClientSecret != "" {
 				value.ClientSecret.ClientSecret = updateAzureConnectionClientSecret
+			} else {
+				// API may return a masked placeholder — don't PUT it back
+				value.ClientSecret.ClientSecret = ""
 			}
 		default:
 			return fmt.Errorf("unsupported azure connection type %q", value.Type)

--- a/cmd/update_azure.go
+++ b/cmd/update_azure.go
@@ -76,7 +76,9 @@ Examples:
 				return fmt.Errorf("--clientSecret is not applicable to connections of type federatedIdentityCredential")
 			}
 			if value.FederatedIdentityCredential == nil {
-				value.FederatedIdentityCredential = &azureconnection.FederatedIdentityCredential{}
+				value.FederatedIdentityCredential = &azureconnection.FederatedIdentityCredential{Consumers: []string{"SVC:com.dynatrace.da"}}
+			} else if len(value.FederatedIdentityCredential.Consumers) == 0 {
+				value.FederatedIdentityCredential.Consumers = []string{"SVC:com.dynatrace.da"}
 			}
 			if updateAzureConnectionDirectoryID != "" {
 				value.FederatedIdentityCredential.DirectoryID = updateAzureConnectionDirectoryID
@@ -86,7 +88,9 @@ Examples:
 			}
 		case "clientSecret":
 			if value.ClientSecret == nil {
-				value.ClientSecret = &azureconnection.ClientSecretCredential{}
+				value.ClientSecret = &azureconnection.ClientSecretCredential{Consumers: []string{"SVC:com.dynatrace.da"}}
+			} else if len(value.ClientSecret.Consumers) == 0 {
+				value.ClientSecret.Consumers = []string{"SVC:com.dynatrace.da"}
 			}
 			if updateAzureConnectionDirectoryID != "" {
 				value.ClientSecret.DirectoryID = updateAzureConnectionDirectoryID

--- a/cmd/update_azure.go
+++ b/cmd/update_azure.go
@@ -17,6 +17,7 @@ var (
 	updateAzureConnectionName          string
 	updateAzureConnectionDirectoryID   string
 	updateAzureConnectionApplicationID string
+	updateAzureConnectionClientSecret  string
 
 	updateAzureMonitoringConfigName              string
 	updateAzureMonitoringConfigLocationFiltering string
@@ -40,8 +41,8 @@ Examples:
   dtctl update azure connection <id> --directoryId "XYZ" --applicationId "ZUZ"`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if updateAzureConnectionDirectoryID == "" && updateAzureConnectionApplicationID == "" {
-			return fmt.Errorf("at least one of --directoryId or --applicationId is required")
+		if updateAzureConnectionDirectoryID == "" && updateAzureConnectionApplicationID == "" && updateAzureConnectionClientSecret == "" {
+			return fmt.Errorf("at least one of --directoryId, --applicationId, or --clientSecret is required")
 		}
 
 		_, c, err := SetupWithSafety(safety.OperationUpdate)
@@ -88,6 +89,9 @@ Examples:
 			}
 			if updateAzureConnectionApplicationID != "" {
 				value.ClientSecret.ApplicationID = updateAzureConnectionApplicationID
+			}
+			if updateAzureConnectionClientSecret != "" {
+				value.ClientSecret.ClientSecret = updateAzureConnectionClientSecret
 			}
 		default:
 			return fmt.Errorf("unsupported azure connection type %q", value.Type)
@@ -191,6 +195,7 @@ func init() {
 	updateAzureConnectionCmd.Flags().StringVar(&updateAzureConnectionApplicationID, "applicationId", "", "Application ID to set")
 	updateAzureConnectionCmd.Flags().StringVar(&updateAzureConnectionApplicationID, "applicationID", "", "Alias for --applicationId")
 	updateAzureConnectionCmd.Flags().StringVar(&updateAzureConnectionApplicationID, "aplicationID", "", "Compatibility alias for typo --aplicationID")
+	updateAzureConnectionCmd.Flags().StringVar(&updateAzureConnectionClientSecret, "clientSecret", "", "Client secret value (clientSecret type only); prefer passing via env var to keep out of shell history")
 
 	updateAzureMonitoringConfigCmd.Flags().StringVar(&updateAzureMonitoringConfigName, "name", "", "Monitoring config name/description (used when ID argument is not provided)")
 	updateAzureMonitoringConfigCmd.Flags().StringVar(&updateAzureMonitoringConfigLocationFiltering, "locationFiltering", "", "Comma-separated locations")

--- a/cmd/update_azure.go
+++ b/cmd/update_azure.go
@@ -88,6 +88,9 @@ Examples:
 			}
 		case "clientSecret":
 			if value.ClientSecret == nil {
+				if updateAzureConnectionDirectoryID == "" || updateAzureConnectionApplicationID == "" {
+					return fmt.Errorf("the API returned no clientSecret data for this connection; provide both --directoryId and --applicationId to initialize it")
+				}
 				value.ClientSecret = &azureconnection.ClientSecretCredential{Consumers: []string{"SVC:com.dynatrace.da"}}
 			} else if len(value.ClientSecret.Consumers) == 0 {
 				value.ClientSecret.Consumers = []string{"SVC:com.dynatrace.da"}

--- a/docs/site/_docs/cloud-integrations.md
+++ b/docs/site/_docs/cloud-integrations.md
@@ -103,8 +103,8 @@ SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 SUBSCRIPTION_NAME=$(az account show --query name -o tsv)
 TENANT_ID=$(az account show --query tenantId -o tsv)
 
-# Connection and service principal will share this name
-CONNECTION_NAME="dtctl-$SUBSCRIPTION_NAME"
+# Subscription names can contain spaces — normalise to dashes
+CONNECTION_NAME="dtctl-$(echo "$SUBSCRIPTION_NAME" | tr ' ' '-')"
 ```
 
 ### Option A: Federated Identity Credential (Recommended)
@@ -187,7 +187,7 @@ dtctl create azure connection \
 
 > **Security tip:** `$CLIENT_SECRET` is a shell variable captured in [Step 2](#step-2-create-the-service-principal-and-assign-reader-role-1) — it never touches bash history or disk.
 
-### Step 6: Create a Monitoring Configuration
+### Create a Monitoring Configuration
 
 ```bash
 dtctl create azure monitoring-config \
@@ -207,7 +207,7 @@ dtctl create azure monitoring-config \
 
 > **Note:** Monitoring configurations are created in a **disabled** state. Use `dtctl enable azure monitoring` in the next step to activate them.
 
-### Step 7: Enable the Monitoring Configuration
+### Enable the Monitoring Configuration
 
 ```bash
 dtctl enable azure monitoring --name "$CONNECTION_NAME"

--- a/docs/site/_docs/cloud-integrations.md
+++ b/docs/site/_docs/cloud-integrations.md
@@ -182,7 +182,7 @@ dtctl create azure connection \
   --clientSecret "$CLIENT_SECRET"
 ```
 
-> **Security tip:** `$CLIENT_SECRET` is a shell variable captured in [Step 2](#step-2-create-the-service-principal-and-assign-reader-role-1) — it never touches bash history or disk.
+> **Security tip:** `$CLIENT_SECRET` is a shell variable captured in Step 2 — it doesn’t touch bash history or disk, but the expanded value can still be visible in the `dtctl` process arguments while the command runs (avoid shared machines / process-argument logging).
 
 ### Create a Monitoring Configuration
 

--- a/docs/site/_docs/cloud-integrations.md
+++ b/docs/site/_docs/cloud-integrations.md
@@ -253,7 +253,7 @@ dtctl update azure connection \
 
 ```bash
 dtctl delete azure monitoring-config "$CONNECTION_NAME"
-dtctl delete azure connection --name "$CONNECTION_NAME"
+dtctl delete azure connection "$CONNECTION_NAME"
 ```
 
 ## GCP Monitoring (Preview)

--- a/docs/site/_docs/cloud-integrations.md
+++ b/docs/site/_docs/cloud-integrations.md
@@ -137,11 +137,7 @@ dtctl create azure connection \
 
 #### Step 4: Configure Federated Credential in Entra ID
 
-Get the issuer and subject values generated for your connection:
-
-```bash
-dtctl describe azure connection "$(dtctl get azure connection "$CONNECTION_NAME" -o json | jq -r '.objectId')"
-```
+`dtctl create azure connection` prints the **Issuer**, **Subject**, and **Audiences** values (and a ready-to-run `az` command) immediately after the connection is created — use those values to add the federated credential.
 
 In the Azure portal (Entra ID > App registrations > `$CONNECTION_NAME` > Certificates & secrets > Federated credentials), add a new credential using those values.
 

--- a/docs/site/_docs/cloud-integrations.md
+++ b/docs/site/_docs/cloud-integrations.md
@@ -139,7 +139,7 @@ dtctl create azure connection \
 Get the issuer and subject values generated for your connection:
 
 ```bash
-dtctl describe azure connection --name "$CONNECTION_NAME"
+dtctl describe azure connection "$(dtctl get azure connection "$CONNECTION_NAME" -o json | jq -r '.objectId')"
 ```
 
 In the Azure portal (Entra ID > App registrations > `$CONNECTION_NAME` > Certificates & secrets > Federated credentials), add a new credential using those values.

--- a/docs/site/_docs/cloud-integrations.md
+++ b/docs/site/_docs/cloud-integrations.md
@@ -87,80 +87,173 @@ dtctl delete aws connection my-aws-connection
 
 ## Azure Monitoring
 
-### Step 1: Create an Azure Connection
+dtctl supports two authentication types for Azure connections:
+
+- **`federatedIdentityCredential`** (recommended) — uses workload identity federation; no long-lived secrets to manage
+- **`clientSecret`** — uses a service principal with a client secret (password)
+
+### Step 1: Choose a Subscription and Name
+
+Pick the Azure subscription you want to monitor. The connection name is derived from it so multiple connections stay easy to tell apart:
 
 ```bash
-# Create a new Azure connection using federated identity credentials
+az account list --output table
+
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+SUBSCRIPTION_NAME=$(az account show --query name -o tsv)
+TENANT_ID=$(az account show --query tenantId -o tsv)
+
+# Connection and service principal will share this name
+CONNECTION_NAME="dtctl-$SUBSCRIPTION_NAME"
+```
+
+### Option A: Federated Identity Credential (Recommended)
+
+#### Step 2: Create the Service Principal and Assign Reader Role
+
+```bash
+CLIENT_ID=$(az ad sp create-for-rbac \
+  --name "$CONNECTION_NAME" \
+  --query appId -o tsv)
+
+az role assignment create \
+  --assignee "$CLIENT_ID" \
+  --role Reader \
+  --scope "/subscriptions/$SUBSCRIPTION_ID"
+```
+
+Repeat `az role assignment create` for each additional subscription.
+
+#### Step 3: Create the Dynatrace Connection
+
+The connection must be created first — its ID becomes the federated credential subject in the next step.
+
+```bash
 dtctl create azure connection \
-  --name "my-azure-connection" \
+  --name "$CONNECTION_NAME" \
   --type federatedIdentityCredential
 ```
 
-### Step 2: Create a Service Principal
+#### Step 4: Configure Federated Credential in Entra ID
 
-Use the Azure CLI to create the service principal that Dynatrace will use:
+Get the issuer and subject values generated for your connection:
 
 ```bash
-# Create a service principal in Azure AD
-az ad sp create-for-rbac --name "dynatrace-monitoring"
+dtctl describe azure connection --name "$CONNECTION_NAME"
 ```
 
-Note the `appId` and `tenant` from the output — you will need them in Step 5.
+In the Azure portal (Entra ID > App registrations > `$CONNECTION_NAME` > Certificates & secrets > Federated credentials), add a new credential using those values.
 
-### Step 3: Assign Reader Role
-
-Grant the service principal read access to the subscriptions you want to monitor:
+#### Step 5: Finalize the Connection
 
 ```bash
-az role assignment create \
-  --assignee <appId> \
-  --role Reader \
-  --scope /subscriptions/<subscription-id>
-```
-
-### Step 4: Create Federated Credential in Entra ID
-
-In the Azure portal (Entra ID > App registrations > your app > Certificates & secrets > Federated credentials), create a new federated credential using the issuer and subject values provided by `dtctl describe azure connection`.
-
-### Step 5: Finalize the Connection
-
-```bash
-# Update the connection with your Azure directory and application IDs
 dtctl update azure connection \
-  --name "my-azure-connection" \
-  --directoryId <tenant-id> \
-  --applicationId <app-id>
+  --name "$CONNECTION_NAME" \
+  --directoryId "$TENANT_ID" \
+  --applicationId "$CLIENT_ID"
 ```
+
+### Option B: Client Secret
+
+#### Step 2: Create the Service Principal and Assign Reader Role
+
+`az ad sp create-for-rbac` prints the client secret **once** — capture it immediately:
+
+```bash
+SP_OUTPUT=$(az ad sp create-for-rbac --name "$CONNECTION_NAME" -o json)
+CLIENT_ID=$(echo "$SP_OUTPUT" | jq -r .appId)
+CLIENT_SECRET=$(echo "$SP_OUTPUT" | jq -r .password)
+
+az role assignment create \
+  --assignee "$CLIENT_ID" \
+  --role Reader \
+  --scope "/subscriptions/$SUBSCRIPTION_ID"
+```
+
+Repeat `az role assignment create` for each additional subscription.
+
+#### Step 3: Create the Dynatrace Connection
+
+All credentials are available now — create the connection in one command:
+
+```bash
+dtctl create azure connection \
+  --name "$CONNECTION_NAME" \
+  --type clientSecret \
+  --directoryId "$TENANT_ID" \
+  --applicationId "$CLIENT_ID" \
+  --clientSecret "$CLIENT_SECRET"
+```
+
+> **Security tip:** `$CLIENT_SECRET` is a shell variable captured in [Step 2](#step-2-create-the-service-principal-and-assign-reader-role-1) — it never touches bash history or disk.
 
 ### Step 6: Create a Monitoring Configuration
 
 ```bash
-# Create a monitoring config linked to the connection (created in disabled state)
 dtctl create azure monitoring-config \
-  --connection "my-azure-connection"
+  --name "$CONNECTION_NAME" \
+  --credentials "$CONNECTION_NAME"
+```
+
+Optionally scope the monitoring to specific Azure regions or feature sets at creation time:
+
+```bash
+dtctl create azure monitoring-config \
+  --name "$CONNECTION_NAME" \
+  --credentials "$CONNECTION_NAME" \
+  --locationFiltering westeurope,northeurope \
+  --featureSets microsoft_compute.virtualmachines_essential,microsoft_storage.storageaccounts_essential
 ```
 
 > **Note:** Monitoring configurations are created in a **disabled** state. Use `dtctl enable azure monitoring` in the next step to activate them.
 
-### Step 7: Update Location Filtering and Feature Sets
+### Step 7: Enable the Monitoring Configuration
 
 ```bash
-# Update monitoring to filter by Azure region or configure feature sets
-dtctl update azure monitoring-config <config-id> \
-  --locations westeurope,northeurope \
-  --feature-sets compute,storage
-```
+dtctl enable azure monitoring --name "$CONNECTION_NAME"
 
-### Step 8: Enable the Monitoring Configuration
-
-```bash
-# Enable the monitoring config (optionally updating connection credentials at the same time)
-dtctl enable azure monitoring --name "my-azure-monitoring"
-
-# Or update directory/application IDs and enable in one step:
-dtctl enable azure monitoring --name "my-azure-monitoring" \
+# Option A only — if you need to update credentials and enable in one step:
+dtctl enable azure monitoring --name "$CONNECTION_NAME" \
   --directoryId "$TENANT_ID" \
   --applicationId "$CLIENT_ID"
+```
+
+## Azure Monitoring — Lifecycle Operations
+
+### Update Location Filtering and Feature Sets
+
+```bash
+dtctl update azure monitoring-config "$CONNECTION_NAME" \
+  --locationFiltering westeurope,northeurope \
+  --featureSets microsoft_compute.virtualmachines_essential,microsoft_storage.storageaccounts_essential
+```
+
+### Rotate an Expired Client Secret (clientSecret type)
+
+Use `--append` to add a new secret without immediately invalidating the old one — this gives you time to update dtctl before the old secret expires:
+
+```bash
+# Add a new secret alongside the existing one (old secret stays valid)
+NEW_SECRET=$(az ad app credential reset \
+  --id "$CLIENT_ID" \
+  --append \
+  --display-name "dtctl-$(date +%Y-%m-%d)" \
+  --query password -o tsv)
+
+# Update the connection with the new secret
+dtctl update azure connection \
+  --name "$CONNECTION_NAME" \
+  --clientSecret "$NEW_SECRET"
+
+# Once verified, remove the old secret from Azure portal or:
+# az ad app credential delete --id "$CLIENT_ID" --key-id <old-key-id>
+```
+
+### Delete
+
+```bash
+dtctl delete azure monitoring-config "$CONNECTION_NAME"
+dtctl delete azure connection --name "$CONNECTION_NAME"
 ```
 
 ## GCP Monitoring (Preview)

--- a/docs/site/_docs/cloud-integrations.md
+++ b/docs/site/_docs/cloud-integrations.md
@@ -114,6 +114,7 @@ CONNECTION_NAME="dtctl-$(echo "$SUBSCRIPTION_NAME" | tr ' ' '-')"
 ```bash
 CLIENT_ID=$(az ad sp create-for-rbac \
   --name "$CONNECTION_NAME" \
+  --create-password false \
   --query appId -o tsv)
 
 az role assignment create \


### PR DESCRIPTION
## feat(azure): clientSecret connection — one-command setup + secret rotation

### What changed

`dtctl create azure connection` and `dtctl update azure connection` now accept credential flags for `clientSecret` type:

- `--directoryId`, `--applicationId`, `--clientSecret` on **create** — full setup in one command, no YAML file needed
- `--clientSecret` on **update** — for secret rotation
- Passing these flags with `--type federatedIdentityCredential` returns a clear error

### Docs rewrite (`cloud-integrations.md` Azure section)

- Shared Step 1 captures subscription vars and derives `CONNECTION_NAME="dtctl-$SUBSCRIPTION_NAME"`
- Option A (federated) and Option B (clientSecret) flows with `$VAR`-based snippets, no `<placeholders>`
- Lifecycle section: zero-downtime secret rotation via `az ad app credential reset --append`

### Tests

Flag validation for both `create` and `update` commands (9 cases).
