### PR TITLE
feat/jq: add jq filter option

### DIFF
--- a/cmd/exec_copilot.go
+++ b/cmd/exec_copilot.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/copilot"
 )
 
@@ -150,14 +149,13 @@ Examples:
 		}
 
 		// Check output format
-		outputFmt, _ := cmd.Flags().GetString("output")
-		if outputFmt == "" || outputFmt == "table" {
+		if outputFormat == "" || outputFormat == "table" {
 			// Default: just print the DQL
 			fmt.Println(result.DQL)
 			return nil
 		}
 
-		printer := output.NewPrinter(outputFmt)
+		printer := NewPrinter()
 		return printer.Print(result)
 	},
 }
@@ -208,14 +206,13 @@ Examples:
 		}
 
 		// Check output format
-		outputFmt, _ := cmd.Flags().GetString("output")
-		if outputFmt == "" || outputFmt == "table" {
+		if outputFormat == "" || outputFormat == "table" {
 			// Default: print summary and explanation
 			fmt.Printf("Summary: %s\n\n%s\n", result.Summary, result.Explanation)
 			return nil
 		}
 
-		printer := output.NewPrinter(outputFmt)
+		printer := NewPrinter()
 		return printer.Print(result)
 	},
 }
@@ -266,13 +263,12 @@ Examples:
 		}
 
 		// Check output format
-		outputFmt, _ := cmd.Flags().GetString("output")
-		if outputFmt == "" || outputFmt == "table" {
-			printer := output.NewPrinter("table")
+		if outputFormat == "" || outputFormat == "table" {
+			printer := NewPrinter()
 			return printer.Print(result.Documents)
 		}
 
-		printer := output.NewPrinter(outputFmt)
+		printer := NewPrinter()
 		return printer.Print(result)
 	},
 }

--- a/cmd/exec_slos.go
+++ b/cmd/exec_slos.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/slo"
 )
 
@@ -58,15 +57,14 @@ Examples:
 			fmt.Printf("SLO Evaluation Complete\n")
 
 			// Check output format
-			outputFmt, _ := cmd.Flags().GetString("output")
-			if outputFmt == "" || outputFmt == "table" {
+			if outputFormat == "" || outputFormat == "table" {
 				// Print in table format
-				printer := output.NewPrinter("table")
+				printer := NewPrinter()
 				return printer.PrintList(evalResult.EvaluationResults)
 			}
 
 			// Print in requested format (json/yaml)
-			printer := output.NewPrinter(outputFmt)
+			printer := NewPrinter()
 			return printer.Print(evalResult)
 		}
 
@@ -108,15 +106,14 @@ Examples:
 					fmt.Printf("\nSLO Evaluation Complete\n")
 
 					// Check output format
-					outputFmt, _ := cmd.Flags().GetString("output")
-					if outputFmt == "" || outputFmt == "table" {
+					if outputFormat == "" || outputFormat == "table" {
 						// Print in table format
-						printer := output.NewPrinter("table")
+						printer := NewPrinter()
 						return printer.PrintList(result.EvaluationResults)
 					}
 
 					// Print in requested format (json/yaml)
-					printer := output.NewPrinter(outputFmt)
+					printer := NewPrinter()
 					return printer.Print(result)
 				}
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -336,6 +336,7 @@ Examples:
 
 		opts := exec.DQLExecuteOptions{
 			OutputFormat:                 outputFormat,
+			JQFilter:                     jqFilter,
 			Decode:                       decodeMode,
 			Width:                        width,
 			Height:                       height,
@@ -387,6 +388,9 @@ Examples:
 			}
 
 			printer := output.NewPrinterWithOpts(printerOpts)
+			if jqFilter != "" {
+				printer = output.NewJQPrinter(printer, jqFilter)
+			}
 			livePrinter := output.NewLivePrinterWithOpts(printer, interval, os.Stdout, printerOpts)
 
 			// Create data fetcher that re-executes the query

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -337,6 +337,7 @@ Examples:
 		opts := exec.DQLExecuteOptions{
 			OutputFormat:                 outputFormat,
 			JQFilter:                     jqFilter,
+			AgentMode:                    agentMode,
 			Decode:                       decodeMode,
 			Width:                        width,
 			Height:                       height,
@@ -386,6 +387,7 @@ Examples:
 				Width:      width,
 				Height:     height,
 				Fullscreen: fullscreen,
+				AgentMode:  agentMode,
 			}
 
 			printer := output.NewPrinterWithOpts(printerOpts)

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -382,15 +382,13 @@ Examples:
 			// Create printer options for live mode (needed for resize support)
 			printerOpts := output.PrinterOptions{
 				Format:     outputFormat,
+				JQFilter:   jqFilter,
 				Width:      width,
 				Height:     height,
 				Fullscreen: fullscreen,
 			}
 
 			printer := output.NewPrinterWithOpts(printerOpts)
-			if jqFilter != "" {
-				printer = output.NewJQPrinter(printer, jqFilter)
-			}
 			livePrinter := output.NewLivePrinterWithOpts(printer, interval, os.Stdout, printerOpts)
 
 			// Create data fetcher that re-executes the query

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -590,7 +590,8 @@ func NewPrinter() output.Printer {
 		Format:    outputFormat,
 		Writer:    os.Stdout,
 		PlainMode: plainMode,
-		JQFilter:  jqFilter,
+		JQFilter:  "jqFilter",
+		AgentMode: agentMode,
 	})
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -805,6 +805,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	rootCmd.PersistentFlags().StringVar(&contextName, "context", "", "use a specific context")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "output format: json|yaml|csv|toon|table|wide")
 	rootCmd.PersistentFlags().StringVar(&jqFilter, "jq", "", "jq filter expression for structured output (json|yaml|toon); non-structured formats are auto-promoted to json")
