### PR TITLE
fix: detect Kiro via the env vars it actually sets

### DIFF
--- a/sdk/agentmode/detect.go
+++ b/sdk/agentmode/detect.go
@@ -23,9 +23,19 @@ var knownAgents = map[string]string{
 	"AMAZON_Q":       "amazon-q",
 	"JUNIE":          "junie",
 	"KIRO":           "kiro",
-	"OPENCODE":       "opencode",
-	"OPENCLAW":       "openclaw",
-	"AI_AGENT":       "generic-ai",
+	// Kiro does not set a KIRO env var; the entry above is kept only as a
+	// manual override. Kiro signals an active agent session via
+	// AGENT_CONTEXT_OUT, a per-invocation FIFO path (Kiro's documented ACP
+	// side-channel, exported only in interactive sessions), and via
+	// KIRO_SESSION_ID, which is set in both interactive and --no-interactive
+	// modes (verified on kiro-cli 2.6.1). Detecting on AGENT_CONTEXT_OUT alone
+	// would miss headless/scripted Kiro, so key on both.
+	// https://kiro.dev/docs/cli/reference/built-in-tools/#side-channels-for-wrapper-scripts
+	"AGENT_CONTEXT_OUT": "kiro",
+	"KIRO_SESSION_ID":   "kiro",
+	"OPENCODE":          "opencode",
+	"OPENCLAW":          "openclaw",
+	"AI_AGENT":          "generic-ai",
 }
 
 // Detect checks environment variables to identify if running under an AI agent.

--- a/sdk/agentmode/detect_test.go
+++ b/sdk/agentmode/detect_test.go
@@ -61,3 +61,33 @@ func TestUserAgentSuffix_WithAgent(t *testing.T) {
 		t.Errorf("got %q", s)
 	}
 }
+
+// TestDetect_Kiro covers the env vars Kiro actually sets. Kiro does not set a
+// KIRO variable; it signals an active agent session via AGENT_CONTEXT_OUT (a
+// per-invocation FIFO path, exported only in interactive sessions) and
+// KIRO_SESSION_ID (set in both interactive and --no-interactive modes).
+func TestDetect_Kiro(t *testing.T) {
+	cases := []struct {
+		name   string
+		envVar string
+		value  string
+	}{
+		{"AGENT_CONTEXT_OUT (interactive ACP side-channel)", "AGENT_CONTEXT_OUT", "/tmp/agent-context-out-1234-tooluse_abc.fifo"},
+		{"KIRO_SESSION_ID (interactive and headless)", "KIRO_SESSION_ID", "2f6fabda-849b-4aeb-8eae-e2b5905106aa"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for envVar := range knownAgents {
+				os.Unsetenv(envVar)
+			}
+			t.Setenv(tc.envVar, tc.value)
+			info := Detect()
+			if !info.Detected {
+				t.Errorf("expected Kiro to be detected via %s", tc.envVar)
+			}
+			if info.Name != "kiro" {
+				t.Errorf("expected kiro, got %q", info.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Kiro detection in `sdk/agentmode` was keyed on a `KIRO` environment variable that Kiro does not set, so `Detect()` never identified a Kiro session and `UserAgentSuffix()` returned empty under Kiro.

This adds the env vars Kiro actually sets. Verified empirically on `kiro-cli` 2.6.1:

| Env var | Interactive `kiro-cli chat` | `kiro-cli chat --no-interactive` |
|---|---|---|
| `KIRO` | not set | not set |
| `AGENT_CONTEXT_OUT` | set (FIFO path) | **not set** |
| `KIRO_SESSION_ID` | set | set |

`AGENT_CONTEXT_OUT` is Kiro's documented ACP side-channel — a per-invocation FIFO path — but it's only exported in interactive sessions, so detecting on it alone (the docs-driven fix) still misses headless/scripted Kiro. `KIRO_SESSION_ID` is the reliable always-on signal. The change keys on both and keeps the existing `KIRO` entry as a manual override.

Kiro side-channel docs: https://kiro.dev/docs/cli/reference/built-in-tools/#side-channels-for-wrapper-scripts

## Related Issues

Closes #282

## Testing

Change is limited to `sdk/agentmode` (two map entries + comment, plus one new test).

- `go test ./...` passes for the `sdk` module, including a new `TestDetect_Kiro` (written red → green) covering both env vars.
- `gofmt` and `go vet ./agentmode/...` clean; `golangci-lint run ./agentmode/...` clean with default linters.
- [ ] Tests pass (`make test`) — deferred to CI: the repo root module targets Go 1.26 and my local toolchain is 1.25, so I validated the `sdk` module (Go 1.25) directly.
- [ ] Linting passes (`make lint`) — deferred to CI: the repo `.golangci.yml` targets Go 1.26, so I ran `golangci-lint` with default linters locally instead.
