### PR TITLE
fix: enforce live debugger filters

### DIFF
--- a/cmd/create_breakpoints.go
+++ b/cmd/create_breakpoints.go
@@ -68,6 +68,14 @@ Examples:
 			}
 		}
 
+		hasFilters, err := livedebugger.WorkspaceHasFilters(workspaceResp)
+		if err != nil {
+			return err
+		}
+		if !hasFilters {
+			return fmt.Errorf("no workspace filters configured; set filters first with:\n  dtctl update breakpoint --filters key:value\nthen retry creating the breakpoint")
+		}
+
 		createResp, err := handler.CreateBreakpoint(workspaceID, fileName, lineNumber)
 		if err != nil {
 			if verbose {

--- a/pkg/resources/livedebugger/types.go
+++ b/pkg/resources/livedebugger/types.go
@@ -35,6 +35,7 @@ var (
 	ExtractWorkspaceID    = sdkld.ExtractWorkspaceID
 	ExtractDeletedRuleIDs = sdkld.ExtractDeletedRuleIDs
 	ExtractRuleStatuses   = sdkld.ExtractRuleStatuses
+	WorkspaceHasFilters   = sdkld.WorkspaceHasFilters
 )
 
 // ExtractWorkspaceRules extracts breakpoint rules from a GraphQL response,

--- a/sdk/api/livedebugger/livedebugger_test.go
+++ b/sdk/api/livedebugger/livedebugger_test.go
@@ -201,3 +201,95 @@ func TestExecuteGraphQL(t *testing.T) {
 		}
 	})
 }
