### PR TITLE
feat(httpclient): surface API error details in error messages

### DIFF
--- a/sdk/httpclient/response.go
+++ b/sdk/httpclient/response.go
@@ -2,6 +2,8 @@ package httpclient
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/go-resty/resty/v2"
 )
@@ -21,23 +23,30 @@ func CheckResponse(resp *resty.Response) error {
 	details := ""
 
 	// Try to extract message from Dynatrace error envelope.
-	// Common shapes: {"error":{"message":"..."}} or {"message":"..."}
+	// Common shapes: {"error":{"message":"...","details":{...}}} or {"message":"..."}
 	var envelope struct {
 		Error *struct {
-			Message string `json:"message"`
+			Message string          `json:"message"`
+			Details json.RawMessage `json:"details"`
 		} `json:"error"`
 		Message string `json:"message"`
 	}
+	const maxDetails = 1024
 	if err := json.Unmarshal(resp.Body(), &envelope); err == nil {
 		if envelope.Error != nil && envelope.Error.Message != "" {
 			msg = envelope.Error.Message
+			// The top-level message is often generic (e.g. "Constraints
+			// violated."); the actionable specifics live in "details".
+			details = formatErrorDetails(envelope.Error.Details)
+			if len(details) > maxDetails {
+				details = details[:maxDetails] + "... (truncated)"
+			}
 		} else if envelope.Message != "" {
 			msg = envelope.Message
 		}
 	} else {
 		// If we can't parse JSON, include raw body as details (truncated to 1KB).
 		if body := resp.String(); body != "" {
-			const maxDetails = 1024
 			if len(body) > maxDetails {
 				body = body[:maxDetails] + "... (truncated)"
 			}
@@ -46,4 +55,57 @@ func CheckResponse(resp *resty.Response) error {
 	}
 
 	return NewAPIError(resp.StatusCode(), msg, details)
+}
+
+// formatErrorDetails renders the "details" of a Dynatrace platform error
+// envelope into a readable string. The actionable specifics that "details"
+// carries would otherwise be dropped behind a generic top-level message.
+//
+// A plain string is returned verbatim; a well-formed constraintViolations array
+// is joined as "path: message; ..." entries. For non-standard shapes the raw
+// JSON bytes are returned as-is. Returns "" when empty.
+func formatErrorDetails(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+
+	// Convention allows details to be a plain string (e.g. an overload message).
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return strings.TrimSpace(s)
+	}
+
+	// Convention: details.constraintViolations is an array of objects, each with
+	// a message and optional path; errorCode is an optional string giving more
+	// detail than the HTTP status. Render those when present and well-formed.
+	var obj struct {
+		ErrorCode            string `json:"errorCode"`
+		ConstraintViolations []struct {
+			Path    string `json:"path"`
+			Message string `json:"message"`
+		} `json:"constraintViolations"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		violations := make([]string, 0, len(obj.ConstraintViolations))
+		for _, cv := range obj.ConstraintViolations {
+			if cv.Message == "" {
+				continue
+			}
+			if cv.Path != "" {
+				violations = append(violations, fmt.Sprintf("%s: %s", cv.Path, cv.Message))
+			} else {
+				violations = append(violations, cv.Message)
+			}
+		}
+		if len(violations) > 0 {
+			parts := violations
+			if obj.ErrorCode != "" {
+				parts = append([]string{fmt.Sprintf("errorCode: %s", obj.ErrorCode)}, violations...)
+			}
+			return strings.Join(parts, "; ")
+		}
+	}
+
+	// Non-standard or malformed: dump the raw JSON so nothing is hidden.
+	return strings.TrimSpace(string(raw))
 }

--- a/sdk/httpclient/response_test.go
+++ b/sdk/httpclient/response_test.go
@@ -1,0 +1,168 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// respFor performs a request against a server that returns the given status and
+// body, yielding a *resty.Response for CheckResponse to inspect.
+func respFor(t *testing.T, status int, body string) *resty.Response {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := resty.New().R().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	return resp
+}
+
+func TestCheckResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		body     string
+		wantMsg  string
+		wantDetl string
+	}{
+		{
+			name:    "success returns nil",
+			status:  200,
+			body:    `{}`,
+			wantMsg: "",
+		},
+
+		// --- Responses that follow the platform error convention: formatted nicely. ---
+		{
+			name:    "error message only",
+			status:  404,
+			body:    `{"error":{"message":"not found"}}`,
+			wantMsg: "not found",
+		},
+		{
+			// Convention: validation failures live in details.constraintViolations
+			// (with an optional errorCode) and must not be dropped behind the
+			// generic top-level message.
+			name:     "constraint violations are surfaced",
+			status:   400,
+			body:     `{"error":{"code":400,"message":"Constraints violated.","details":{"errorCode":"InvalidPaginationToken","constraintViolations":[{"path":"detectionRules[0].filterConfig.pattern","message":"may not be null","parameterLocation":"PAYLOAD_BODY"}]}}}`,
+			wantMsg:  "Constraints violated.",
+			wantDetl: "errorCode: InvalidPaginationToken; detectionRules[0].filterConfig.pattern: may not be null",
+		},
+		{
+			name:     "multiple constraint violations are surfaced",
+			status:   400,
+			body:     `{"error":{"code":400,"message":"Constraints violated.","details":{"constraintViolations":[{"path":"name","message":"may not be null"},{"path":"tasks[0].position.y","message":"must be greater than or equal to 1"},{"message":"at least one task is required"}]}}}`,
+			wantMsg:  "Constraints violated.",
+			wantDetl: "name: may not be null; tasks[0].position.y: must be greater than or equal to 1; at least one task is required",
+		},
+		{
+			// Convention also allows details to be a plain string.
+			name:     "string details are surfaced",
+			status:   503,
+			body:     `{"error":{"code":503,"message":"service is overloaded","details":"service is busy, good luck next time!"}}`,
+			wantMsg:  "service is overloaded",
+			wantDetl: "service is busy, good luck next time!",
+		},
+
+		// --- Responses that deviate from the convention: degrade gracefully, never drop. ---
+		{
+			// Some services key validation messages by field rather than using
+			// constraintViolations. We don't guess at the shape — dump the raw
+			// JSON so nothing is hidden.
+			name:     "non-standard keyed details are dumped as json",
+			status:   400,
+			body:     `{"error":{"message":"Invalid request.","code":400,"details":{"tasks":["noop -> position -> y: Input should be greater than or equal to 1"]}}}`,
+			wantMsg:  "Invalid request.",
+			wantDetl: `{"tasks":["noop -> position -> y: Input should be greater than or equal to 1"]}`,
+		},
+		{
+			// A details object with no constraintViolations is dumped as raw JSON
+			// rather than interpreted.
+			name:     "non-violation object details are dumped as json",
+			status:   403,
+			body:     `{"error":{"code":403,"message":"Insufficient permissions.","details":{"missingScopes":["document:documents:read","state:app-states:write"]}}}`,
+			wantMsg:  "Insufficient permissions.",
+			wantDetl: `{"missingScopes":["document:documents:read","state:app-states:write"]}`,
+		},
+		{
+			// Body isn't the error envelope at all: keep it verbatim as details.
+			name:    "unparseable body kept as details",
+			status:  400,
+			body:    `not json`,
+			wantMsg: "400 Bad Request",
+		},
+		{
+			name:    "null details yield no detail",
+			status:  400,
+			body:    `{"error":{"message":"Invalid request.","details":null}}`,
+			wantMsg: "Invalid request.",
+		},
+
+		// --- Truncation: details must never bloat error strings beyond 1 KB. ---
+		{
+			// A plain-string details value longer than 1 KB must be truncated.
+			name:    "large string details are truncated",
+			status:  503,
+			body:    `{"error":{"message":"overloaded","details":"` + strings.Repeat("x", 2000) + `"}}`,
+			wantMsg: "overloaded",
+			// Details field must be capped at 1024 chars + truncation marker.
+			wantDetl: strings.Repeat("x", 1024) + "... (truncated)",
+		},
+		{
+			// A non-standard details object whose raw JSON exceeds 1 KB must be truncated.
+			name:    "large raw-json details are truncated",
+			status:  400,
+			body:    `{"error":{"message":"bad","details":{"items":["` + strings.Repeat("y", 2000) + `"]}}}`,
+			wantMsg: "bad",
+			// Raw JSON fallback also subject to 1 KB cap.
+			wantDetl: (`{"items":["` + strings.Repeat("y", 2000) + `"]}`)[:1024] + "... (truncated)",
+		},
+		{
+			// An unparseable body longer than 1 KB must also be truncated.
+			name:     "large unparseable body is truncated",
+			status:   500,
+			body:     strings.Repeat("z", 2000),
+			wantMsg:  "500 Internal Server Error",
+			wantDetl: strings.Repeat("z", 1024) + "... (truncated)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckResponse(respFor(t, tt.status, tt.body))
+			if tt.wantMsg == "" {
+				if err != nil {
+					t.Fatalf("expected nil, got %v", err)
+				}
+				return
+			}
+			apiErr, ok := err.(*APIError)
+			if !ok {
+				t.Fatalf("expected *APIError, got %T: %v", err, err)
+			}
+			if apiErr.Message != tt.wantMsg {
+				t.Errorf("Message = %q, want %q", apiErr.Message, tt.wantMsg)
+			}
+			if tt.wantDetl != "" && apiErr.Details != tt.wantDetl {
+				t.Errorf("Details = %q, want %q", apiErr.Details, tt.wantDetl)
+			}
+			if tt.name == "null details yield no detail" && apiErr.Details != "" {
+				t.Errorf("Details = %q, want empty", apiErr.Details)
+			}
+			if tt.name == "unparseable body kept as details" && !strings.Contains(apiErr.Details, "not json") {
+				t.Errorf("Details = %q, want to contain raw body", apiErr.Details)
+			}
+		})
+	}
+}

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -212,31 +213,34 @@ func TestWorkflowCreateInvalid(t *testing.T) {
 	handler := workflow.NewHandler(env.Client)
 
 	tests := []struct {
-		name    string
-		data    []byte
-		wantErr bool
+		name            string
+		data            []byte
+		wantErrContains string
 	}{
 		{
-			name:    "invalid json",
-			data:    []byte(`{"invalid": json`),
-			wantErr: true,
+			name:            "invalid json",
+			data:            []byte(`{"invalid": json`),
+			wantErrContains: "400",
 		},
 		{
-			name:    "empty workflow",
-			data:    []byte(`{}`),
-			wantErr: true,
+			// API validates task position constraints and surfaces details.
+			// y must be >= 1; the error should carry the field path.
+			name:            "negative task y position",
+			data:            []byte(`{"title":"dtctl-test-invalid-position","tasks":{"t":{"action":"dynatrace.automations:run-javascript","position":{"x":0,"y":-1},"input":{"script":"export default async function(){return{}}"}}}}`),
+			wantErrContains: "position",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := handler.Create(tt.data)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
+			if err == nil {
+				t.Fatalf("Create() expected error, got nil")
 			}
-			if err != nil {
-				t.Logf("✓ Got expected error: %v", err)
+			if !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Errorf("Create() error = %v, want containing %q", err, tt.wantErrContains)
 			}
+			t.Logf("✓ Got expected error: %v", err)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`CheckResponse` was discarding `error.details` from error responses, leaving only the generic top-level message (e.g. "Invalid request.", "Constraints violated."). The actionable specifics — field paths, constraint violations — were silently dropped. This is important information for agents using dtctl.

**What changed:**
- `CheckResponse` now renders `error.details` into the error message.
- When the response follows the [platform error convention](https://developer.dynatrace.com/develop/platform-services/core-concepts/error-handling/): a `constraintViolations` array is formatted as `path: message` lines (with `errorCode` prepended when present); a string `details` is shown verbatim.
- Non-compliant shapes (services that key validation by field rather than using `constraintViolations`, etc.) are dumped as raw JSON — never pretty-printed, never dropped.

**Before:** `API error (400): Invalid request.`  
**After:** `API error (400): Invalid request. - {"tasks":["noop -> position -> y: Input should be greater than or equal to 1"]}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)