### PR TITLE
ci: make releases manual (workflow_dispatch only)

### DIFF
--- a/.agents/skills/dtctl-release/SKILL.md
+++ b/.agents/skills/dtctl-release/SKILL.md
@@ -5,17 +5,20 @@ description: Explain and operate the dtctl release process, which is automated b
 
 # dtctl Release Process (release-please)
 
-dtctl releases are **automated by [release-please](https://github.com/googleapis/release-please)**. There is no manual version bump, no `CHANGELOG.md` to edit, and no tag to push by hand. Releasing is just **merging the release PR**.
+dtctl releases use [release-please](https://github.com/googleapis/release-please) but are **triggered manually** — **nothing releases on ordinary merges to `main`**. There is no manual version bump, no `CHANGELOG.md` to edit, and no tag to push by hand. The release notes and version are computed from the [Conventional Commits](https://www.conventionalcommits.org/) since the last release.
 
 ## How it works
 
-1. Every push to `main` runs `.github/workflows/release.yml`.
-2. The `release-please` job inspects the [Conventional Commits](https://www.conventionalcommits.org/) since the last release and maintains a **release PR** titled like `chore(main): release 0.31.0`. That PR:
+The `.github/workflows/release.yml` workflow runs **only when you trigger it** (`workflow_dispatch` — the "Run workflow" button on the Actions tab, or `gh workflow run`). A full release is **two dispatches with a merge in between**:
+
+1. **Dispatch #1** — the `release-please` job inspects the conventional commits since the last release and opens/updates a **release PR** titled like `chore(main): release 0.31.0`. That PR:
    - bumps `.release-please-manifest.json`,
    - bumps the fallback version in `pkg/version/version.go` (via the `// x-release-please-version` annotation),
-   - and accumulates the pending release notes (in the PR body).
-3. **Merging the release PR** makes release-please create the git tag (`vX.Y.Z`) and the **GitHub Release** with generated notes.
-4. The same workflow then runs the gated `goreleaser` job (`release_created == true`), which builds cross-platform binaries, signs checksums with cosign, generates SBOMs with syft, attaches everything to the release (without overwriting the notes — `release.mode: keep-existing`), and pushes the updated Homebrew cask to `dynatrace-oss/homebrew-tap`.
+   - and contains the pending release notes (in the PR body).
+2. **Merge the release PR** once you're happy with the version + notes.
+3. **Dispatch #2** — release-please detects the merged release PR, creates the git tag (`vX.Y.Z`) and the **GitHub Release** with generated notes, and `release_created == true` gates the `goreleaser` job, which builds cross-platform binaries, signs checksums with cosign, generates SBOMs with syft, attaches everything to the release (without overwriting the notes — `release.mode: keep-existing`), and pushes the updated Homebrew cask to `dynatrace-oss/homebrew-tap`.
+
+> ⚠️ Don't forget **Dispatch #2**: merging the release PR alone does **not** publish anything, because the workflow only runs on manual dispatch.
 
 There is **no `CHANGELOG.md` file** in the repo by design — the GitHub Release is the canonical changelog (`skip-changelog: true` in `release-please-config.json`).
 
@@ -32,24 +35,24 @@ So the way to "control the version" is to **write good conventional commits** (s
 
 ## To cut a release
 
-Usually nothing to do but merge:
-
 ```bash
-# Find the open release PR
-gh pr list --search "release" --state open
+# 1. Dispatch the workflow to build/update the release PR from commits since the last release
+gh workflow run release.yml
+gh run watch    # wait for the release-please run to finish
 
-# Review the version bump and notes it proposes, then merge it
+# 2. Review the proposed version + notes, then merge the release PR
+gh pr list --search "chore(main): release in:title" --state open
 gh pr merge <number> --squash
-```
 
-After the merge, watch the release workflow finish both jobs:
-
-```bash
+# 3. Dispatch AGAIN to create the tag + GitHub Release and publish artifacts
+gh workflow run release.yml
 gh run watch
+
+# 4. Confirm
 gh release view "$(gh release list --limit 1 --json tagName -q '.[0].tagName')"
 ```
 
-That's it — the tag, GitHub Release, binaries, signatures, SBOMs, and Homebrew cask are all produced automatically.
+The tag, GitHub Release, binaries, signatures, SBOMs, and Homebrew cask are produced by the second dispatch.
 
 ## Polishing release notes (optional)
 
@@ -61,7 +64,8 @@ gh release edit vX.Y.Z --notes-file notes.md
 
 ## Troubleshooting
 
-- **No release PR appeared** — there are no releasable commits since the last release (only `docs`/`chore`/`test`/etc.), or a commit isn't a valid conventional commit. Check `gh run list --workflow=release.yml`.
+- **No release PR appeared** — did you dispatch the workflow? It does **not** run on merges; run `gh workflow run release.yml`. If it ran and still no PR, there are no releasable commits since the last release (only `docs`/`chore`/`test`/etc.), or a commit isn't a valid conventional commit. Check `gh run list --workflow=release.yml`.
+- **Merged the release PR but nothing published** — that's expected: dispatch the workflow a **second time** so release-please creates the tag/Release and GoReleaser runs.
 - **Wrong version bump** — caused by the commit types. To force a specific bump, use a `Release-As: x.y.z` footer in a commit on `main`.
 - **Release created but no binaries** — inspect the `goreleaser` job in the release workflow run; the `release-please` job must have output `release_created: true` for it to run.
 - **Homebrew didn't update** — check the `HOMEBREW_TAP_APP_ID` / `HOMEBREW_TAP_APP_PRIVATE_KEY` secrets and the GoReleaser step logs; `skip_upload: auto` intentionally skips pre-release tags.
@@ -69,8 +73,10 @@ gh release edit vX.Y.Z --notes-file notes.md
 ## Checklist
 
 1. [ ] All intended changes merged to `main` as conventional commits
-2. [ ] Open release PR reflects the expected version and notes
-3. [ ] Merge the release PR (squash)
-4. [ ] `release.yml` run is green for both `release-please` and `goreleaser` jobs
-5. [ ] GitHub Release shows binaries, checksums, signatures, and SBOMs
-6. [ ] (Optional) Polished the release notes via `gh release edit`
+2. [ ] **Dispatch #1**: `gh workflow run release.yml` → release PR created/updated
+3. [ ] Open release PR reflects the expected version and notes
+4. [ ] Merge the release PR (squash)
+5. [ ] **Dispatch #2**: `gh workflow run release.yml` → tag + Release created
+6. [ ] `release.yml` run is green for both `release-please` and `goreleaser` jobs
+7. [ ] GitHub Release shows binaries, checksums, signatures, and SBOMs
+8. [ ] (Optional) Polished the release notes via `gh release edit`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,25 @@
 name: Release
 
-# Releases are driven by release-please. On every push to main it maintains a
-# "release PR" that bumps the version (manifest + pkg/version/version.go) based on
-# the conventional commits since the last release. Merging that PR creates the
-# git tag and GitHub Release (with auto-generated notes), which then triggers the
-# GoReleaser job below to build, sign, and publish the artifacts.
+# Releases are driven by release-please but triggered MANUALLY — nothing happens
+# on ordinary merges to main. Run this workflow from the Actions tab ("Run
+# workflow") when you want to act on releases. Each run does ONE of two things,
+# depending on repo state:
 #
-# Note: release-please creates the tag with GITHUB_TOKEN, which does NOT trigger
-# `on: push: tags` workflows — that is why GoReleaser runs as a gated job in this
-# same workflow rather than in a separate tag-triggered one.
+#   1. If there are releasable commits since the last release and no release PR is
+#      merged yet → release-please opens/updates the release PR (version bump in
+#      the manifest + pkg/version/version.go, plus generated notes). Review it.
+#   2. After you merge that release PR → run this workflow AGAIN; release-please
+#      detects the merged release PR, creates the git tag and GitHub Release, and
+#      the gated GoReleaser job below builds, signs, and publishes the artifacts.
+#
+# So a full release is: dispatch → merge the release PR → dispatch again.
+#
+# Note: release-please creates the tag with GITHUB_TOKEN, which would not trigger
+# `on: push: tags` workflows anyway — that is why GoReleaser runs as a gated job
+# in this same workflow rather than in a separate tag-triggered one.
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions: {}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,12 +331,13 @@ Fixes #456
 
 ## Releases
 
-Releases are fully automated with [release-please](https://github.com/googleapis/release-please) — **contributors never edit a changelog or bump a version**, and there is no `CHANGELOG.md` file (the GitHub Release is the changelog).
+Releases use [release-please](https://github.com/googleapis/release-please) — **contributors never edit a changelog or bump a version**, and there is no `CHANGELOG.md` file (the GitHub Release is the changelog). Releases are **triggered manually by maintainers**; ordinary merges to `main` do **not** publish anything.
 
-How it works:
+How it works (maintainers):
 
-- On every push to `main`, release-please opens/updates a **release PR** that bumps the version based on the [Conventional Commits](#commit-messages) merged since the last release.
-- Merging that release PR creates the git tag, the GitHub Release (with generated notes), and triggers GoReleaser to build and publish the binaries and Homebrew cask.
+- The release workflow runs only on manual dispatch (Actions → **Release** → **Run workflow**, or `gh workflow run release.yml`).
+- **First dispatch**: release-please opens/updates a **release PR** that bumps the version based on the [Conventional Commits](#commit-messages) since the last release.
+- Merge that release PR, then **dispatch again**: release-please creates the git tag and GitHub Release (with generated notes), and GoReleaser builds and publishes the binaries and Homebrew cask.
 
 Version impact of commit types (pre-1.0):
 


### PR DESCRIPTION
## What

Switch the release workflow trigger from `push: [main]` to **`workflow_dispatch`** so releases are fully maintainer-controlled. **Ordinary merges to `main` no longer trigger anything.**

## New release flow (two dispatches)

1. **Run workflow** (Actions → Release → Run workflow, or `gh workflow run release.yml`) → release-please opens/updates the release PR (version bump + notes from conventional commits since the last release).
2. Review and **merge the release PR**.
3. **Run workflow again** → release-please creates the tag + GitHub Release, and GoReleaser builds/signs/publishes binaries + Homebrew cask.

> ⚠️ Merging the release PR alone publishes nothing now — the second dispatch is what cuts the release. This is documented in the workflow header, the `dtctl-release` skill, and CONTRIBUTING.md.

## Bonus

This also eliminates the race we just hit, where two overlapping push-triggered runs could overwrite the release PR with stale notes — there's only ever one run, when you start it.

## Files

- `.github/workflows/release.yml` — trigger + explanatory header
- `.agents/skills/dtctl-release/SKILL.md` — manual two-dispatch flow, troubleshooting, checklist
- `CONTRIBUTING.md` — Releases section