+
+func TestWorkspaceHasFilters(t *testing.T) {
+	workspaceResp := func(filterSets interface{}) map[string]interface{} {
+		ws := map[string]interface{}{"id": "ws-1"}
+		if filterSets != nil {
+			ws["filterSets"] = filterSets
+		}
+		return map[string]interface{}{
+			"data": map[string]interface{}{
+				"org": map[string]interface{}{
+					"getOrCreateUserWorkspaceV2": ws,
+				},
+			},
+		}
+	}
+
+	t.Run("no filterSets field", func(t *testing.T) {
+		got, err := WorkspaceHasFilters(workspaceResp(nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Fatal("expected false when filterSets is absent")
+		}
+	})
+
+	t.Run("empty filterSets slice", func(t *testing.T) {
+		got, err := WorkspaceHasFilters(workspaceResp([]interface{}{}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Fatal("expected false when filterSets is empty")
+		}
+	})
+
+	t.Run("filterSet with empty labels and filters", func(t *testing.T) {
+		got, err := WorkspaceHasFilters(workspaceResp([]interface{}{
+			map[string]interface{}{
+				"labels":  []interface{}{},
+				"filters": []interface{}{},
+			},
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Fatal("expected false when all labels/filters are empty")
+		}
+	})
+
+	t.Run("filterSet with label values", func(t *testing.T) {
+		got, err := WorkspaceHasFilters(workspaceResp([]interface{}{
+			map[string]interface{}{
+				"labels": []interface{}{
+					map[string]interface{}{"field": "k8s.container.name", "values": []interface{}{"my-service"}},
+				},
+				"filters": []interface{}{},
+			},
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got {
+			t.Fatal("expected true when labels have values")
+		}
+	})
+
+	t.Run("filterSet with filter values", func(t *testing.T) {
+		got, err := WorkspaceHasFilters(workspaceResp([]interface{}{
+			map[string]interface{}{
+				"labels": []interface{}{},
+				"filters": []interface{}{
+					map[string]interface{}{"field": "dt.entity.host", "values": []interface{}{"HOST-123"}},
+				},
+			},
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got {
+			t.Fatal("expected true when filters have values")
+		}
+	})
+
+	t.Run("invalid response", func(t *testing.T) {
+		_, err := WorkspaceHasFilters(map[string]interface{}{"bad": "response"})
+		if err != nil {
+			t.Fatalf("unexpected error on empty response (missing workspace id is not checked here): %v", err)
+		}
+	})
+}

--- a/sdk/api/livedebugger/types.go
+++ b/sdk/api/livedebugger/types.go
@@ -15,9 +15,20 @@ type GraphQLWorkspaceResponse struct {
 	} `json:"data"`
 }
 
+type FilterField struct {
+	Field  string   `json:"field"`
+	Values []string `json:"values"`
+}
+
+type FilterSet struct {
+	Labels  []FilterField `json:"labels"`
+	Filters []FilterField `json:"filters"`
+}
+
 type Workspace struct {
-	ID    string           `json:"id"`
-	Rules []BreakpointRule `json:"rules"`
+	ID         string           `json:"id"`
+	Rules      []BreakpointRule `json:"rules"`
+	FilterSets []FilterSet      `json:"filterSets"`
 }
 
 type BreakpointRule struct {
@@ -111,6 +122,29 @@ func ExtractRuleStatuses(resp map[string]interface{}) ([]RuleStatusNode, error) 
 		return nil, err
 	}
 	return decoded.Data.Org.RuleStatuses, nil
+}
+
+// WorkspaceHasFilters reports whether the getOrCreateUserWorkspaceV2 response
+// contains at least one filterSet with at least one label or filter with values.
+func WorkspaceHasFilters(resp map[string]interface{}) (bool, error) {
+	var decoded GraphQLWorkspaceResponse
+	if err := decodeGraphQLResponse(resp, &decoded); err != nil {
+		return false, err
+	}
+	ws := decoded.Data.Org.GetOrCreateWorkspace
+	for _, fs := range ws.FilterSets {
+		for _, lbl := range fs.Labels {
+			if len(lbl.Values) > 0 {
+				return true, nil
+			}
+		}
+		for _, f := range fs.Filters {
+			if len(f.Values) > 0 {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func ExtractDeletedRuleIDs(resp map[string]interface{}) ([]string, error) {


### PR DESCRIPTION
## Summary

- `dtctl create breakpoint` was silently creating rules that appeared `Active` but were never distributed to any OneAgent, because the workspace had no entity filters configured. The failure was invisible — no error, no warning.
- Added a pre-flight check: before creating a breakpoint, the workspace's `filterSets` are inspected. If no filters are configured, the command fails immediately with a clear error pointing the user to `dtctl update breakpoint --filters`.
- Extended the SDK `Workspace` type to decode `filterSets` from the `getOrCreateUserWorkspaceV2` GraphQL response, and added a `WorkspaceHasFilters` helper that is re-exported through the pkg layer.

Fixes #267 - https://github.com/dynatrace-oss/dtctl/issues/267

## Changes

- **`sdk/api/livedebugger/types.go`** — added `FilterField`, `FilterSet` types; extended `Workspace` with `FilterSets []FilterSet`; added `WorkspaceHasFilters(resp)` helper
- **`pkg/resources/livedebugger/types.go`** — re-exported `WorkspaceHasFilters` following existing pattern
- **`cmd/create_breakpoints.go`** — calls `WorkspaceHasFilters` after `GetOrCreateWorkspace`; returns an actionable error if filters are absent
- **`sdk/api/livedebugger/livedebugger_test.go`** — added `TestWorkspaceHasFilters` covering empty, absent, and populated filterSets

## Test plan

- [ ] `go test ./pkg/resources/livedebugger/... ./cmd/...` passes
- [ ] `cd sdk && go test ./api/livedebugger/...` passes
- [ ] Against a live environment with no workspace filters: `dtctl create breakpoint File.java:10` returns an error referencing `dtctl update breakpoint --filters`
- [ ] After running `dtctl update breakpoint --filters k8s.container.name:my-service`: `dtctl create breakpoint File.java:10` succeeds and the rule is distributed to agents
