### PR TITLE
feat(cloud): add disable command and edit support for cloud monitoring configs

### DIFF
--- a/cmd/disable.go
+++ b/cmd/disable.go
@@ -1,0 +1,31 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var disableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable cloud monitoring configurations",
+	Long: `Disable a cloud monitoring configuration by setting it and all its credentials
+to disabled in a single step.
+
+This is the inverse of 'dtctl enable'. The monitoring configuration and linked
+connection are preserved — only the enabled flag is toggled off.
+
+Available resources:
+  aws monitoring          Disable AWS monitoring configuration
+  azure monitoring        Disable Azure monitoring configuration
+  gcp monitoring          Disable GCP monitoring configuration (Preview)`,
+	Example: `  # Disable an AWS monitoring configuration by name
+  dtctl disable aws monitoring --name "my-aws-monitoring"
+
+  # Disable a GCP monitoring configuration by ID
+  dtctl disable gcp monitoring <id>
+
+  # Disable an Azure monitoring configuration
+  dtctl disable azure monitoring --name "my-azure-monitoring"`,
+	RunE: requireSubcommand,
+}
+
+func init() {
+	rootCmd.AddCommand(disableCmd)
+}

--- a/cmd/disable_aws.go
+++ b/cmd/disable_aws.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/awsmonitoringconfig"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
+)
+
+var disableAWSMonitoringName string
+
+var disableAWSProviderCmd = &cobra.Command{
+	Use:   "aws",
+	Short: "Disable AWS resources",
+	RunE:  requireSubcommand,
+}
+
+var disableAWSMonitoringCmd = &cobra.Command{
+	Use:     "monitoring [id]",
+	Aliases: []string{"monitoring-config"},
+	Short:   "Disable AWS monitoring configuration",
+	Long: `Disable an AWS monitoring configuration by setting it and all its credentials
+to disabled in a single step.
+
+The monitoring configuration and linked connection are preserved — only the
+enabled flag is toggled off.
+
+Examples:
+  dtctl disable aws monitoring --name "my-aws-monitoring"
+  dtctl disable aws monitoring <id>`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 && disableAWSMonitoringName == "" {
+			return fmt.Errorf("provide monitoring config ID argument or --name")
+		}
+
+		if dryRun {
+			name := disableAWSMonitoringName
+			if len(args) > 0 {
+				name = args[0]
+			}
+			output.PrintInfo("Dry run: would resolve AWS monitoring config %q", name)
+			output.PrintInfo("Dry run: would disable monitoring config and all credentials")
+			return nil
+		}
+
+		_, c, err := SetupWithSafety(safety.OperationUpdate)
+		if err != nil {
+			return err
+		}
+
+		monitoringHandler := awsmonitoringconfig.NewHandler(c)
+
+		var existing *awsmonitoringconfig.AWSMonitoringConfig
+		if len(args) > 0 {
+			identifier := args[0]
+			existing, err = monitoringHandler.FindByName(identifier)
+			if err != nil {
+				existing, err = monitoringHandler.Get(identifier)
+				if err != nil {
+					return fmt.Errorf("AWS monitoring config %q not found by name or ID", identifier)
+				}
+			}
+		} else {
+			existing, err = monitoringHandler.FindByName(disableAWSMonitoringName)
+			if err != nil {
+				return err
+			}
+		}
+
+		configName := existing.Value.Description
+		if configName == "" {
+			configName = existing.ObjectID
+		}
+
+		output.PrintInfo("Disabling AWS monitoring config %q...", configName)
+		value := existing.Value
+		value.Enabled = false
+		for i := range value.Aws.Credentials {
+			value.Aws.Credentials[i].Enabled = false
+		}
+
+		payload := awsmonitoringconfig.AWSMonitoringConfig{Scope: existing.Scope, Value: value}
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("failed to prepare request payload: %w", err)
+		}
+
+		updated, err := monitoringHandler.Update(existing.ObjectID, body)
+		if err != nil {
+			return err
+		}
+
+		output.PrintSuccess("AWS monitoring config %q disabled (%s)", configName, updated.ObjectID)
+		return nil
+	},
+}
+
+func init() {
+	disableAWSProviderCmd.AddCommand(disableAWSMonitoringCmd)
+
+	disableAWSMonitoringCmd.Flags().StringVar(&disableAWSMonitoringName, "name", "", "Monitoring config name/description (used when ID argument is not provided)")
+}

