### PR TITLE
docs(skills): add token-frugal log pattern analysis loop to dtctl skill

### DIFF
--- a/pkg/skills/installer_test.go
+++ b/pkg/skills/installer_test.go
@@ -644,10 +644,9 @@ func TestInstalledSkillContent_ContainsMainSections(t *testing.T) {
 
 	mustContain := []string{
 		"Dynatrace Control with dtctl",
-		"Available Resources",
-		"Command Verbs",
-		"Output Modes",
-		"Template Variables",
+		"Resources & verbs",
+		"Output for agents",
+		"Apply & templates",
 	}
 	for _, s := range mustContain {
 		if !strings.Contains(content, s) {
@@ -672,8 +671,8 @@ func TestInstalledSkillContent_SubstantialSize(t *testing.T) {
 	}
 
 	lines := strings.Count(string(data), "\n")
-	if lines < 200 {
-		t.Errorf("SKILL.md has only %d lines, expected 200+", lines)
+	if lines < 100 {
+		t.Errorf("SKILL.md has only %d lines, expected 100+", lines)
 	}
 }
 

--- a/skills/dtctl/SKILL.md
+++ b/skills/dtctl/SKILL.md
@@ -84,6 +84,13 @@ dtctl query "fetch logs" --spill-to ./out.jsonl      # explicit path: jsonl|json
 dtctl query "fetch logs" --spill=auto --spill-threshold 100KB
 ```
 
+## Log pattern analysis (token-frugal)
+
+For free-text log triage, don't dump raw `content` — extract the taxonomy server-side, then drill:
+1. `dtctl exec analyzer dt.statistics.clustering.LogPatternExtractor --input '{"logQuery":"<DQL>","numberOfExamples":2}'` → DPL templates + match counts. `logQuery` is a **plain DQL string** (not an object) yielding `timestamp`+`content`. Projects well with `--jq` to `{patternExpression, numberOfMatches}`.
+2. Lift a `patternExpression` verbatim into `parse content, "..."` (rename captures `f_1`→meaningful), then `summarize … by:{field}` to extract/count at row scale. Unmatched lines yield null captures.
+3. Need raw rows? Drill with `fetch … --agent` and let it spill (above), then interrogate the file locally.
+
 ## Apply & templates
 
 `dtctl apply` is idempotent: POST when new, PUT when the file has an `id`. YAML/DQL files support Go templates filled via `--set`:


### PR DESCRIPTION
## What

Adds a short **Log pattern analysis (token-frugal)** section to the dtctl skill, documenting the three-step loop for free-text log triage:

1. `dt.statistics.clustering.LogPatternExtractor` (via `dtctl exec analyzer`) → DPL templates + match counts, instead of dumping raw `content`.
2. Lift a `patternExpression` verbatim into `parse content, "..."` + `summarize … by:{field}` to extract/count at row scale.
3. Drill to raw rows with `fetch … --agent` and let spill handle the volume, then interrogate the file locally.

## Why

The skill's trigger description already advertises "log patterns" but the body gave no mechanism, and the analyzer is undiscoverable without knowing its exact name (it's behind `exec analyzer`, not a dedicated command). The spill half was already documented; this completes the loop.

Verified end-to-end on a live tenant: 5,000 raw log lines (~204k tokens) → 147 DPL templates (~8k tokens, ~25× smaller), patterns lift verbatim into `parse`, and the raw drill-down spills as expected. Notes the `logQuery`-is-a-plain-string gotcha and the null-capture-on-non-match behavior.

## Incidental test fix

Also updates `pkg/skills/installer_test.go`. PR #307 compacted `SKILL.md` (307→~128 lines) and renamed its sections, but the installed-skill assertions still expected the old section names (`Available Resources`, `Command Verbs`, …) and a `200+` line floor — leaving `main` red on `TestInstalledSkillContent_ContainsMainSections` and `TestInstalledSkillContent_SubstantialSize`. Assertions are realigned to the current structure (and the floor lowered to 100). This is what was failing CI here; the docs change itself is inert.