### PR TITLE
test(e2e): use Grail data objects in query-verify tests

### DIFF
--- a/test/e2e/verify_query_test.go
+++ b/test/e2e/verify_query_test.go
@@ -43,8 +43,12 @@ func TestQueryVerify_ValidQuery(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "fetch dt.entity.host query",
-			query:   "fetch dt.entity.host | fields entity.name | limit 10",
+			// Use a core Grail data object with a fields projection. Classic
+			// dt.entity.* / smartscapeNodes data objects are not available in
+			// Grail-only tenants (the API rejects them as UNKNOWN_DATA_OBJECT),
+			// so they cannot be used in a query that must verify as valid.
+			name:    "fetch spans with fields query",
+			query:   "fetch spans | fields timestamp, span.name | limit 10",
 			wantErr: false,
 		},
 	}
@@ -311,9 +315,11 @@ func TestQueryVerify_TemplateVariables(t *testing.T) {
 			expectValid:   true,
 		},
 		{
-			name:          "query with entity variable",
-			queryTemplate: "fetch dt.entity.{{.entityType}} | fields entity.name | limit 10",
-			renderedQuery: "fetch dt.entity.host | fields entity.name | limit 10",
+			// Templating the data object itself. Avoids dt.entity.* so the
+			// rendered query verifies as valid on Grail-only tenants too.
+			name:          "query with data object variable",
+			queryTemplate: "fetch {{.dataObject}} | fields timestamp | limit 10",
+			renderedQuery: "fetch spans | fields timestamp | limit 10",
 			expectValid:   true,
 		},
 	}


### PR DESCRIPTION
## Problem

`TestQueryVerify_ValidQuery` and `TestQueryVerify_TemplateVariables` (in `test/e2e/verify_query_test.go`, `-tags integration`) hard-coded `fetch dt.entity.host`. On Grail-only tenants the DQL verify API rejects classic `dt.entity.*` (and `smartscapeNodes`) data objects with:

```
UNKNOWN_DATA_OBJECT: dt.entity.host isn't a valid data object.
```

so both expected-valid cases failed with `valid=false`. dtctl itself is correct here — it faithfully reports what the API returns; the test data was stale.

## Fix

Switch the two cases to core Grail data objects (`spans`) that verify as valid on any tenant, preserving each case's intent:
- a `fetch` with a `fields` projection, and
- a template variable in the data-object position.

Comments note why `dt.entity.*` is avoided so it isn't reintroduced.

## Verification

Ran the full `-tags integration` suite against a live tenant:
- `test/e2e` — **ok** (was failing on the two cases above)
- `test/integration` — **ok**

No production code changes; test-only.