+	rootCmd.PersistentFlags().StringVar(&jqFilter, "jsonpath", "", "alias for --jq")
 	rootCmd.PersistentFlags().CountVarP(&verbosity, "verbose", "v", "verbose output (-v for details, -vv for full debug including auth headers)")
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "enable debug mode (full HTTP request/response logging, equivalent to -vv)")
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "print what would be done without doing it")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ var (
 	cfgFile      string
 	contextName  string
 	outputFormat string
+	jqFilter     string
 	verbosity    int
 	debugMode    bool // --debug flag (alias for -vv)
 	dryRun       bool
@@ -57,10 +58,27 @@ var rootCmd = &cobra.Command{
 	Short:         "Dynatrace platform CLI",
 	SilenceErrors: true,
 	SilenceUsage:  true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return validateGlobalFlags()
+	},
 	Long: `dtctl is a kubectl-inspired CLI tool for managing Dynatrace platform resources.
 
 It provides a consistent interface for interacting with workflows, documents,
 SLOs, queries, and other Dynatrace platform capabilities.`,
+}
+
+// validateGlobalFlags enforces cross-command constraints for root persistent flags.
+func validateGlobalFlags() error {
+	if jqFilter == "" {
+		return nil
+	}
+
+	switch outputFormat {
+	case "json", "yaml", "yml":
+		return nil
+	default:
+		return fmt.Errorf("--jq supports only json or yaml output; got %q (use -o json or -o yaml)", outputFormat)
+	}
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -558,6 +576,7 @@ func NewSafetyChecker(cfg *config.Config) (*safety.Checker, error) {
 
 // NewPrinter creates a new printer respecting agent and plain mode settings
 func NewPrinter() output.Printer {
+	var p output.Printer
 	if agentMode {
 		ctx := &output.ResponseContext{}
 		ap := output.NewAgentPrinter(os.Stdout, ctx)
@@ -568,9 +587,14 @@ func NewPrinter() output.Printer {
 		if outputFlag != nil && outputFlag.Changed {
 			ap.SetResultFormat(outputFormat)
 		}
-		return ap
+		p = ap
+	} else {
+		p = output.NewPrinterWithOptions(outputFormat, os.Stdout, plainMode)
 	}
-	return output.NewPrinterWithOptions(outputFormat, os.Stdout, plainMode)
+	if jqFilter != "" {
+		p = output.NewJQPrinter(p, jqFilter)
+	}
+	return p
 }
 
 // enrichAgent configures agent-mode metadata on the printer if agent mode is active.
@@ -645,6 +669,7 @@ var flagsTakingValues = map[string]bool{
 	"--config":     true,
 	"--context":    true,
 	"--output":     true,
+	"--jq":         true,
 	"--chunk-size": true,
 }
 
@@ -782,6 +807,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (searches .dtctl.yaml upward, then $XDG_CONFIG_HOME/dtctl/config)")
 	rootCmd.PersistentFlags().StringVar(&contextName, "context", "", "use a specific context")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "output format: json|yaml|csv|toon|table|wide")
+	rootCmd.PersistentFlags().StringVar(&jqFilter, "jq", "", "jq filter expression applied before rendering (works with all output formats)")
 	rootCmd.PersistentFlags().CountVarP(&verbosity, "verbose", "v", "verbose output (-v for details, -vv for full debug including auth headers)")
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "enable debug mode (full HTTP request/response logging, equivalent to -vv)")
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "print what would be done without doing it")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -590,7 +590,7 @@ func NewPrinter() output.Printer {
 		Format:    outputFormat,
 		Writer:    os.Stdout,
 		PlainMode: plainMode,
-		JQFilter:  "jqFilter",
+		JQFilter:  jqFilter,
 		AgentMode: agentMode,
 	})
 }
@@ -806,7 +806,6 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	rootCmd.PersistentFlags().StringVar(&contextName, "context", "", "use a specific context")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "output format: json|yaml|csv|toon|table|wide")
 	rootCmd.PersistentFlags().StringVar(&jqFilter, "jq", "", "jq filter expression for structured output (json|yaml|toon); non-structured formats are auto-promoted to json")
-	rootCmd.PersistentFlags().StringVar(&jqFilter, "jsonpath", "", "alias for --jq")
 	rootCmd.PersistentFlags().CountVarP(&verbosity, "verbose", "v", "verbose output (-v for details, -vv for full debug including auth headers)")
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "enable debug mode (full HTTP request/response logging, equivalent to -vv)")
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "print what would be done without doing it")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,12 +73,8 @@ func validateGlobalFlags() error {
 		return nil
 	}
 
