### PR TITLE
fix: workflow pagination

### DIFF
--- a/sdk/api/workflow/workflow.go
+++ b/sdk/api/workflow/workflow.go
@@ -42,6 +42,7 @@ type Workflow struct {
 // WorkflowList represents a list of workflows.
 type WorkflowList struct {
 	Count   int        `json:"count"`
+	Next    *string    `json:"next"`
 	Results []Workflow `json:"results"`
 }
 
@@ -50,29 +51,48 @@ type WorkflowFilters struct {
 	Owner string // Filter by owner ID (user ID)
 }
 
-// List retrieves workflows with optional filters.
+// pageSize is the number of workflows requested per page.
+const pageSize = 100
+
+// List retrieves all workflows with optional filters, fetching all pages automatically.
 func (h *Handler) List(ctx context.Context, filters WorkflowFilters) (*WorkflowList, error) {
-	req := h.client.HTTP().R().SetContext(ctx)
+	var allWorkflows []Workflow
+	offset := 0
+	totalCount := 0
 
-	if filters.Owner != "" {
-		req.SetQueryParam("owner", filters.Owner)
+	for {
+		req := h.client.HTTP().R().SetContext(ctx).
+			SetQueryParam("limit", fmt.Sprintf("%d", pageSize)).
+			SetQueryParam("offset", fmt.Sprintf("%d", offset))
+
+		if filters.Owner != "" {
+			req.SetQueryParam("owner", filters.Owner)
+		}
+
+		resp, err := req.Get("/platform/automation/v1/workflows")
+		if err != nil {
+			return nil, fmt.Errorf("list workflows: %w", err)
+		}
+
+		if err := httpclient.CheckResponse(resp); err != nil {
+			return nil, fmt.Errorf("list workflows: %w", err)
+		}
+
+		var result WorkflowList
+		if err := json.Unmarshal(resp.Body(), &result); err != nil {
+			return nil, fmt.Errorf("list workflows: parse response: %w", err)
+		}
+
+		allWorkflows = append(allWorkflows, result.Results...)
+		totalCount = result.Count
+
+		if len(result.Results) == 0 || len(allWorkflows) >= totalCount {
+			break
+		}
+		offset += pageSize
 	}
 
-	resp, err := req.Get("/platform/automation/v1/workflows")
-	if err != nil {
-		return nil, fmt.Errorf("list workflows: %w", err)
-	}
-
-	if err := httpclient.CheckResponse(resp); err != nil {
-		return nil, fmt.Errorf("list workflows: %w", err)
-	}
-
-	var result WorkflowList
-	if err := json.Unmarshal(resp.Body(), &result); err != nil {
-		return nil, fmt.Errorf("list workflows: parse response: %w", err)
-	}
-
-	return &result, nil
+	return &WorkflowList{Count: totalCount, Results: allWorkflows}, nil
 }
 
 // Get retrieves a specific workflow.

--- a/sdk/api/workflow/workflow_test.go
+++ b/sdk/api/workflow/workflow_test.go
@@ -57,6 +57,53 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestList_Pagination(t *testing.T) {
+	// Simulate an API that reports count=2 but serves 1 result per page (no "next" field).
+	callCount := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		callCount++
+		offset := r.URL.Query().Get("offset")
+		w.Header().Set("Content-Type", "application/json")
+		if offset == "" || offset == "0" {
+			// First page: count=2 but only 1 result — no "next" field in response.
+			resp := WorkflowList{
+				Count:   2,
+				Results: []Workflow{{ID: "wf-1", Title: "Deploy", Owner: "user-1"}},
+			}
+			json.NewEncoder(w).Encode(resp)
+		} else {
+			resp := WorkflowList{
+				Count:   2,
+				Results: []Workflow{{ID: "wf-2", Title: "Remediation", Owner: "user-2"}},
+			}
+			json.NewEncoder(w).Encode(resp)
+		}
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.List(context.Background(), WorkflowFilters{})
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if result.Count != 2 {
+		t.Errorf("Count = %d, want 2", result.Count)
+	}
+	if len(result.Results) != 2 {
+		t.Errorf("got %d workflows, want 2", len(result.Results))
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 HTTP calls, got %d", callCount)
+	}
+	if result.Results[0].ID != "wf-1" || result.Results[1].ID != "wf-2" {
+		t.Errorf("unexpected results order: %v", result.Results)
+	}
+}
+
 func TestList_WithOwnerFilter(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/platform/automation/v1/workflows", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description

dtctl get workflows were silently capped at 100 results. The Automation API (/platform/automation/v1/workflows) uses offset-based pagination. Each response includes a count field with the total number of workflows, but only returns one page of results. The SDK List() function was making a single request with no pagination, so any environment with more than 100 workflows would get incomplete results.

This PR adds a pagination loop that advances through pages using limit/offset query parameters, stopping when the accumulated results reach the total count. The next field is also added to WorkflowList to match the full API response shape.

## Related Issues

none

## Testing

<!-- How did you test this? -->

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)

**Note:** `make lint` does not introduce new errors, but there are already some.