--- a/cmd/disable_azure.go
+++ b/cmd/disable_azure.go
@@ -62,7 +62,7 @@ Examples:
 			if err != nil {
 				existing, err = monitoringHandler.Get(identifier)
 				if err != nil {
-					return fmt.Errorf("Azure monitoring config %q not found by name or ID", identifier)
+					return fmt.Errorf("azure monitoring config %q not found by name or ID", identifier)
 				}
 			}
 		} else {

--- a/cmd/disable_azure.go
+++ b/cmd/disable_azure.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/azuremonitoringconfig"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
+)
+
+var disableAzureMonitoringName string
+
+var disableAzureProviderCmd = &cobra.Command{
+	Use:   "azure",
+	Short: "Disable Azure resources",
+	RunE:  requireSubcommand,
+}
+
+var disableAzureMonitoringCmd = &cobra.Command{
+	Use:     "monitoring [id]",
+	Aliases: []string{"monitoring-config"},
+	Short:   "Disable Azure monitoring configuration",
+	Long: `Disable an Azure monitoring configuration by setting it and all its credentials
+to disabled in a single step.
+
+The monitoring configuration and linked connection are preserved — only the
+enabled flag is toggled off.
+
+Examples:
+  dtctl disable azure monitoring --name "my-azure-monitoring"
+  dtctl disable azure monitoring <id>`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 && disableAzureMonitoringName == "" {
+			return fmt.Errorf("provide monitoring config ID argument or --name")
+		}
+
+		if dryRun {
+			name := disableAzureMonitoringName
+			if len(args) > 0 {
+				name = args[0]
+			}
+			output.PrintInfo("Dry run: would resolve Azure monitoring config %q", name)
+			output.PrintInfo("Dry run: would disable monitoring config and all credentials")
+			return nil
+		}
+
+		_, c, err := SetupWithSafety(safety.OperationUpdate)
+		if err != nil {
+			return err
+		}
+
+		monitoringHandler := azuremonitoringconfig.NewHandler(c)
+
+		var existing *azuremonitoringconfig.AzureMonitoringConfig
+		if len(args) > 0 {
+			identifier := args[0]
+			existing, err = monitoringHandler.FindByName(identifier)
+			if err != nil {
+				existing, err = monitoringHandler.Get(identifier)
+				if err != nil {
+					return fmt.Errorf("Azure monitoring config %q not found by name or ID", identifier)
+				}
+			}
+		} else {
+			existing, err = monitoringHandler.FindByName(disableAzureMonitoringName)
+			if err != nil {
+				return err
+			}
+		}
+
+		configName := existing.Value.Description
+		if configName == "" {
+			configName = existing.ObjectID
+		}
+
+		output.PrintInfo("Disabling Azure monitoring config %q...", configName)
+		value := existing.Value
+		value.Enabled = false
+		for i := range value.Azure.Credentials {
+			value.Azure.Credentials[i].Enabled = false
+		}
+
+		payload := azuremonitoringconfig.AzureMonitoringConfig{Scope: existing.Scope, Value: value}
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("failed to prepare request payload: %w", err)
+		}
+
+		updated, err := monitoringHandler.Update(existing.ObjectID, body)
+		if err != nil {
+			return err
+		}
+
+		output.PrintSuccess("Azure monitoring config %q disabled (%s)", configName, updated.ObjectID)
+		return nil
+	},
+}
+
+func init() {
+	disableAzureProviderCmd.AddCommand(disableAzureMonitoringCmd)
+
+	disableAzureMonitoringCmd.Flags().StringVar(&disableAzureMonitoringName, "name", "", "Monitoring config name/description (used when ID argument is not provided)")
+}

--- a/cmd/disable_gcp.go
+++ b/cmd/disable_gcp.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/gcpmonitoringconfig"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
+)
+
+var disableGCPMonitoringName string
+
+var disableGCPProviderCmd = &cobra.Command{
+	Use:   "gcp",
+	Short: "Disable GCP resources (Preview)",
+	RunE:  requireSubcommand,
+}
+
+var disableGCPMonitoringCmd = &cobra.Command{
+	Use:     "monitoring [id]",
+	Aliases: []string{"monitoring-config"},
+	Short:   "Disable GCP monitoring configuration",
+	Long: `Disable a GCP monitoring configuration by setting it and all its credentials
+to disabled in a single step.
+
+The monitoring configuration and linked connection are preserved — only the
+enabled flag is toggled off.
+
+Examples:
+  dtctl disable gcp monitoring --name "my-gcp-monitoring"
+  dtctl disable gcp monitoring <id>`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 && disableGCPMonitoringName == "" {
+			return fmt.Errorf("provide monitoring config ID argument or --name")
+		}
+
+		if dryRun {
+			name := disableGCPMonitoringName
+			if len(args) > 0 {
+				name = args[0]
+			}
+			output.PrintInfo("Dry run: would resolve GCP monitoring config %q", name)
+			output.PrintInfo("Dry run: would disable monitoring config and all credentials")
+			return nil
+		}
+
+		_, c, err := SetupWithSafety(safety.OperationUpdate)
+		if err != nil {
+			return err
+		}
+
+		monitoringHandler := gcpmonitoringconfig.NewHandler(c)
+
+		var existing *gcpmonitoringconfig.GCPMonitoringConfig
+		if len(args) > 0 {
+			identifier := args[0]
+			existing, err = monitoringHandler.FindByName(identifier)
+			if err != nil {
+				existing, err = monitoringHandler.Get(identifier)
+				if err != nil {
+					return fmt.Errorf("GCP monitoring config %q not found by name or ID", identifier)
+				}
+			}
+		} else {
+			existing, err = monitoringHandler.FindByName(disableGCPMonitoringName)
+			if err != nil {
+				return err
+			}
+		}
+
+		configName := existing.Value.Description
+		if configName == "" {
+			configName = existing.ObjectID
+		}
+
+		output.PrintInfo("Disabling GCP monitoring config %q...", configName)
+		value := existing.Value
+		value.Enabled = false
+		for i := range value.GoogleCloud.Credentials {
+			value.GoogleCloud.Credentials[i].Enabled = false
+		}
+
+		payload := gcpmonitoringconfig.GCPMonitoringConfig{Scope: existing.Scope, Value: value}
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("failed to prepare request payload: %w", err)
+		}
+
+		updated, err := monitoringHandler.Update(existing.ObjectID, body)
+		if err != nil {
+			return err
+		}
+
+		output.PrintSuccess("GCP monitoring config %q disabled (%s)", configName, updated.ObjectID)
+		return nil
+	},
+}
+
+func init() {
+	disableGCPProviderCmd.AddCommand(disableGCPMonitoringCmd)
+
+	disableGCPMonitoringCmd.Flags().StringVar(&disableGCPMonitoringName, "name", "", "Monitoring config name/description (used when ID argument is not provided)")
+}

