### PR TITLE
feat(workflow): workflow & execution list filtering, pagination, and --limit

### DIFF
--- a/cmd/describe_workflows.go
+++ b/cmd/describe_workflows.go
@@ -45,7 +45,7 @@ Examples:
 
 		// For table output, show detailed human-readable information
 		if outputFormat == "table" {
-			execList, err := execHandler.List(workflowID)
+			execList, err := execHandler.List(workflow.ExecutionFilters{WorkflowID: workflowID}, 10)
 			if err != nil {
 				execList = nil
 			}

--- a/cmd/describe_workflows_test.go
+++ b/cmd/describe_workflows_test.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
 )
 
@@ -328,5 +331,45 @@ func TestTriggerSummaryNilTrigger(t *testing.T) {
 	var trigger map[string]interface{}
 	if got := triggerSummary(trigger); got != "" {
 		t.Fatalf("triggerSummary(nil) = %q, want empty", got)
+	}
+}
+
+func TestDescribeWorkflowCmd_TableOutputFetchesExecutions(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/workflows/wf-describe-1": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"id": "wf-describe-1", "title": "Describe Me", "owner": "u1", "ownerType": "USER",
+				"type": "STANDARD", "isDeployed": true,
+			})
+		},
+		"/platform/automation/v1/executions": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"count": 0, "results": []any{}})
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origOutputFormat := outputFormat
+	origPlain := plainMode
+	defer func() {
+		cfgFile = origCfgFile
+		outputFormat = origOutputFormat
+		plainMode = origPlain
+	}()
+
+	cfgFile = configPath
+	outputFormat = "table"
+	plainMode = true
+
+	if err := describeWorkflowCmd.RunE(describeWorkflowCmd, []string{"wf-describe-1"}); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+	if ms.RequestCount != 2 {
+		t.Errorf("expected 2 requests (get workflow + list executions), got %d", ms.RequestCount)
 	}
 }

--- a/cmd/get_workflows.go
+++ b/cmd/get_workflows.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/prompt"
@@ -14,6 +18,23 @@ import (
 
 // workflowFilter holds the workflow ID filter for executions
 var workflowFilter string
+
+// minWorkflowChunkSize is the smallest allowed --chunk-size for workflow listing.
+// Smaller pages multiply the request count for no benefit and risk hammering the API.
+const minWorkflowChunkSize = 20
+
+// validateWorkflowChunkSize rejects tiny page sizes that fan a full listing out
+// into excessive API requests. 0 (single page) and >= minWorkflowChunkSize are allowed.
+func validateWorkflowChunkSize(chunk int64) error {
+	if chunk > 0 && chunk < minWorkflowChunkSize {
+		return fmt.Errorf("--chunk-size must be 0 or at least %d (got %d)", minWorkflowChunkSize, chunk)
+	}
+	return nil
+}
+
+// triggerTypeCaser normalizes trigger-type filter values to the API's title-case form
+// (e.g. "schedule" -> "Schedule").
+var triggerTypeCaser = cases.Title(language.Und)
 
 // getWorkflowsCmd retrieves workflows
 var getWorkflowsCmd = &cobra.Command{
@@ -61,8 +82,24 @@ Examples:
 
 		// List workflows with filters
 		mineOnly, _ := cmd.Flags().GetBool("mine")
+		filterStr, _ := cmd.Flags().GetString("filter")
+		typeStr, _ := cmd.Flags().GetString("type")
+		triggerStr, _ := cmd.Flags().GetString("trigger")
+		limit, _ := cmd.Flags().GetInt64("limit")
 
-		filters := workflow.WorkflowFilters{}
+		chunk := GetChunkSize()
+		if err := validateWorkflowChunkSize(chunk); err != nil {
+			return err
+		}
+
+		filters := workflow.WorkflowFilters{
+			Search:      filterStr,
+			TriggerType: triggerTypeCaser.String(strings.ToLower(triggerStr)),
+		}
+
+		if typeStr != "" {
+			filters.Type = strings.ToUpper(typeStr)
+		}
 
 		// If --mine flag is set, get current user ID and filter by owner
 		if mineOnly {
@@ -77,7 +114,7 @@ Examples:
 		watchMode, _ := cmd.Flags().GetBool("watch")
 		if watchMode {
 			fetcher := func() (interface{}, error) {
-				list, err := handler.List(filters)
+				list, err := handler.List(filters, chunk, limit)
 				if err != nil {
 					return nil, err
 				}
@@ -86,7 +123,7 @@ Examples:
 			return executeWithWatch(cmd, fetcher, printer)
 		}
 
-		list, err := handler.List(filters)
+		list, err := handler.List(filters, chunk, limit)
 		if err != nil {
 			return err
 		}
@@ -97,10 +134,16 @@ Examples:
 				"Run 'dtctl describe workflow <id>' for details",
 				"Run 'dtctl exec workflow <id>' to trigger a workflow",
 			}
-			// If count from API exceeds returned results, more data exists
+			// If count from API exceeds returned results, more data exists. The
+			// remedy depends on what capped the result: an explicit --limit, or
+			// single-page mode (--chunk-size 0).
 			if list.Count > len(list.Results) {
 				ap.SetHasMore(true)
-				suggestions = append(suggestions, "More results available. Use '--chunk-size 0' to retrieve all, or filter with DQL")
+				if limit > 0 {
+					suggestions = append(suggestions, fmt.Sprintf("Showing %d of %d. Raise --limit (currently %d) or set it to 0 for unlimited.", len(list.Results), list.Count, limit))
+				} else {
+					suggestions = append(suggestions, fmt.Sprintf("Showing %d of %d. Increase --chunk-size to page through all results.", len(list.Results), list.Count))
+				}
 			}
 			ap.SetSuggestions(suggestions)
 		}
@@ -154,18 +197,46 @@ Examples:
 			return printer.Print(exec)
 		}
 
-		// List executions (optionally filtered by workflow)
-		list, err := handler.List(workflowFilter)
+		// List executions (optionally filtered)
+		limit, _ := cmd.Flags().GetInt64("limit")
+		stateStr, _ := cmd.Flags().GetString("state")
+		triggerStr, _ := cmd.Flags().GetString("trigger")
+		sinceStr, _ := cmd.Flags().GetString("started-since")
+		untilStr, _ := cmd.Flags().GetString("started-until")
+
+		since, err := parseExecTime(sinceStr, false)
+		if err != nil {
+			return fmt.Errorf("invalid --started-since: %w", err)
+		}
+		until, err := parseExecTime(untilStr, true)
+		if err != nil {
+			return fmt.Errorf("invalid --started-until: %w", err)
+		}
+
+		list, err := handler.List(workflow.ExecutionFilters{
+			WorkflowID:   workflowFilter,
+			State:        strings.ToUpper(stateStr),
+			TriggerType:  triggerTypeCaser.String(strings.ToLower(triggerStr)),
+			StartedSince: since,
+			StartedUntil: until,
+		}, limit)
 		if err != nil {
 			return err
 		}
 
 		if ap != nil {
 			ap.SetTotal(len(list.Results))
-			ap.SetSuggestions([]string{
+			suggestions := []string{
 				"Run 'dtctl get workflow-executions <id>' for execution details",
 				"Run 'dtctl logs workflow-execution <id>' to view execution logs",
-			})
+			}
+			// Executions are limit-windowed (not fully paginated); flag when the
+			// server total exceeds what was returned so agents don't assume completeness.
+			if list.Count > len(list.Results) {
+				ap.SetHasMore(true)
+				suggestions = append(suggestions, fmt.Sprintf("Showing %d of %d. Raise --limit (currently %d) or narrow the window with --started-since/--state.", len(list.Results), list.Count, limit))
+			}
+			ap.SetSuggestions(suggestions)
 		}
 
 		return printer.PrintList(list.Results)
@@ -266,7 +337,44 @@ func init() {
 	addWatchFlags(getWorkflowsCmd)
 
 	getWorkflowExecutionsCmd.Flags().StringVarP(&workflowFilter, "workflow", "w", "", "Filter executions by workflow ID")
+	getWorkflowExecutionsCmd.Flags().Int64("limit", 100, "Maximum number of executions to return (max 1000)")
+	getWorkflowExecutionsCmd.Flags().String("state", "", "Filter by state: RUNNING, SUCCESS, ERROR, CANCELLED, UNKNOWN")
+	getWorkflowExecutionsCmd.Flags().String("trigger", "", "Filter by trigger type: Manual, Schedule, Event, Workflow")
+	getWorkflowExecutionsCmd.Flags().String("started-since", "", "Show executions started at or after this time (YYYY-MM-DD or ISO 8601)")
+	getWorkflowExecutionsCmd.Flags().String("started-until", "", "Show executions started at or before this time (YYYY-MM-DD = end of day 23:59:59, or ISO 8601)")
 	getWorkflowsCmd.Flags().Bool("mine", false, "Show only workflows owned by current user")
+	getWorkflowsCmd.Flags().String("filter", "", "Search workflows by title")
+	getWorkflowsCmd.Flags().String("type", "", "Filter by workflow type: standard or simple")
+	getWorkflowsCmd.Flags().String("trigger", "", "Filter by trigger type: Manual, Schedule, Event")
+	getWorkflowsCmd.Flags().Int64("limit", 0, "Maximum number of workflows to return (0 = unlimited)")
 
 	deleteWorkflowCmd.Flags().BoolVarP(&forceDelete, "yes", "y", false, "Skip confirmation prompt")
+}
+
+// parseExecTime parses a date string as YYYY-MM-DD or ISO 8601 and returns RFC3339.
+// When endOfDay is true and input is date-only, the time is set to 23:59:59.
+func parseExecTime(s string, endOfDay bool) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	// Common ISO 8601 date-time forms (with/without seconds, with/without zone).
+	for _, layout := range []string{
+		time.RFC3339,             // 2006-01-02T15:04:05Z07:00
+		"2006-01-02T15:04Z07:00", // seconds omitted, with zone
+		"2006-01-02T15:04:05",    // no zone (treated as UTC)
+		"2006-01-02T15:04",       // no seconds, no zone
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC().Format(time.RFC3339), nil
+		}
+	}
+	// Fall back to date-only
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return "", fmt.Errorf("use YYYY-MM-DD or ISO 8601 (e.g. 2006-01-02T15:04:05Z)")
+	}
+	if endOfDay {
+		t = t.Add(23*time.Hour + 59*time.Minute + 59*time.Second)
+	}
+	return t.UTC().Format(time.RFC3339), nil
 }

