### PR TITLE
fix(auth): fall back to file storage when refresh token exceeds macOS Keychain limit

### DIFF
--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -233,7 +233,10 @@ func (tm *TokenManager) DeleteToken(tokenName string) error {
 	keyringName := tm.getKeyringName(tokenName)
 
 	if tm.deps.keyringAvailable() {
-		return tm.deps.deleteToken(tm.tokenStore, keyringName)
+		err := tm.deps.deleteToken(tm.tokenStore, keyringName)
+		// Best-effort cleanup of any file-based fallback token.
+		_ = tm.deps.fileDeleteToken(keyringName)
+		return err
 	}
 
 	// Fall back to file-based storage
@@ -271,16 +274,27 @@ func (tm *TokenManager) loadToken(tokenName string) (*StoredToken, error) {
 	// Try to load from keyring
 	if tm.deps.keyringAvailable() {
 		data, err := tm.deps.getToken(tm.tokenStore, keyringName)
-		if err != nil {
+		if err == nil {
+			var stored StoredToken
+			if err := json.Unmarshal([]byte(data), &stored); err != nil {
+				return nil, fmt.Errorf("failed to parse stored token: %w", err)
+			}
+			return &stored, nil
+		}
+		// Non-"not found" errors are fatal (e.g. keyring locked or corrupted).
+		if !strings.Contains(err.Error(), "not found") {
 			return nil, fmt.Errorf("failed to load token from keyring: %w", err)
 		}
-
-		var stored StoredToken
-		if err := json.Unmarshal([]byte(data), &stored); err != nil {
-			return nil, fmt.Errorf("failed to parse stored token: %w", err)
+		// Token not in keyring — may have been saved to file as a size-limit fallback.
+		// Also try file store before returning an error.
+		if data, fileErr := tm.deps.fileGetToken(keyringName); fileErr == nil {
+			var stored StoredToken
+			if err := json.Unmarshal([]byte(data), &stored); err != nil {
+				return nil, fmt.Errorf("failed to parse stored token: %w", err)
+			}
+			return &stored, nil
 		}
-
-		return &stored, nil
+		return nil, fmt.Errorf("failed to load token from keyring: %w", err)
 	}
 
 	// Fall back to file-based storage
@@ -331,6 +345,15 @@ func (tm *TokenManager) saveToken(tokenName string, stored *StoredToken) error {
 				return fmt.Errorf("failed to save token to keyring: %w", err)
 			}
 			if compactErr := tm.deps.setToken(tm.tokenStore, keyringName, string(compactData)); compactErr != nil {
+				// Even the refresh token alone exceeds the keyring limit (e.g. macOS Keychain).
+				// Fall back to file storage as a last resort.
+				if isKeyringTooLargeErr(compactErr) {
+					if fileErr := tm.deps.fileSetToken(keyringName, string(data)); fileErr == nil {
+						// Remove any stale keyring entry so loadToken reads from file next time.
+						_ = tm.deps.deleteToken(tm.tokenStore, keyringName)
+						return nil
+					}
+				}
 				return fmt.Errorf("failed to save token to keyring: %w (compact fallback also failed: %v)", err, compactErr)
 			}
 			return nil
@@ -347,6 +370,17 @@ func (tm *TokenManager) saveToken(tokenName string, stored *StoredToken) error {
 	}
 
 	return fmt.Errorf("OAuth tokens require a storage backend (keyring or file); set %s=file to use file-based storage", config.EnvTokenStorage)
+}
+
+// isKeyringTooLargeErr reports whether err is a keyring "data too large" error.
+// On macOS the go-keyring library surfaces errSecDataTooLarge (-25313) as
+// "data passed to Set was too big"; the security(1) CLI exits with code 161.
+func isKeyringTooLargeErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "too big") || strings.Contains(msg, "exit status 161")
 }
 
 // mediumCompactStoredTokenForKeyring drops the large access/ID token JWTs but

--- a/pkg/auth/token_manager_file_test.go
+++ b/pkg/auth/token_manager_file_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -235,4 +237,57 @@ func containsStr(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// TestTokenManager_SaveToken_KeyringTooLarge simulates the macOS scenario where
+// even the minimal compact form (refresh token only) exceeds the Keychain limit.
+// saveToken should fall back to file storage and loadToken should find it there.
+func TestTokenManager_SaveToken_KeyringTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	fileStore := config.NewOAuthFileStoreWithDir(dir)
+
+	oauthConfig := OAuthConfigForEnvironment(EnvironmentProd, config.DefaultSafetyLevel)
+	tm, err := NewTokenManager(oauthConfig)
+	if err != nil {
+		t.Fatalf("NewTokenManager() error: %v", err)
+	}
+
+	tm.deps.keyringAvailable = func() bool { return true }
+	tm.deps.getToken = func(_ *config.TokenStore, name string) (string, error) {
+		return "", fmt.Errorf("token %q not found in keyring", name)
+	}
+	// All keyring Set calls fail — simulates macOS "data passed to Set was too big".
+	tm.deps.setToken = func(_ *config.TokenStore, name, val string) error {
+		return fmt.Errorf("failed to store token in keyring: data passed to Set was too big")
+	}
+	tm.deps.deleteToken = func(_ *config.TokenStore, name string) error { return nil }
+	// fileStoreAvailable is false because keyring IS available (current system behaviour).
+	tm.deps.fileStoreAvailable = func() bool { return false }
+	tm.deps.fileGetToken = func(name string) (string, error) { return fileStore.GetToken(name) }
+	tm.deps.fileSetToken = func(name, token string) error { return fileStore.SetToken(name, token) }
+	tm.deps.fileDeleteToken = func(name string) error { return fileStore.DeleteToken(name) }
+
+	tokens := &TokenSet{
+		AccessToken:  "access-token",
+		RefreshToken: strings.Repeat("x", 3000), // large enough to exceed macOS Keychain
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+		ExpiresAt:    time.Now().Add(1 * time.Hour),
+	}
+
+	if err := tm.SaveToken("large-token", tokens); err != nil {
+		t.Fatalf("SaveToken() should fall back to file storage, got error: %v", err)
+	}
+
+	// loadToken must find the token in file storage (keyring has nothing).
+	stored, err := tm.loadToken("large-token")
+	if err != nil {
+		t.Fatalf("loadToken() error: %v", err)
+	}
+	if stored.AccessToken != tokens.AccessToken {
+		t.Errorf("AccessToken = %q, want %q", stored.AccessToken, tokens.AccessToken)
+	}
+	if stored.RefreshToken != tokens.RefreshToken {
+		t.Errorf("RefreshToken = %q, want %q", stored.RefreshToken, tokens.RefreshToken)
+	}
 }


### PR DESCRIPTION
Fixes #290

## Problem

On macOS, OAuth token refresh fails when the refresh token JWT is too large for the Keychain (`errSecDataTooLarge`, exit status 161). dtctl already has a compact-storage fallback chain (strips access/ID tokens → strips everything except the refresh token), but when the refresh token itself is too large, all three attempts fail and the operation errors out instead of trying file storage.

## Changes

- **`saveToken`**: When the minimal compact form also fails with a "too large" error (`isTooLargeErr` checks for `"too big"` / `exit status 161`), falls back to writing the full token to file storage and removes the stale keyring entry. Other keyring errors still propagate normally.
- **`loadToken`**: When keyring is available but returns "not found" (which happens after the save fallback clears the keyring entry), also checks file storage before failing.
- **`DeleteToken`**: Best-effort file cleanup when deleting via keyring, so tokens saved to file as a size fallback get cleaned up on logout.
- **Test**: `TestTokenManager_SaveToken_KeyringTooLarge` verifies the full save → load cycle when all keyring Set calls return "data passed to Set was too big".

## Test plan

- [ ] `go test ./pkg/auth/ -run TestTokenManager_SaveToken_KeyringTooLarge` passes
- [ ] `go test ./pkg/auth/...` shows no new failures vs `main`
- [ ] Reproduce on macOS with a large-claims account and confirm token refresh succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)