-	switch outputFormat {
-	case "json", "yaml", "yml":
-		return nil
-	default:
-		return fmt.Errorf("--jq supports only json or yaml output; got %q (use -o json or -o yaml)", outputFormat)
-	}
+	outputFormat = output.NormalizeJQOutputFormat(outputFormat)
+	return nil
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -576,10 +572,10 @@ func NewSafetyChecker(cfg *config.Config) (*safety.Checker, error) {
 
 // NewPrinter creates a new printer respecting agent and plain mode settings
 func NewPrinter() output.Printer {
-	var p output.Printer
 	if agentMode {
 		ctx := &output.ResponseContext{}
 		ap := output.NewAgentPrinter(os.Stdout, ctx)
+		ap.SetJQFilter(jqFilter)
 		// If the user explicitly requested an output format via -o,
 		// use that format for the result field inside the agent envelope
 		// (e.g. -o toon for token-efficient encoding).
@@ -587,14 +583,15 @@ func NewPrinter() output.Printer {
 		if outputFlag != nil && outputFlag.Changed {
 			ap.SetResultFormat(outputFormat)
 		}
-		p = ap
-	} else {
-		p = output.NewPrinterWithOptions(outputFormat, os.Stdout, plainMode)
+		return ap
 	}
-	if jqFilter != "" {
-		p = output.NewJQPrinter(p, jqFilter)
-	}
-	return p
+
+	return output.NewPrinterWithOpts(output.PrinterOptions{
+		Format:    outputFormat,
+		Writer:    os.Stdout,
+		PlainMode: plainMode,
+		JQFilter:  jqFilter,
+	})
 }
 
 // enrichAgent configures agent-mode metadata on the printer if agent mode is active.
@@ -807,7 +804,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (searches .dtctl.yaml upward, then $XDG_CONFIG_HOME/dtctl/config)")
 	rootCmd.PersistentFlags().StringVar(&contextName, "context", "", "use a specific context")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "output format: json|yaml|csv|toon|table|wide")
-	rootCmd.PersistentFlags().StringVar(&jqFilter, "jq", "", "jq filter expression applied before rendering (works with all output formats)")
+	rootCmd.PersistentFlags().StringVar(&jqFilter, "jq", "", "jq filter expression for structured output (json|yaml|toon); non-structured formats are auto-promoted to json")
 	rootCmd.PersistentFlags().CountVarP(&verbosity, "verbose", "v", "verbose output (-v for details, -vv for full debug including auth headers)")
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "enable debug mode (full HTTP request/response logging, equivalent to -vv)")
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "print what would be done without doing it")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -38,6 +38,9 @@ func TestBuildSpanName(t *testing.T) {
 		{[]string{"-v", "get", "workflows"}, "dtctl get workflows"},
 		// Short flags that take values: -o json should skip "json".
 		{[]string{"-o", "json", "get", "workflows"}, "dtctl get workflows"},
+		// Long flags that take values: --jq should skip the filter expression.
+		{[]string{"--jq", ".name", "get", "workflows"}, "dtctl get workflows"},
+		{[]string{"--jq=.name", "get", "workflows"}, "dtctl get workflows"},
 		// Mixed short and long flags.
 		{[]string{"-v", "--context", "prod", "get", "workflows"}, "dtctl get workflows"},
 		// Extra positional args after verb+resource are not included.
@@ -1213,5 +1216,43 @@ func TestFlagsTakingValues_SyncGuard(t *testing.T) {
 		if !found {
 			t.Errorf("shortFlagsTakingValues contains %s but no PersistentFlag has that shorthand", short)
 		}
+	}
+}
+
+func TestValidateGlobalFlags_JQFormatConstraint(t *testing.T) {
+	origOutput := outputFormat
+	origJQ := jqFilter
+	defer func() {
+		outputFormat = origOutput
+		jqFilter = origJQ
+	}()
+
+	tests := []struct {
+		name        string
+		format      string
+		jq          string
+		expectError bool
+	}{
+		{name: "jq disabled allows table", format: "table", jq: "", expectError: false},
+		{name: "jq with json", format: "json", jq: ".records", expectError: false},
+		{name: "jq with yaml", format: "yaml", jq: ".records", expectError: false},
+		{name: "jq with yml", format: "yml", jq: ".records", expectError: false},
+		{name: "jq with table rejected", format: "table", jq: ".records", expectError: true},
+		{name: "jq with csv rejected", format: "csv", jq: ".records", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputFormat = tt.format
+			jqFilter = tt.jq
+
+			err := validateGlobalFlags()
+			if tt.expectError && err == nil {
+				t.Fatalf("expected error for format=%q jq=%q, got nil", tt.format, tt.jq)
+			}
+			if !tt.expectError && err != nil {
+				t.Fatalf("unexpected error for format=%q jq=%q: %v", tt.format, tt.jq, err)
+			}
+		})
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +18,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/suggest"
 )