--- a/cmd/get_workflows_test.go
+++ b/cmd/get_workflows_test.go
@@ -1,0 +1,309 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
+)
+
+func TestGetWorkflowsCmd_ListWithFilters(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("search") != "deploy" {
+				t.Errorf("expected search=deploy, got %q", r.URL.Query().Get("search"))
+			}
+			if r.URL.Query().Get("type") != "STANDARD" {
+				t.Errorf("expected type=STANDARD, got %q", r.URL.Query().Get("type"))
+			}
+			if r.URL.Query().Get("triggerType") != "Schedule" {
+				t.Errorf("expected triggerType=Schedule, got %q", r.URL.Query().Get("triggerType"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"count": 1, "results": []any{
+				map[string]any{"id": "wf-1", "title": "Deploy", "owner": "u1", "ownerType": "USER"},
+			}})
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	origChunk := chunkSize
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+		chunkSize = origChunk
+	}()
+
+	cfgFile = configPath
+	plainMode = true
+	chunkSize = 500
+
+	testutil.ResetCommandFlags(getWorkflowsCmd)
+	_ = getWorkflowsCmd.Flags().Set("filter", "deploy")
+	_ = getWorkflowsCmd.Flags().Set("type", "standard")
+	_ = getWorkflowsCmd.Flags().Set("trigger", "schedule")
+
+	if err := getWorkflowsCmd.RunE(getWorkflowsCmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+}
+
+func TestGetWorkflowsCmd_InvalidChunkSize(t *testing.T) {
+	origCfgFile := cfgFile
+	origChunk := chunkSize
+	defer func() {
+		cfgFile = origCfgFile
+		chunkSize = origChunk
+	}()
+
+	cfgFile = "nonexistent-cfg"
+	chunkSize = 5 // below minimum of 20
+
+	// Need a valid config so Setup() doesn't fail before chunk validation.
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{})
+	defer ms.Close()
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+	cfgFile = configPath
+
+	testutil.ResetCommandFlags(getWorkflowsCmd)
+	err := getWorkflowsCmd.RunE(getWorkflowsCmd, nil)
+	if err == nil || err.Error() != "--chunk-size must be 0 or at least 20 (got 5)" {
+		t.Fatalf("expected chunk-size validation error, got %v", err)
+	}
+}
+
+func TestGetWorkflowsCmd_HasMoreWithLimit(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/workflows": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			// count > len(results) simulates server having more
+			json.NewEncoder(w).Encode(map[string]any{"count": 50, "results": []any{
+				map[string]any{"id": "wf-1", "title": "WF1", "owner": "u1", "ownerType": "USER"},
+			}})
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	origChunk := chunkSize
+	origAgent := agentMode
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+		chunkSize = origChunk
+		agentMode = origAgent
+	}()
+
+	cfgFile = configPath
+	plainMode = true
+	chunkSize = 0 // single-page mode: stop after first page
+	agentMode = true
+
+	testutil.ResetCommandFlags(getWorkflowsCmd)
+	_ = getWorkflowsCmd.Flags().Set("limit", "10")
+
+	if err := getWorkflowsCmd.RunE(getWorkflowsCmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+}
+
+func TestGetWorkflowExecutionsCmd_ListWithFilters(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/executions": func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("workflow") != "wf-abc" {
+				t.Errorf("expected workflow=wf-abc, got %q", r.URL.Query().Get("workflow"))
+			}
+			if r.URL.Query().Get("state") != "SUCCESS" {
+				t.Errorf("expected state=SUCCESS, got %q", r.URL.Query().Get("state"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"count": 1, "results": []any{
+				map[string]any{
+					"id": "exec-1", "workflow": "wf-abc", "state": "SUCCESS",
+					"startedAt": "2026-06-01T10:00:00Z", "runtime": 5,
+				},
+			}})
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	origFilter := workflowFilter
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+		workflowFilter = origFilter
+	}()
+
+	cfgFile = configPath
+	plainMode = true
+
+	testutil.ResetCommandFlags(getWorkflowExecutionsCmd)
+	_ = getWorkflowExecutionsCmd.Flags().Set("workflow", "wf-abc")
+	_ = getWorkflowExecutionsCmd.Flags().Set("state", "success")
+
+	if err := getWorkflowExecutionsCmd.RunE(getWorkflowExecutionsCmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+}
+
+func TestGetWorkflowExecutionsCmd_InvalidStartedSince(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+	}()
+
+	cfgFile = configPath
+	plainMode = true
+
+	testutil.ResetCommandFlags(getWorkflowExecutionsCmd)
+	_ = getWorkflowExecutionsCmd.Flags().Set("started-since", "not-a-date")
+
+	err := getWorkflowExecutionsCmd.RunE(getWorkflowExecutionsCmd, nil)
+	if err == nil || err.Error()[:len("invalid --started-since:")] != "invalid --started-since:" {
+		t.Fatalf("expected invalid --started-since error, got %v", err)
+	}
+}
+
+func TestGetWorkflowExecutionsCmd_InvalidStartedUntil(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+	}()
+
+	cfgFile = configPath
+	plainMode = true
+
+	testutil.ResetCommandFlags(getWorkflowExecutionsCmd)
+	_ = getWorkflowExecutionsCmd.Flags().Set("started-until", "bad-date")
+
+	err := getWorkflowExecutionsCmd.RunE(getWorkflowExecutionsCmd, nil)
+	if err == nil || err.Error()[:len("invalid --started-until:")] != "invalid --started-until:" {
+		t.Fatalf("expected invalid --started-until error, got %v", err)
+	}
+}
+
+func TestGetWorkflowExecutionsCmd_HasMore(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/automation/v1/executions": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"count": 200, "results": []any{
+				map[string]any{
+					"id": "exec-1", "workflow": "wf-1", "state": "SUCCESS",
+					"startedAt": "2026-06-01T10:00:00Z", "runtime": 5,
+				},
+			}})
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	origAgent := agentMode
+	origFilter := workflowFilter
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+		agentMode = origAgent
+		workflowFilter = origFilter
+	}()
+
+	cfgFile = configPath
+	plainMode = true
+	agentMode = true
+	workflowFilter = ""
+
+	testutil.ResetCommandFlags(getWorkflowExecutionsCmd)
+
+	if err := getWorkflowExecutionsCmd.RunE(getWorkflowExecutionsCmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+}
+
+func TestParseExecTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		endOfDay bool
+		want     string
+		wantErr  bool
+	}{
+		{name: "empty returns empty", in: "", want: ""},
+		{name: "RFC3339 passthrough (UTC)", in: "2026-06-10T15:04:05Z", want: "2026-06-10T15:04:05Z"},
+		{name: "RFC3339 with offset normalized to UTC", in: "2026-06-10T17:04:05+02:00", want: "2026-06-10T15:04:05Z"},
+		{name: "ISO 8601 without seconds, with zone", in: "2026-06-10T15:04Z", want: "2026-06-10T15:04:00Z"},
+		{name: "ISO 8601 without zone treated as UTC", in: "2026-06-10T15:04:05", want: "2026-06-10T15:04:05Z"},
+		{name: "date-only start of day", in: "2026-06-10", endOfDay: false, want: "2026-06-10T00:00:00Z"},
+		{name: "date-only end of day", in: "2026-06-10", endOfDay: true, want: "2026-06-10T23:59:59Z"},
+		{name: "invalid input errors", in: "notadate", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseExecTime(tt.in, tt.endOfDay)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseExecTime(%q, %v) error = %v, wantErr %v", tt.in, tt.endOfDay, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseExecTime(%q, %v) = %q, want %q", tt.in, tt.endOfDay, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateWorkflowChunkSize(t *testing.T) {
+	tests := []struct {
+		name    string
+		chunk   int64
+		wantErr bool
+	}{
+		{name: "zero is allowed (single page)", chunk: 0, wantErr: false},
+		{name: "below minimum rejected", chunk: 1, wantErr: true},
+		{name: "just below minimum rejected", chunk: 19, wantErr: true},
+		{name: "at minimum allowed", chunk: 20, wantErr: false},
+		{name: "default allowed", chunk: 500, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWorkflowChunkSize(tt.chunk)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateWorkflowChunkSize(%d) error = %v, wantErr %v", tt.chunk, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/output/golden_test.go
+++ b/pkg/output/golden_test.go
@@ -74,6 +74,8 @@ func assertGolden(t *testing.T, name string, actual string) {
 
 var fixedTime = time.Date(2025, 3, 15, 10, 30, 0, 0, time.UTC)
 
+// workflowFixtures mirrors a real `get workflows` (list) response, which the SDK
+// restricts to listFields (no tasks/input/result/guide — see sdk/api/workflow).
 func workflowFixtures() []workflow.Workflow {
 	return []workflow.Workflow{
 		{
@@ -91,17 +93,9 @@ func workflowFixtures() []workflow.Workflow {
 					"trigger": map[string]interface{}{"type": "cron", "cron": "0 9 * * 1-5"},
 				},
 			},
-			Result:               stringPtr("{{ result('deploy') }}"),
+			TriggerType:          "Schedule",
 			Type:                 "STANDARD",
-			Input:                map[string]interface{}{"environment": map[string]interface{}{"type": "string"}},
 			HourlyExecutionLimit: intPtr(1000),
-			Guide:                stringPtr("# Deploy to Production\n\nRun this workflow after validating the release candidate."),
-			Tasks: map[string]interface{}{
-				"deploy": map[string]interface{}{
-					"action": "dynatrace.automations:run-javascript",
-					"input":  map[string]interface{}{"script": "// deploy logic"},
-				},
-			},
 		},
 		{
 			ID:          "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
@@ -109,10 +103,10 @@ func workflowFixtures() []workflow.Workflow {
 			IsDeployed:  true,
 			Description: "Removes stale resources older than 30 days",
 			Type:        "STANDARD",
+			TriggerType: "Manual",
 			Owner:       "00000000-0000-0000-0000-000000000000",
 			OwnerType:   "USER",
 			Private:     false,
-			Tasks:       map[string]interface{}{},
 		},
 		{
 			ID:          "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
@@ -120,12 +114,28 @@ func workflowFixtures() []workflow.Workflow {
 			IsDeployed:  false,
 			Description: "",
 			Type:        "STANDARD",
+			TriggerType: "Event",
 			Owner:       "8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e",
 			OwnerType:   "USER",
 			Private:     true,
-			Tasks:       map[string]interface{}{},
 		},
 	}
+}
+
+// describeWorkflowFixture is the full single-workflow response returned by Get
+// (used by `describe workflow`), including tasks/input/result/guide.
+func describeWorkflowFixture() workflow.Workflow {
+	wf := workflowFixtures()[0]
+	wf.Result = stringPtr("{{ result('deploy') }}")
+	wf.Input = map[string]interface{}{"environment": map[string]interface{}{"type": "string"}}
+	wf.Guide = stringPtr("# Deploy to Production\n\nRun this workflow after validating the release candidate.")
+	wf.Tasks = map[string]interface{}{
+		"deploy": map[string]interface{}{
+			"action": "dynatrace.automations:run-javascript",
+			"input":  map[string]interface{}{"script": "// deploy logic"},
+		},
+	}
+	return wf
 }
 
 func sloFixtures() []slo.SLO {
@@ -1064,7 +1074,7 @@ func TestGolden_GetTaskResult(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestGolden_DescribeWorkflow(t *testing.T) {
-	wf := workflowFixtures()[0]
+	wf := describeWorkflowFixture()
 
 	formats := map[string]string{
 		"table": "table",

--- a/pkg/output/testdata/golden/describe/workflow-json.golden
+++ b/pkg/output/testdata/golden/describe/workflow-json.golden
@@ -16,6 +16,7 @@
       }
     }
   },
+  "triggerType": "Schedule",
   "result": "{{ result('deploy') }}",
   "type": "STANDARD",
   "input": {

--- a/pkg/output/testdata/golden/describe/workflow-table.golden
+++ b/pkg/output/testdata/golden/describe/workflow-table.golden
@@ -1,2 +1,2 @@
-ID                                     TITLE                  DEPLOYED   TYPE       
-a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true       STANDARD   
+ID                                     TITLE                  DEPLOYED   TRIGGER    TYPE       
+a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true       Schedule   STANDARD   

--- a/pkg/output/testdata/golden/describe/workflow-toon.golden
+++ b/pkg/output/testdata/golden/describe/workflow-toon.golden
@@ -23,4 +23,5 @@ trigger:
     trigger:
       cron: 0 9 * * 1-5
       type: cron
+triggerType: Schedule
 type: STANDARD

--- a/pkg/output/testdata/golden/describe/workflow-yaml.golden
+++ b/pkg/output/testdata/golden/describe/workflow-yaml.golden
@@ -12,6 +12,7 @@ trigger:
     trigger:
       cron: 0 9 * * 1-5
       type: cron
+triggerType: Schedule
 result: '{{ result(''deploy'') }}'
 type: STANDARD
 input:

--- a/pkg/output/testdata/golden/get/workflows-agent.golden
+++ b/pkg/output/testdata/golden/get/workflows-agent.golden
@@ -19,23 +19,9 @@
           }
         }
       },
-      "result": "{{ result('deploy') }}",
+      "triggerType": "Schedule",
       "type": "STANDARD",
-      "input": {
-        "environment": {
-          "type": "string"
-        }
-      },
-      "hourlyExecutionLimit": 1000,
-      "guide": "# Deploy to Production\n\nRun this workflow after validating the release candidate.",
-      "tasks": {
-        "deploy": {
-          "action": "dynatrace.automations:run-javascript",
-          "input": {
-            "script": "// deploy logic"
-          }
-        }
-      }
+      "hourlyExecutionLimit": 1000
     },
     {
       "id": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
@@ -45,8 +31,8 @@
       "owner": "00000000-0000-0000-0000-000000000000",
       "ownerType": "USER",
       "isPrivate": false,
-      "type": "STANDARD",
-      "tasks": {}
+      "triggerType": "Manual",
+      "type": "STANDARD"
     },
     {
       "id": "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
@@ -55,8 +41,8 @@
       "owner": "8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e",
       "ownerType": "USER",
       "isPrivate": true,
-      "type": "STANDARD",
-      "tasks": {}
+      "triggerType": "Event",
+      "type": "STANDARD"
     }
   ],
   "context": {

--- a/pkg/output/testdata/golden/get/workflows-csv.golden
+++ b/pkg/output/testdata/golden/get/workflows-csv.golden
@@ -1,4 +1,4 @@
-ID,TITLE,DEPLOYED,DESCRIPTION,TYPE
-a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d,Deploy to Production,true,Deploys latest build to prod environment,STANDARD
-b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e,Daily Cleanup,true,Removes stale resources older than 30 days,STANDARD
-c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f,Incident Response,false,,STANDARD
+ID,TITLE,DEPLOYED,DESCRIPTION,TRIGGER,TYPE
+a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d,Deploy to Production,true,Deploys latest build to prod environment,Schedule,STANDARD
+b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e,Daily Cleanup,true,Removes stale resources older than 30 days,Manual,STANDARD
+c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f,Incident Response,false,,Event,STANDARD

--- a/pkg/output/testdata/golden/get/workflows-json.golden
+++ b/pkg/output/testdata/golden/get/workflows-json.golden
@@ -17,23 +17,9 @@
         }
       }
     },
-    "result": "{{ result('deploy') }}",
+    "triggerType": "Schedule",
     "type": "STANDARD",
-    "input": {
-      "environment": {
-        "type": "string"
-      }
-    },
-    "hourlyExecutionLimit": 1000,
-    "guide": "# Deploy to Production\n\nRun this workflow after validating the release candidate.",
-    "tasks": {
-      "deploy": {
-        "action": "dynatrace.automations:run-javascript",
-        "input": {
-          "script": "// deploy logic"
-        }
-      }
-    }
+    "hourlyExecutionLimit": 1000
   },
   {
     "id": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
@@ -43,8 +29,8 @@
     "owner": "00000000-0000-0000-0000-000000000000",
     "ownerType": "USER",
     "isPrivate": false,
-    "type": "STANDARD",
-    "tasks": {}
+    "triggerType": "Manual",
+    "type": "STANDARD"
   },
   {
     "id": "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
@@ -53,7 +39,7 @@
     "owner": "8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e",
     "ownerType": "USER",
     "isPrivate": true,
-    "type": "STANDARD",
-    "tasks": {}
+    "triggerType": "Event",
+    "type": "STANDARD"
   }
 ]