--- a/cmd/disable_providers.go
+++ b/cmd/disable_providers.go
@@ -1,0 +1,8 @@
+package cmd
+
+func init() {
+	disableCmd.AddCommand(disableAWSProviderCmd)
+	disableCmd.AddCommand(disableAzureProviderCmd)
+	disableCmd.AddCommand(disableGCPProviderCmd)
+	attachPreviewNotice(disableGCPProviderCmd, "GCP")
+}

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -19,7 +19,8 @@ Blocked by safety level if the current context is set to 'readonly'.
 
 Supported resources:
   workflows (wf)          dashboards (dash, db)     notebooks (nb)
-  settings`,
+  settings                aws monitoring             azure monitoring
+  gcp monitoring`,
 	Example: `  # Edit a workflow in your default editor
   dtctl edit workflow my-workflow
 
@@ -27,7 +28,13 @@ Supported resources:
   dtctl edit dashboard "My Dashboard"
 
   # Edit a settings object by ID
-  dtctl edit setting <object-id>`,
+  dtctl edit setting <object-id>
+
+  # Edit an AWS monitoring configuration
+  dtctl edit aws monitoring --name "my-aws-monitoring"
+
+  # Edit an Azure monitoring configuration by ID
+  dtctl edit azure monitoring <id>`,
 	RunE: requireSubcommand,
 }
 
@@ -41,4 +48,14 @@ func init() {
 	editCmd.AddCommand(editSettingCmd)
 	editCmd.AddCommand(editSegmentCmd)
 	editCmd.AddCommand(editAnomalyDetectorCmd)
+
+	editCmd.AddCommand(editAWSProviderCmd)
+	editAWSProviderCmd.AddCommand(editAWSMonitoringCmd)
+
+	editCmd.AddCommand(editAzureProviderCmd)
+	editAzureProviderCmd.AddCommand(editAzureMonitoringCmd)
+
+	editCmd.AddCommand(editGCPProviderCmd)
+	editGCPProviderCmd.AddCommand(editGCPMonitoringCmd)
+	attachPreviewNotice(editGCPProviderCmd, "GCP")
 }

--- a/cmd/edit_anomalydetector.go
+++ b/cmd/edit_anomalydetector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -86,7 +87,8 @@ Examples:
 		}
 
 		// Open the editor
-		editorCmd := exec.Command(editor, tmpfile.Name())
+		parts := strings.Fields(editor)
+		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
 		editorCmd.Stderr = os.Stderr

--- a/cmd/edit_aws.go
+++ b/cmd/edit_aws.go
@@ -117,6 +117,9 @@ Examples:
 		}
 
 		parts := strings.Fields(editor)
+		if len(parts) == 0 {
+			return fmt.Errorf("no editor configured")
+		}
 		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
@@ -149,7 +152,17 @@ Examples:
 			return nil
 		}
 
-		updated, err := handler.Update(existing.ObjectID, jsonData)
+		var editedValue awsmonitoringconfig.Value
+		if err := json.Unmarshal(jsonData, &editedValue); err != nil {
+			return fmt.Errorf("failed to parse edited config: %w", err)
+		}
+		payload := awsmonitoringconfig.AWSMonitoringConfig{Scope: existing.Scope, Value: editedValue}
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("failed to marshal payload: %w", err)
+		}
+
+		updated, err := handler.Update(existing.ObjectID, payloadBytes)
 		if err != nil {
 			return err
 		}

--- a/cmd/edit_aws.go
+++ b/cmd/edit_aws.go
@@ -11,90 +11,81 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/output"
-	"github.com/dynatrace-oss/dtctl/pkg/resources/resolver"
-	"github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/awsmonitoringconfig"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
 )
 
-// editWorkflowCmd edits a workflow
-var editWorkflowCmd = &cobra.Command{
-	Use:     "workflow <workflow-id-or-name>",
-	Aliases: []string{"workflows", "wf"},
-	Short:   "Edit a workflow",
-	Long: `Edit a workflow by opening it in your default editor.
+var editAWSMonitoringName string
 
