### PR TITLE
fix(ci): match existing v* tags in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "go",
   "skip-changelog": true,
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "package-name": "dtctl",


### PR DESCRIPTION
## Problem

The first release-please run produced **PR #303 "chore(main): release dtctl 0.31.0"** with a correct version bump but **broken release notes** — it listed the *entire* commit history (with duplicates) and the comparison link read `dtctl-v0.30.3...dtctl-v0.31.0`.

Root cause from the workflow log:

```
⚠ Found release tag with component '', but not configured in manifest
```

In the **config file**, `include-component-in-tag` defaults to **true**. With `package-name: dtctl`, release-please prepended the `dtctl` component and searched for `dtctl-v*` tags to find the last release. Our existing tags are `v0.30.3` (no component), so it found no baseline and treated every commit as unreleased.

## Fix

Set `include-component-in-tag: false`. release-please now matches the existing `v0.30.3` tags as the baseline (and keeps producing `vX.Y.Z` tags).

## After merge

release-please re-runs on `main` and regenerates the release PR with correct notes — only the commits since `v0.30.3` (including #295, #296, #298, #300, #297, #293) — still bumping to `0.31.0`. Then that release PR can be merged to cut the release.