### PR TITLE
fix(skills): stop recommending 'auth whoami' as a connectivity check

### DIFF
--- a/skills/dtctl/SKILL.md
+++ b/skills/dtctl/SKILL.md
@@ -21,14 +21,21 @@ dtctl config current-context
 # Show context details
 dtctl config describe-context $(dtctl config current-context) --plain
 
-# Show authenticated user
-dtctl auth whoami --plain
+# Show auth context: token type (OAuth vs API/platform) and safety level
+dtctl auth status --plain
 ```
 
 This displays:
 - Current context name and environment URL
 - Safety level (readonly, readwrite-mine, readwrite-all, dangerously-unrestricted)
-- Authenticated user identity (name, email, UUID)
+- Token type (OAuth vs API/platform token)
+
+> **Note:** Do not use `dtctl auth whoami` to verify a connection. It performs an
+> identity lookup against the platform metadata API and needs an OAuth/JWT token
+> with the `app-engine:apps:run` scope; with a plain API token or a read-scoped
+> platform token it returns a spurious 403 even though read access works fine.
+> Confirm connectivity with your first real query (`dtctl get ...` or
+> `dtctl query ...`), not with an identity probe.
 
 ## DQL Reference Usage
 
@@ -186,8 +193,8 @@ Prefer `get ... -o json --plain` first, then `describe`/`exec` with explicit IDs
 ### Authentication & Permissions
 
 ```bash
-# Check current user and permissions
-dtctl auth whoami --plain
+# Check auth context and permissions
+dtctl auth status --plain
 dtctl auth can-i create workflows
 dtctl auth can-i delete dashboards
 ```

--- a/skills/dtctl/references/troubleshooting.md
+++ b/skills/dtctl/references/troubleshooting.md
@@ -29,8 +29,8 @@ dtctl config set-context "default" \
   --token-ref "my-token"
 dtctl config use-context "default"
 
-# Verify
-dtctl auth whoami --plain
+# Verify the context loaded (local; works with any token type)
+dtctl auth status --plain
 ```
 
 **Note:** Always use `--token "$TOKEN"` directly. Stdin piping does not work reliably and stores corrupted values in the keychain.
@@ -42,12 +42,17 @@ dtctl auth whoami --plain
 # Re-store credentials
 dtctl config set-credentials "my-token" --token "$TOKEN"
 
-# Verify identity
-dtctl auth whoami --plain
+# Check auth context (token type, not identity)
+dtctl auth status --plain
 
 # Check permissions
 dtctl auth can-i <verb> <resource>
 ```
+
+> **Note:** `dtctl auth whoami` is not a connectivity check. It hits the platform
+> metadata API and needs an OAuth/JWT token with `app-engine:apps:run`; a plain API
+> token or read-scoped platform token returns a spurious 403 here even though read
+> access works. Confirm connectivity with a real `dtctl get`/`dtctl query`.
 
 ### Wrong Tenant
 ```bash


### PR DESCRIPTION
## Problem

The skill recommends `dtctl auth whoami` as a connectivity / "verify your setup" step in three places (`SKILL.md` context-inspection block, `SKILL.md` Authentication & Permissions, `references/troubleshooting.md`).

`auth whoami` performs an **identity lookup** against the platform metadata API (`/platform/metadata/v1/user`) and requires an OAuth/JWT token carrying the `app-engine:apps:run` scope. When the configured credential is a plain API token or a read-scoped **platform token** (not a JWT), the call returns a spurious **403 Forbidden**, and the JWT fallback also fails (platform tokens aren't JWTs) — **even though read access works fine**. Agents and users following the skill mis-read this as a broken connection.

## Fix

- Replace `dtctl auth whoami` in the context-inspection and troubleshooting flows with **`dtctl auth status`**, which is token-type aware, works with any credential, and is purely local (no metadata-API call, so no spurious 403). It reports `isOAuth` and token health.
- Add a note clarifying that connectivity is confirmed by the **first real query** (`dtctl get …` / `dtctl query …`), not by an identity probe, and explaining the `app-engine:apps:run` scope requirement of `whoami`.

`whoami` remains available and documented for genuine identity lookups on OAuth contexts — it is simply no longer recommended as a connection check.

## Why `auth status` is safe here

`cmd/auth.go` `buildSessionStatus` returns cleanly for non-OAuth tokens (`stored == nil` → `IsOAuth:false`) without contacting the metadata API, so it cannot reproduce the 403.