-The workflow will be fetched, opened in your editor (defined by EDITOR env var,
+var editAWSProviderCmd = &cobra.Command{
+	Use:   "aws",
+	Short: "Edit AWS resources",
+	RunE:  requireSubcommand,
+}
+
+var editAWSMonitoringCmd = &cobra.Command{
+	Use:     "monitoring [id]",
+	Aliases: []string{"monitoring-config"},
+	Short:   "Edit an AWS monitoring configuration",
+	Long: `Edit an AWS monitoring configuration by opening it in your default editor.
+
+The configuration will be fetched, opened in your editor (defined by EDITOR env var,
 defaults to vim), and updated when you save and close the editor.
 
 By default, resources are edited in YAML format for better readability.
 Use --format=json to edit in JSON format.
 
 Examples:
-  # Edit a workflow in YAML (default)
-  dtctl edit workflow <workflow-id>
-  dtctl edit workflow "My Workflow"
-
-  # Edit a workflow in JSON
-  dtctl edit workflow <workflow-id> --format=json
-`,
-	Args: cobra.ExactArgs(1),
+  dtctl edit aws monitoring <id>
+  dtctl edit aws monitoring --name "my-aws-monitoring"
+  dtctl edit aws monitoring --name "my-aws-monitoring" --format=json`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		identifier := args[0]
+		if len(args) == 0 && editAWSMonitoringName == "" {
+			return fmt.Errorf("provide monitoring config ID argument or --name")
+		}
 
-		cfg, c, err := SetupClient()
+		cfg, c, err := SetupWithSafety(safety.OperationUpdate)
 		if err != nil {
 			return err
 		}
 
-		// Resolve name to ID
-		res := resolver.NewResolver(c)
-		workflowID, err := res.ResolveID(resolver.TypeWorkflow, identifier)
+		handler := awsmonitoringconfig.NewHandler(c)
+
+		var existing *awsmonitoringconfig.AWSMonitoringConfig
+		if len(args) > 0 {
+			identifier := args[0]
+			existing, err = handler.FindByName(identifier)
+			if err != nil {
+				existing, err = handler.Get(identifier)
+				if err != nil {
+					return fmt.Errorf("AWS monitoring config %q not found by name or ID", identifier)
+				}
+			}
+		} else {
+			existing, err = handler.FindByName(editAWSMonitoringName)
+			if err != nil {
+				return err
+			}
+		}
+
+		data, err := handler.GetRaw(existing.ObjectID)
 		if err != nil {
 			return err
 		}
 
-		handler := workflow.NewHandler(c)
-
-		// Get workflow to check ownership
-		wf, err := handler.Get(workflowID)
-		if err != nil {
-			return err
-		}
-
-		// Determine ownership for safety check
-		currentUserID, _ := c.CurrentUserID() // Ignore error - will be empty string
-		ownership := safety.DetermineOwnership(wf.Owner, currentUserID)
-
-		// Safety check with actual ownership
-		checker, err := NewSafetyChecker(cfg)
-		if err != nil {
-			return err
-		}
-		if err := checker.CheckError(safety.OperationUpdate, ownership); err != nil {
-			return err
-		}
-
-		// Get the workflow as raw JSON
-		data, err := handler.GetRaw(workflowID)
-		if err != nil {
-			return err
-		}
-
-		// Get format preference
 		editFormat, _ := cmd.Flags().GetString("format")
 		var editData []byte
 		var fileExt string
 
 		if editFormat == "yaml" {
-			// Convert JSON to YAML for editing
 			editData, err = format.JSONToYAML(data)
 			if err != nil {
 				return fmt.Errorf("failed to convert to YAML: %w", err)
 			}
 			fileExt = "*.yaml"
 		} else {
-			// Pretty print JSON for editing
 			editData, err = format.PrettyJSON(data)
 			if err != nil {
 				return fmt.Errorf("failed to format JSON: %w", err)
@@ -102,8 +93,7 @@ Examples:
 			fileExt = "*.json"
 		}
 
-		// Create a temp file with appropriate extension
-		tmpfile, err := os.CreateTemp("", "dtctl-workflow-"+fileExt)
+		tmpfile, err := os.CreateTemp("", "dtctl-aws-monitoring-"+fileExt)
 		if err != nil {
 			return fmt.Errorf("failed to create temp file: %w", err)
 		}
@@ -118,7 +108,6 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		// Get the editor
 		editor := os.Getenv("EDITOR")
 		if editor == "" {
 			editor = cfg.Preferences.Editor
@@ -127,7 +116,6 @@ Examples:
 			editor = "vim"
 		}
 
-		// Open the editor
 		parts := strings.Fields(editor)
 		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
@@ -138,19 +126,16 @@ Examples:
 			return fmt.Errorf("editor failed: %w", err)
 		}
 
-		// Read the edited file
 		editedData, err := os.ReadFile(tmpfile.Name())
 		if err != nil {
 			return fmt.Errorf("failed to read edited file: %w", err)
 		}
 
-		// Convert edited data to JSON (auto-detect format)
 		jsonData, err := format.ValidateAndConvert(editedData)
 		if err != nil {
 			return fmt.Errorf("invalid format: %w", err)
 		}
 
-		// Check if anything changed
 		var originalCompact, editedCompact bytes.Buffer
 		if err := json.Compact(&originalCompact, data); err != nil {
 			return fmt.Errorf("failed to compact original JSON: %w", err)
@@ -164,17 +149,21 @@ Examples:
 			return nil
 		}
 
-		// Update the workflow
-		result, err := handler.Update(workflowID, jsonData)
+		updated, err := handler.Update(existing.ObjectID, jsonData)
 		if err != nil {
 			return err
 		}
 
-		output.PrintSuccess("Workflow %q updated", result.Title)
+		configName := updated.Value.Description
+		if configName == "" {
+			configName = updated.ObjectID
+		}
+		output.PrintSuccess("AWS monitoring config %q updated", configName)
 		return nil
 	},
 }
 
 func init() {
-	editWorkflowCmd.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
+	editAWSMonitoringCmd.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
+	editAWSMonitoringCmd.Flags().StringVar(&editAWSMonitoringName, "name", "", "Monitoring config name/description (used when ID argument is not provided)")
 }

--- a/cmd/edit_azure.go
+++ b/cmd/edit_azure.go
@@ -117,6 +117,9 @@ Examples:
 		}
 
 		parts := strings.Fields(editor)
+		if len(parts) == 0 {
+			return fmt.Errorf("no editor configured")
+		}
 		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
@@ -149,7 +152,17 @@ Examples:
 			return nil
 		}
 
-		updated, err := handler.Update(existing.ObjectID, jsonData)
+		var editedValue azuremonitoringconfig.Value
+		if err := json.Unmarshal(jsonData, &editedValue); err != nil {
+			return fmt.Errorf("failed to parse edited config: %w", err)
+		}
+		payload := azuremonitoringconfig.AzureMonitoringConfig{Scope: existing.Scope, Value: editedValue}
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("failed to marshal payload: %w", err)
+		}
+
+		updated, err := handler.Update(existing.ObjectID, payloadBytes)
 		if err != nil {
 			return err
 		}

--- a/cmd/edit_azure.go
+++ b/cmd/edit_azure.go
@@ -11,90 +11,81 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/output"
-	"github.com/dynatrace-oss/dtctl/pkg/resources/resolver"
-	"github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/azuremonitoringconfig"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
 )
 
-// editWorkflowCmd edits a workflow
-var editWorkflowCmd = &cobra.Command{
-	Use:     "workflow <workflow-id-or-name>",
-	Aliases: []string{"workflows", "wf"},
-	Short:   "Edit a workflow",
-	Long: `Edit a workflow by opening it in your default editor.
+var editAzureMonitoringName string
 
-The workflow will be fetched, opened in your editor (defined by EDITOR env var,
+var editAzureProviderCmd = &cobra.Command{
+	Use:   "azure",
+	Short: "Edit Azure resources",
+	RunE:  requireSubcommand,
+}
+
+var editAzureMonitoringCmd = &cobra.Command{
+	Use:     "monitoring [id]",
+	Aliases: []string{"monitoring-config"},
+	Short:   "Edit an Azure monitoring configuration",
+	Long: `Edit an Azure monitoring configuration by opening it in your default editor.
+
+The configuration will be fetched, opened in your editor (defined by EDITOR env var,
 defaults to vim), and updated when you save and close the editor.
 
 By default, resources are edited in YAML format for better readability.
 Use --format=json to edit in JSON format.
 
 Examples:
-  # Edit a workflow in YAML (default)
-  dtctl edit workflow <workflow-id>
-  dtctl edit workflow "My Workflow"
-
-  # Edit a workflow in JSON
-  dtctl edit workflow <workflow-id> --format=json
-`,
-	Args: cobra.ExactArgs(1),
+  dtctl edit azure monitoring <id>
+  dtctl edit azure monitoring --name "my-azure-monitoring"
+  dtctl edit azure monitoring --name "my-azure-monitoring" --format=json`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		identifier := args[0]
+		if len(args) == 0 && editAzureMonitoringName == "" {
+			return fmt.Errorf("provide monitoring config ID argument or --name")
+		}
 
-		cfg, c, err := SetupClient()
+		cfg, c, err := SetupWithSafety(safety.OperationUpdate)
 		if err != nil {
 			return err
 		}
 
-		// Resolve name to ID
-		res := resolver.NewResolver(c)
-		workflowID, err := res.ResolveID(resolver.TypeWorkflow, identifier)
+		handler := azuremonitoringconfig.NewHandler(c)
+
+		var existing *azuremonitoringconfig.AzureMonitoringConfig
+		if len(args) > 0 {
+			identifier := args[0]
+			existing, err = handler.FindByName(identifier)
+			if err != nil {
+				existing, err = handler.Get(identifier)
+				if err != nil {
+					return fmt.Errorf("Azure monitoring config %q not found by name or ID", identifier)
+				}
+			}
+		} else {
+			existing, err = handler.FindByName(editAzureMonitoringName)
+			if err != nil {
+				return err
+			}
+		}
+
+		data, err := handler.GetRaw(existing.ObjectID)
 		if err != nil {
 			return err
 		}
 
-		handler := workflow.NewHandler(c)
-
-		// Get workflow to check ownership
-		wf, err := handler.Get(workflowID)
-		if err != nil {
-			return err
-		}
-
-		// Determine ownership for safety check
-		currentUserID, _ := c.CurrentUserID() // Ignore error - will be empty string
-		ownership := safety.DetermineOwnership(wf.Owner, currentUserID)
-
-		// Safety check with actual ownership
-		checker, err := NewSafetyChecker(cfg)
-		if err != nil {
-			return err
-		}
-		if err := checker.CheckError(safety.OperationUpdate, ownership); err != nil {
-			return err
-		}
-
-		// Get the workflow as raw JSON
-		data, err := handler.GetRaw(workflowID)
-		if err != nil {
-			return err
-		}
-
-		// Get format preference
 		editFormat, _ := cmd.Flags().GetString("format")
 		var editData []byte
 		var fileExt string
 
 		if editFormat == "yaml" {
-			// Convert JSON to YAML for editing
 			editData, err = format.JSONToYAML(data)
 			if err != nil {
 				return fmt.Errorf("failed to convert to YAML: %w", err)
 			}
 			fileExt = "*.yaml"
 		} else {
-			// Pretty print JSON for editing
 			editData, err = format.PrettyJSON(data)
 			if err != nil {
 				return fmt.Errorf("failed to format JSON: %w", err)
@@ -102,8 +93,7 @@ Examples:
 			fileExt = "*.json"
 		}
 
-		// Create a temp file with appropriate extension
-		tmpfile, err := os.CreateTemp("", "dtctl-workflow-"+fileExt)
+		tmpfile, err := os.CreateTemp("", "dtctl-azure-monitoring-"+fileExt)
 		if err != nil {
 			return fmt.Errorf("failed to create temp file: %w", err)
 		}
@@ -118,7 +108,6 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		// Get the editor
 		editor := os.Getenv("EDITOR")
 		if editor == "" {
 			editor = cfg.Preferences.Editor
@@ -127,7 +116,6 @@ Examples:
 			editor = "vim"
 		}
 
-		// Open the editor
 		parts := strings.Fields(editor)
 		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
@@ -138,19 +126,16 @@ Examples:
 			return fmt.Errorf("editor failed: %w", err)
 		}
 
-		// Read the edited file
 		editedData, err := os.ReadFile(tmpfile.Name())
 		if err != nil {
 			return fmt.Errorf("failed to read edited file: %w", err)
 		}
 
-		// Convert edited data to JSON (auto-detect format)
 		jsonData, err := format.ValidateAndConvert(editedData)
 		if err != nil {
 			return fmt.Errorf("invalid format: %w", err)
 		}
 
-		// Check if anything changed
 		var originalCompact, editedCompact bytes.Buffer
 		if err := json.Compact(&originalCompact, data); err != nil {
 			return fmt.Errorf("failed to compact original JSON: %w", err)
@@ -164,17 +149,21 @@ Examples:
 			return nil
 		}
 
-		// Update the workflow
-		result, err := handler.Update(workflowID, jsonData)
+		updated, err := handler.Update(existing.ObjectID, jsonData)
 		if err != nil {
 			return err
 		}
 
-		output.PrintSuccess("Workflow %q updated", result.Title)
+		configName := updated.Value.Description
+		if configName == "" {
+			configName = updated.ObjectID
+		}
+		output.PrintSuccess("Azure monitoring config %q updated", configName)
 		return nil
 	},
 }
 
 func init() {
-	editWorkflowCmd.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
+	editAzureMonitoringCmd.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
+	editAzureMonitoringCmd.Flags().StringVar(&editAzureMonitoringName, "name", "", "Monitoring config name/description (used when ID argument is not provided)")
 }

--- a/cmd/edit_azure.go
+++ b/cmd/edit_azure.go
@@ -60,7 +60,7 @@ Examples:
 			if err != nil {
 				existing, err = handler.Get(identifier)
 				if err != nil {
-					return fmt.Errorf("Azure monitoring config %q not found by name or ID", identifier)
+					return fmt.Errorf("azure monitoring config %q not found by name or ID", identifier)
 				}
 			}
 		} else {

--- a/cmd/edit_documents.go
+++ b/cmd/edit_documents.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -130,7 +131,8 @@ Examples:
 		}
 
 		// Open the editor
-		editorCmd := exec.Command(editor, tmpfile.Name())
+		parts := strings.Fields(editor)
+		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
 		editorCmd.Stderr = os.Stderr
@@ -293,7 +295,8 @@ Examples:
 		}
 
 		// Open the editor
-		editorCmd := exec.Command(editor, tmpfile.Name())
+		parts := strings.Fields(editor)
+		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
 		editorCmd.Stderr = os.Stderr
@@ -457,7 +460,8 @@ Examples:
 		}
 
 		// Open the editor
-		editorCmd := exec.Command(editor, tmpfile.Name())
+		parts := strings.Fields(editor)
+		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
 		editorCmd.Stderr = os.Stderr

--- a/cmd/edit_gcp.go
+++ b/cmd/edit_gcp.go
@@ -11,90 +11,81 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/output"
-	"github.com/dynatrace-oss/dtctl/pkg/resources/resolver"
-	"github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/gcpmonitoringconfig"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
 )
 
-// editWorkflowCmd edits a workflow
-var editWorkflowCmd = &cobra.Command{
-	Use:     "workflow <workflow-id-or-name>",
-	Aliases: []string{"workflows", "wf"},
-	Short:   "Edit a workflow",
-	Long: `Edit a workflow by opening it in your default editor.
+var editGCPMonitoringName string
 
-The workflow will be fetched, opened in your editor (defined by EDITOR env var,
+var editGCPProviderCmd = &cobra.Command{
+	Use:   "gcp",
+	Short: "Edit GCP resources (Preview)",
+	RunE:  requireSubcommand,
+}
+
+var editGCPMonitoringCmd = &cobra.Command{
+	Use:     "monitoring [id]",
+	Aliases: []string{"monitoring-config"},
+	Short:   "Edit a GCP monitoring configuration",
+	Long: `Edit a GCP monitoring configuration by opening it in your default editor.
+
+The configuration will be fetched, opened in your editor (defined by EDITOR env var,
 defaults to vim), and updated when you save and close the editor.
 
 By default, resources are edited in YAML format for better readability.
 Use --format=json to edit in JSON format.
 
 Examples:
-  # Edit a workflow in YAML (default)
-  dtctl edit workflow <workflow-id>
-  dtctl edit workflow "My Workflow"
-
-  # Edit a workflow in JSON
-  dtctl edit workflow <workflow-id> --format=json
-`,
-	Args: cobra.ExactArgs(1),
+  dtctl edit gcp monitoring <id>
+  dtctl edit gcp monitoring --name "my-gcp-monitoring"
+  dtctl edit gcp monitoring --name "my-gcp-monitoring" --format=json`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		identifier := args[0]
+		if len(args) == 0 && editGCPMonitoringName == "" {
+			return fmt.Errorf("provide monitoring config ID argument or --name")
+		}
 
-		cfg, c, err := SetupClient()
+		cfg, c, err := SetupWithSafety(safety.OperationUpdate)
 		if err != nil {
 			return err
 		}
 
-		// Resolve name to ID
-		res := resolver.NewResolver(c)
-		workflowID, err := res.ResolveID(resolver.TypeWorkflow, identifier)
+		handler := gcpmonitoringconfig.NewHandler(c)
+
+		var existing *gcpmonitoringconfig.GCPMonitoringConfig
+		if len(args) > 0 {
+			identifier := args[0]
+			existing, err = handler.FindByName(identifier)
+			if err != nil {
+				existing, err = handler.Get(identifier)
+				if err != nil {
+					return fmt.Errorf("GCP monitoring config %q not found by name or ID", identifier)
+				}
+			}
+		} else {
+			existing, err = handler.FindByName(editGCPMonitoringName)
+			if err != nil {
+				return err
+			}
+		}
+
+		data, err := handler.GetRaw(existing.ObjectID)
 		if err != nil {
 			return err
 		}
 
-		handler := workflow.NewHandler(c)
-
-		// Get workflow to check ownership
-		wf, err := handler.Get(workflowID)
-		if err != nil {
-			return err
-		}
-
-		// Determine ownership for safety check
-		currentUserID, _ := c.CurrentUserID() // Ignore error - will be empty string
-		ownership := safety.DetermineOwnership(wf.Owner, currentUserID)
-
-		// Safety check with actual ownership
-		checker, err := NewSafetyChecker(cfg)
-		if err != nil {
-			return err
-		}
-		if err := checker.CheckError(safety.OperationUpdate, ownership); err != nil {
-			return err
-		}
-
-		// Get the workflow as raw JSON
-		data, err := handler.GetRaw(workflowID)
-		if err != nil {
-			return err
-		}
-
-		// Get format preference
 		editFormat, _ := cmd.Flags().GetString("format")
 		var editData []byte
 		var fileExt string
 
 		if editFormat == "yaml" {
-			// Convert JSON to YAML for editing
 			editData, err = format.JSONToYAML(data)
 			if err != nil {
 				return fmt.Errorf("failed to convert to YAML: %w", err)
 			}
 			fileExt = "*.yaml"
 		} else {
-			// Pretty print JSON for editing
 			editData, err = format.PrettyJSON(data)
 			if err != nil {
 				return fmt.Errorf("failed to format JSON: %w", err)
@@ -102,8 +93,7 @@ Examples:
 			fileExt = "*.json"
 		}
 
-		// Create a temp file with appropriate extension
-		tmpfile, err := os.CreateTemp("", "dtctl-workflow-"+fileExt)
+		tmpfile, err := os.CreateTemp("", "dtctl-gcp-monitoring-"+fileExt)
 		if err != nil {
 			return fmt.Errorf("failed to create temp file: %w", err)
 		}
@@ -118,7 +108,6 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		// Get the editor
 		editor := os.Getenv("EDITOR")
 		if editor == "" {
 			editor = cfg.Preferences.Editor
@@ -127,7 +116,6 @@ Examples:
 			editor = "vim"
 		}
 
-		// Open the editor
 		parts := strings.Fields(editor)
 		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
@@ -138,19 +126,16 @@ Examples:
 			return fmt.Errorf("editor failed: %w", err)
 		}
 
-		// Read the edited file
 		editedData, err := os.ReadFile(tmpfile.Name())
 		if err != nil {
 			return fmt.Errorf("failed to read edited file: %w", err)
 		}
 
-		// Convert edited data to JSON (auto-detect format)
 		jsonData, err := format.ValidateAndConvert(editedData)
 		if err != nil {
 			return fmt.Errorf("invalid format: %w", err)
 		}
 
-		// Check if anything changed
 		var originalCompact, editedCompact bytes.Buffer
 		if err := json.Compact(&originalCompact, data); err != nil {
 			return fmt.Errorf("failed to compact original JSON: %w", err)
@@ -164,17 +149,21 @@ Examples:
 			return nil
 		}
 
-		// Update the workflow
-		result, err := handler.Update(workflowID, jsonData)
+		updated, err := handler.Update(existing.ObjectID, jsonData)
 		if err != nil {
 			return err
 		}
 
-		output.PrintSuccess("Workflow %q updated", result.Title)
+		configName := updated.Value.Description
+		if configName == "" {
+			configName = updated.ObjectID
+		}
+		output.PrintSuccess("GCP monitoring config %q updated", configName)
 		return nil
 	},
 }
 
 func init() {
-	editWorkflowCmd.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
+	editGCPMonitoringCmd.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
+	editGCPMonitoringCmd.Flags().StringVar(&editGCPMonitoringName, "name", "", "Monitoring config name/description (used when ID argument is not provided)")
 }

--- a/cmd/edit_gcp.go
+++ b/cmd/edit_gcp.go
@@ -117,6 +117,9 @@ Examples:
 		}
 
 		parts := strings.Fields(editor)
+		if len(parts) == 0 {
+			return fmt.Errorf("no editor configured")
+		}
 		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
@@ -149,7 +152,17 @@ Examples:
 			return nil
 		}
 
-		updated, err := handler.Update(existing.ObjectID, jsonData)
+		var editedValue gcpmonitoringconfig.Value
+		if err := json.Unmarshal(jsonData, &editedValue); err != nil {
+			return fmt.Errorf("failed to parse edited config: %w", err)
+		}
+		payload := gcpmonitoringconfig.GCPMonitoringConfig{Scope: existing.Scope, Value: editedValue}
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("failed to marshal payload: %w", err)
+		}
+
+		updated, err := handler.Update(existing.ObjectID, payloadBytes)
 		if err != nil {
 			return err
 		}

--- a/cmd/edit_segments.go
+++ b/cmd/edit_segments.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -118,7 +119,8 @@ Examples:
 		}
 
 		// Open the editor
-		editorCmd := exec.Command(editor, tmpfile.Name())
+		parts := strings.Fields(editor)
+		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
 		editorCmd.Stderr = os.Stderr

--- a/cmd/edit_settings.go
+++ b/cmd/edit_settings.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -97,7 +98,8 @@ Examples:
 		}
 
 		// Open the editor
-		editorCmd := exec.Command(editor, tmpfile.Name())
+		parts := strings.Fields(editor)
+		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
 		editorCmd.Stderr = os.Stderr

--- a/pkg/commands/listing.go
+++ b/pkg/commands/listing.go
@@ -95,6 +95,7 @@ var MutatingVerbs = map[string]string{
 	"update":  "OperationUpdate",
 	"exec":    "OperationCreate", // semantically mutating (runs workflows, functions)
 	"enable":  "OperationUpdate", // PUTs updated monitoring/credential config to the tenant
+	"disable": "OperationUpdate", // PUTs updated monitoring config with enabled=false
 }
 
 // ResourceAliases are the standard resource aliases built into dtctl.

--- a/pkg/resources/awsmonitoringconfig/awsmonitoringconfig.go
+++ b/pkg/resources/awsmonitoringconfig/awsmonitoringconfig.go
@@ -3,6 +3,7 @@
 package awsmonitoringconfig
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -293,6 +294,14 @@ func (h *Handler) fetchLatestSchema() (*ExtensionSchemaResponse, error) {
 		return nil, fmt.Errorf("failed to fetch extension schema: %s", resp.String())
 	}
 	return &schema, nil
+}
+
+func (h *Handler) GetRaw(id string) ([]byte, error) {
+	result, err := h.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(result, "", "  ")
 }
 
 func (h *Handler) Get(id string) (*AWSMonitoringConfig, error) {

--- a/pkg/resources/awsmonitoringconfig/awsmonitoringconfig.go
+++ b/pkg/resources/awsmonitoringconfig/awsmonitoringconfig.go
@@ -301,7 +301,7 @@ func (h *Handler) GetRaw(id string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json.MarshalIndent(result, "", "  ")
+	return json.MarshalIndent(result.Value, "", "  ")
 }
 
 func (h *Handler) Get(id string) (*AWSMonitoringConfig, error) {

--- a/pkg/resources/azuremonitoringconfig/azuremonitoringconfig.go
+++ b/pkg/resources/azuremonitoringconfig/azuremonitoringconfig.go
@@ -1,6 +1,7 @@
 package azuremonitoringconfig
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -237,6 +238,14 @@ func (h *Handler) ListAvailableFeatureSets() ([]FeatureSet, error) {
 	})
 
 	return featureSets, nil
+}
+
+func (h *Handler) GetRaw(id string) ([]byte, error) {
+	result, err := h.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(result, "", "  ")
 }
 
 func (h *Handler) Get(id string) (*AzureMonitoringConfig, error) {

--- a/pkg/resources/azuremonitoringconfig/azuremonitoringconfig.go
+++ b/pkg/resources/azuremonitoringconfig/azuremonitoringconfig.go
@@ -245,7 +245,7 @@ func (h *Handler) GetRaw(id string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json.MarshalIndent(result, "", "  ")
+	return json.MarshalIndent(result.Value, "", "  ")
 }
 
 func (h *Handler) Get(id string) (*AzureMonitoringConfig, error) {

--- a/pkg/resources/gcpmonitoringconfig/gcpmonitoringconfig.go
+++ b/pkg/resources/gcpmonitoringconfig/gcpmonitoringconfig.go
@@ -245,7 +245,7 @@ func (h *Handler) GetRaw(id string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json.MarshalIndent(result, "", "  ")
+	return json.MarshalIndent(result.Value, "", "  ")
 }
 
 func (h *Handler) Get(id string) (*GCPMonitoringConfig, error) {

--- a/pkg/resources/gcpmonitoringconfig/gcpmonitoringconfig.go
+++ b/pkg/resources/gcpmonitoringconfig/gcpmonitoringconfig.go
@@ -1,6 +1,7 @@
 package gcpmonitoringconfig
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -237,6 +238,14 @@ func (h *Handler) ListAvailableFeatureSets() ([]FeatureSet, error) {
 	})
 
 	return featureSets, nil
+}
+
+func (h *Handler) GetRaw(id string) ([]byte, error) {
+	result, err := h.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(result, "", "  ")
 }
 
 func (h *Handler) Get(id string) (*GCPMonitoringConfig, error) {

--- a/pkg/skills/installer_test.go
+++ b/pkg/skills/installer_test.go
@@ -650,6 +650,7 @@ func TestInstalledSkillContent_ContainsMainSections(t *testing.T) {
 		"Output for agents",
 		"Apply & templates",
 		"Permissions & safety",
+		"Initialization",
 	}
 	for _, s := range mustContain {
 		if !strings.Contains(content, s) {


### PR DESCRIPTION
## Summary

- Add `dtctl disable aws|azure|gcp monitoring` — disables a monitoring config and all its credentials in a single step (inverse of `dtctl enable`)
- Add `dtctl edit aws|azure|gcp monitoring` — interactive editor support for cloud monitoring configs, matching existing `edit workflow`/`edit dashboard` pattern
- Fix `$EDITOR` parsing in all `edit_*.go` commands: values like `code --wait` previously failed because `exec.Command` received the whole string as an executable name instead of splitting command from flags

## Test plan

- [ ] `dtctl disable aws monitoring --name <name>` — verify `enabled: false` on config and all credentials
- [ ] `dtctl disable aws monitoring --dry-run` — verify no API call is made
- [ ] `dtctl edit aws monitoring --name <name>` — verify editor opens, saves, and PUT is sent
- [ ] `dtctl disable gcp monitoring` — verify GCP preview notice appears
- [ ] `go test ./cmd/... ./pkg/resources/awsmonitoringconfig/... ./pkg/resources/azuremonitoringconfig/... ./pkg/resources/gcpmonitoringconfig/...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)