--- a/pkg/output/testdata/golden/get/workflows-table.golden
+++ b/pkg/output/testdata/golden/get/workflows-table.golden
@@ -1,4 +1,4 @@
-ID                                     TITLE                  DEPLOYED   TYPE       
-a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true       STANDARD   
-b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup          true       STANDARD   
-c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response      false      STANDARD   
+ID                                     TITLE                  DEPLOYED   TRIGGER    TYPE       
+a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true       Schedule   STANDARD   
+b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup          true       Manual     STANDARD   
+c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response      false      Event      STANDARD   

--- a/pkg/output/testdata/golden/get/workflows-toon.golden
+++ b/pkg/output/testdata/golden/get/workflows-toon.golden
@@ -1,29 +1,20 @@
 [#3]:
   - actor: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
     description: Deploys latest build to prod environment
-    guide: "# Deploy to Production\n\nRun this workflow after validating the release candidate."
     hourlyExecutionLimit: 1000
     id: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
-    input:
-      environment:
-        type: string
     isDeployed: true
     isPrivate: false
     owner: 7a8b9c0d-1e2f-4a3b-8c4d-5e6f7a8b9c0d
     ownerType: USER
-    result: "{{ result('deploy') }}"
     schemaVersion: 4
-    tasks:
-      deploy:
-        action: "dynatrace.automations:run-javascript"
-        input:
-          script: // deploy logic
     title: Deploy to Production
     trigger:
       schedule:
         trigger:
           cron: 0 9 * * 1-5
           type: cron
+    triggerType: Schedule
     type: STANDARD
   - description: Removes stale resources older than 30 days
     id: b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e
@@ -31,14 +22,14 @@
     isPrivate: false
     owner: "00000000-0000-0000-0000-000000000000"
     ownerType: USER
-    tasks:
     title: Daily Cleanup
+    triggerType: Manual
     type: STANDARD
   - id: c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
     isDeployed: false
     isPrivate: true
     owner: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
     ownerType: USER
-    tasks:
     title: Incident Response
+    triggerType: Event
     type: STANDARD

--- a/pkg/output/testdata/golden/get/workflows-watch-changes.golden
+++ b/pkg/output/testdata/golden/get/workflows-watch-changes.golden
@@ -1,3 +1,3 @@
-+ a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true   STANDARD
-~ b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup   true   STANDARD
-- c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response   false   STANDARD
++ a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true   Schedule   STANDARD
+~ b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup   true   Manual   STANDARD
+- c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response   false   Event   STANDARD

--- a/pkg/output/testdata/golden/get/workflows-wide.golden
+++ b/pkg/output/testdata/golden/get/workflows-wide.golden
@@ -1,4 +1,4 @@
-ID                                     TITLE                  DEPLOYED   DESCRIPTION                                  TYPE       
-a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true       Deploys latest build to prod environment     STANDARD   
-b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup          true       Removes stale resources older than 30 days   STANDARD   
-c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response      false                                                   STANDARD   
+ID                                     TITLE                  DEPLOYED   DESCRIPTION                                  TRIGGER    TYPE       
+a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d   Deploy to Production   true       Deploys latest build to prod environment     Schedule   STANDARD   
+b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e   Daily Cleanup          true       Removes stale resources older than 30 days   Manual     STANDARD   
+c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f   Incident Response      false                                                   Event      STANDARD   

--- a/pkg/output/testdata/golden/get/workflows-yaml.golden
+++ b/pkg/output/testdata/golden/get/workflows-yaml.golden
@@ -12,21 +12,9 @@
       trigger:
         cron: 0 9 * * 1-5
         type: cron
-  result: '{{ result(''deploy'') }}'
+  triggerType: Schedule
   type: STANDARD
-  input:
-    environment:
-      type: string
   hourlyExecutionLimit: 1000
-  guide: |-
-    # Deploy to Production
-
-    Run this workflow after validating the release candidate.
-  tasks:
-    deploy:
-      action: dynatrace.automations:run-javascript
-      input:
-        script: // deploy logic
 - id: b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e
   title: Daily Cleanup
   isDeployed: true
@@ -34,13 +22,13 @@
   owner: 00000000-0000-0000-0000-000000000000
   ownerType: USER
   isPrivate: false
+  triggerType: Manual
   type: STANDARD
-  tasks: {}
 - id: c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
   title: Incident Response
   isDeployed: false
   owner: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
   ownerType: USER
   isPrivate: true
+  triggerType: Event
   type: STANDARD
-  tasks: {}

--- a/pkg/resources/resolver/resolver.go
+++ b/pkg/resources/resolver/resolver.go
@@ -106,7 +106,7 @@ func (r *Resolver) searchByName(resourceType ResourceType, name string) ([]Resou
 // searchWorkflows searches for workflows by name
 func (r *Resolver) searchWorkflows(name string) ([]Resource, error) {
 	handler := workflow.NewHandler(r.client)
-	list, err := handler.List(workflow.WorkflowFilters{})
+	list, err := handler.List(workflow.WorkflowFilters{}, 500, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resources/workflow/execution.go
+++ b/pkg/resources/workflow/execution.go
@@ -102,9 +102,12 @@ func NewExecutionHandler(c *client.Client) *ExecutionHandler {
 	}
 }
 
-// List retrieves all executions with optional workflow filter
-func (h *ExecutionHandler) List(workflowID string) (*ExecutionList, error) {
-	sdkResult, err := h.sdk.List(context.Background(), workflowID)
+// Re-export SDK type so callers don't need to import the SDK directly.
+type ExecutionFilters = sdkworkflow.ExecutionFilters
+
+// List retrieves executions with optional filters.
+func (h *ExecutionHandler) List(filters ExecutionFilters, limit int64) (*ExecutionList, error) {
+	sdkResult, err := h.sdk.List(context.Background(), filters, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resources/workflow/execution_test.go
+++ b/pkg/resources/workflow/execution_test.go
@@ -50,7 +50,7 @@ func TestExecutionList_Success(t *testing.T) {
 	h, cleanup := newExecTestHandler(t, mux)
 	defer cleanup()
 
-	result, err := h.List("")
+	result, err := h.List(ExecutionFilters{}, 0)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -71,7 +71,7 @@ func TestExecutionList_WithWorkflowFilter(t *testing.T) {
 	h, cleanup := newExecTestHandler(t, mux)
 	defer cleanup()
 
-	_, err := h.List("wf-abc")
+	_, err := h.List(ExecutionFilters{WorkflowID: "wf-abc"}, 0)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -85,7 +85,7 @@ func TestExecutionList_ServerError(t *testing.T) {
 	h, cleanup := newExecTestHandler(t, mux)
 	defer cleanup()
 
-	_, err := h.List("")
+	_, err := h.List(ExecutionFilters{}, 0)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/pkg/resources/workflow/triggertype_test.go
+++ b/pkg/resources/workflow/triggertype_test.go
@@ -1,0 +1,25 @@
+package workflow
+
+import "testing"
+
+func TestTriggerType(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]interface{}
+		want string
+	}{
+		{name: "nil trigger is Manual", in: nil, want: "Manual"},
+		{name: "empty trigger is Manual", in: map[string]interface{}{}, want: "Manual"},
+		{name: "schedule", in: map[string]interface{}{"schedule": map[string]interface{}{}}, want: "Schedule"},
+		{name: "eventTrigger", in: map[string]interface{}{"eventTrigger": map[string]interface{}{}}, want: "Event"},
+		{name: "unknown key is Manual", in: map[string]interface{}{"something": 1}, want: "Manual"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := triggerType(tt.in); got != tt.want {
+				t.Errorf("triggerType(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resources/workflow/workflow.go
+++ b/pkg/resources/workflow/workflow.go
@@ -23,12 +23,13 @@ type Workflow struct {
 	Private              bool                   `json:"isPrivate" yaml:"isPrivate" table:"-"`
 	SchemaVersion        int                    `json:"schemaVersion,omitempty" yaml:"schemaVersion,omitempty" table:"-"`
 	Trigger              map[string]interface{} `json:"trigger,omitempty" yaml:"trigger,omitempty" table:"-"`
+	TriggerType          string                 `json:"triggerType,omitempty" yaml:"triggerType,omitempty" table:"TRIGGER"`
 	Result               *string                `json:"result,omitempty" yaml:"result,omitempty" table:"-"`
 	Type                 string                 `json:"type,omitempty" yaml:"type,omitempty" table:"TYPE"`
 	Input                map[string]interface{} `json:"input,omitempty" yaml:"input,omitempty" table:"-"`
 	HourlyExecutionLimit *int                   `json:"hourlyExecutionLimit,omitempty" yaml:"hourlyExecutionLimit,omitempty" table:"-"`
 	Guide                *string                `json:"guide,omitempty" yaml:"guide,omitempty" table:"-"`
-	Tasks                map[string]interface{} `json:"tasks" yaml:"tasks" table:"-"`
+	Tasks                map[string]interface{} `json:"tasks,omitempty" yaml:"tasks,omitempty" table:"-"`
 }
 
 // WorkflowList represents a list of workflows.
@@ -50,6 +51,21 @@ type HistoryList struct {
 	Results []HistoryRecord `json:"results"`
 }
 
+// triggerType derives a human-readable trigger type from the trigger map.
+// Matches the UI logic: schedule → "Schedule", eventTrigger → "Event", else "Manual".
+func triggerType(t map[string]interface{}) string {
+	if t == nil {
+		return "Manual"
+	}
+	if _, ok := t["schedule"]; ok {
+		return "Schedule"
+	}
+	if _, ok := t["eventTrigger"]; ok {
+		return "Event"
+	}
+	return "Manual"
+}
+
 // fromSDKWorkflow converts an SDK Workflow to a CLI Workflow.
 func fromSDKWorkflow(s *sdkworkflow.Workflow) Workflow {
 	return Workflow{
@@ -63,6 +79,7 @@ func fromSDKWorkflow(s *sdkworkflow.Workflow) Workflow {
 		Private:              s.Private,
 		SchemaVersion:        s.SchemaVersion,
 		Trigger:              s.Trigger,
+		TriggerType:          triggerType(s.Trigger),
 		Result:               s.Result,
 		Type:                 s.Type,
 		Input:                s.Input,
@@ -94,9 +111,19 @@ func NewHandler(c *client.Client) *Handler {
 	}
 }
 
-// List retrieves workflows with optional filters
-func (h *Handler) List(filters WorkflowFilters) (*WorkflowList, error) {
-	sdkResult, err := h.sdk.List(context.Background(), filters)
+// listFields is the field projection used for workflow listing: it omits heavy
+// fields (tasks, input, result, guide) not shown in list output. This is a CLI
+// display concern, so it lives here rather than in the SDK.
+const listFields = "id,title,isDeployed,description,type,owner,ownerType,actor,isPrivate,schemaVersion,hourlyExecutionLimit,trigger"
+
+// List retrieves workflows with optional filters.
+// chunkSize controls page size (0 = first page only); limit caps total results (0 = unlimited).
+func (h *Handler) List(filters WorkflowFilters, chunkSize, limit int64) (*WorkflowList, error) {
+	// Callers may pass a custom projection; default to the lean list set.
+	if filters.Fields == "" {
+		filters.Fields = listFields
+	}
+	sdkResult, err := h.sdk.List(context.Background(), filters, chunkSize, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resources/workflow/workflow_test.go
+++ b/pkg/resources/workflow/workflow_test.go
@@ -13,6 +13,31 @@ func stringPtr(v string) *string { return &v }
 
 func intPtr(v int) *int { return &v }
 
+// TestHandler_List_DefaultFieldProjection verifies the CLI handler applies the
+// listFields projection (a display concern owned by this layer, not the SDK).
+func TestHandler_List_DefaultFieldProjection(t *testing.T) {
+	var gotFields string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotFields = r.URL.Query().Get("fields")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WorkflowList{Count: 0, Results: []Workflow{}})
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("client.NewForTesting() error = %v", err)
+	}
+	c.HTTP().SetRetryCount(0)
+
+	if _, err := NewHandler(c).List(WorkflowFilters{}, 0, 0); err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if gotFields != listFields {
+		t.Errorf("fields query param = %q, want %q", gotFields, listFields)
+	}
+}
+
 func TestHandler_List(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -88,7 +113,7 @@ func TestHandler_List(t *testing.T) {
 			c.HTTP().SetRetryCount(0)
 
 			handler := NewHandler(c)
-			list, err := handler.List(tt.filters)
+			list, err := handler.List(tt.filters, 0, 0)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("List() error = %v, wantErr %v", err, tt.wantErr)

--- a/sdk/api/workflow/execution.go
+++ b/sdk/api/workflow/execution.go
@@ -44,12 +44,53 @@ func NewExecutionHandler(c *httpclient.Client) *ExecutionHandler {
 	return &ExecutionHandler{client: c}
 }
 
-// List retrieves all executions with optional workflow filter.
-func (h *ExecutionHandler) List(ctx context.Context, workflowID string) (*ExecutionList, error) {
+// maxExecutionLimit caps how many executions can be requested in one call.
+// Executions can number in the thousands; unlike workflows (where --chunk-size
+// drives a full-scan loop), here we intentionally fetch only a window of
+// recent results. A hard cap prevents accidental backend overload.
+const maxExecutionLimit = 1000
+
+// ExecutionFilters contains filter options for listing executions.
+type ExecutionFilters struct {
+	WorkflowID string
+	// State filters by execution state: RUNNING, SUCCESS, ERROR, CANCELLED, UNKNOWN.
+	// NOTE: state=ERROR also returns CANCELLED results (server-side implementation detail).
+	State        string
+	TriggerType  string // Manual, Schedule, Event, Workflow
+	StartedSince string // RFC3339 lower bound for startedAt
+	StartedUntil string // RFC3339 upper bound for startedAt
+}
+
+// List retrieves executions with optional filters.
+// limit is a result cap, not a page size — there is no pagination loop.
+// Use --limit (not --chunk-size) because executions are time-series data:
+// callers want a recent window, not an exhaustive scan.
+func (h *ExecutionHandler) List(ctx context.Context, filters ExecutionFilters, limit int64) (*ExecutionList, error) {
+	if limit > maxExecutionLimit {
+		limit = maxExecutionLimit
+	}
+
 	req := h.client.HTTP().R().SetContext(ctx)
 
-	if workflowID != "" {
-		req.SetQueryParam("workflow", workflowID)
+	if filters.WorkflowID != "" {
+		req.SetQueryParam("workflow", filters.WorkflowID)
+	}
+	if filters.State != "" {
+		req.SetQueryParam("state", filters.State)
+	}
+	if filters.TriggerType != "" {
+		req.SetQueryParam("triggerType", filters.TriggerType)
+	}
+	if filters.StartedSince != "" {
+		req.SetQueryParam("startedAt__gte", filters.StartedSince)
+	}
+	if filters.StartedUntil != "" {
+		req.SetQueryParam("startedAt__lte", filters.StartedUntil)
+	}
+	// limit == 0 omits the param, so the server applies its default page size
+	// (100) — NOT unlimited. This differs from workflow List, where 0 = unlimited.
+	if limit > 0 {
+		req.SetQueryParam("limit", fmt.Sprintf("%d", limit))
 	}
 
 	resp, err := req.Get("/platform/automation/v1/executions")

--- a/sdk/api/workflow/execution_test.go
+++ b/sdk/api/workflow/execution_test.go
@@ -1,0 +1,113 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestExecutionList_Filters(t *testing.T) {
+	var got map[string]string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/executions", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		got = map[string]string{
+			"workflow":       q.Get("workflow"),
+			"state":          q.Get("state"),
+			"triggerType":    q.Get("triggerType"),
+			"startedAt__gte": q.Get("startedAt__gte"),
+			"startedAt__lte": q.Get("startedAt__lte"),
+			"limit":          q.Get("limit"),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ExecutionList{Count: 1, Results: []Execution{{ID: "e-1", State: "SUCCESS"}}})
+	})
+
+	h := NewExecutionHandler(newTestClient(t, mux))
+	_, err := h.List(context.Background(), ExecutionFilters{
+		WorkflowID:   "wf-1",
+		State:        "SUCCESS",
+		TriggerType:  "Schedule",
+		StartedSince: "2026-06-01T00:00:00Z",
+		StartedUntil: "2026-06-10T23:59:59Z",
+	}, 50)
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+
+	want := map[string]string{
+		"workflow":       "wf-1",
+		"state":          "SUCCESS",
+		"triggerType":    "Schedule",
+		"startedAt__gte": "2026-06-01T00:00:00Z",
+		"startedAt__lte": "2026-06-10T23:59:59Z",
+		"limit":          "50",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("query param %q = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestExecutionList_LimitCappedAtMax(t *testing.T) {
+	var gotLimit string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/executions", func(w http.ResponseWriter, r *http.Request) {
+		gotLimit = r.URL.Query().Get("limit")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ExecutionList{Count: 0, Results: []Execution{}})
+	})
+
+	h := NewExecutionHandler(newTestClient(t, mux))
+	if _, err := h.List(context.Background(), ExecutionFilters{}, 2000); err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if gotLimit != fmt.Sprint(maxExecutionLimit) {
+		t.Errorf("limit query param = %q, want %d (capped)", gotLimit, maxExecutionLimit)
+	}
+}
+
+func TestExecutionList_NoLimitWhenZero(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/executions", func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := r.URL.Query()["limit"]; ok {
+			t.Errorf("limit query param should be absent when limit is 0")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ExecutionList{Count: 0, Results: []Execution{}})
+	})
+
+	h := NewExecutionHandler(newTestClient(t, mux))
+	if _, err := h.List(context.Background(), ExecutionFilters{}, 0); err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+}
+
+func TestExecutionList_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/executions", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"error":{"message":"boom"}}`)
+	})
+
+	h := NewExecutionHandler(newTestClient(t, mux))
+	if _, err := h.List(context.Background(), ExecutionFilters{}, 10); err == nil {
+		t.Fatal("List() expected error for 500")
+	}
+}
+
+func TestExecutionList_ParseError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/executions", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{invalid-json`)
+	})
+
+	h := NewExecutionHandler(newTestClient(t, mux))
+	if _, err := h.List(context.Background(), ExecutionFilters{}, 10); err == nil {
+		t.Fatal("List() expected parse error")
+	}
+}

--- a/sdk/api/workflow/workflow.go
+++ b/sdk/api/workflow/workflow.go
@@ -47,32 +47,94 @@ type WorkflowList struct {
 
 // WorkflowFilters contains filter options for listing workflows.
 type WorkflowFilters struct {
-	Owner string // Filter by owner ID (user ID)
+	Owner       string // Filter by owner ID (user ID)
+	Search      string // Full-text search on title
+	Type        string // Workflow type: STANDARD or SIMPLE
+	TriggerType string // Trigger type: Manual, Schedule, Event, Workflow
+	Fields      string // Optional field projection (comma-separated); empty fetches full objects
 }
 
 // List retrieves workflows with optional filters.
-func (h *Handler) List(ctx context.Context, filters WorkflowFilters) (*WorkflowList, error) {
-	req := h.client.HTTP().R().SetContext(ctx)
+// chunkSize controls page size; 0 returns only the first page.
+// limit caps the total number of results; 0 means unlimited.
+func (h *Handler) List(ctx context.Context, filters WorkflowFilters, chunkSize, limit int64) (*WorkflowList, error) {
+	var all []Workflow
+	var totalCount int
+	offset := 0
 
-	if filters.Owner != "" {
-		req.SetQueryParam("owner", filters.Owner)
+	for {
+		// Per-request page size: chunkSize, narrowed to the remaining budget when a limit is set.
+		pageSize := chunkSize
+		if limit > 0 {
+			remaining := limit - int64(len(all))
+			if remaining <= 0 {
+				break
+			}
+			// chunkSize==0 (single-page mode) combined with a limit: use the limit
+			// as the page size so we fetch exactly N in one request, then break.
+			if pageSize == 0 || remaining < pageSize {
+				pageSize = remaining
+			}
+		}
+
+		req := h.client.HTTP().R().SetContext(ctx)
+
+		if filters.Fields != "" {
+			req.SetQueryParam("fields", filters.Fields)
+		}
+		if filters.Owner != "" {
+			req.SetQueryParam("owner", filters.Owner)
+		}
+		if filters.Search != "" {
+			req.SetQueryParam("search", filters.Search)
+		}
+		if filters.Type != "" {
+			req.SetQueryParam("type", filters.Type)
+		}
+		if filters.TriggerType != "" {
+			req.SetQueryParam("triggerType", filters.TriggerType)
+		}
+
+		if pageSize > 0 {
+			req.SetQueryParam("limit", fmt.Sprintf("%d", pageSize))
+			if offset > 0 {
+				req.SetQueryParam("offset", fmt.Sprintf("%d", offset))
+			}
+		}
+
+		resp, err := req.Get("/platform/automation/v1/workflows")
+		if err != nil {
+			return nil, fmt.Errorf("list workflows: %w", err)
+		}
+		if err := httpclient.CheckResponse(resp); err != nil {
+			return nil, fmt.Errorf("list workflows: %w", err)
+		}
+
+		var page WorkflowList
+		if err := json.Unmarshal(resp.Body(), &page); err != nil {
+			return nil, fmt.Errorf("list workflows: parse response: %w", err)
+		}
+
+		totalCount = page.Count
+		all = append(all, page.Results...)
+
+		if limit > 0 && int64(len(all)) >= limit {
+			break
+		}
+		// chunkSize == 0 means single-page mode (no pagination loop).
+		if chunkSize == 0 || len(all) >= totalCount || len(page.Results) == 0 {
+			break
+		}
+		offset += len(page.Results)
 	}
 
-	resp, err := req.Get("/platform/automation/v1/workflows")
-	if err != nil {
-		return nil, fmt.Errorf("list workflows: %w", err)
+	// Defensive: the loop already caps well-behaved servers, but a server that
+	// ignores the limit param could over-return — trim to the requested limit.
+	if limit > 0 && int64(len(all)) > limit {
+		all = all[:limit]
 	}
 
-	if err := httpclient.CheckResponse(resp); err != nil {
-		return nil, fmt.Errorf("list workflows: %w", err)
-	}
-
-	var result WorkflowList
-	if err := json.Unmarshal(resp.Body(), &result); err != nil {
-		return nil, fmt.Errorf("list workflows: parse response: %w", err)
-	}
-
-	return &result, nil
+	return &WorkflowList{Count: totalCount, Results: all}, nil
 }
 
 // Get retrieves a specific workflow.

--- a/sdk/api/workflow/workflow_test.go
+++ b/sdk/api/workflow/workflow_test.go
@@ -45,7 +45,7 @@ func TestList(t *testing.T) {
 	})
 
 	h := NewHandler(newTestClient(t, mux))
-	result, err := h.List(context.Background(), WorkflowFilters{})
+	result, err := h.List(context.Background(), WorkflowFilters{}, 0, 0)
 	if err != nil {
 		t.Fatalf("List() error: %v", err)
 	}
@@ -68,9 +68,23 @@ func TestList_WithOwnerFilter(t *testing.T) {
 	})
 
 	h := NewHandler(newTestClient(t, mux))
-	_, err := h.List(context.Background(), WorkflowFilters{Owner: "user-1"})
+	_, err := h.List(context.Background(), WorkflowFilters{Owner: "user-1"}, 0, 0)
 	if err != nil {
 		t.Fatalf("List() error: %v", err)
+	}
+}
+
+func TestList_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"error":{"message":"internal error"}}`)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.List(context.Background(), WorkflowFilters{}, 0, 0)
+	if err == nil {
+		t.Fatal("List() expected error for 500")
 	}
 }
 
@@ -82,9 +96,117 @@ func TestList_ParseError(t *testing.T) {
 	})
 
 	h := NewHandler(newTestClient(t, mux))
-	_, err := h.List(context.Background(), WorkflowFilters{})
+	_, err := h.List(context.Background(), WorkflowFilters{}, 0, 0)
 	if err == nil {
 		t.Fatal("List() expected parse error")
+	}
+}
+
+// newPagingMux returns a mock /workflows endpoint backed by `total` synthetic
+// workflows, honoring limit/offset like the real LimitOffsetPagination backend.
+// Unlike the real backend it has no default page size, so a request without a
+// limit returns all `total` rows in one response. It records every (limit,
+// offset) request pair into reqs.
+func newPagingMux(total int, reqs *[][2]string) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		*reqs = append(*reqs, [2]string{q.Get("limit"), q.Get("offset")})
+
+		offset := 0
+		if v := q.Get("offset"); v != "" {
+			fmt.Sscanf(v, "%d", &offset)
+		}
+		limit := total
+		if v := q.Get("limit"); v != "" {
+			fmt.Sscanf(v, "%d", &limit)
+		}
+
+		var results []Workflow
+		for i := offset; i < total && i < offset+limit; i++ {
+			results = append(results, Workflow{ID: fmt.Sprintf("wf-%d", i)})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(WorkflowList{Count: total, Results: results})
+	})
+	return mux
+}
+
+func TestList_Pagination(t *testing.T) {
+	tests := []struct {
+		name      string
+		total     int
+		chunkSize int64
+		limit     int64
+		wantLen   int
+		wantReqs  int // number of HTTP requests issued
+	}{
+		// Mock has no default page cap, so a no-limit single request returns all rows.
+		{name: "chunkSize 0: single request, server returns all", total: 25, chunkSize: 0, limit: 0, wantLen: 25, wantReqs: 1},
+		{name: "pages through all with chunkSize", total: 5, chunkSize: 2, limit: 0, wantLen: 5, wantReqs: 3},
+		{name: "chunkSize 0 with limit: requests exactly limit in one GET", total: 100, chunkSize: 0, limit: 10, wantLen: 10, wantReqs: 1},
+		{name: "limit caps and stops paging", total: 100, chunkSize: 2, limit: 5, wantLen: 5, wantReqs: 3},
+		{name: "limit larger than total", total: 3, chunkSize: 2, limit: 50, wantLen: 3, wantReqs: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reqs [][2]string
+			h := NewHandler(newTestClient(t, newPagingMux(tt.total, &reqs)))
+
+			result, err := h.List(context.Background(), WorkflowFilters{}, tt.chunkSize, tt.limit)
+			if err != nil {
+				t.Fatalf("List() error: %v", err)
+			}
+			if len(result.Results) != tt.wantLen {
+				t.Errorf("got %d results, want %d", len(result.Results), tt.wantLen)
+			}
+			if len(reqs) != tt.wantReqs {
+				t.Errorf("issued %d requests, want %d (reqs=%v)", len(reqs), tt.wantReqs, reqs)
+			}
+		})
+	}
+}
+
+func TestList_TruncatesOverReturn(t *testing.T) {
+	// Server ignores the limit param and returns more than requested; the client
+	// must still cap the result slice at the requested limit.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/automation/v1/workflows", func(w http.ResponseWriter, r *http.Request) {
+		results := make([]Workflow, 10)
+		for i := range results {
+			results[i] = Workflow{ID: fmt.Sprintf("wf-%d", i)}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(WorkflowList{Count: 10, Results: results})
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.List(context.Background(), WorkflowFilters{}, 0, 3)
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(result.Results) != 3 {
+		t.Errorf("got %d results, want 3 (truncated)", len(result.Results))
+	}
+}
+
+func TestList_LimitNarrowsLastPage(t *testing.T) {
+	// chunkSize 4, limit 5: first page requests limit=4, second page requests
+	// limit=1 (the remaining budget), not another full chunk.
+	var reqs [][2]string
+	h := NewHandler(newTestClient(t, newPagingMux(100, &reqs)))
+
+	result, err := h.List(context.Background(), WorkflowFilters{}, 4, 5)
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(result.Results) != 5 {
+		t.Fatalf("got %d results, want 5", len(result.Results))
+	}
+	want := [][2]string{{"4", ""}, {"1", "4"}}
+	if fmt.Sprint(reqs) != fmt.Sprint(want) {
+		t.Errorf("requests = %v, want %v", reqs, want)
 	}
 }
 

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -65,7 +65,7 @@ func TestWorkflowLifecycle(t *testing.T) {
 
 			// Step 3: List workflows (verify our workflow appears)
 			t.Log("Step 3: Listing workflows...")
-			list, err := handler.List(workflow.WorkflowFilters{})
+			list, err := handler.List(workflow.WorkflowFilters{}, 500, 0)
 			if err != nil {
 				t.Fatalf("Failed to list workflows: %v", err)
 			}


### PR DESCRIPTION
## TL;DR

Adds filtering, result limiting, and proper pagination to `dtctl get workflows` and `dtctl get workflow-executions`, plus a TRIGGER column. Introduces a per-resource `--limit` distinct from the global `--chunk-size`, with semantics matched to each resource: workflows are bounded resources (kubectl-style, `--limit 0` = unlimited), executions are effectively unbounded (`gh run list -L`-style, default 100 / hard cap 1000). Includes an anti-DoS floor on workflow `--chunk-size`, leaner list payloads, and corrected agent-mode guidance.

## Functional

Shown columns and filter options are closely aligned with the *Workflows* App.

**`get workflows`**
- Filters: `--filter` (title search), `--type standard|simple`, `--trigger Manual|Schedule|Event`, `--mine`.
- New **TRIGGER** column, derived from the trigger config (Schedule/Event/Manual), mirroring the UI.
- Full pagination via `--chunk-size` (page size); new `--limit` (default `0` = unlimited) caps total results. Combined, chunk-size is the page size and limit is the stop-after-N total.

**`get workflow-executions`**
- Filters: `-w/--workflow`, `--state`, `--trigger` (incl. `Workflow`), `--started-since`, `--started-until` (accept `YYYY-MM-DD` or ISO 8601; date-only `--started-until` → end of day; normalized to UTC).
- `--limit` (default 100, hard cap 1000) — executions are time-series, callers want a recent window, not a full scan. Single GET, no pagination loop.

**Correctness/UX fixes**
- Agent mode now sets `HasMore` for executions when the server total exceeds what was returned (previously silent truncation).
- Has-more guidance is cause-aware: suggests raising `--limit` when limit-capped, `--chunk-size` when in single-page mode (the old message always said `--chunk-size 0`, which does the opposite of "fetch all").
- Dropped `Workflow` from the workflows `--trigger` help (no-op server-side for workflows; valid only for executions).
- Trigger-type input is case-normalized (`schedule` → `Schedule`).

## Non-Functional

- **API protection (anti-DoS):** workflow listing rejects `--chunk-size` in `1..19`; `0` (single page) and `>= 20` allowed. Tiny pages fan a full listing into excessive requests for no benefit.
- **Bounded executions cost:** default 100 + hard cap 1000 prevents pulling millions of rows.
- **Leaner payloads:** list path requests only the fields it displays (`listFields` projection); `Tasks` gained `omitempty` so list output no longer emits `"tasks": null`.
- **Layering:** the field projection lives in the CLI layer, not the SDK (SDK `WorkflowFilters` exposes an optional `Fields`; empty = full objects) — honoring the repo's "no display logic in the SDK" rule.
- **Lint:** replaced deprecated `strings.Title` with the repo's `cases.Title` idiom.
- **Backward compatible:** `--chunk-size` default (500) and semantics unchanged; `--limit 0` preserves "fetch all" for workflows.

## QA

- **Unit + golden tests:** updated all call sites and golden files; list goldens trimmed to reflect the real `listFields` response while describe goldens keep full detail; added pagination/limit/cap tests and the `validateWorkflowChunkSize` / `parseExecTime` / `triggerType` tables.
- **Coverage:** deliberately raised coverage on the touched code — `parseExecTime` and `triggerType` 0→100%, the SDK execution `List` 0→~96% (it had **no** test file before), workflow `List` to ~88%. Remaining gaps are transport-error branches (network-failure simulation, low value).
- **`/code-review` passes:** ran the review skill in multiple passes.
- **Live smoke test:** exercised every flag read-only against a non-production dev environment — filtering, case-normalization, limit cap (incl. 2000→1000 clamp), combined `--limit`/`--chunk-size`, date bounds, and clean validation errors — all passing.
- All green: `go test ./...` (main + SDK), `go vet -tags integration`, `make lint-strict` / `lint-sdk` (0 issues), `make security-scan` (no vulnerabilities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
