### PR TITLE
fix: detect GitHub Copilot CLI via COPILOT_CLI env var

### DIFF
--- a/sdk/agentmode/detect.go
+++ b/sdk/agentmode/detect.go
@@ -15,8 +15,13 @@ type AgentInfo struct {
 
 // knownAgents maps environment variables to AI agent names.
 var knownAgents = map[string]string{
-	"CLAUDECODE":     "claude-code",
-	"CURSOR_AGENT":   "cursor",
+	"CLAUDECODE":   "claude-code",
+	"CURSOR_AGENT": "cursor",
+	// GitHub Copilot: the copilot CLI (and VS Code's bundled Copilot, which shares
+	// the @github/copilot SDK) sets COPILOT_CLI=1 — verified on copilot v1.0.63.
+	// The bare GITHUB_COPILOT is a legacy entry that no Copilot surface sets,
+	// kept as a harmless fallback.
+	"COPILOT_CLI":    "github-copilot",
 	"GITHUB_COPILOT": "github-copilot",
 	"CODEIUM_AGENT":  "codeium",
 	"TABNINE_AGENT":  "tabnine",

--- a/sdk/agentmode/detect_test.go
+++ b/sdk/agentmode/detect_test.go
@@ -91,3 +91,21 @@ func TestDetect_Kiro(t *testing.T) {
 		})
 	}
 }
+
+// TestDetect_CopilotCLI covers the GitHub Copilot CLI, which sets COPILOT_CLI=1
+// in every subprocess it spawns. The standalone `copilot` and VS Code's bundled
+// Copilot share the @github/copilot SDK that injects it (verified on copilot
+// v1.0.63); a bare GITHUB_COPILOT is not set by either.
+func TestDetect_CopilotCLI(t *testing.T) {
+	for envVar := range knownAgents {
+		os.Unsetenv(envVar)
+	}
+	t.Setenv("COPILOT_CLI", "1")
+	info := Detect()
+	if !info.Detected {
+		t.Error("expected GitHub Copilot to be detected via COPILOT_CLI")
+	}
+	if info.Name != "github-copilot" {
+		t.Errorf("expected github-copilot, got %q", info.Name)
+	}
+}


### PR DESCRIPTION
Fixes #288

## Summary

The agent-mode detection map keyed GitHub Copilot on `GITHUB_COPILOT`, which the
standalone Copilot CLI does **not** set — so dtctl never detected a Copilot
session (empty `(AI-Agent: …)` User-Agent suffix, no agent name on the DQL
`dt-client-context` header).

GitHub Copilot actually exports **`COPILOT_CLI=1`** into every subprocess it
spawns. The standalone `copilot` CLI and VS Code's bundled Copilot share the
`@github/copilot` SDK that sets it, so a single map entry covers both surfaces.

## Verification

Confirmed empirically on `copilot` v1.0.63 — inspecting the environment of a
Copilot-spawned shell shows `COPILOT_CLI=1`, while a bare `GITHUB_COPILOT` is
unset:

```
COPILOT_CLI=1
GITHUB_COPILOT=UNSET
```

`copilot help environment` and GitHub's published docs don't list `COPILOT_CLI`,
because it's an exported detection marker rather than a configuration input — the
same pattern as `CLAUDECODE` for Claude Code.

## Changes

- Add `COPILOT_CLI` → `github-copilot` to the detection map in `sdk/agentmode/detect.go`.
- Keep the existing `GITHUB_COPILOT` entry as a harmless legacy fallback (no current Copilot surface sets it).
- Add a `COPILOT_CLI` detection test.

Same shape as #283 (Kiro detection fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
