### PR TITLE
fix(ci): bump Go toolchain to 1.26.4 to fix stdlib vulnerabilities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Get version info
         id: version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Check goimports formatting
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.26.3']
+        go: ['1.26.4']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Check for forbidden dependencies
         run: make sdk-check-deps

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.26.3']
+        go: ['1.26.4']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynatrace-oss/dtctl
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/adrg/xdg v0.5.3


### PR DESCRIPTION
## Summary

- Bumps Go toolchain from `1.26.3` to `1.26.4` in `go.mod` and all CI workflow files (`build`, `lint`, `release`, `sdk`, `security`, `test`)
- Fixes two Go standard library vulnerabilities detected by `govulncheck` that caused the Vulnerability Scan CI check to fail

## Vulnerabilities fixed

| ID | Description | Fixed in |
|---|---|---|
| GO-2025-3749 | `textproto.Reader.ReadMIMEHeader` — affects `pkg/auth/oauth_flow.go` | go1.26.4 |
| GO-2026-5037 | Inefficient candidate hostname parsing in `crypto/x509` — affects `pkg/commands/howto.go`, `pkg/output/table.go` | go1.26.4 |

## Test plan

- [ ] Vulnerability Scan CI check passes after merge
- [ ] All other CI jobs (build, lint, test) continue to pass