@@ -1228,17 +1232,18 @@ func TestValidateGlobalFlags_JQFormatConstraint(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name        string
-		format      string
-		jq          string
-		expectError bool
+		name       string
+		format     string
+		jq         string
+		wantFormat string
 	}{
-		{name: "jq disabled allows table", format: "table", jq: "", expectError: false},
-		{name: "jq with json", format: "json", jq: ".records", expectError: false},
-		{name: "jq with yaml", format: "yaml", jq: ".records", expectError: false},
-		{name: "jq with yml", format: "yml", jq: ".records", expectError: false},
-		{name: "jq with table rejected", format: "table", jq: ".records", expectError: true},
-		{name: "jq with csv rejected", format: "csv", jq: ".records", expectError: true},
+		{name: "jq disabled keeps table", format: "table", jq: "", wantFormat: "table"},
+		{name: "jq with json", format: "json", jq: ".records", wantFormat: "json"},
+		{name: "jq with yaml", format: "yaml", jq: ".records", wantFormat: "yaml"},
+		{name: "jq with yml", format: "yml", jq: ".records", wantFormat: "yml"},
+		{name: "jq with toon", format: "toon", jq: ".records", wantFormat: "toon"},
+		{name: "jq with table promoted", format: "table", jq: ".records", wantFormat: "json"},
+		{name: "jq with csv promoted", format: "csv", jq: ".records", wantFormat: "json"},
 	}
 
 	for _, tt := range tests {
@@ -1247,12 +1252,136 @@ func TestValidateGlobalFlags_JQFormatConstraint(t *testing.T) {
 			jqFilter = tt.jq
 
 			err := validateGlobalFlags()
-			if tt.expectError && err == nil {
-				t.Fatalf("expected error for format=%q jq=%q, got nil", tt.format, tt.jq)
-			}
-			if !tt.expectError && err != nil {
+			if err != nil {
 				t.Fatalf("unexpected error for format=%q jq=%q: %v", tt.format, tt.jq, err)
 			}
+			if outputFormat != tt.wantFormat {
+				t.Fatalf("outputFormat = %q, want %q", outputFormat, tt.wantFormat)
+			}
 		})
+	}
+}
+
+func TestAgentJQ_KeepContextAndFilterResult(t *testing.T) {
+	origOutput := outputFormat
+	origJQ := jqFilter
+	origAgent := agentMode
+	origPlain := plainMode
+	defer func() {
+		outputFormat = origOutput
+		jqFilter = origJQ
+		agentMode = origAgent
+		plainMode = origPlain
+	}()
+
+	outputFormat = "json"
+	jqFilter = ".name"
+	agentMode = true
+	plainMode = true
+
+	var buf bytes.Buffer
+	withCapturedStdout(t, &buf, func() {
+		printer := NewPrinter()
+		ap := enrichAgent(printer, "get", "workflow")
+		if ap == nil {
+			t.Fatal("expected AgentPrinter from NewPrinter in agent mode")
+		}
+		if err := printer.Print(map[string]interface{}{"name": "alpha", "id": 42}); err != nil {
+			t.Fatalf("print failed: %v", err)
+		}
+	})
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal output: %v", err)
+	}
+
+	if ok, _ := resp["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true response, got: %v", resp)
+	}
+	if result, _ := resp["result"].(string); result != "alpha" {
+		t.Fatalf("expected jq-filtered result 'alpha', got: %#v", resp["result"])
+	}
+	ctx, _ := resp["context"].(map[string]interface{})
+	if ctx == nil {
+		t.Fatalf("expected context in response, got: %v", resp)
+	}
+	if verb, _ := ctx["verb"].(string); verb != "get" {
+		t.Fatalf("expected context.verb=get, got %q", verb)
+	}
+	if resource, _ := ctx["resource"].(string); resource != "workflow" {
+		t.Fatalf("expected context.resource=workflow, got %q", resource)
+	}
+}
+
+func TestAgentJQ_BadFilterYieldsErrorEnvelope(t *testing.T) {
+	origOutput := outputFormat
+	origJQ := jqFilter
+	origAgent := agentMode
+	origPlain := plainMode
+	defer func() {
+		outputFormat = origOutput
+		jqFilter = origJQ
+		agentMode = origAgent
+		plainMode = origPlain
+	}()
+
+	outputFormat = "json"
+	jqFilter = ".["
+	agentMode = true
+	plainMode = true
+
+	var buf bytes.Buffer
+	withCapturedStdout(t, &buf, func() {
+		printer := NewPrinter()
+		err := printer.Print(map[string]interface{}{"name": "alpha"})
+		if err == nil {
+			t.Fatal("expected invalid --jq filter error")
+		}
+		detail := errorToDetail(err)
+		if printErr := output.PrintError(os.Stdout, detail); printErr != nil {
+			t.Fatalf("failed to print error envelope: %v", printErr)
+		}
+	})
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal output: %v", err)
+	}
+
+	if ok, _ := resp["ok"].(bool); ok {
+		t.Fatalf("expected ok=false response, got: %v", resp)
+	}
+	errObj, _ := resp["error"].(map[string]interface{})
+	if errObj == nil {
+		t.Fatalf("expected error object in response, got: %v", resp)
+	}
+	if msg, _ := errObj["message"].(string); !strings.Contains(msg, "invalid --jq filter") {
+		t.Fatalf("expected jq error message, got: %q", msg)
+	}
+}
+
+func withCapturedStdout(t *testing.T, buf *bytes.Buffer, fn func()) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	os.Stdout = w
+
+	defer func() {
+		os.Stdout = oldStdout
+		_ = r.Close()
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close write pipe: %v", err)
+	}
+	if _, err := io.Copy(buf, r); err != nil {
+		t.Fatalf("failed to read captured stdout: %v", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/guptarohit/asciigraph v0.9.0
+	github.com/itchyny/gojq v0.12.17
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/sirupsen/logrus v1.9.4
@@ -44,7 +45,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/itchyny/gojq v0.12.17 // indirect
 	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,8 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/itchyny/gojq v0.12.17 // indirect
+	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,10 @@ github.com/guptarohit/asciigraph v0.9.0 h1:MvCSRRVkT2XvU1IO6n92o7l7zqx1DiFaoszOU
 github.com/guptarohit/asciigraph v0.9.0/go.mod h1:dYl5wwK4gNsnFf9Zp+l06rFiDZ5YtXM6x7SRWZ3KGag=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
+github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
+github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=
+github.com/itchyny/timefmt-go v0.1.6/go.mod h1:RRDZYC5s9ErkjQvTvvU7keJjxUYzIISJGxm9/mAERQg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -101,6 +101,7 @@ type DQLExecuteOptions struct {
 	// Output formatting options
 	OutputFormat string
 	JQFilter     string     // jq filter expression applied before rendering
+	AgentMode    bool       // Enable agent mode (e.g. for Dynatrace API)
 	Decode       DecodeMode // Snapshot payload decoding mode
 	Width        int        // Chart width (0 = default)
 	Height       int        // Chart height (0 = default)
@@ -404,6 +405,7 @@ func (e *DQLExecutor) printResults(result *DQLQueryResponse, opts DQLExecuteOpti
 	printer := output.NewPrinterWithOpts(output.PrinterOptions{
 		Format:     effectiveFormat,
 		JQFilter:   opts.JQFilter,
+		AgentMode:  opts.AgentMode,
 		Width:      opts.Width,
 		Height:     opts.Height,
 		Fullscreen: opts.Fullscreen,

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -100,6 +100,7 @@ const (
 type DQLExecuteOptions struct {
 	// Output formatting options
 	OutputFormat string
+	JQFilter     string     // jq filter expression applied before rendering
 	Decode       DecodeMode // Snapshot payload decoding mode
 	Width        int        // Chart width (0 = default)
 	Height       int        // Chart height (0 = default)
@@ -401,12 +402,15 @@ func (e *DQLExecutor) printResults(result *DQLQueryResponse, opts DQLExecuteOpti
 		Height:     opts.Height,
 		Fullscreen: opts.Fullscreen,
 	})
+	if opts.JQFilter != "" {
+		printer = output.NewJQPrinter(printer, opts.JQFilter)
+	}
 
 	switch opts.OutputFormat {
 	case "table", "wide":
 		var err error
 		if opts.OutputFormat == "table" {
-			err = e.printTable(records)
+			err = printer.PrintList(records)
 		} else {
 			if len(records) == 0 {
 				return nil

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -371,6 +371,11 @@ func (e *DQLExecutor) PrintNotifications(notifications []QueryNotification) {
 
 // printResults prints the query results with the given options
 func (e *DQLExecutor) printResults(result *DQLQueryResponse, opts DQLExecuteOptions) error {
+	effectiveFormat := opts.OutputFormat
+	if opts.JQFilter != "" {
+		effectiveFormat = output.NormalizeJQOutputFormat(effectiveFormat)
+	}
+
 	// Print any notifications/warnings first
 	if notifications := result.GetNotifications(); len(notifications) > 0 {
 		e.PrintNotifications(notifications)
@@ -384,7 +389,7 @@ func (e *DQLExecutor) printResults(result *DQLQueryResponse, opts DQLExecuteOpti
 		simplify := opts.Decode == DecodeSimplified
 		records = output.DecodeSnapshotRecords(records, simplify)
 
-		switch opts.OutputFormat {
+		switch effectiveFormat {
 		case "", "table", "wide", "csv":
 			records = output.SummarizeSnapshotForTable(records)
 		}
@@ -397,19 +402,17 @@ func (e *DQLExecutor) printResults(result *DQLQueryResponse, opts DQLExecuteOpti
 	}
 
 	printer := output.NewPrinterWithOpts(output.PrinterOptions{
-		Format:     opts.OutputFormat,
+		Format:     effectiveFormat,
+		JQFilter:   opts.JQFilter,
 		Width:      opts.Width,
 		Height:     opts.Height,
 		Fullscreen: opts.Fullscreen,
 	})
-	if opts.JQFilter != "" {
-		printer = output.NewJQPrinter(printer, opts.JQFilter)
-	}
 
-	switch opts.OutputFormat {
+	switch effectiveFormat {
 	case "table", "wide":
 		var err error
-		if opts.OutputFormat == "table" {
+		if effectiveFormat == "table" {
 			err = printer.PrintList(records)
 		} else {
 			if len(records) == 0 {
@@ -529,24 +532,4 @@ func (e *DQLExecutor) ExecuteFromFile(filename string, outputFormat string) erro
 	}
 
 	return e.Execute(string(data), outputFormat)
-}
-
-// printTable prints query results as a table
-func (e *DQLExecutor) printTable(records []map[string]interface{}) error {
-	if len(records) == 0 {
-		return nil
-	}
-
-	data, err := json.Marshal(records)
-	if err != nil {
-		return err
-	}
-
-	var results []map[string]interface{}
-	if err := json.Unmarshal(data, &results); err != nil {
-		return err
-	}
-
-	printer := output.NewPrinter("table")
-	return printer.PrintList(results)
 }

--- a/pkg/output/agent.go
+++ b/pkg/output/agent.go
@@ -74,6 +74,7 @@ type AgentPrinter struct {
 	writer       io.Writer
 	ctx          *ResponseContext
 	resultFormat string // "json" (default) or "toon"
+	jqFilter     string
 }
 
 // NewAgentPrinter creates an AgentPrinter that writes envelope-wrapped JSON to writer.
@@ -103,7 +104,12 @@ func (p *AgentPrinter) SetResultFormat(format string) {
 
 // Print writes a single result wrapped in the agent envelope.
 func (p *AgentPrinter) Print(data interface{}) error {
-	result, err := p.encodeResult(data)
+	transformed, err := ApplyJQ(p.jqFilter, data)
+	if err != nil {
+		return err
+	}
+
+	result, err := p.encodeResult(transformed)
 	if err != nil {
 		return err
 	}
@@ -155,6 +161,11 @@ func (p *AgentPrinter) addWarning(msg string) {
 // If Total has been set via SetTotal, it is included in the context.
 func (p *AgentPrinter) PrintList(data interface{}) error {
 	return p.Print(data)
+}
+
+// SetJQFilter applies a jq transform to the result before envelope encoding.
+func (p *AgentPrinter) SetJQFilter(filter string) {
+	p.jqFilter = filter
 }
 
 // SetTotal sets the total item count in the response context.

--- a/pkg/output/jq.go
+++ b/pkg/output/jq.go
@@ -1,0 +1,94 @@
+package output
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/itchyny/gojq"
+)
+
+// JQPrinter applies a jq filter before delegating rendering to the wrapped printer.
+// This allows --jq to work consistently across all output formats.
+type JQPrinter struct {
+	base   Printer
+	filter string
+}
+
+// NewJQPrinter wraps base with jq filtering. If filter is empty, base is returned unchanged.
+func NewJQPrinter(base Printer, filter string) Printer {
+	if filter == "" {
+		return base
+	}
+	return &JQPrinter{base: base, filter: filter}
+}
+
+// Print applies the jq filter and renders the result.
+func (p *JQPrinter) Print(obj interface{}) error {
+	filtered, err := applyJQ(p.filter, obj)
+	if err != nil {
+		return err
+	}
+	return printAuto(p.base, filtered)
+}
+
+// PrintList applies the jq filter and renders the result.
+func (p *JQPrinter) PrintList(obj interface{}) error {
+	filtered, err := applyJQ(p.filter, obj)
+	if err != nil {
+		return err
+	}
+	return printAuto(p.base, filtered)
+}
+
+func printAuto(p Printer, data interface{}) error {
+	if isSliceLike(data) {
+		return p.PrintList(data)
+	}
+	return p.Print(data)
+}
+
+func isSliceLike(v interface{}) bool {
+	if v == nil {
+		return false
+	}
+	rv := reflect.ValueOf(v)
+	return rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array
+}
+
+func applyJQ(filter string, input interface{}) (interface{}, error) {
+	query, err := gojq.Parse(filter)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --jq filter: %w", err)
+	}
+	code, err := gojq.Compile(query)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --jq filter: %w", err)
+	}
+
+	generic, err := toGeneric(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply --jq filter: %w", err)
+	}
+
+	iter := code.Run(generic)
+	results := make([]interface{}, 0, 1)
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if runErr, ok := v.(error); ok {
+			return nil, fmt.Errorf("failed to apply --jq filter: %w", runErr)
+		}
+		results = append(results, v)
+	}
+
+	switch len(results) {
+	case 0:
+		return nil, nil
+	case 1:
+		return results[0], nil
+	default:
+		return results, nil
+	}
+}

--- a/pkg/output/jq.go
+++ b/pkg/output/jq.go
@@ -2,60 +2,36 @@ package output
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/itchyny/gojq"
 )
 
-// JQPrinter applies a jq filter before delegating rendering to the wrapped printer.
-// This allows --jq to work consistently across all output formats.
-type JQPrinter struct {
-	base   Printer
-	filter string
-}
-
-// NewJQPrinter wraps base with jq filtering. If filter is empty, base is returned unchanged.
-func NewJQPrinter(base Printer, filter string) Printer {
-	if filter == "" {
-		return base
-	}
-	return &JQPrinter{base: base, filter: filter}
-}
-
-// Print applies the jq filter and renders the result.
-func (p *JQPrinter) Print(obj interface{}) error {
-	filtered, err := applyJQ(p.filter, obj)
-	if err != nil {
-		return err
-	}
-	return printAuto(p.base, filtered)
-}
-
-// PrintList applies the jq filter and renders the result.
-func (p *JQPrinter) PrintList(obj interface{}) error {
-	filtered, err := applyJQ(p.filter, obj)
-	if err != nil {
-		return err
-	}
-	return printAuto(p.base, filtered)
-}
-
-func printAuto(p Printer, data interface{}) error {
-	if isSliceLike(data) {
-		return p.PrintList(data)
-	}
-	return p.Print(data)
-}
-
-func isSliceLike(v interface{}) bool {
-	if v == nil {
+// IsStructuredOutputFormat reports whether a format can represent arbitrary
+// JSON values emitted by jq.
+func IsStructuredOutputFormat(format string) bool {
+	switch format {
+	case "json", "yaml", "yml", "toon":
+		return true
+	default:
 		return false
 	}
-	rv := reflect.ValueOf(v)
-	return rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array
 }
 
-func applyJQ(filter string, input interface{}) (interface{}, error) {
+// NormalizeJQOutputFormat promotes non-structured formats to json when --jq is used.
+func NormalizeJQOutputFormat(format string) string {
+	if IsStructuredOutputFormat(format) {
+		return format
+	}
+	return "json"
+}
+
+// ApplyJQ transforms input using the provided jq filter.
+// If filter is empty, input is returned unchanged.
+func ApplyJQ(filter string, input interface{}) (interface{}, error) {
+	if filter == "" {
+		return input, nil
+	}
+
 	query, err := gojq.Parse(filter)
 	if err != nil {
 		return nil, fmt.Errorf("invalid --jq filter: %w", err)

--- a/pkg/output/jq_test.go
+++ b/pkg/output/jq_test.go
@@ -1,0 +1,62 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestJQPrinter_JsonFormat(t *testing.T) {
+	var buf bytes.Buffer
+	base := NewPrinterWithWriter("json", &buf)
+	p := NewJQPrinter(base, ".name")
+
+	in := map[string]interface{}{"name": "alpha", "id": 42}
+	if err := p.Print(in); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "alpha") {
+		t.Fatalf("expected filtered value in output, got: %s", out)
+	}
+	if strings.Contains(out, "id") {
+		t.Fatalf("expected id field to be filtered out, got: %s", out)
+	}
+}
+
+func TestJQPrinter_TableFormat(t *testing.T) {
+	var buf bytes.Buffer
+	base := NewPrinterWithWriter("table", &buf)
+	p := NewJQPrinter(base, ".[] | {name: .name}")
+
+	in := []map[string]interface{}{
+		{"name": "alpha", "id": "1"},
+		{"name": "beta", "id": "2"},
+	}
+	if err := p.PrintList(in); err != nil {
+		t.Fatalf("PrintList failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "NAME") {
+		t.Fatalf("expected NAME header in table output, got: %s", out)
+	}
+	if strings.Contains(out, "ID") {
+		t.Fatalf("expected ID column to be filtered out, got: %s", out)
+	}
+}
+
+func TestJQPrinter_InvalidFilter(t *testing.T) {
+	var buf bytes.Buffer
+	base := NewPrinterWithWriter("json", &buf)
+	p := NewJQPrinter(base, ".[")
+
+	err := p.Print(map[string]interface{}{"name": "alpha"})
+	if err == nil {
+		t.Fatal("expected invalid jq filter error")
+	}
+	if !strings.Contains(err.Error(), "invalid --jq filter") {
+		t.Fatalf("expected invalid filter error, got: %v", err)
+	}
+}

--- a/pkg/output/jq_test.go
+++ b/pkg/output/jq_test.go
@@ -1,62 +1,72 @@
 package output
 
 import (
-	"bytes"
+	"reflect"
 	"strings"
 	"testing"
 )
 
-func TestJQPrinter_JsonFormat(t *testing.T) {
-	var buf bytes.Buffer
-	base := NewPrinterWithWriter("json", &buf)
-	p := NewJQPrinter(base, ".name")
-
+func TestApplyJQ_SingleResult(t *testing.T) {
 	in := map[string]interface{}{"name": "alpha", "id": 42}
-	if err := p.Print(in); err != nil {
-		t.Fatalf("Print failed: %v", err)
+	out, err := ApplyJQ(".name", in)
+	if err != nil {
+		t.Fatalf("ApplyJQ failed: %v", err)
 	}
 
-	out := buf.String()
-	if !strings.Contains(out, "alpha") {
-		t.Fatalf("expected filtered value in output, got: %s", out)
-	}
-	if strings.Contains(out, "id") {
-		t.Fatalf("expected id field to be filtered out, got: %s", out)
+	if out != "alpha" {
+		t.Fatalf("expected filtered value 'alpha', got: %#v", out)
 	}
 }
 
-func TestJQPrinter_TableFormat(t *testing.T) {
-	var buf bytes.Buffer
-	base := NewPrinterWithWriter("table", &buf)
-	p := NewJQPrinter(base, ".[] | {name: .name}")
-
+func TestApplyJQ_MultiResult(t *testing.T) {
 	in := []map[string]interface{}{
 		{"name": "alpha", "id": "1"},
 		{"name": "beta", "id": "2"},
 	}
-	if err := p.PrintList(in); err != nil {
-		t.Fatalf("PrintList failed: %v", err)
+	out, err := ApplyJQ(".[] | {name: .name}", in)
+	if err != nil {
+		t.Fatalf("ApplyJQ failed: %v", err)
 	}
 
-	out := buf.String()
-	if !strings.Contains(out, "NAME") {
-		t.Fatalf("expected NAME header in table output, got: %s", out)
+	want := []interface{}{
+		map[string]interface{}{"name": "alpha"},
+		map[string]interface{}{"name": "beta"},
 	}
-	if strings.Contains(out, "ID") {
-		t.Fatalf("expected ID column to be filtered out, got: %s", out)
+	if !reflect.DeepEqual(out, want) {
+		t.Fatalf("unexpected result:\nwant: %#v\ngot:  %#v", want, out)
 	}
 }
 
-func TestJQPrinter_InvalidFilter(t *testing.T) {
-	var buf bytes.Buffer
-	base := NewPrinterWithWriter("json", &buf)
-	p := NewJQPrinter(base, ".[")
-
-	err := p.Print(map[string]interface{}{"name": "alpha"})
+func TestApplyJQ_InvalidFilter(t *testing.T) {
+	errInput := map[string]interface{}{"name": "alpha"}
+	_, err := ApplyJQ(".[", errInput)
 	if err == nil {
 		t.Fatal("expected invalid jq filter error")
 	}
 	if !strings.Contains(err.Error(), "invalid --jq filter") {
 		t.Fatalf("expected invalid filter error, got: %v", err)
+	}
+}
+
+func TestNormalizeJQOutputFormat(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "json", want: "json"},
+		{in: "yaml", want: "yaml"},
+		{in: "yml", want: "yml"},
+		{in: "toon", want: "toon"},
+		{in: "table", want: "json"},
+		{in: "csv", want: "json"},
+		{in: "", want: "json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := NormalizeJQOutputFormat(tt.in); got != tt.want {
+				t.Fatalf("NormalizeJQOutputFormat(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/output/printer.go
+++ b/pkg/output/printer.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 
@@ -19,6 +20,7 @@ type PrinterOptions struct {
 	Format     string
 	Writer     io.Writer
 	PlainMode  bool
+	AgentMode  bool
 	JQFilter   string
 	Width      int  // Chart width (0 = default)
 	Height     int  // Chart height (0 = default)
@@ -67,15 +69,25 @@ func NewPrinterWithOpts(opts PrinterOptions) Printer {
 		width, height = GetFullscreenDimensions()
 	}
 
+	effectiveJQFilter := opts.JQFilter
+	if effectiveJQFilter != "" && opts.AgentMode {
+		// In agent mode we have to print the metadata as well
+		// The jq filter is transformed in a way that it returns the result as {"result": <filtered>, "metadata": .metadata}
+		effectiveJQFilter = fmt.Sprintf(
+			`. as $root | {result: ([$root | %s] | if length == 0 then null elif length == 1 then .[0] else . end), metadata: $root.metadata}`,
+			effectiveJQFilter,
+		)
+	}
+
 	switch format {
 	case "json":
-		return &JSONPrinter{writer: writer, jqFilter: opts.JQFilter}
+		return &JSONPrinter{writer: writer, jqFilter: effectiveJQFilter}
 	case "yaml", "yml":
-		return &YAMLPrinter{writer: writer, jqFilter: opts.JQFilter}
+		return &YAMLPrinter{writer: writer, jqFilter: effectiveJQFilter}
 	case "csv":
 		return &CSVPrinter{writer: writer}
 	case "toon":
-		return &ToonPrinter{writer: writer, jqFilter: opts.JQFilter}
+		return &ToonPrinter{writer: writer, jqFilter: effectiveJQFilter}
 	case "chart":
 		if width > 0 || height > 0 {
 			return NewChartPrinterWithSize(writer, width, height)

--- a/pkg/output/printer.go
+++ b/pkg/output/printer.go
@@ -19,6 +19,7 @@ type PrinterOptions struct {
 	Format     string
 	Writer     io.Writer
 	PlainMode  bool
+	JQFilter   string
 	Width      int  // Chart width (0 = default)
 	Height     int  // Chart height (0 = default)
 	Fullscreen bool // Use terminal dimensions
@@ -68,13 +69,13 @@ func NewPrinterWithOpts(opts PrinterOptions) Printer {
 
 	switch format {
 	case "json":
-		return &JSONPrinter{writer: writer}
+		return &JSONPrinter{writer: writer, jqFilter: opts.JQFilter}
 	case "yaml", "yml":
-		return &YAMLPrinter{writer: writer}
+		return &YAMLPrinter{writer: writer, jqFilter: opts.JQFilter}
 	case "csv":
 		return &CSVPrinter{writer: writer}
 	case "toon":
-		return &ToonPrinter{writer: writer}
+		return &ToonPrinter{writer: writer, jqFilter: opts.JQFilter}
 	case "chart":
 		if width > 0 || height > 0 {
 			return NewChartPrinterWithSize(writer, width, height)
@@ -113,14 +114,20 @@ func NewPrinterWithOpts(opts PrinterOptions) Printer {
 
 // JSONPrinter prints output as JSON
 type JSONPrinter struct {
-	writer io.Writer
+	writer   io.Writer
+	jqFilter string
 }
 
 // Print prints a single object as JSON
 func (p *JSONPrinter) Print(obj interface{}) error {
+	transformed, err := ApplyJQ(p.jqFilter, obj)
+	if err != nil {
+		return err
+	}
+
 	encoder := json.NewEncoder(p.writer)
 	encoder.SetIndent("", "  ")
-	return encoder.Encode(obj)
+	return encoder.Encode(transformed)
 }
 
 // PrintList prints a list of objects as JSON
@@ -130,14 +137,20 @@ func (p *JSONPrinter) PrintList(obj interface{}) error {
 
 // YAMLPrinter prints output as YAML
 type YAMLPrinter struct {
-	writer io.Writer
+	writer   io.Writer
+	jqFilter string
 }
 
 // Print prints a single object as YAML
 func (p *YAMLPrinter) Print(obj interface{}) error {
+	transformed, err := ApplyJQ(p.jqFilter, obj)
+	if err != nil {
+		return err
+	}
+
 	encoder := yaml.NewEncoder(p.writer)
 	encoder.SetIndent(2)
-	return encoder.Encode(obj)
+	return encoder.Encode(transformed)
 }
 
 // PrintList prints a list of objects as YAML

--- a/pkg/output/toon.go
+++ b/pkg/output/toon.go
@@ -14,7 +14,8 @@ import (
 // round-trips through encoding/json to obtain a map[string]any representation
 // that preserves the json field names, then passes it to toon.Marshal.
 type ToonPrinter struct {
-	writer io.Writer
+	writer   io.Writer
+	jqFilter string
 }
 
 // Print prints a single object as TOON.
@@ -29,7 +30,12 @@ func (p *ToonPrinter) PrintList(obj interface{}) error {
 
 // marshal converts obj to a json-tag-aware representation and encodes it as TOON.
 func (p *ToonPrinter) marshal(obj interface{}) error {
-	generic, err := toGeneric(obj)
+	transformed, err := ApplyJQ(p.jqFilter, obj)
+	if err != nil {
+		return err
+	}
+
+	generic, err := toGeneric(transformed)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Adding a `--jq` option for format `json` and `yaml` which will work like this:

```shell
dtctl query 'fetch logs | sort timestamp desc | limit 100' -o yaml --jq '.records[].timestamp'
```

Following the same principle of [`qwctl`](https://www.cwcloud.tech/docs/tutorials/observability/qwctl?_highlight=qwctl#search-logs) (allowing us to have a self-sufficiant cli for our troubleshooting agents).

## Related Issues

Closes #272 

## Testing

<!-- How did you test this? -->

- [ ] Tests pass (`make test`)
- [ ] Linting passes (`make lint`)
