### PR TITLE
feat(inspect): add `dtctl inspect` for local analysis of spilled results (PR4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Token-based authentication and multi-environment configuration are covered in th
 | Workflows | get, describe, create, edit, delete, apply, execute, logs, history, restore, diff, watch |
 | Dashboards & Notebooks | get, describe, create, edit, delete, apply, share, history, restore, diff, watch |
 | Documents & Trash | get, describe, create, edit, delete, share, history, restore |
-| DQL Queries | execute, verify, template variables, live mode, filter segments, wait conditions |
+| DQL Queries | execute, verify, template variables, live mode, filter segments, wait conditions, spill large results to a file + local `inspect` (rows/schema/stats) |
 | SLOs | get, describe, create, edit, delete, apply, evaluate, watch |
 | Settings | get schemas, get/create/update/delete objects |
 | Buckets | get, describe, create, delete, apply, watch |

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/inspect"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// statsAllColumns is the NoOptDefVal for --stats: a bare `--stats` (no value)
+// profiles every column, while `--stats a,b` selects columns. It is a sentinel
+// that cannot collide with a real column name.
+const statsAllColumns = "\x00all"
+
+var inspectCmd = &cobra.Command{
+	Use:   "inspect <file>",
+	Short: "Inspect a spilled query-result file locally (row access, schema, stats)",
+	Long: `Inspect a query-result file that 'dtctl query' spilled to disk, without
+re-querying Grail and without pulling the whole result back into context.
+
+The expensive Grail scan happens once (the original query). 'inspect' reads only
+what each call needs from the file and emits only the answer — so a paused agent
+session, a large export, or a sandbox with no shell tooling can still interrogate
+the rows.
+
+Its primary capability is ROW ACCESS — specific rows, ranges, the tail, a column
+projection — which the spill summary never carried:
+
+  --head N                 first N rows
+  --tail N                 last N rows
+  --page --offset O --limit L   a paginated window (row order = result order)
+  --fields col1,col2,…     project columns (composable with the row-access flags)
+
+It can also re-derive the summary for a file whose manifest is no longer in
+context (a stale spill, a file handed between sessions):
+
+  --schema                 columns + types + null counts
+  --stats [col,col]        per-column profile (counts, null%, min/max, mean, top-K)
+  --sample N               N representative (leading) rows
+
+And when the file handle itself is gone — the original spill envelope was
+trimmed or summarised out of context, but the file is still on disk — it can
+enumerate the spilled files in the active context and their provenance, so you
+can recover a handle instead of re-querying Grail:
+
+  --list                   list spilled files in the active context (query, rows, age)
+
+Choose exactly one primitive per call. 'inspect' is not a query engine: there is
+no filter, no SQL, no GROUP BY. For aggregate questions, push the work back into
+DQL and re-query ('… | summarize …'); for complex local analysis, hand the file
+to your preferred local analytics tooling.`,
+	Example: `  # First 20 rows of a spilled result
+  dtctl inspect ~/.cache/dtctl/results/prod/q-7f3a9c.jsonl --head 20
+
+  # A projected window deep in the result
+  dtctl inspect q-7f3a9c.jsonl --page --offset 1000 --limit 50 --fields timestamp,content
+
+  # The tail of the result
+  dtctl inspect q-7f3a9c.jsonl --tail 10
+
+  # Re-derive the per-column profile for an out-of-context file
+  dtctl inspect q-7f3a9c.jsonl --stats
+
+  # Just the schema, as an agent envelope
+  dtctl inspect q-7f3a9c.jsonl --schema --agent
+
+  # Recover a lost handle: what has been spilled in this context?
+  dtctl inspect --list`,
+	// At most one positional <file>. --list takes none; every primitive takes one.
+	// The exact requirement is enforced in RunE so usage errors share the typed
+	// inspect_bad_flags envelope rather than cobra's generic arg error.
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// --list is a directory-scoped enumeration, not a file primitive: it takes
+		// no <file> and stands alone.
+		if cmd.Flags().Changed("list") {
+			return runInspectList(cmd, args)
+		}
+
+		if len(args) != 1 {
+			return inspect.BadFlags(
+				"inspect requires exactly one <file> argument",
+				"pass a spilled file (e.g. dtctl inspect q-7f3a9c.jsonl --head 20), or use --list to enumerate spilled files",
+			)
+		}
+
+		req, err := buildInspectRequest(cmd, args[0])
+		if err != nil {
+			return err
+		}
+
+		// Local-only command: no client, no auth. Load config best-effort purely
+		// to learn the active context/tenant for the cross-context refusal (D9) and
+		// to resolve re-spill settings (IN8). A missing/unusable config is fine.
+		cfg, _ := LoadConfig()
+		if cfg != nil {
+			req.ActiveTenant, req.ActiveContext = spillProvenance(cfg)
+		}
+
+		res, err := inspect.Run(req)
+		if err != nil {
+			return err // typed *inspect.Error → structured envelope via errorToDetail
+		}
+
+		return emitInspectResult(cmd, cfg, req, res)
+	},
+}
+
+// buildInspectRequest parses and validates the inspect flag surface into a
+// fully-formed engine request, enforcing exactly-one-primitive and the
+// --offset/--limit-requires-page rule (IN9 inspect_bad_flags).
+func buildInspectRequest(cmd *cobra.Command, path string) (inspect.Request, error) {
+	f := cmd.Flags()
+	var selected []string
+	add := func(name string) bool {
+		if f.Changed(name) {
+			selected = append(selected, name)
+			return true
+		}
+		return false
+	}
+
+	hasSchema := add("schema")
+	hasStats := add("stats")
+	hasSample := add("sample")
+	hasHead := add("head")
+	hasTail := add("tail")
+	hasPage := add("page")
+
+	fieldsRaw, _ := f.GetString("fields")
+	fields := splitCSVList(fieldsRaw)
+
+	offsetChanged := f.Changed("offset")
+	limitChanged := f.Changed("limit")
+
+	if len(selected) > 1 {
+		return inspect.Request{}, inspect.BadFlags(
+			fmt.Sprintf("choose exactly one primitive, not %d (%s)", len(selected), strings.Join(dashify(selected), ", ")),
+			"e.g. dtctl inspect "+path+" --head 20",
+		)
+	}
+	if (offsetChanged || limitChanged) && !hasPage {
+		return inspect.Request{}, inspect.BadFlags(
+			"--offset/--limit require --page",
+			"e.g. dtctl inspect "+path+" --page --offset 1000 --limit 50",
+		)
+	}
+
+	req := inspect.Request{Path: path, Fields: fields}
+	switch {
+	case hasSchema:
+		req.Primitive = inspect.PrimSchema
+	case hasStats:
+		req.Primitive = inspect.PrimStats
+		statsVal, _ := f.GetString("stats")
+		if statsVal != statsAllColumns {
+			req.StatsColumns = splitCSVList(statsVal)
+		}
+	case hasSample:
+		req.Primitive = inspect.PrimSample
+		req.N, _ = f.GetInt("sample")
+	case hasHead:
+		req.Primitive = inspect.PrimHead
+		req.N, _ = f.GetInt("head")
+	case hasTail:
+		req.Primitive = inspect.PrimTail
+		req.N, _ = f.GetInt("tail")
+	case hasPage:
+		req.Primitive = inspect.PrimPage
+		req.Offset, _ = f.GetInt("offset")
+		req.Limit, _ = f.GetInt("limit")
+	default:
+		// No primitive chosen. A bare --fields defaults to --head (row access is
+		// the point of the command); nothing at all is a usage error.
+		if len(fields) == 0 {
+			return inspect.Request{}, inspect.BadFlags(
+				"no primitive selected",
+				"choose one of --head, --tail, --page, --schema, --stats, --sample, or pass --fields to project the first rows",
+			)
+		}
+		req.Primitive = inspect.PrimHead
+	}
+	return req, nil
+}
+
+func init() {
+	rootCmd.AddCommand(inspectCmd)
+	addInspectFlags(inspectCmd)
+}
+
+// addInspectFlags registers the closed primitive set and the shared spill
+// namespace on a command. Factored out so tests can build an equivalent command.
+func addInspectFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("schema", false, "re-derive the schema: columns + types + null counts")
+	// --stats takes an OPTIONAL column list: bare `--stats` profiles every column,
+	// `--stats=col,col` selects (the value must use '=', like --spill).
+	cmd.Flags().String("stats", "", "re-derive per-column stats; bare profiles all columns, or --stats=col,col to select")
+	cmd.Flags().Lookup("stats").NoOptDefVal = statsAllColumns
+	cmd.Flags().Int("sample", 0, "re-emit N representative (leading) rows")
+	cmd.Flags().Int("head", 0, "the first N rows")
+	cmd.Flags().Int("tail", 0, "the last N rows")
+	cmd.Flags().Bool("page", false, "a paginated row window (use with --offset/--limit)")
+	cmd.Flags().Int("offset", 0, "row offset for --page")
+	cmd.Flags().Int("limit", 0, fmt.Sprintf("row limit for --page (default %d)", inspect.DefaultRowCount))
+	cmd.Flags().String("fields", "", "project to these columns (comma-separated); composable with row-access primitives")
+	cmd.Flags().Bool("list", false, "list spilled files in the active context (recover a lost file handle); takes no <file>")
+
+	// inspect honours the same --spill* namespace as query (IN8): an oversized
+	// row window re-spills to a new managed file rather than becoming a context
+	// hazard itself.
+	addSpillFlags(cmd)
+}
+
+// splitCSVList splits a comma-separated flag value into trimmed, non-empty parts.
+func splitCSVList(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// dashify renders flag names with their leading -- for an error message.
+func dashify(names []string) []string {
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = "--" + n
+	}
+	return out
+}
+
+// inspectResourceFromSidecar best-effort extracts the fetched resource (e.g.
+// "logs") from the original query recorded in the sidecar, for context.resource.
+func inspectResourceFromSidecar(sc *output.SidecarManifest) string {
+	if sc == nil {
+		return ""
+	}
+	fields := strings.Fields(strings.ToLower(sc.Query))
+	for i, f := range fields {
+		if f == "fetch" && i+1 < len(fields) {
+			return strings.TrimRight(fields[i+1], ",")
+		}
+	}
+	return ""
+}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -171,7 +171,14 @@ func buildInspectRequest(cmd *cobra.Command, path string) (inspect.Request, erro
 	case hasPage:
 		req.Primitive = inspect.PrimPage
 		req.Offset, _ = f.GetInt("offset")
-		req.Limit, _ = f.GetInt("limit")
+		// An unspecified --limit defaults to DefaultRowCount; an explicit value
+		// (including 0) is honoured by the engine. The command layer owns
+		// defaulting so `--limit 0` means an empty window, not the default.
+		if limitChanged {
+			req.Limit, _ = f.GetInt("limit")
+		} else {
+			req.Limit = inspect.DefaultRowCount
+		}
 	default:
 		// No primitive chosen. A bare --fields defaults to --head (row access is
 		// the point of the command); nothing at all is a usage error.
@@ -181,7 +188,10 @@ func buildInspectRequest(cmd *cobra.Command, path string) (inspect.Request, erro
 				"choose one of --head, --tail, --page, --schema, --stats, --sample, or pass --fields to project the first rows",
 			)
 		}
+		// Bare --fields is an unspecified head, so apply the default count here
+		// (the engine honours an explicit count, including 0, verbatim).
 		req.Primitive = inspect.PrimHead
+		req.N = inspect.DefaultRowCount
 	}
 	return req, nil
 }

--- a/cmd/inspect_list.go
+++ b/cmd/inspect_list.go
@@ -65,6 +65,13 @@ func runInspectList(cmd *cobra.Command, args []string) error {
 	if managed {
 		// Mirror the write-side partitioning (D9): list only the active context's
 		// subdirectory, never the whole cache.
+		if contextName == "" {
+			// No active context could be determined (missing/unusable config), so
+			// SanitizeContextName falls back to the "default" partition — which is
+			// NOT where files spilled under a named context live. Warn so an empty
+			// listing isn't mistaken for "nothing has been spilled".
+			warnings = append(warnings, "the active context could not be determined (no usable config), so only the default partition is listed; spills made under a named context are not shown — set a context with 'dtctl ctx use <name>' and retry")
+		}
 		dir = filepath.Join(dir, output.SanitizeContextName(contextName))
 	} else {
 		warnings = append(warnings, "listing a user-chosen spill dir (DTCTL_SPILL_DIR / spill.dir): it is not context-partitioned, so entries may span contexts")

--- a/cmd/inspect_list.go
+++ b/cmd/inspect_list.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/inspect"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// inspectListIncompatibleFlags are the file-primitive flags that cannot be
+// combined with --list: --list enumerates a directory and takes no <file>, so a
+// primitive (which operates on one file) is a contradiction.
+var inspectListIncompatibleFlags = []string{
+	"schema", "stats", "sample", "head", "tail", "page", "offset", "limit", "fields",
+}
+
+// runInspectList implements `dtctl inspect --list`: it enumerates the spilled
+// files visible in the active context's managed partition (or in a user-chosen
+// spill dir) and emits them with their sidecar provenance, so an agent that has
+// lost a file handle (the original spill envelope aged out of context) can
+// recover it from disk instead of re-querying Grail. It is local-only — no
+// client, no auth — and never reads across contexts (it lists only the active
+// context's partition, the read-side mirror of the D9 write partitioning).
+func runInspectList(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return inspect.BadFlags(
+			"--list takes no <file> argument",
+			"run 'dtctl inspect --list' to enumerate spilled files, then inspect one by its path",
+		)
+	}
+	for _, name := range inspectListIncompatibleFlags {
+		if cmd.Flags().Changed(name) {
+			return inspect.BadFlags(
+				"--list cannot be combined with --"+name,
+				"run 'dtctl inspect --list' alone, then inspect a listed file with --"+name,
+			)
+		}
+	}
+
+	// Local command: config is loaded best-effort, only to learn the active
+	// context (for the partition to list) and the configured spill dir.
+	cfg, _ := LoadConfig()
+	opts, err := resolveSpillOptions(cmd, cfg)
+	if err != nil {
+		return err
+	}
+
+	contextName := ""
+	if cfg != nil {
+		_, contextName = spillProvenance(cfg)
+	}
+
+	var warnings []string
+	dir, managed, berr := output.SpillBaseDir(opts.Dir)
+	if berr != nil {
+		// No writable/known spill location resolves — there is nothing to list.
+		// Emit an empty listing with a note rather than an error: "nothing spilled"
+		// is a valid, useful answer for a handle-recovery probe.
+		return emitInspectList(dir, managed, nil, []string{"no spill location is configured or writable, so no spilled files could be listed"})
+	}
+	if managed {
+		// Mirror the write-side partitioning (D9): list only the active context's
+		// subdirectory, never the whole cache.
+		dir = filepath.Join(dir, output.SanitizeContextName(contextName))
+	} else {
+		warnings = append(warnings, "listing a user-chosen spill dir (DTCTL_SPILL_DIR / spill.dir): it is not context-partitioned, so entries may span contexts")
+	}
+
+	entries, lerr := output.ListSpillFiles(dir)
+	if lerr != nil {
+		return fmt.Errorf("failed to list spill dir %q: %w", dir, lerr)
+	}
+
+	missing := 0
+	for _, e := range entries {
+		if e.SidecarMissing {
+			missing++
+		}
+	}
+	if missing > 0 {
+		warnings = append(warnings, fmt.Sprintf("%d listed file(s) have no manifest — their query and sampling provenance are unknown", missing))
+	}
+
+	return emitInspectList(dir, managed, entries, warnings)
+}
+
+// emitInspectList renders a KindFileList listing. Agent mode emits the
+// discriminated envelope (opaque to pre-inspect consumers, D31); human / scripted
+// mode prints the nested structure (a file list does not table well, so a
+// tabular format defaults to JSON, mirroring the --schema/--stats summary path).
+func emitInspectList(dir string, managed bool, entries []output.SpillFileEntry, warnings []string) error {
+	list := &output.SpillList{Kind: output.KindFileList, Dir: dir, Managed: managed, Files: entries}
+	total := len(entries)
+
+	if agentMode {
+		ctx := &output.ResponseContext{
+			Verb:        "inspect",
+			Total:       &total,
+			Warnings:    warnings,
+			Suggestions: inspectListSuggestions(entries),
+		}
+		if jqFilter != "" {
+			ap := output.NewAgentPrinter(os.Stdout, ctx)
+			ap.SetResultFormat(outputFormat)
+			ap.SetJQFilter(jqFilter)
+			return ap.Print(list)
+		}
+		resp := output.Response{
+			OK:              true,
+			EnvelopeVersion: output.EnvelopeVersion,
+			Result:          list,
+			Context:         ctx,
+		}
+		return output.EncodeEnvelope(os.Stdout, resp)
+	}
+
+	printInspectWarnings(warnings)
+	format := outputFormat
+	if jqFilter != "" {
+		format = output.NormalizeJQOutputFormat(format)
+	}
+	switch format {
+	case "", "table", "wide":
+		format = "json"
+	}
+	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: format, Writer: os.Stdout, JQFilter: jqFilter})
+	return p.Print(list)
+}
+
+// inspectListSuggestions returns the follow-up hints for a listing: the call an
+// agent makes next is row access on a recovered handle (D28: no third-party tool
+// is named).
+func inspectListSuggestions(entries []output.SpillFileEntry) []string {
+	if len(entries) == 0 {
+		return []string{
+			"# no spilled files in this context yet — run a query large enough to spill (it returns a file handle), or lower --spill-threshold",
+		}
+	}
+	return []string{
+		"# recover a handle by path, then read its rows, e.g. dtctl inspect " + entries[0].Path + " --head 20",
+		"# re-derive a file's summary with --schema/--stats if its manifest is also out of context",
+	}
+}

--- a/cmd/inspect_list_test.go
+++ b/cmd/inspect_list_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/inspect"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+func TestRunInspectList_RejectsFileArg(t *testing.T) {
+	c := newInspectTestCmd(t, "--list")
+	err := runInspectList(c, []string{"q-x.jsonl"})
+	if ie, ok := err.(*inspect.Error); !ok || ie.Code != "inspect_bad_flags" {
+		t.Fatalf("err = %v, want inspect_bad_flags for --list with a file arg", err)
+	}
+}
+
+func TestRunInspectList_RejectsPrimitiveCombination(t *testing.T) {
+	for _, argv := range [][]string{
+		{"--list", "--head", "5"},
+		{"--list", "--schema"},
+		{"--list", "--fields", "a,b"},
+		{"--list", "--page", "--offset", "10"},
+	} {
+		c := newInspectTestCmd(t, argv...)
+		err := runInspectList(c, nil)
+		if ie, ok := err.(*inspect.Error); !ok || ie.Code != "inspect_bad_flags" {
+			t.Fatalf("argv %v: err = %v, want inspect_bad_flags", argv, err)
+		}
+	}
+}
+
+func TestRunInspectList_EmitsFileListEnvelope(t *testing.T) {
+	// A user-chosen spill dir (managed=false) keeps the test independent of the
+	// machine's real context/cache: the listing targets <dir>/results directly.
+	base := t.TempDir()
+	t.Setenv("DTCTL_SPILL_DIR", base)
+	resultsDir := filepath.Join(base, "results")
+	if err := os.MkdirAll(resultsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	spill := filepath.Join(resultsDir, "q-1234.jsonl")
+	if err := os.WriteFile(spill, []byte("{\"a\":1}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := output.WriteSidecar(spill, &output.SidecarManifest{
+		Format: "jsonl", Query: "fetch logs", Rows: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	origAgent, origFormat, origJQ := agentMode, outputFormat, jqFilter
+	defer func() { agentMode, outputFormat, jqFilter = origAgent, origFormat, origJQ }()
+	agentMode, outputFormat, jqFilter = true, "json", ""
+
+	var runErr error
+	out := captureStdout(t, func() {
+		c := newInspectTestCmd(t, "--list")
+		runErr = runInspectList(c, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("runInspectList: %v", runErr)
+	}
+
+	var resp struct {
+		OK     bool `json:"ok"`
+		Result struct {
+			Kind  string `json:"kind"`
+			Files []struct {
+				Path  string `json:"path"`
+				Query string `json:"query"`
+			} `json:"files"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("envelope not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.OK || resp.Result.Kind != output.KindFileList {
+		t.Fatalf("want ok file-list envelope, got %+v", resp)
+	}
+	if len(resp.Result.Files) != 1 || resp.Result.Files[0].Query != "fetch logs" {
+		t.Fatalf("want one listed file with provenance, got %+v", resp.Result.Files)
+	}
+}

--- a/cmd/inspect_output.go
+++ b/cmd/inspect_output.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/inspect"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// emitInspectResult renders an inspect result. Row access (kind:records) and the
+// re-derived summary (kind:file-summary) reuse the same envelope contract and
+// printers as the rest of dtctl, so an agent learns nothing new (IN5). In agent
+// mode an oversized row window re-spills to a new managed file instead of
+// flooding context (IN8).
+func emitInspectResult(cmd *cobra.Command, cfg *config.Config, req inspect.Request, res *inspect.Result) error {
+	if res.Kind == output.KindFileSummary {
+		return emitInspectSummary(req, res)
+	}
+	return emitInspectRecords(cmd, cfg, req, res)
+}
+
+// emitInspectRecords renders a row-access result. In agent mode it first checks
+// whether the rows are themselves a context hazard and re-spills if so (IN8),
+// otherwise emits a self-describing kind:records envelope (or, when a --jq /
+// non-JSON encoding owns the shape, the standard agent printer).
+func emitInspectRecords(cmd *cobra.Command, cfg *config.Config, req inspect.Request, res *inspect.Result) error {
+	records := res.Records
+
+	if agentMode {
+		spilled, err := maybeRespill(cmd, cfg, req, res)
+		if err != nil {
+			return err
+		}
+		if spilled != nil {
+			return output.EncodeEnvelope(os.Stdout, *spilled)
+		}
+
+		// --jq or a non-JSON result encoding owns the output shape; defer to the
+		// standard agent printer (mirrors `query`'s inline path).
+		if jqFilter != "" || output.NormalizeMeasureEncoding(outputFormat) != "json" {
+			ctx := inspectContext(req, res, len(records))
+			ap := output.NewAgentPrinter(os.Stdout, ctx)
+			ap.SetResultFormat(outputFormat)
+			ap.SetJQFilter(jqFilter)
+			return ap.PrintList(records)
+		}
+
+		ctx := inspectContext(req, res, len(records))
+		resp := output.Response{
+			OK:              true,
+			EnvelopeVersion: output.EnvelopeVersion,
+			Result:          &output.InlineRecords{Kind: output.KindRecords, Records: records},
+			Context:         ctx,
+		}
+		return output.EncodeEnvelope(os.Stdout, resp)
+	}
+
+	// Human / scripted output: print the rows in the chosen format, warnings to
+	// stderr so they never corrupt a piped result.
+	printInspectWarnings(res.Warnings)
+	format := outputFormat
+	if jqFilter != "" {
+		format = output.NormalizeJQOutputFormat(format)
+	}
+	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: format, Writer: os.Stdout, JQFilter: jqFilter})
+	return p.PrintList(records)
+}
+
+// emitInspectSummary renders a re-derived file-summary (--schema/--stats/--sample).
+func emitInspectSummary(req inspect.Request, res *inspect.Result) error {
+	total := 0
+	if res.Summary != nil {
+		total = res.Summary.Rows
+	}
+
+	if agentMode {
+		ctx := inspectContext(req, res, total)
+		if jqFilter != "" {
+			ap := output.NewAgentPrinter(os.Stdout, ctx)
+			ap.SetResultFormat(outputFormat)
+			ap.SetJQFilter(jqFilter)
+			return ap.Print(res.Summary)
+		}
+		resp := output.Response{
+			OK:              true,
+			EnvelopeVersion: output.EnvelopeVersion,
+			Result:          res.Summary,
+			Context:         ctx,
+		}
+		return output.EncodeEnvelope(os.Stdout, resp)
+	}
+
+	// Human output: a struct does not table well, so default tabular formats to
+	// pretty JSON; honour an explicit structured format otherwise.
+	printInspectWarnings(res.Warnings)
+	format := outputFormat
+	if jqFilter != "" {
+		format = output.NormalizeJQOutputFormat(format)
+	}
+	switch format {
+	case "", "table", "wide":
+		format = "json"
+	}
+	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: format, Writer: os.Stdout, JQFilter: jqFilter})
+	return p.Print(res.Summary)
+}
+
+// inspectContext builds the agent envelope context shared by both result kinds.
+func inspectContext(req inspect.Request, res *inspect.Result, total int) *output.ResponseContext {
+	t := total
+	ctx := &output.ResponseContext{
+		Verb:        "inspect",
+		Resource:    inspectResourceFromSidecar(res.Sidecar),
+		Total:       &t,
+		Warnings:    res.Warnings,
+		Suggestions: inspectSuggestions(req, res),
+	}
+	return ctx
+}
+
+// inspectSuggestions returns tool-agnostic follow-up hints (D28: no third-party
+// project is ever named). A re-derived summary leads with row access (IN4) since
+// that is the call an agent cannot satisfy from a manifest it already holds.
+func inspectSuggestions(req inspect.Request, res *inspect.Result) []string {
+	if res.Kind != output.KindFileSummary {
+		return nil
+	}
+	return []string{
+		"# this is a re-derived summary; for the rows themselves use row access, e.g. dtctl inspect " + req.Path + " --head 20",
+		"# for aggregate questions, prefer pushing the work into DQL and re-querying ('… | summarize …')",
+	}
+}
+
+// printInspectWarnings prints engine warnings to stderr for a human reader.
+func printInspectWarnings(warnings []string) {
+	for _, w := range warnings {
+		output.PrintWarning("%s", w)
+	}
+}

--- a/cmd/inspect_spill.go
+++ b/cmd/inspect_spill.go
@@ -1,0 +1,243 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/exec"
+	"github.com/dynatrace-oss/dtctl/pkg/inspect"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// maybeRespill implements INSPECT IN8: a row-access result that is itself a
+// context hazard (e.g. --head 1000000, or a wide projection over many rows)
+// re-spills to a NEW managed file and returns a result-file manifest, exactly
+// like `query` does — inspect must not become the very context blowup the spill
+// feature exists to prevent. It reuses the Layer 1 spill machinery (dir
+// resolution, atomic write, stats, sidecar, TTL prune); only the provenance is
+// inspect-specific (derived from the source file's sidecar, not a Grail query).
+//
+// It returns (nil, nil) when the result should be emitted inline (spill disabled,
+// or under threshold in auto mode). A spill of a spill is fine — it just
+// re-partitions under the active context dir.
+func maybeRespill(cmd *cobra.Command, cfg *config.Config, req inspect.Request, res *inspect.Result) (*output.Response, error) {
+	opts, err := resolveSpillOptions(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if !opts.Enabled() {
+		return nil, nil
+	}
+
+	measured, encoding := output.MeasureSerializedBytes(res.Records, outputFormat)
+	if opts.Mode == exec.SpillAuto && measured <= opts.Threshold {
+		return nil, nil // inline: small enough
+	}
+
+	// Provenance: carry the original sampling/tenant forward from the source
+	// sidecar; partition the new file under the active context.
+	var sampled bool
+	var samplingRatio float64
+	tenantID := req.ActiveTenant
+	if res.Sidecar != nil {
+		sampled = res.Sidecar.Sampled
+		samplingRatio = res.Sidecar.SamplingRatio
+		if tenantID == "" {
+			tenantID = res.Sidecar.TenantID
+		}
+	}
+	synthQuery := describeInspectCall(req)
+
+	format, targetPath, baseDir, managed, summaryOnly, warnings := resolveRespillTarget(opts, req.ActiveContext, synthQuery)
+
+	records := res.Records
+	cols := output.ComputeColumnStats(records, sampled, output.DefaultStatsTopK, output.DefaultStatsMaxDistinct)
+	envCols, omitted := output.CapColumnsForEnvelope(cols, output.DefaultMaxSummaryColumns)
+
+	manifest := &output.ResultFileManifest{
+		Query:         synthQuery,
+		Format:        format,
+		Rows:          len(records),
+		ContextName:   req.ActiveContext,
+		TenantID:      tenantID,
+		Sampled:       sampled,
+		SamplingRatio: samplingRatio,
+		SampleRows:    output.SampleRows(records, output.DefaultSampleRows),
+	}
+	manifest.SetStats(envCols, sampled)
+	manifest.ColumnsOmitted = omitted
+
+	decided := "spilled"
+	if !summaryOnly {
+		written, werr := output.WriteSpillFile(targetPath, func(w io.Writer) error {
+			p := output.NewPrinterWithOpts(output.PrinterOptions{
+				Format: format,
+				Writer: w,
+				Types:  respillTypes(res.Sidecar),
+			})
+			return p.PrintList(records)
+		})
+		if werr != nil {
+			if opts.ToPath != "" {
+				return nil, fmt.Errorf("failed to write spill file %q: %w", targetPath, werr)
+			}
+			summaryOnly = true
+			warnings = append(warnings, "spill write failed; returning overview only")
+		} else {
+			manifest.Kind = output.KindResultFile
+			manifest.Path = targetPath
+			manifest.Bytes = written
+			_ = output.WriteSidecar(targetPath, &output.SidecarManifest{
+				EnvelopeVersion: output.EnvelopeVersion,
+				Format:          format,
+				Sampled:         sampled,
+				SamplingRatio:   samplingRatio,
+				TenantID:        tenantID,
+				ContextName:     req.ActiveContext,
+				Query:           synthQuery,
+				Rows:            len(records),
+				Bytes:           written,
+				Created:         time.Now().UTC(),
+				Columns:         cols,
+			})
+			if managed && baseDir != "" {
+				output.PruneOldSpills(baseDir, opts.TTL)
+			}
+		}
+	}
+
+	if summaryOnly {
+		manifest.Kind = output.KindSummaryOnly
+		decided = "summary-only"
+	}
+
+	// Carry forward any engine warnings (e.g. sampling-unknown) onto the spill.
+	warnings = append(res.Warnings, warnings...)
+
+	suggestions := []string{}
+	if manifest.Kind == output.KindResultFile {
+		suggestions = append(suggestions,
+			"# the inspected rows were large, so they were re-spilled to the path above; read it with your file tooling for row-level follow-up",
+			"# for complex local analysis, process the spilled file with your preferred local analytics tooling")
+	} else {
+		suggestions = append(suggestions,
+			"# the inspected rows were large but no writable spill location was available, so only this overview is returned",
+			"# narrow the request (smaller --head/--limit, or --fields) to get rows inline")
+	}
+
+	total := len(records)
+	resp := &output.Response{
+		OK:              true,
+		EnvelopeVersion: output.EnvelopeVersion,
+		Result:          manifest,
+		Context: &output.ResponseContext{
+			Verb:             "inspect",
+			Resource:         inspectResourceFromSidecar(res.Sidecar),
+			Total:            &total,
+			Decided:          decided,
+			ThresholdBytes:   opts.Threshold,
+			MeasuredBytes:    measured,
+			MeasuredEncoding: encoding,
+			Warnings:         warnings,
+			Suggestions:      suggestions,
+		},
+	}
+	return resp, nil
+}
+
+// resolveRespillTarget picks the format, destination, and base dir for a re-spill,
+// degrading to summary-only when there is no writable location (D8). It mirrors
+// the query path's resolution but is kept local so the query spill path stays
+// untouched.
+func resolveRespillTarget(opts exec.SpillOptions, contextName, synthQuery string) (format, targetPath, baseDir string, managed, summaryOnly bool, warnings []string) {
+	if opts.ToPath != "" {
+		format = respillFormatForPath(opts.ToPath, opts.Format)
+		return format, opts.ToPath, "", false, false, []string{
+			"spill path is a user-chosen location and opts out of the managed privacy guarantees (no TTL pruning, no per-context partitioning); you own its lifetime",
+		}
+	}
+
+	format = strings.ToLower(opts.Format)
+	if format == "" {
+		format = "jsonl"
+	}
+
+	base, isManaged, berr := output.SpillBaseDir(opts.Dir)
+	if berr != nil {
+		return format, "", "", false, true, []string{"no writable spill location — overview only; narrow the request to get rows inline"}
+	}
+	dir := base
+	if isManaged {
+		dir = filepath.Join(base, output.SanitizeContextName(contextName))
+	} else {
+		warnings = append(warnings, "spill dir is a user-chosen location and opts out of the managed privacy guarantees")
+	}
+	hash := output.SpillHash(synthQuery)
+	targetPath = filepath.Join(dir, "q-"+hash+"."+respillExt(format))
+	return format, targetPath, base, isManaged, false, warnings
+}
+
+// respillTypes builds the Parquet column-type mapping from the source sidecar's
+// column profile so a Parquet re-spill carries a faithful columnar schema. nil
+// (no sidecar) lets the Parquet writer fall back to value inference.
+func respillTypes(sc *output.SidecarManifest) []output.ColumnTypeMapping {
+	if sc == nil || len(sc.Columns) == 0 {
+		return nil
+	}
+	out := make([]output.ColumnTypeMapping, 0, len(sc.Columns))
+	for _, c := range sc.Columns {
+		out = append(out, output.ColumnTypeMapping{Name: c.Name, Type: c.Type})
+	}
+	return out
+}
+
+// describeInspectCall renders a stable, human-legible description of the inspect
+// invocation, recorded as the re-spilled file's `query` provenance (so a later
+// stale-file recovery suggests re-running the same inspect) and hashed into its
+// filename (so re-running overwrites in place rather than accumulating).
+func describeInspectCall(req inspect.Request) string {
+	var b strings.Builder
+	b.WriteString("inspect ")
+	b.WriteString(req.Path)
+	switch req.Primitive {
+	case inspect.PrimHead:
+		fmt.Fprintf(&b, " --head %d", req.N)
+	case inspect.PrimTail:
+		fmt.Fprintf(&b, " --tail %d", req.N)
+	case inspect.PrimPage:
+		fmt.Fprintf(&b, " --page --offset %d --limit %d", req.Offset, req.Limit)
+	}
+	if len(req.Fields) > 0 {
+		fmt.Fprintf(&b, " --fields %s", strings.Join(req.Fields, ","))
+	}
+	return b.String()
+}
+
+func respillExt(format string) string {
+	switch strings.ToLower(format) {
+	case "csv":
+		return "csv"
+	case "json":
+		return "json"
+	case "parquet":
+		return "parquet"
+	default:
+		return "jsonl"
+	}
+}
+
+func respillFormatForPath(path, fallback string) string {
+	if ext := spillFormatFromExt(path); ext != "" {
+		return ext
+	}
+	if fallback != "" {
+		return strings.ToLower(fallback)
+	}
+	return "jsonl"
+}

--- a/cmd/inspect_spill.go
+++ b/cmd/inspect_spill.go
@@ -120,6 +120,13 @@ func maybeRespill(cmd *cobra.Command, cfg *config.Config, req inspect.Request, r
 	// Carry forward any engine warnings (e.g. sampling-unknown) onto the spill.
 	warnings = append(res.Warnings, warnings...)
 
+	// A --jq transform cannot be applied to a re-spilled result (the rows went to
+	// a file, not through the inline jq path), so warn rather than silently drop
+	// the filter — mirroring the query spill path's behaviour.
+	if jqFilter != "" {
+		warnings = append(warnings, "--jq was not applied to the re-spilled result; the file holds the full untransformed rows — apply your filter to the file locally")
+	}
+
 	suggestions := []string{}
 	if manifest.Kind == output.KindResultFile {
 		suggestions = append(suggestions,
@@ -220,16 +227,7 @@ func describeInspectCall(req inspect.Request) string {
 }
 
 func respillExt(format string) string {
-	switch strings.ToLower(format) {
-	case "csv":
-		return "csv"
-	case "json":
-		return "json"
-	case "parquet":
-		return "parquet"
-	default:
-		return "jsonl"
-	}
+	return output.ExtForFormat(format)
 }
 
 func respillFormatForPath(path, fallback string) string {

--- a/cmd/inspect_test.go
+++ b/cmd/inspect_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -169,5 +170,40 @@ func TestMaybeRespill_SpillsAboveThreshold(t *testing.T) {
 	}
 	if resp.Context.Decided != "spilled" {
 		t.Errorf("decided = %q, want spilled", resp.Context.Decided)
+	}
+}
+
+// TestMaybeRespill_WarnsJQDropped confirms that a --jq filter set when a row
+// window re-spills produces a warning rather than being silently dropped (parity
+// with the query spill path).
+func TestMaybeRespill_WarnsJQDropped(t *testing.T) {
+	origAgent, origJQ := agentMode, jqFilter
+	defer func() { agentMode, jqFilter = origAgent, origJQ }()
+	agentMode = true
+	jqFilter = ".[].host"
+
+	dir := t.TempDir()
+	c := newInspectTestCmd(t, "--head", "100", "--spill=auto", "--spill-threshold", "10", "--spill-to", filepath.Join(dir, "out.jsonl"))
+
+	records := []map[string]interface{}{
+		{"host": "web-01", "status": float64(200)},
+		{"host": "web-02", "status": float64(500)},
+	}
+	res := &inspect.Result{Kind: output.KindRecords, Records: records, Format: "jsonl"}
+	resp, err := maybeRespill(c, &config.Config{}, inspect.Request{Path: "src.jsonl", Primitive: inspect.PrimHead, N: 100}, res)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected a re-spill response")
+	}
+	var found bool
+	for _, w := range resp.Context.Warnings {
+		if strings.Contains(w, "--jq was not applied") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a --jq-not-applied warning, got %v", resp.Context.Warnings)
 	}
 }

--- a/cmd/inspect_test.go
+++ b/cmd/inspect_test.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/inspect"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// newInspectTestCmd builds a command carrying the inspect flag surface and parses
+// argv, so buildInspectRequest can be exercised exactly as cobra would invoke it.
+func newInspectTestCmd(t *testing.T, argv ...string) *cobra.Command {
+	t.Helper()
+	c := &cobra.Command{Use: "inspect", RunE: func(*cobra.Command, []string) error { return nil }}
+	addInspectFlags(c)
+	c.SetArgs(argv)
+	if err := c.ParseFlags(argv); err != nil {
+		t.Fatalf("parse %v: %v", argv, err)
+	}
+	return c
+}
+
+func TestBuildInspectRequest_Primitives(t *testing.T) {
+	cases := []struct {
+		name string
+		argv []string
+		want inspect.Primitive
+		n    int
+	}{
+		{"head", []string{"--head", "20"}, inspect.PrimHead, 20},
+		{"tail", []string{"--tail", "5"}, inspect.PrimTail, 5},
+		{"sample", []string{"--sample", "3"}, inspect.PrimSample, 3},
+		{"schema", []string{"--schema"}, inspect.PrimSchema, 0},
+		{"bare-fields-defaults-to-head", []string{"--fields", "a,b"}, inspect.PrimHead, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newInspectTestCmd(t, tc.argv...)
+			req, err := buildInspectRequest(c, "f.jsonl")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if req.Primitive != tc.want {
+				t.Errorf("primitive = %q, want %q", req.Primitive, tc.want)
+			}
+			if tc.n != 0 && req.N != tc.n {
+				t.Errorf("N = %d, want %d", req.N, tc.n)
+			}
+		})
+	}
+}
+
+func TestBuildInspectRequest_Page(t *testing.T) {
+	c := newInspectTestCmd(t, "--page", "--offset", "100", "--limit", "25")
+	req, err := buildInspectRequest(c, "f.jsonl")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if req.Primitive != inspect.PrimPage || req.Offset != 100 || req.Limit != 25 {
+		t.Errorf("page req = %+v", req)
+	}
+}
+
+func TestBuildInspectRequest_StatsColumns(t *testing.T) {
+	all := newInspectTestCmd(t, "--stats")
+	req, err := buildInspectRequest(all, "f.jsonl")
+	if err != nil || req.Primitive != inspect.PrimStats || req.StatsColumns != nil {
+		t.Fatalf("bare --stats req = %+v, err %v (want all columns)", req, err)
+	}
+
+	sel := newInspectTestCmd(t, "--stats=host,status")
+	req, err = buildInspectRequest(sel, "f.jsonl")
+	if err != nil || len(req.StatsColumns) != 2 || req.StatsColumns[0] != "host" {
+		t.Fatalf("--stats=host,status req = %+v, err %v", req, err)
+	}
+}
+
+func TestBuildInspectRequest_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		argv []string
+	}{
+		{"two-primitives", []string{"--head", "2", "--tail", "2"}},
+		{"offset-without-page", []string{"--offset", "5"}},
+		{"limit-without-page", []string{"--limit", "5"}},
+		{"nothing", []string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newInspectTestCmd(t, tc.argv...)
+			_, err := buildInspectRequest(c, "f.jsonl")
+			ie, ok := err.(*inspect.Error)
+			if !ok || ie.Code != "inspect_bad_flags" {
+				t.Fatalf("err = %v, want inspect_bad_flags", err)
+			}
+		})
+	}
+}
+
+// writeRecords writes records to path using the jsonl printer (mirrors a spill).
+func writeRecords(t *testing.T, path string, records []map[string]interface{}) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: "jsonl", Writer: f})
+	if err := p.PrintList(records); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+}
+
+func TestMaybeRespill_InlineBelowThreshold(t *testing.T) {
+	orig := agentMode
+	defer func() { agentMode = orig }()
+	agentMode = true
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "q-x.jsonl")
+	writeRecords(t, path, []map[string]interface{}{{"a": 1}, {"a": 2}})
+
+	c := newInspectTestCmd(t, "--head", "2", "--spill=auto")
+	res := &inspect.Result{Kind: output.KindRecords, Records: []map[string]interface{}{{"a": 1}, {"a": 2}}}
+	resp, err := maybeRespill(c, &config.Config{}, inspect.Request{Path: path, Primitive: inspect.PrimHead}, res)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp != nil {
+		t.Errorf("small result should stay inline, got a spill response")
+	}
+}
+
+func TestMaybeRespill_SpillsAboveThreshold(t *testing.T) {
+	orig := agentMode
+	defer func() { agentMode = orig }()
+	agentMode = true
+
+	dir := t.TempDir()
+	// Force a tiny threshold via --spill-threshold so a small set still spills.
+	c := newInspectTestCmd(t, "--head", "100", "--spill=auto", "--spill-threshold", "10", "--spill-to", filepath.Join(dir, "out.jsonl"))
+
+	records := []map[string]interface{}{
+		{"host": "web-01", "status": float64(200)},
+		{"host": "web-02", "status": float64(500)},
+	}
+	res := &inspect.Result{Kind: output.KindRecords, Records: records, Format: "jsonl"}
+	resp, err := maybeRespill(c, &config.Config{}, inspect.Request{Path: "src.jsonl", Primitive: inspect.PrimHead, N: 100}, res)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected a re-spill response above threshold")
+	}
+	m, ok := resp.Result.(*output.ResultFileManifest)
+	if !ok || m.Kind != output.KindResultFile {
+		t.Fatalf("result = %#v, want a result-file manifest", resp.Result)
+	}
+	if m.Rows != 2 {
+		t.Errorf("rows = %d, want 2", m.Rows)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "out.jsonl")); statErr != nil {
+		t.Errorf("spill file not written: %v", statErr)
+	}
+	if resp.Context.Decided != "spilled" {
+		t.Errorf("decided = %q, want spilled", resp.Context.Decided)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
+	"github.com/dynatrace-oss/dtctl/pkg/inspect"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/suggest"
@@ -387,6 +388,17 @@ func errorToDetail(err error) *output.ErrorDetail {
 			}
 		}
 		return detail
+	}
+
+	// inspect.Error — `dtctl inspect` carries a stable envelope code (spill_file_*,
+	// inspect_bad_flags, inspect_unknown_field) plus actionable suggestions.
+	var inspectErr *inspect.Error
+	if errors.As(err, &inspectErr) {
+		return &output.ErrorDetail{
+			Code:        inspectErr.Code,
+			Message:     inspectErr.Message,
+			Suggestions: inspectErr.Suggestions,
+		}
 	}
 
 	// Fallback — generic error with no structured context

--- a/cmd/spill.go
+++ b/cmd/spill.go
@@ -20,7 +20,12 @@ import (
 // (D15), and enforces the fixed flag-conflict rules (D25). It emits a warning
 // (not an error) for flags that are inert under --spill=never.
 func resolveSpillOptions(cmd *cobra.Command, cfg *config.Config) (exec.SpillOptions, error) {
-	base := cfg.EffectiveSpillConfig()
+	// A nil config (e.g. `dtctl inspect` on a local file with no usable context)
+	// resolves against the built-in defaults; flags and env vars still apply.
+	var base config.SpillConfig
+	if cfg != nil {
+		base = cfg.EffectiveSpillConfig()
+	}
 
 	spillChanged := cmd.Flags().Changed("spill")
 	spillVal, _ := cmd.Flags().GetString("spill")
@@ -114,6 +119,31 @@ func resolveSpillOptions(cmd *cobra.Command, cfg *config.Config) (exec.SpillOpti
 	}
 
 	return opts, nil
+}
+
+// addSpillFlags registers the shared --spill* flag namespace (D4) on a command.
+// Both `query` and `inspect` honour the same spill controls so an oversized
+// result — a Grail query result, or a wide/large `inspect` row window (IN8) —
+// collapses to a managed file + summary instead of flooding the agent context.
+func addSpillFlags(cmd *cobra.Command) {
+	cmd.Flags().String("spill", "", `spill a large result to a local file and return a summary instead of the rows
+bare --spill = always; --spill=auto spills above --spill-threshold; --spill=never forces rows
+(default: auto in agent mode, never otherwise)`)
+	cmd.Flags().Lookup("spill").NoOptDefVal = "always"
+	cmd.Flags().String("spill-to", "", "explicit spill destination file (implies --spill=always; format inferred from extension)")
+	cmd.Flags().String("spill-format", "", "spill file format when spilling to the default dir: jsonl|json|csv|parquet (default jsonl)")
+	cmd.Flags().String("spill-threshold", "", "serialised output size above which a result spills, e.g. 50KB (default 50KB)")
+
+	_ = cmd.RegisterFlagCompletionFunc("spill", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{
+			"auto\tspill above the threshold, inline below",
+			"always\talways spill",
+			"never\tnever spill (rows inline)",
+		}, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = cmd.RegisterFlagCompletionFunc("spill-format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"jsonl", "json", "csv", "parquet"}, cobra.ShellCompDirectiveNoFileComp
+	})
 }
 
 // spillProvenance returns the tenant id (environment subdomain) and the active

--- a/cmd/spill.go
+++ b/cmd/spill.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -150,6 +149,12 @@ bare --spill = always; --spill=auto spills above --spill-threshold; --spill=neve
 // context name for the spill manifest (D9). Both are best-effort: a missing or
 // unparseable environment simply yields an empty tenant id.
 func spillProvenance(cfg *config.Config) (tenantID, contextName string) {
+	// A nil config (local-only `inspect` with no usable config) carries no
+	// provenance — return zero values rather than nil-panicking, mirroring the
+	// nil tolerance of resolveSpillOptions.
+	if cfg == nil {
+		return "", ""
+	}
 	contextName = cfg.CurrentContext
 	if ctx, err := cfg.CurrentContextObj(); err == nil {
 		if sub, serr := httpclient.ExtractSubdomain(ctx.Environment); serr == nil {
@@ -187,18 +192,8 @@ func spillWritesParquet(opts exec.SpillOptions) bool {
 }
 
 // spillFormatFromExt maps a destination file extension to a spill format, or ""
-// for an unrecognised/missing extension.
+// for an unrecognised/missing extension. It delegates to the shared
+// output.FormatForExt so the supported-extension set lives in one place.
 func spillFormatFromExt(path string) string {
-	switch strings.ToLower(strings.TrimPrefix(filepath.Ext(path), ".")) {
-	case "jsonl":
-		return "jsonl"
-	case "json":
-		return "json"
-	case "csv":
-		return "csv"
-	case "parquet":
-		return "parquet"
-	default:
-		return ""
-	}
+	return output.FormatForExt(path)
 }

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -41,6 +41,7 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] `exec` - Execute workflows, analyzers, copilot, functions, SLOs
 - [x] `logs` - View execution logs
 - [x] `query` - Execute DQL queries
+- [x] `inspect` - Local row access / schema / stats over a spilled query-result file (no Grail re-query); `--list` enumerates spilled files in the active context to recover a lost handle
 - [x] `wait` - Wait for conditions on resources (polling with exponential backoff)
 - [x] `history` - Show version history (snapshots)
 - [x] `restore` - Restore to previous version
@@ -140,6 +141,9 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] Customizable chart dimensions: `--width`, `--height`, `--fullscreen`
 - [x] Custom record/byte/scan limits
 - [x] Query metadata output: `--metadata` / `-M` with field selection
+- [x] Spill large results to a local file with a summary envelope: `--spill[=auto|always|never]`, `--spill-to`, `--spill-format`, `--spill-threshold`
+- [x] Local inspection of a spilled file (no Grail re-query): `dtctl inspect <file> --head/--tail/--page/--fields/--schema/--stats/--sample`
+- [x] Recover a lost file handle by listing spilled files in the active context: `dtctl inspect --list`
 
 ### SLO Features
 - [x] List SLOs: `dtctl get slos`

--- a/docs/site/_docs/ai-agent-mode.md
+++ b/docs/site/_docs/ai-agent-mode.md
@@ -70,11 +70,16 @@ regardless of how big the result was. There are three kinds:
 | `result-file` | large result [spilled to a file](dql-queries#spilling-large-results-to-a-file) | a manifest: `path`, `format`, `rows`, `bytes`, column stats, `sample_rows` |
 | `summary-only` | large result but the rows could not be written to disk | the same manifest **minus `path`** |
 
-On a `summary-only` result the rows are not on disk, so `context.suggestions`
-carries the right next step for *why* the spill degraded: a read-only filesystem
-steers you to re-query with `--spill=never` and a bound (`| fields …` / `| limit N`,
-or `--max-result-records N`) so the inline result stays small, while a one-off
-write failure suggests retrying with an explicit `--spill-to <path>`.
+On a `result-file` result the rows are on disk, so read them with
+[`dtctl inspect <path>`](command-reference#inspect-commands) — `--head`/`--tail`/
+`--page`/`--fields` for bounded row access, `--schema`/`--stats` to re-derive the
+profile, `--list` to recover a path that has aged out of context — instead of
+re-querying Grail. On a `summary-only` result the rows are not on disk, so
+`context.suggestions` carries the right next step for *why* the spill degraded: a
+read-only filesystem steers you to re-query with `--spill=never` and a bound
+(`| fields …` / `| limit N`, or `--max-result-records N`) so the inline result
+stays small, while a one-off write failure suggests retrying with an explicit
+`--spill-to <path>`.
 
 ```json
 {

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -23,6 +23,7 @@ dtctl [verb] [resource-type] [resource-name] [flags]
 | `apply` | Apply configuration from file (create or update) |
 | `logs` | Print logs for a resource |
 | `query` | Execute a DQL query |
+| `inspect` | Inspect a spilled query-result file locally (rows, schema, stats) without re-querying Grail |
 | `exec` | Execute a workflow, function, analyzer, or CoPilot skill |
 | `history` | Show version history (snapshots) of a document |
 | `restore` | Restore a document to a previous version |
@@ -168,6 +169,36 @@ dtctl query "..." --segments-file segments.yaml  # Segments with variables from 
 dtctl verify query "fetch logs | limit 10"
 dtctl verify query -f query.dql --canonical --fail-on-warn
 ```
+
+## Inspect Commands
+
+`dtctl inspect` reads a query-result file that `dtctl query` spilled to disk (see
+[Spilling Large Results](dql-queries#spilling-large-results-to-a-file)) — without
+re-querying Grail and without pulling the whole result back into context. Its
+primary capability is **row access**, which the spill summary never carried.
+Choose exactly one primitive per call; it is not a query engine (no filter, no
+SQL, no GROUP BY — push aggregates back into DQL).
+
+```bash
+# Row access
+dtctl inspect q-7f3a9c.jsonl --head 20            # first N rows
+dtctl inspect q-7f3a9c.jsonl --tail 10            # last N rows
+dtctl inspect q-7f3a9c.jsonl --page --offset 1000 --limit 50   # a paginated window (result order)
+dtctl inspect q-7f3a9c.jsonl --head 20 --fields timestamp,content  # column projection (composable)
+
+# Re-derive the summary for a file whose manifest is out of context
+dtctl inspect q-7f3a9c.jsonl --schema             # columns + types + null counts
+dtctl inspect q-7f3a9c.jsonl --stats              # per-column profile (or --stats=col,col)
+dtctl inspect q-7f3a9c.jsonl --sample 5           # N representative (leading) rows
+
+# Recover a lost file handle
+dtctl inspect --list                              # spilled files in the active context, with provenance
+```
+
+Reads jsonl, json, csv, and parquet. Honours the shared `--spill*` flags: an
+oversized inspect window re-spills to a new managed file instead of flooding
+output. It lists/reads only the active context's partition and refuses a file
+that belongs to a different context or tenant.
 
 ## Execution Commands
 

--- a/docs/site/_docs/dql-queries.md
+++ b/docs/site/_docs/dql-queries.md
@@ -155,6 +155,27 @@ Spill is configurable globally or per-context under a `spill:` config section an
 via the `DTCTL_SPILL` / `DTCTL_SPILL_DIR` environment variables — see
 [Configuration](configuration#result-spill).
 
+### Inspecting a Spilled File
+
+Once a result has spilled, `dtctl inspect` interrogates the file locally — the
+expensive Grail scan already happened, so every inspect call reads only what it
+needs and emits only the answer, without re-querying. Its primary capability is
+**row access** (the summary only carried per-column stats and a few sample rows):
+
+```bash
+dtctl inspect ./out.jsonl --head 20                       # first 20 rows
+dtctl inspect ./out.jsonl --page --offset 1000 --limit 50 # a window deep in the result
+dtctl inspect ./out.jsonl --tail 10 --fields timestamp,content  # last rows, projected
+dtctl inspect ./out.jsonl --schema                        # re-derive columns + types + null counts
+dtctl inspect ./out.jsonl --stats                         # re-derive the per-column profile
+dtctl inspect --list                                      # lost the path? list spilled files in this context
+```
+
+`inspect` is not a query engine — for aggregate questions push the work back into
+DQL (`… | summarize …`) and re-query. See the
+[Inspect Commands](command-reference#inspect-commands) reference for the full flag
+set.
+
 ## Filter Segments
 
 Apply [filter segments](segments) at query time to narrow results to specific data subsets. Segments are AND-combined when multiple are specified. See [Filter Segments](segments) for how to manage segments.

--- a/pkg/exec/spill_exec.go
+++ b/pkg/exec/spill_exec.go
@@ -172,6 +172,13 @@ func (e *DQLExecutor) buildSpillResponse(query string, result *DQLQueryResponse,
 	}
 
 	suggestions := spillSuggestions(query, manifest.Kind, summaryReason)
+	// Now that `dtctl inspect` ships (Layer 2), point at concrete, bounded
+	// row-access follow-ups on the spilled file — the calls an agent cannot
+	// satisfy from the summary it just received (INSPECT IN4/D30).
+	if manifest.Kind == output.KindResultFile && manifest.Path != "" {
+		suggestions = append(suggestions,
+			"# for bounded row access without re-querying Grail: dtctl inspect "+manifest.Path+" --head 20 (also --tail, --page --offset N --limit M, --fields a,b)")
+	}
 	if n := len(omittedCols); n > 0 {
 		if manifest.Kind == output.KindResultFile {
 			suggestions = append(suggestions, fmt.Sprintf("# %d sparser columns were omitted from this summary to keep it compact; their names are in result.columns_omitted and full per-column stats are in the sidecar manifest next to the file", n))

--- a/pkg/exec/spill_exec.go
+++ b/pkg/exec/spill_exec.go
@@ -333,16 +333,7 @@ func spillFormatForPath(path, fallback string) (string, error) {
 }
 
 func extForFormat(format string) string {
-	switch strings.ToLower(format) {
-	case "csv":
-		return "csv"
-	case "json":
-		return "json"
-	case "parquet":
-		return "parquet"
-	default:
-		return "jsonl"
-	}
+	return output.ExtForFormat(format)
 }
 
 // Summary-only degradation causes. They select the right next-step advice:

--- a/pkg/inspect/errors.go
+++ b/pkg/inspect/errors.go
@@ -75,6 +75,26 @@ func errWrongContext(path, fileContext, activeContext string) *Error {
 	}
 }
 
+// errWrongTenant refuses a path whose recorded tenant differs from the active
+// tenant (D9/D32) — the strongest cross-account signal. It carries the same
+// envelope code as errWrongContext but names the tenant axis so the message
+// matches the mismatch that was actually detected.
+func errWrongTenant(path, fileTenant, activeTenant string) *Error {
+	msg := "spill file belongs to a different tenant"
+	if fileTenant != "" && activeTenant != "" {
+		msg += " (file tenant: " + fileTenant + ", active tenant: " + activeTenant + ")"
+	}
+	msg += ": " + path
+	return &Error{
+		Code:    output.ErrCodeSpillFileWrongContext,
+		Message: msg,
+		Suggestions: []string{
+			"switch to the file's tenant/context with 'dtctl ctx use <name>', or",
+			"re-run the original query in the active context to spill a fresh file",
+		},
+	}
+}
+
 // errUnknownField reports a --fields name absent from the file schema (IN9). The
 // suggestion lists the available columns so the caller can correct the call.
 func errUnknownField(field string, available []string) *Error {

--- a/pkg/inspect/errors.go
+++ b/pkg/inspect/errors.go
@@ -1,0 +1,114 @@
+// Package inspect implements `dtctl inspect`: a small, fixed set of pure-Go
+// analytics primitives over a spilled query-result file (Layer 2 of the result
+// spill design). Its genuinely new capability over the Layer 1 manifest is row
+// access (--head/--tail/--page/--fields); --schema/--stats/--sample re-derive the
+// manifest from disk for a file whose envelope is no longer in context.
+//
+// The package is pure: it reads files and returns data structures. It never
+// writes to stdout, parses CLI flags, or talks to Grail — the command layer owns
+// those. It deliberately exposes no query/expression language (D16): aggregate
+// questions go back to DQL, complex local analysis goes to an external tool on
+// the file.
+package inspect
+
+import "github.com/dynatrace-oss/dtctl/pkg/output"
+
+// Error is a typed inspect failure carrying a stable envelope error code (D32 /
+// INSPECT IN9) and actionable suggestions. The command layer surfaces Code and
+// Suggestions in the agent envelope (via errorToDetail) and Message to humans.
+type Error struct {
+	Code        string
+	Message     string
+	Suggestions []string
+	// Err is an optional wrapped cause for errors.Is/As chains; it is not shown
+	// to the user (Message already carries the human-readable text).
+	Err error
+}
+
+func (e *Error) Error() string { return e.Message }
+
+func (e *Error) Unwrap() error { return e.Err }
+
+// errNotFound reports a spilled path that is missing / pruned / never existed
+// (D32). The suggestion re-runs the original query when it is known from the
+// sidecar, otherwise it nudges to re-query generically.
+func errNotFound(path, query string, cause error) *Error {
+	return &Error{
+		Code:        output.ErrCodeSpillFileNotFound,
+		Message:     "spill file not found: " + path,
+		Suggestions: requerySuggestions(query),
+		Err:         cause,
+	}
+}
+
+// errUnreadable reports a present-but-unreadable file: a truncated .tmp survivor,
+// a corrupt/partial file, or one written by an incompatible dtctl version (D32).
+func errUnreadable(path, query string, cause error) *Error {
+	msg := "spill file is unreadable: " + path
+	if cause != nil {
+		msg += " (" + cause.Error() + ")"
+	}
+	return &Error{
+		Code:        output.ErrCodeSpillFileUnreadable,
+		Message:     msg,
+		Suggestions: requerySuggestions(query),
+		Err:         cause,
+	}
+}
+
+// errWrongContext refuses a path that belongs to a different context/tenant than
+// the active one (D9/D32) — never read another tenant's spilled data after a
+// context switch.
+func errWrongContext(path, fileContext, activeContext string) *Error {
+	msg := "spill file belongs to a different context"
+	if fileContext != "" && activeContext != "" {
+		msg += " (file: " + fileContext + ", active: " + activeContext + ")"
+	}
+	msg += ": " + path
+	return &Error{
+		Code:    output.ErrCodeSpillFileWrongContext,
+		Message: msg,
+		Suggestions: []string{
+			"switch to the file's context with 'dtctl ctx use <name>', or",
+			"re-run the original query in the active context to spill a fresh file",
+		},
+	}
+}
+
+// errUnknownField reports a --fields name absent from the file schema (IN9). The
+// suggestion lists the available columns so the caller can correct the call.
+func errUnknownField(field string, available []string) *Error {
+	return &Error{
+		Code:        codeUnknownField,
+		Message:     "unknown field " + quote(field) + " is not a column in this file",
+		Suggestions: []string{"available columns: " + joinColumns(available)},
+	}
+}
+
+// errBadFlags reports invalid primitive/flag usage (IN9). It is constructed in
+// the command layer (which owns flag parsing) but uses the shared code so the
+// envelope error contract is consistent.
+func errBadFlags(message string, suggestions ...string) *Error {
+	return &Error{Code: codeBadFlags, Message: message, Suggestions: suggestions}
+}
+
+// BadFlags builds an inspect_bad_flags error. It is exported for the command
+// layer, which owns flag parsing and one-primitive-per-call validation (IN9), so
+// usage errors share the same stable envelope code as engine-side failures.
+func BadFlags(message string, suggestions ...string) *Error {
+	return errBadFlags(message, suggestions...)
+}
+
+// Inspect-local error codes (IN9). The spill_file_* codes are shared with Layer 1
+// (output.ErrCodeSpillFile*) so the stale/missing-file contract is identical.
+const (
+	codeBadFlags     = "inspect_bad_flags"
+	codeUnknownField = "inspect_unknown_field"
+)
+
+func requerySuggestions(query string) []string {
+	if query != "" {
+		return []string{"re-run the original query to spill a fresh file: dtctl query " + quote(query)}
+	}
+	return []string{"re-run the original query to spill a fresh file"}
+}

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -1,0 +1,254 @@
+package inspect
+
+import (
+	"io"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// Primitive is the single analytics operation an inspect call performs. Exactly
+// one is chosen per call (IN1); the set is closed (IN6) — adding to it is a
+// deliberate decision, not an open extension point, which is how "no second
+// query language" stays true over time.
+type Primitive string
+
+const (
+	// Row-access primitives — the reason inspect exists (D30). They return
+	// arbitrary rows the Layer 1 manifest never carried.
+	PrimHead Primitive = "head" // first N rows
+	PrimTail Primitive = "tail" // last N rows
+	PrimPage Primitive = "page" // a paginated window: offset O, limit L
+
+	// Re-derivation primitives — conveniences for a file whose manifest is no
+	// longer in context (a stale spill, a cross-session hand-off). They re-emit
+	// the Layer 1 manifest shape from disk rather than re-querying Grail.
+	PrimSchema Primitive = "schema" // columns + types + null counts
+	PrimStats  Primitive = "stats"  // per-column profile
+	PrimSample Primitive = "sample" // N representative (leading) rows
+)
+
+// DefaultRowCount is the row cap applied to head/tail/sample (and a bare
+// --fields, which defaults to head) when the caller does not specify one. Kept
+// small so a row-access call stays inline and agent-context-friendly by default.
+const DefaultRowCount = 10
+
+// Request is a fully-validated inspect invocation. The command layer parses
+// flags, enforces one-primitive-per-call, and resolves the active context/tenant
+// before constructing it; the engine assumes it is well-formed.
+type Request struct {
+	Path      string
+	Primitive Primitive
+
+	// N is the row count for head/tail/sample.
+	N int
+	// Offset/Limit are the page window for PrimPage.
+	Offset, Limit int
+	// Fields projects row-access output to these columns, in DQL `fields` style.
+	// Empty means all columns.
+	Fields []string
+	// StatsColumns restricts PrimStats to these columns. Empty means all.
+	StatsColumns []string
+
+	// ActiveContext / ActiveTenant are the live dtctl context name and tenant id,
+	// used for the structural cross-context/tenant refusal (D9/D32).
+	ActiveContext string
+	ActiveTenant  string
+}
+
+// Result is the engine output. Exactly one of Records / Summary is populated,
+// matching Kind (output.KindRecords for row access, output.KindFileSummary for
+// the re-derived manifest primitives).
+type Result struct {
+	Kind     string
+	Records  []map[string]interface{}
+	Summary  *output.ResultFileManifest
+	Format   string
+	Sidecar  *output.SidecarManifest
+	Warnings []string
+}
+
+// Run executes a validated inspect request against the spilled file. It resolves
+// the file format and provenance (sidecar), refuses a cross-context/tenant file
+// structurally before opening it (D9/D32), then dispatches the chosen primitive.
+// All failure paths return a *Error carrying a stable envelope code.
+func Run(req Request) (*Result, error) {
+	// Provenance: the sidecar carries what cannot be re-derived from raw rows —
+	// sampling flag/ratio, tenant, context, original query (IN3). Absent for an
+	// older/hand-copied file; present is the common fresh-spill case.
+	sidecar, err := output.ReadSidecar(req.Path)
+	if err != nil {
+		return nil, errUnreadable(req.Path, "", err)
+	}
+	query := ""
+	if sidecar != nil {
+		query = sidecar.Query
+	}
+
+	// Refuse a file that belongs to another context/tenant — without opening it
+	// (D9/D32). Structural for managed paths (the path's context segment); for
+	// user-chosen paths (which opt out of partitioning, D25) fall back to the
+	// sidecar's tenant id when both are known.
+	if cerr := checkContext(req, sidecar); cerr != nil {
+		return nil, cerr
+	}
+
+	format := ""
+	if sidecar != nil {
+		format = sidecar.Format
+	}
+	if format == "" {
+		format = formatFromExtension(req.Path)
+	}
+	if format == "" {
+		return nil, errBadFlags(
+			"cannot determine the format of "+quote(req.Path)+" (no sidecar manifest and an unrecognised extension)",
+			"name the file with a .jsonl, .json, .csv, or .parquet extension, or re-run the original query to spill a self-describing file",
+		)
+	}
+
+	r, err := openReader(req.Path, format, query)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	res := &Result{Format: format, Sidecar: sidecar}
+
+	switch req.Primitive {
+	case PrimHead, PrimTail, PrimPage:
+		return res, runRowAccess(r, req, sidecar, res)
+	case PrimSchema, PrimStats, PrimSample:
+		return res, runSummary(r, req, sidecar, res)
+	default:
+		return nil, errBadFlags("no primitive selected (choose one of --head, --tail, --page, --schema, --stats, --sample, or --fields)")
+	}
+}
+
+// checkContext enforces the cross-context/tenant refusal (D9/D32).
+func checkContext(req Request, sidecar *output.SidecarManifest) error {
+	// Structural: a managed path embeds its context as a directory segment.
+	if seg, ok := output.ManagedContextFor(req.Path); ok && req.ActiveContext != "" {
+		if seg != output.SanitizeContextName(req.ActiveContext) {
+			return errWrongContext(req.Path, seg, req.ActiveContext)
+		}
+	}
+	// Cross-tenant guard for any path (covers user-chosen, non-partitioned paths)
+	// when both tenant ids are known and disagree.
+	if sidecar != nil && sidecar.TenantID != "" && req.ActiveTenant != "" && sidecar.TenantID != req.ActiveTenant {
+		fileCtx := sidecar.ContextName
+		if fileCtx == "" {
+			fileCtx = sidecar.TenantID
+		}
+		return errWrongContext(req.Path, fileCtx, req.ActiveContext)
+	}
+	return nil
+}
+
+// runRowAccess executes head/tail/page, applying --fields projection, and fills
+// res with the resulting records (output.KindRecords).
+func runRowAccess(r Reader, req Request, sidecar *output.SidecarManifest, res *Result) error {
+	if err := validateFields(r, sidecar, req.Fields); err != nil {
+		return err
+	}
+
+	var (
+		rows []map[string]interface{}
+		err  error
+	)
+	switch req.Primitive {
+	case PrimHead:
+		rows, err = readHead(r, rowCount(req.N), req.Fields)
+	case PrimTail:
+		rows, err = readTail(r, rowCount(req.N), req.Fields)
+	case PrimPage:
+		rows, err = readPage(r, req.Offset, pageLimit(req.Limit), req.Fields)
+	}
+	if err != nil {
+		return err
+	}
+
+	res.Kind = output.KindRecords
+	res.Records = rows
+	// When the schema was unknowable up front (NDJSON/JSON, no sidecar), surface
+	// any requested field that never appeared rather than silently returning
+	// empty projections.
+	res.Warnings = append(res.Warnings, missingFieldWarnings(r, sidecar, req.Fields, rows)...)
+	return nil
+}
+
+// runSummary executes schema/stats/sample, re-deriving the manifest shape from
+// disk (output.KindFileSummary).
+func runSummary(r Reader, req Request, sidecar *output.SidecarManifest, res *Result) error {
+	m := &output.ResultFileManifest{
+		Kind:   output.KindFileSummary,
+		Path:   req.Path,
+		Format: res.Format,
+	}
+	if sidecar != nil {
+		m.ContextName = sidecar.ContextName
+		m.TenantID = sidecar.TenantID
+		m.Sampled = sidecar.Sampled
+		m.SamplingRatio = sidecar.SamplingRatio
+		m.Query = sidecar.Query
+		m.Rows = sidecar.Rows
+	}
+
+	switch req.Primitive {
+	case PrimSample:
+		rows, err := readHead(r, rowCount(req.N), req.Fields)
+		if err != nil {
+			return err
+		}
+		m.SampleRows = output.SampleRows(rows, len(rows))
+
+	case PrimSchema, PrimStats:
+		acc := output.NewStatsAccumulator(output.DefaultStatsTopK, output.DefaultStatsMaxDistinct)
+		for {
+			rec, err := r.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return wrapReadError(err)
+			}
+			acc.Observe(rec)
+		}
+		cols := acc.Finalize(m.Sampled)
+		m.Rows = acc.Rows() // authoritative: we scanned the whole file
+
+		if req.Primitive == PrimSchema {
+			m.Columns = schemaView(cols)
+		} else { // PrimStats
+			if len(req.StatsColumns) > 0 {
+				var ferr error
+				cols, ferr = selectColumns(cols, req.StatsColumns)
+				if ferr != nil {
+					return ferr
+				}
+			}
+			m.SetStats(cols, m.Sampled)
+			if sidecar == nil {
+				res.Warnings = append(res.Warnings,
+					"no manifest found next to this file — sampling is unknown; these stats may reflect a Grail sample, not the full population")
+			}
+		}
+	}
+
+	res.Kind = output.KindFileSummary
+	res.Summary = m
+	return nil
+}
+
+func rowCount(n int) int {
+	if n <= 0 {
+		return DefaultRowCount
+	}
+	return n
+}
+
+func pageLimit(l int) int {
+	if l <= 0 {
+		return DefaultRowCount
+	}
+	return l
+}

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -125,21 +125,41 @@ func Run(req Request) (*Result, error) {
 }
 
 // checkContext enforces the cross-context/tenant refusal (D9/D32).
+//
+// Limitation: a file with no sidecar on a non-managed (user-chosen) path carries
+// no recorded identity, so it cannot be structurally attributed to a context or
+// tenant — inspecting such a file is allowed because there is nothing to compare
+// against. The structural managed-path partition and the sidecar provenance below
+// are what make the refusal enforceable for managed and self-spilled files.
 func checkContext(req Request, sidecar *output.SidecarManifest) error {
-	// Structural: a managed path embeds its context as a directory segment.
+	// 1. Structural: a managed path embeds its context as a directory segment, so
+	// a cross-context read is refused from the path alone — before opening the
+	// file — whenever the active context is known.
 	if seg, ok := output.ManagedContextFor(req.Path); ok && req.ActiveContext != "" {
 		if seg != output.SanitizeContextName(req.ActiveContext) {
 			return errWrongContext(req.Path, seg, req.ActiveContext)
 		}
 	}
-	// Cross-tenant guard for any path (covers user-chosen, non-partitioned paths)
-	// when both tenant ids are known and disagree.
-	if sidecar != nil && sidecar.TenantID != "" && req.ActiveTenant != "" && sidecar.TenantID != req.ActiveTenant {
-		fileCtx := sidecar.ContextName
-		if fileCtx == "" {
-			fileCtx = sidecar.TenantID
-		}
-		return errWrongContext(req.Path, fileCtx, req.ActiveContext)
+
+	// The remaining guards rely on sidecar provenance; without it there is nothing
+	// to attribute the file to.
+	if sidecar == nil {
+		return nil
+	}
+
+	// 2. Cross-tenant: the strongest cross-account signal. Refuse when both tenant
+	// ids are known and disagree, naming the tenant axis.
+	if sidecar.TenantID != "" && req.ActiveTenant != "" && sidecar.TenantID != req.ActiveTenant {
+		return errWrongTenant(req.Path, sidecar.TenantID, req.ActiveTenant)
+	}
+
+	// 3. Cross-context via provenance: covers a user-chosen-path file that records
+	// its origin context but no (or a blank) tenant id — refuse when it disagrees
+	// with the active context. This closes the gap where a non-managed file from
+	// another context with no tenant id would otherwise be read.
+	if sidecar.ContextName != "" && req.ActiveContext != "" &&
+		output.SanitizeContextName(sidecar.ContextName) != output.SanitizeContextName(req.ActiveContext) {
+		return errWrongContext(req.Path, sidecar.ContextName, req.ActiveContext)
 	}
 	return nil
 }
@@ -217,14 +237,28 @@ func runSummary(r Reader, req Request, sidecar *output.SidecarManifest, res *Res
 		m.Rows = acc.Rows() // authoritative: we scanned the whole file
 
 		if req.Primitive == PrimSchema {
-			m.Columns = schemaView(cols)
+			// Bound a wide schema to the same envelope cap the query summary uses,
+			// recording the trimmed columns in ColumnsOmitted — re-deriving a
+			// summary must not itself become a context blowup (the hazard inspect
+			// exists to prevent).
+			capped, omitted := output.CapColumnsForEnvelope(cols, output.DefaultMaxSummaryColumns)
+			m.Columns = schemaView(capped)
+			m.ColumnsOmitted = omitted
 		} else { // PrimStats
 			if len(req.StatsColumns) > 0 {
+				// An explicit column selection is the caller's chosen scope; honour
+				// it verbatim (no cap).
 				var ferr error
 				cols, ferr = selectColumns(cols, req.StatsColumns)
 				if ferr != nil {
 					return ferr
 				}
+			} else {
+				// Bare --stats over all columns is capped to the envelope limit, as
+				// the query spill summary is, with the rest named in ColumnsOmitted.
+				var omitted []string
+				cols, omitted = output.CapColumnsForEnvelope(cols, output.DefaultMaxSummaryColumns)
+				m.ColumnsOmitted = omitted
 			}
 			m.SetStats(cols, m.Sampled)
 			if sidecar == nil {
@@ -239,16 +273,23 @@ func runSummary(r Reader, req Request, sidecar *output.SidecarManifest, res *Res
 	return nil
 }
 
+// rowCount clamps a row count to a non-negative value. The command layer is
+// authoritative for defaulting an *unspecified* count to DefaultRowCount, so the
+// engine honours an explicit 0 ("zero rows") rather than reinterpreting it as the
+// default; only a negative (defensive) is clamped to 0.
 func rowCount(n int) int {
-	if n <= 0 {
-		return DefaultRowCount
+	if n < 0 {
+		return 0
 	}
 	return n
 }
 
+// pageLimit clamps a page limit the same way rowCount does: an explicit 0 yields
+// an empty window, a negative is clamped to 0, and defaulting an unspecified
+// limit is the command layer's responsibility.
 func pageLimit(l int) int {
-	if l <= 0 {
-		return DefaultRowCount
+	if l < 0 {
+		return 0
 	}
 	return l
 }

--- a/pkg/inspect/inspect_edge_test.go
+++ b/pkg/inspect/inspect_edge_test.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,14 +64,24 @@ func TestRun_TailAndPageBoundaries(t *testing.T) {
 		t.Errorf("page past end = %v, want empty", page.Records)
 	}
 
-	// tail N<=0 → empty (defensive; the CLI defaults this, but the engine must hold).
+	// tail N<=0 → empty. The engine honours an explicit count (the command layer
+	// owns defaulting an unspecified count), so a negative clamps to 0 rows rather
+	// than being reinterpreted as the default.
 	zero, err := Run(Request{Path: path, Primitive: PrimTail, N: -1})
 	if err != nil {
 		t.Fatalf("tail(-1): %v", err)
 	}
-	// rowCount() promotes a non-positive N to DefaultRowCount, so this returns all rows.
-	if len(zero.Records) != 4 {
-		t.Errorf("tail(-1) = %d rows, want 4 (defaulted)", len(zero.Records))
+	if len(zero.Records) != 0 {
+		t.Errorf("tail(-1) = %d rows, want 0 (negative clamps to empty)", len(zero.Records))
+	}
+
+	// tail 0 → explicit empty (no longer the default).
+	none, err := Run(Request{Path: path, Primitive: PrimTail, N: 0})
+	if err != nil {
+		t.Fatalf("tail(0): %v", err)
+	}
+	if len(none.Records) != 0 {
+		t.Errorf("tail(0) = %d rows, want 0 (explicit zero honoured)", len(none.Records))
 	}
 }
 
@@ -366,5 +377,90 @@ func TestRun_StatsMixedAndComplexColumns(t *testing.T) {
 	}
 	if byName["ts"].Type != "timestamp" {
 		t.Errorf("ts type = %q, want timestamp", byName["ts"].Type)
+	}
+}
+
+// TestRun_StatsCapsWideColumns confirms that re-deriving stats over a file with
+// more columns than the envelope cap returns at most DefaultMaxSummaryColumns
+// columns and names the rest in ColumnsOmitted — inspect must not become the
+// context blowup it exists to prevent.
+func TestRun_StatsCapsWideColumns(t *testing.T) {
+	dir := t.TempDir()
+	wide := map[string]interface{}{}
+	for i := 0; i < output.DefaultMaxSummaryColumns+15; i++ {
+		wide[fmt.Sprintf("c%03d", i)] = float64(i)
+	}
+	path := writeSpill(t, dir, "jsonl", []map[string]interface{}{wide}, &output.SidecarManifest{Format: "jsonl", Rows: 1})
+
+	stats, err := Run(Request{Path: path, Primitive: PrimStats})
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if len(stats.Summary.Columns) > output.DefaultMaxSummaryColumns {
+		t.Errorf("stats returned %d columns, want at most %d", len(stats.Summary.Columns), output.DefaultMaxSummaryColumns)
+	}
+	if len(stats.Summary.ColumnsOmitted) == 0 {
+		t.Errorf("expected omitted columns to be reported for a wide file")
+	}
+
+	// --schema is capped the same way.
+	schema, err := Run(Request{Path: path, Primitive: PrimSchema})
+	if err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	if len(schema.Summary.Columns) > output.DefaultMaxSummaryColumns {
+		t.Errorf("schema returned %d columns, want at most %d", len(schema.Summary.Columns), output.DefaultMaxSummaryColumns)
+	}
+
+	// An explicit column selection is NOT capped — the caller chose the scope.
+	sel, err := Run(Request{Path: path, Primitive: PrimStats, StatsColumns: []string{"c000", "c001"}})
+	if err != nil {
+		t.Fatalf("stats select: %v", err)
+	}
+	if len(sel.Summary.Columns) != 2 {
+		t.Errorf("explicit selection = %d columns, want 2 (uncapped)", len(sel.Summary.Columns))
+	}
+}
+
+// TestRun_CrossContextUserPathViaSidecar covers the provenance context guard: a
+// non-managed (user-chosen) path whose sidecar records a different context (and no
+// tenant id) is refused when an active context is set.
+func TestRun_CrossContextUserPathViaSidecar(t *testing.T) {
+	dir := t.TempDir() // user-chosen location, not the managed cache
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), &output.SidecarManifest{
+		Format: "jsonl", ContextName: "ctx-a", // note: no TenantID
+	})
+
+	// Active context differs → refuse via the sidecar context provenance.
+	errCode(t, Request{Path: path, Primitive: PrimHead, ActiveContext: "ctx-b"},
+		output.ErrCodeSpillFileWrongContext)
+
+	// Same context → allowed.
+	res, err := Run(Request{Path: path, Primitive: PrimHead, N: 1, ActiveContext: "ctx-a"})
+	if err != nil {
+		t.Fatalf("same-context head: %v", err)
+	}
+	if len(res.Records) != 1 {
+		t.Errorf("rows = %d, want 1", len(res.Records))
+	}
+}
+
+// TestFormatTimestamp_OverflowGuard confirms a far-future millis timestamp that
+// would overflow int64 when scaled to nanoseconds surfaces the raw value rather
+// than a wrapped, garbage wall-clock string.
+func TestFormatTimestamp_OverflowGuard(t *testing.T) {
+	const millis = int64(1)
+	mult := int64(1_000_000) // ms → ns
+
+	// In range: converts to an RFC3339 string.
+	if got := formatTimestamp(millis, mult); got != "1970-01-01T00:00:00.001Z" {
+		t.Errorf("in-range = %v, want RFC3339 string", got)
+	}
+
+	// Overflow: value*mult exceeds int64 → raw value returned.
+	huge := int64(9_300_000_000_000) // ms past year 2262 once scaled
+	got := formatTimestamp(huge, mult)
+	if got != huge {
+		t.Errorf("overflow = %v (%T), want raw int64 %d", got, got, huge)
 	}
 }

--- a/pkg/inspect/inspect_edge_test.go
+++ b/pkg/inspect/inspect_edge_test.go
@@ -1,0 +1,362 @@
+package inspect
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// writeRaw writes exact bytes to dir/name (so a test can craft empty, blank-line,
+// non-array, or corrupt files the printers would never produce), optionally with a
+// sidecar declaring the format authoritatively.
+func writeRaw(t *testing.T, dir, name, content string, sc *output.SidecarManifest) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	if sc != nil {
+		if err := output.WriteSidecar(path, sc); err != nil {
+			t.Fatalf("sidecar: %v", err)
+		}
+	}
+	return path
+}
+
+// errCode runs req and asserts it fails with a *Error carrying the wanted code.
+func errCode(t *testing.T, req Request, want string) {
+	t.Helper()
+	_, err := Run(req)
+	ie, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("err = %v (%T), want *inspect.Error with code %q", err, err, want)
+	}
+	if ie.Code != want {
+		t.Fatalf("err code = %q, want %q (msg: %s)", ie.Code, want, ie.Message)
+	}
+}
+
+// TestRun_TailAndPageBoundaries covers the count<n tail branch and an offset past
+// the end (both untested by the happy-path suite).
+func TestRun_TailAndPageBoundaries(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), &output.SidecarManifest{Format: "jsonl", Rows: 4})
+
+	// tail N larger than the file → all rows, in file order.
+	tail, err := Run(Request{Path: path, Primitive: PrimTail, N: 100})
+	if err != nil {
+		t.Fatalf("tail: %v", err)
+	}
+	if len(tail.Records) != 4 || tail.Records[0]["host"] != "web-01" || tail.Records[3]["host"] != "web-03" {
+		t.Errorf("tail(100) = %v, want all 4 rows in order", tail.Records)
+	}
+
+	// page offset past the end → empty window, not an error.
+	page, err := Run(Request{Path: path, Primitive: PrimPage, Offset: 100, Limit: 10})
+	if err != nil {
+		t.Fatalf("page past end: %v", err)
+	}
+	if len(page.Records) != 0 {
+		t.Errorf("page past end = %v, want empty", page.Records)
+	}
+
+	// tail N<=0 → empty (defensive; the CLI defaults this, but the engine must hold).
+	zero, err := Run(Request{Path: path, Primitive: PrimTail, N: -1})
+	if err != nil {
+		t.Fatalf("tail(-1): %v", err)
+	}
+	// rowCount() promotes a non-positive N to DefaultRowCount, so this returns all rows.
+	if len(zero.Records) != 4 {
+		t.Errorf("tail(-1) = %d rows, want 4 (defaulted)", len(zero.Records))
+	}
+}
+
+// TestRun_EmptyFiles ensures an empty NDJSON and an empty (headerless) CSV both
+// read as a valid zero-row result rather than erroring.
+func TestRun_EmptyFiles(t *testing.T) {
+	dir := t.TempDir()
+	for _, tc := range []struct{ name, content, format string }{
+		{"q-empty.jsonl", "", "jsonl"},
+		{"q-blanklines.jsonl", "\n\n", "jsonl"},
+		{"q-empty.csv", "", "csv"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeRaw(t, dir, tc.name, tc.content, &output.SidecarManifest{Format: tc.format})
+			res, err := Run(Request{Path: path, Primitive: PrimHead, N: 10})
+			if err != nil {
+				t.Fatalf("head: %v", err)
+			}
+			if len(res.Records) != 0 {
+				t.Errorf("rows = %d, want 0 for empty file", len(res.Records))
+			}
+		})
+	}
+}
+
+// TestRun_NDJSONBlankLinesBetweenRecords confirms blank lines interleaved with
+// records (and a missing trailing newline) are tolerated.
+func TestRun_NDJSONBlankLinesBetweenRecords(t *testing.T) {
+	dir := t.TempDir()
+	// Two records separated by a blank line, last line has no trailing newline.
+	path := writeRaw(t, dir, "q-gaps.jsonl",
+		"{\"a\":1}\n\n{\"a\":2}", &output.SidecarManifest{Format: "jsonl"})
+	res, err := Run(Request{Path: path, Primitive: PrimHead, N: 10})
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	if len(res.Records) != 2 {
+		t.Fatalf("rows = %d, want 2 (blank line skipped)", len(res.Records))
+	}
+	if res.Records[1]["a"] != float64(2) {
+		t.Errorf("last record = %v, want a=2", res.Records[1])
+	}
+}
+
+// TestRun_UnreadableAndUndeterminable covers the error contract for files the
+// reader cannot stream as records, and for a path whose format cannot be resolved.
+func TestRun_UnreadableAndUndeterminable(t *testing.T) {
+	dir := t.TempDir()
+
+	// A JSON document that is an object, not an array of records → unreadable.
+	obj := writeRaw(t, dir, "q-obj.json", `{"not":"an array"}`, &output.SidecarManifest{Format: "json"})
+	errCode(t, Request{Path: obj, Primitive: PrimHead}, output.ErrCodeSpillFileUnreadable)
+
+	// Garbage bytes declared as parquet → the reader fails to initialise → unreadable.
+	pq := writeRaw(t, dir, "q-corrupt.parquet", "definitely not parquet", &output.SidecarManifest{Format: "parquet"})
+	errCode(t, Request{Path: pq, Primitive: PrimHead}, output.ErrCodeSpillFileUnreadable)
+
+	// No sidecar and an unrecognised extension → the format is undeterminable → bad flags.
+	txt := writeRaw(t, dir, "q-mystery.txt", "{}", nil)
+	errCode(t, Request{Path: txt, Primitive: PrimHead}, codeBadFlags)
+}
+
+// TestRun_FormatFromExtensionWithoutSidecar exercises extension-based format
+// inference (the no-sidecar fallback) for csv, including header-derived schema.
+func TestRun_FormatFromExtensionWithoutSidecar(t *testing.T) {
+	dir := t.TempDir()
+	// A real CSV with no sidecar: format is inferred from .csv, the header gives
+	// the schema, and --fields validates against it (the authoritative-Columns path).
+	path := writeSpill(t, dir, "csv", sampleRecords(), nil)
+	res, err := Run(Request{Path: path, Primitive: PrimHead, N: 2, Fields: []string{"host"}})
+	if err != nil {
+		t.Fatalf("csv head: %v", err)
+	}
+	if res.Format != "csv" {
+		t.Errorf("format = %q, want csv (inferred from extension)", res.Format)
+	}
+	if len(res.Records) != 2 || len(res.Records[0]) != 1 || res.Records[0]["host"] == nil {
+		t.Errorf("projected csv rows = %v, want host-only", res.Records)
+	}
+
+	// An unknown --fields name is a hard error against the CSV header even without a sidecar.
+	errCode(t, Request{Path: path, Primitive: PrimHead, Fields: []string{"ghost"}}, codeUnknownField)
+}
+
+// TestRun_CrossTenantUserPath covers the sidecar-tenant branch of checkContext:
+// a non-managed (user-chosen) path is refused when its sidecar tenant disagrees
+// with the active tenant.
+func TestRun_CrossTenantUserPath(t *testing.T) {
+	dir := t.TempDir() // user-chosen location, not the managed cache
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), &output.SidecarManifest{
+		Format: "jsonl", TenantID: "tenant-a", ContextName: "ctx-a",
+	})
+
+	// Active tenant differs → refuse.
+	errCode(t, Request{Path: path, Primitive: PrimHead, ActiveTenant: "tenant-b"},
+		output.ErrCodeSpillFileWrongContext)
+
+	// Same tenant → allowed.
+	res, err := Run(Request{Path: path, Primitive: PrimHead, N: 1, ActiveTenant: "tenant-a"})
+	if err != nil {
+		t.Fatalf("same-tenant head: %v", err)
+	}
+	if len(res.Records) != 1 {
+		t.Errorf("rows = %d, want 1", len(res.Records))
+	}
+}
+
+// TestRun_StatsColumnSelection covers selectColumns: restricting --stats to named
+// columns, and the unknown-column error.
+func TestRun_StatsColumnSelection(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), &output.SidecarManifest{Format: "jsonl", Rows: 4})
+
+	res, err := Run(Request{Path: path, Primitive: PrimStats, StatsColumns: []string{"host"}})
+	if err != nil {
+		t.Fatalf("stats select: %v", err)
+	}
+	if res.Summary == nil || len(res.Summary.Columns) != 1 || res.Summary.Columns[0].Name != "host" {
+		t.Fatalf("selected stats = %+v, want only host", res.Summary)
+	}
+
+	errCode(t, Request{Path: path, Primitive: PrimStats, StatsColumns: []string{"nope"}}, codeUnknownField)
+}
+
+// TestRun_DeferredFieldsWarning covers the NDJSON-without-schema path: an unknown
+// --fields name cannot be validated up front, so it is not an error but produces
+// a missing-field warning; a present field produces none.
+func TestRun_DeferredFieldsWarning(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), nil) // no sidecar → schema unknowable up front
+
+	// Unknown field: no error, but a warning.
+	missing, err := Run(Request{Path: path, Primitive: PrimHead, N: 2, Fields: []string{"nonexistent"}})
+	if err != nil {
+		t.Fatalf("unexpected error for deferred field: %v", err)
+	}
+	if len(missing.Warnings) == 0 {
+		t.Errorf("expected a missing-field warning for an absent field on a schemaless file")
+	}
+
+	// Present field: no warning.
+	present, err := Run(Request{Path: path, Primitive: PrimHead, N: 2, Fields: []string{"host"}})
+	if err != nil {
+		t.Fatalf("present field: %v", err)
+	}
+	if len(present.Warnings) != 0 {
+		t.Errorf("unexpected warnings for a present field: %v", present.Warnings)
+	}
+}
+
+// TestRun_ParquetProjectionTailPage exercises Parquet beyond head: --fields
+// projection (which Parquet applies after decode), tail, and a page window.
+func TestRun_ParquetProjectionTailPage(t *testing.T) {
+	dir := t.TempDir()
+	recs := []map[string]interface{}{
+		{"host": "web-01", "count": float64(10)},
+		{"host": "web-02", "count": float64(20)},
+		{"host": "web-03", "count": float64(30)},
+	}
+	path := filepath.Join(dir, "q-p.parquet")
+	f, _ := os.Create(path)
+	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: "parquet", Writer: f, Types: []output.ColumnTypeMapping{
+		{Name: "host", Type: "string"}, {Name: "count", Type: "long"},
+	}})
+	if err := p.PrintList(recs); err != nil {
+		t.Fatalf("write parquet: %v", err)
+	}
+	_ = f.Close()
+	_ = output.WriteSidecar(path, &output.SidecarManifest{Format: "parquet", Rows: 3})
+
+	// Projection: keep only host.
+	proj, err := Run(Request{Path: path, Primitive: PrimHead, N: 3, Fields: []string{"host"}})
+	if err != nil {
+		t.Fatalf("parquet head+fields: %v", err)
+	}
+	if len(proj.Records) != 3 || len(proj.Records[0]) != 1 || proj.Records[0]["host"] == nil {
+		t.Errorf("projected parquet rows = %v, want host-only", proj.Records)
+	}
+
+	// Tail.
+	tail, err := Run(Request{Path: path, Primitive: PrimTail, N: 1})
+	if err != nil {
+		t.Fatalf("parquet tail: %v", err)
+	}
+	if len(tail.Records) != 1 || tail.Records[0]["host"] != "web-03" {
+		t.Errorf("parquet tail = %v, want web-03", tail.Records)
+	}
+
+	// Page window [1,3).
+	page, err := Run(Request{Path: path, Primitive: PrimPage, Offset: 1, Limit: 2})
+	if err != nil {
+		t.Fatalf("parquet page: %v", err)
+	}
+	if len(page.Records) != 2 || page.Records[0]["host"] != "web-02" {
+		t.Errorf("parquet page = %v, want [web-02, web-03]", page.Records)
+	}
+	// Parquet integers round-trip as int64.
+	if page.Records[0]["count"] != int64(20) {
+		t.Errorf("count = %#v, want int64(20)", page.Records[0]["count"])
+	}
+}
+
+// TestRun_Sample covers the sample primitive end to end (leading N rows as a
+// file-summary, with embedded sample_rows).
+func TestRun_Sample(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), &output.SidecarManifest{Format: "jsonl", Rows: 4})
+	res, err := Run(Request{Path: path, Primitive: PrimSample, N: 2})
+	if err != nil {
+		t.Fatalf("sample: %v", err)
+	}
+	if res.Kind != output.KindFileSummary || res.Summary == nil {
+		t.Fatalf("sample kind = %q", res.Kind)
+	}
+	if len(res.Summary.SampleRows) != 2 {
+		t.Errorf("sample_rows = %d, want 2", len(res.Summary.SampleRows))
+	}
+}
+
+// TestRun_NDJSONCorruptMidStream confirms a malformed record encountered while
+// streaming surfaces as an unreadable-file error (the wrapReadError path), rather
+// than silently truncating the result.
+func TestRun_NDJSONCorruptMidStream(t *testing.T) {
+	dir := t.TempDir()
+	// First line valid, second line malformed JSON.
+	path := writeRaw(t, dir, "q-corrupt.jsonl",
+		"{\"a\":1}\n{not valid json}\n", &output.SidecarManifest{Format: "jsonl"})
+	// N large enough to reach the bad line.
+	errCode(t, Request{Path: path, Primitive: PrimHead, N: 10}, output.ErrCodeSpillFileUnreadable)
+}
+
+// TestRun_ParquetScalarKinds covers the boolean and double branches of the Parquet
+// value→map conversion (the int64/timestamp branches are covered elsewhere).
+func TestRun_ParquetScalarKinds(t *testing.T) {
+	dir := t.TempDir()
+	recs := []map[string]interface{}{
+		{"ok": true, "ratio": float64(1.5)},
+		{"ok": false, "ratio": float64(2.25)},
+	}
+	path := filepath.Join(dir, "q-kinds.parquet")
+	f, _ := os.Create(path)
+	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: "parquet", Writer: f, Types: []output.ColumnTypeMapping{
+		{Name: "ok", Type: "boolean"}, {Name: "ratio", Type: "double"},
+	}})
+	if err := p.PrintList(recs); err != nil {
+		t.Fatalf("write parquet: %v", err)
+	}
+	_ = f.Close()
+	_ = output.WriteSidecar(path, &output.SidecarManifest{Format: "parquet", Rows: 2})
+
+	res, err := Run(Request{Path: path, Primitive: PrimHead, N: 2})
+	if err != nil {
+		t.Fatalf("parquet head: %v", err)
+	}
+	if res.Records[0]["ok"] != true || res.Records[1]["ok"] != false {
+		t.Errorf("boolean round-trip = %v / %v, want true / false", res.Records[0]["ok"], res.Records[1]["ok"])
+	}
+	if res.Records[0]["ratio"] != float64(1.5) {
+		t.Errorf("double round-trip = %#v, want 1.5", res.Records[0]["ratio"])
+	}
+}
+
+// TestRun_StatsMixedAndComplexColumns confirms the streaming stats path classifies
+// type-mixed and nested columns as "complex" (never crashing on a variant column)
+// and reports timestamps as a timestamp column.
+func TestRun_StatsMixedAndComplexColumns(t *testing.T) {
+	dir := t.TempDir()
+	recs := []map[string]interface{}{
+		{"mixed": float64(1), "nested": map[string]interface{}{"k": "v"}, "ts": "2026-06-01T10:00:00Z"},
+		{"mixed": "two", "nested": map[string]interface{}{"k": "w"}, "ts": "2026-06-01T11:00:00Z"},
+	}
+	path := writeSpill(t, dir, "jsonl", recs, &output.SidecarManifest{Format: "jsonl", Rows: 2})
+	res, err := Run(Request{Path: path, Primitive: PrimStats})
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	byName := map[string]output.ColumnStats{}
+	for _, c := range res.Summary.Columns {
+		byName[c.Name] = c
+	}
+	if byName["mixed"].Type != "complex" {
+		t.Errorf("mixed type = %q, want complex", byName["mixed"].Type)
+	}
+	if byName["nested"].Type != "complex" {
+		t.Errorf("nested type = %q, want complex", byName["nested"].Type)
+	}
+	if byName["ts"].Type != "timestamp" {
+		t.Errorf("ts type = %q, want timestamp", byName["ts"].Type)
+	}
+}

--- a/pkg/inspect/inspect_edge_test.go
+++ b/pkg/inspect/inspect_edge_test.go
@@ -85,6 +85,32 @@ func TestRun_TailAndPageBoundaries(t *testing.T) {
 	}
 }
 
+// TestRun_HugeRowCountDoesNotPreallocate exercises the capped-preallocation path
+// (N far larger than rowPreallocCap) on a tiny file: head and tail must still
+// return exactly the rows present, growing the buffer lazily rather than
+// reserving N slots up front.
+func TestRun_HugeRowCountDoesNotPreallocate(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), &output.SidecarManifest{Format: "jsonl", Rows: 4})
+	huge := rowPreallocCap * 1000 // well past the prealloc cap
+
+	head, err := Run(Request{Path: path, Primitive: PrimHead, N: huge})
+	if err != nil {
+		t.Fatalf("head(huge): %v", err)
+	}
+	if len(head.Records) != 4 || head.Records[0]["host"] != "web-01" {
+		t.Errorf("head(huge) = %d rows, want all 4 in order", len(head.Records))
+	}
+
+	tail, err := Run(Request{Path: path, Primitive: PrimTail, N: huge})
+	if err != nil {
+		t.Fatalf("tail(huge): %v", err)
+	}
+	if len(tail.Records) != 4 || tail.Records[3]["host"] != "web-03" {
+		t.Errorf("tail(huge) = %d rows, want all 4 in order", len(tail.Records))
+	}
+}
+
 // TestRun_EmptyFiles ensures an empty NDJSON and an empty (headerless) CSV both
 // read as a valid zero-row result rather than erroring.
 func TestRun_EmptyFiles(t *testing.T) {

--- a/pkg/inspect/inspect_edge_test.go
+++ b/pkg/inspect/inspect_edge_test.go
@@ -3,6 +3,7 @@ package inspect
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dynatrace-oss/dtctl/pkg/output"
@@ -299,6 +300,13 @@ func TestRun_NDJSONCorruptMidStream(t *testing.T) {
 		"{\"a\":1}\n{not valid json}\n", &output.SidecarManifest{Format: "jsonl"})
 	// N large enough to reach the bad line.
 	errCode(t, Request{Path: path, Primitive: PrimHead, N: 10}, output.ErrCodeSpillFileUnreadable)
+
+	// The error message names the offending file (the NDJSON reader wraps with its
+	// path, matching the json/csv/parquet readers).
+	_, err := Run(Request{Path: path, Primitive: PrimHead, N: 10})
+	if ie, ok := err.(*Error); !ok || !strings.Contains(ie.Message, path) {
+		t.Errorf("unreadable error %q should contain the path %q", err, path)
+	}
 }
 
 // TestRun_ParquetScalarKinds covers the boolean and double branches of the Parquet

--- a/pkg/inspect/inspect_test.go
+++ b/pkg/inspect/inspect_test.go
@@ -1,0 +1,216 @@
+package inspect
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// writeSpill writes records to a managed-style spill file in dir using the given
+// format's printer, plus a sidecar, and returns the data path. It mirrors what
+// the query spill path produces so the engine reads real artifacts.
+func writeSpill(t *testing.T, dir, format string, records []map[string]interface{}, sc *output.SidecarManifest) string {
+	t.Helper()
+	ext := format
+	if format == "jsonl" {
+		ext = "jsonl"
+	}
+	path := filepath.Join(dir, "q-test."+ext)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: format, Writer: f})
+	if err := p.PrintList(records); err != nil {
+		t.Fatalf("print %s: %v", format, err)
+	}
+	_ = f.Close()
+	if sc != nil {
+		if err := output.WriteSidecar(path, sc); err != nil {
+			t.Fatalf("sidecar: %v", err)
+		}
+	}
+	return path
+}
+
+func sampleRecords() []map[string]interface{} {
+	return []map[string]interface{}{
+		{"host": "web-01", "status": float64(200), "ts": "2026-06-01T10:00:00Z"},
+		{"host": "web-02", "status": float64(500), "ts": "2026-06-01T10:01:00Z"},
+		{"host": "web-01", "status": float64(404), "ts": "2026-06-01T10:02:00Z"},
+		{"host": "web-03", "status": float64(200), "ts": "2026-06-01T10:03:00Z"},
+	}
+}
+
+func TestRun_HeadTailPage(t *testing.T) {
+	dir := t.TempDir()
+	for _, format := range []string{"jsonl", "json", "csv"} {
+		t.Run(format, func(t *testing.T) {
+			path := writeSpill(t, dir, format, sampleRecords(), &output.SidecarManifest{
+				Format: format, Rows: 4, ContextName: "prod",
+			})
+
+			head, err := Run(Request{Path: path, Primitive: PrimHead, N: 2})
+			if err != nil {
+				t.Fatalf("head: %v", err)
+			}
+			if got := len(head.Records); got != 2 {
+				t.Fatalf("head rows = %d, want 2", got)
+			}
+			if head.Records[0]["host"] != "web-01" {
+				t.Errorf("head[0].host = %v, want web-01", head.Records[0]["host"])
+			}
+
+			tail, err := Run(Request{Path: path, Primitive: PrimTail, N: 1})
+			if err != nil {
+				t.Fatalf("tail: %v", err)
+			}
+			if len(tail.Records) != 1 || tail.Records[0]["host"] != "web-03" {
+				t.Errorf("tail = %v, want last row web-03", tail.Records)
+			}
+
+			page, err := Run(Request{Path: path, Primitive: PrimPage, Offset: 1, Limit: 2})
+			if err != nil {
+				t.Fatalf("page: %v", err)
+			}
+			if len(page.Records) != 2 || page.Records[0]["host"] != "web-02" {
+				t.Errorf("page = %v, want [web-02, web-01]", page.Records)
+			}
+		})
+	}
+}
+
+func TestRun_FieldsProjection(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), &output.SidecarManifest{
+		Format: "jsonl", Rows: 4,
+		Columns: []output.ColumnStats{{Name: "host"}, {Name: "status"}, {Name: "ts"}},
+	})
+	res, err := Run(Request{Path: path, Primitive: PrimHead, N: 1, Fields: []string{"host"}})
+	if err != nil {
+		t.Fatalf("head+fields: %v", err)
+	}
+	row := res.Records[0]
+	if len(row) != 1 || row["host"] != "web-01" {
+		t.Errorf("projected row = %v, want only host", row)
+	}
+
+	// Unknown field is rejected against the sidecar schema.
+	_, err = Run(Request{Path: path, Primitive: PrimHead, Fields: []string{"nope"}})
+	ie, ok := err.(*Error)
+	if !ok || ie.Code != codeUnknownField {
+		t.Fatalf("unknown field err = %v, want inspect_unknown_field", err)
+	}
+}
+
+func TestRun_StatsAndSchema(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), &output.SidecarManifest{Format: "jsonl", Rows: 4})
+
+	stats, err := Run(Request{Path: path, Primitive: PrimStats})
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Kind != output.KindFileSummary || stats.Summary == nil {
+		t.Fatalf("stats kind = %q", stats.Kind)
+	}
+	if stats.Summary.Rows != 4 {
+		t.Errorf("stats rows = %d, want 4", stats.Summary.Rows)
+	}
+	var host *output.ColumnStats
+	for i := range stats.Summary.Columns {
+		if stats.Summary.Columns[i].Name == "host" {
+			host = &stats.Summary.Columns[i]
+		}
+	}
+	if host == nil || host.Distinct == nil || *host.Distinct != 3 {
+		t.Errorf("host distinct = %v, want 3", host)
+	}
+
+	schema, err := Run(Request{Path: path, Primitive: PrimSchema})
+	if err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	for _, c := range schema.Summary.Columns {
+		if c.Distinct != nil || c.Top != nil {
+			t.Errorf("schema col %q should be trimmed, got %+v", c.Name, c)
+		}
+	}
+}
+
+func TestRun_StatsSampledWarnsWithoutSidecar(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), nil) // no sidecar
+	res, err := Run(Request{Path: path, Primitive: PrimStats})
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if len(res.Warnings) == 0 {
+		t.Errorf("expected a sampling-unknown warning when no sidecar is present")
+	}
+}
+
+func TestRun_WrongContextManagedPath(t *testing.T) {
+	// Simulate a managed cache path: <cache>/dtctl/results/<ctx>/q-...
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		t.Skip("no user cache dir")
+	}
+	dir := filepath.Join(cache, "dtctl", "results", "other-ctx")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), &output.SidecarManifest{Format: "jsonl", ContextName: "other-ctx"})
+	t.Cleanup(func() { _ = os.Remove(path); _ = os.Remove(output.SidecarPathFor(path)) })
+
+	_, err = Run(Request{Path: path, Primitive: PrimHead, ActiveContext: "prod"})
+	ie, ok := err.(*Error)
+	if !ok || ie.Code != output.ErrCodeSpillFileWrongContext {
+		t.Fatalf("err = %v, want spill_file_wrong_context", err)
+	}
+}
+
+func TestRun_NotFound(t *testing.T) {
+	_, err := Run(Request{Path: filepath.Join(t.TempDir(), "q-gone.jsonl"), Primitive: PrimHead})
+	ie, ok := err.(*Error)
+	if !ok || ie.Code != output.ErrCodeSpillFileNotFound {
+		t.Fatalf("err = %v, want spill_file_not_found", err)
+	}
+}
+
+func TestRun_Parquet(t *testing.T) {
+	dir := t.TempDir()
+	recs := []map[string]interface{}{
+		{"host": "web-01", "count": float64(10), "ts": "2026-06-01T10:00:00Z"},
+		{"host": "web-02", "count": float64(20), "ts": "2026-06-01T10:01:00Z"},
+	}
+	path := filepath.Join(dir, "q-test.parquet")
+	f, _ := os.Create(path)
+	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: "parquet", Writer: f, Types: []output.ColumnTypeMapping{
+		{Name: "host", Type: "string"}, {Name: "count", Type: "long"}, {Name: "ts", Type: "timestamp"},
+	}})
+	if err := p.PrintList(recs); err != nil {
+		t.Fatalf("write parquet: %v", err)
+	}
+	_ = f.Close()
+	_ = output.WriteSidecar(path, &output.SidecarManifest{Format: "parquet", Rows: 2})
+
+	res, err := Run(Request{Path: path, Primitive: PrimHead, N: 5})
+	if err != nil {
+		t.Fatalf("parquet head: %v", err)
+	}
+	if len(res.Records) != 2 {
+		t.Fatalf("rows = %d, want 2", len(res.Records))
+	}
+	if res.Records[0]["count"] != int64(10) {
+		t.Errorf("count = %#v, want int64(10)", res.Records[0]["count"])
+	}
+	// Timestamp round-trips to an RFC3339 string, not raw nanos.
+	ts, _ := res.Records[0]["ts"].(string)
+	if _, perr := time.Parse(time.RFC3339Nano, ts); perr != nil {
+		t.Errorf("ts = %#v, want RFC3339 string", res.Records[0]["ts"])
+	}
+}

--- a/pkg/inspect/paginate.go
+++ b/pkg/inspect/paginate.go
@@ -7,10 +7,26 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 )
 
+// rowPreallocCap bounds the up-front slice capacity a row-access primitive
+// reserves. A pathological --head/--tail/--limit (e.g. 2_000_000_000) must grow
+// the buffer incrementally as rows are actually read, not allocate gigabytes for
+// a file that may hold only a handful of rows — otherwise the very large window
+// that IN8 re-spill exists to handle would OOM before the re-spill could run.
+const rowPreallocCap = 4096
+
+// prealloc caps an up-front capacity hint at rowPreallocCap; append grows the
+// slice the rest of the way only if the rows are really there.
+func prealloc(n int) int {
+	if n < rowPreallocCap {
+		return n
+	}
+	return rowPreallocCap
+}
+
 // readHead returns the first n records, projected to fields. It stops after n,
-// so memory and time are O(n) — it never reads the rest of the file.
+// so memory and time are O(min(n, rows)) — it never reads the rest of the file.
 func readHead(r Reader, n int, fields []string) ([]map[string]interface{}, error) {
-	out := make([]map[string]interface{}, 0, n)
+	out := make([]map[string]interface{}, 0, prealloc(n))
 	for len(out) < n {
 		rec, err := r.Next()
 		if err == io.EOF {
@@ -46,15 +62,17 @@ func readPage(r Reader, offset, limit int, fields []string) ([]map[string]interf
 }
 
 // readTail returns the last n records, projected to fields. It keeps an n-slot
-// ring buffer while streaming, so memory is O(n) regardless of file size. (Time
-// is O(file) for NDJSON/JSON — a reverse-read optimisation is possible but tail
-// is rare; Parquet could read trailing row groups — both are future
-// optimisations; correctness and bounded memory hold today.)
+// ring buffer while streaming, so memory is O(min(n, rows)) regardless of file
+// size — the ring is grown lazily (capped initial capacity) so a huge --tail on
+// a small file never allocates n slots up front, then overwrites oldest-first
+// once full. (Time is O(file) for NDJSON/JSON — a reverse-read optimisation is
+// possible but tail is rare; Parquet could read trailing row groups — both are
+// future optimisations; correctness and bounded memory hold today.)
 func readTail(r Reader, n int, fields []string) ([]map[string]interface{}, error) {
 	if n <= 0 {
 		return []map[string]interface{}{}, nil
 	}
-	ring := make([]map[string]interface{}, n)
+	ring := make([]map[string]interface{}, 0, prealloc(n))
 	count := 0
 	for {
 		rec, err := r.Next()
@@ -64,7 +82,12 @@ func readTail(r Reader, n int, fields []string) ([]map[string]interface{}, error
 		if err != nil {
 			return nil, wrapReadError(err)
 		}
-		ring[count%n] = project(rec, fields)
+		row := project(rec, fields)
+		if len(ring) < n {
+			ring = append(ring, row) // ring not yet full — grow it
+		} else {
+			ring[count%n] = row // full — overwrite the oldest slot
+		}
 		count++
 	}
 

--- a/pkg/inspect/paginate.go
+++ b/pkg/inspect/paginate.go
@@ -1,0 +1,190 @@
+package inspect
+
+import (
+	"io"
+	"sort"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// readHead returns the first n records, projected to fields. It stops after n,
+// so memory and time are O(n) — it never reads the rest of the file.
+func readHead(r Reader, n int, fields []string) ([]map[string]interface{}, error) {
+	out := make([]map[string]interface{}, 0, n)
+	for len(out) < n {
+		rec, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, wrapReadError(err)
+		}
+		out = append(out, project(rec, fields))
+	}
+	return out, nil
+}
+
+// readPage returns the window [offset, offset+limit), projected to fields. It
+// skips offset records and emits up to limit, so memory is O(limit). Row order
+// is file order, so pagination is stable across calls on the same file (IN7).
+func readPage(r Reader, offset, limit int, fields []string) ([]map[string]interface{}, error) {
+	if offset < 0 {
+		offset = 0
+	}
+	skipped := 0
+	for skipped < offset {
+		_, err := r.Next()
+		if err == io.EOF {
+			return []map[string]interface{}{}, nil // offset past the end → empty window
+		}
+		if err != nil {
+			return nil, wrapReadError(err)
+		}
+		skipped++
+	}
+	return readHead(r, limit, fields)
+}
+
+// readTail returns the last n records, projected to fields. It keeps an n-slot
+// ring buffer while streaming, so memory is O(n) regardless of file size. (Time
+// is O(file) for NDJSON/JSON — a reverse-read optimisation is possible but tail
+// is rare; Parquet could read trailing row groups — both are future
+// optimisations; correctness and bounded memory hold today.)
+func readTail(r Reader, n int, fields []string) ([]map[string]interface{}, error) {
+	if n <= 0 {
+		return []map[string]interface{}{}, nil
+	}
+	ring := make([]map[string]interface{}, n)
+	count := 0
+	for {
+		rec, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, wrapReadError(err)
+		}
+		ring[count%n] = project(rec, fields)
+		count++
+	}
+
+	size := n
+	if count < n {
+		size = count
+	}
+	out := make([]map[string]interface{}, 0, size)
+	start := count - size
+	for i := start; i < count; i++ {
+		out = append(out, ring[i%n])
+	}
+	return out, nil
+}
+
+// validateFields rejects a --fields name that is not a column in the file, but
+// only when the schema is knowable up front: the reader's own schema (Parquet
+// footer / CSV header) or, failing that, the sidecar's column list. For NDJSON /
+// JSON with no sidecar the schema is only knowable by scanning, so validation is
+// deferred to a post-hoc warning (missingFieldWarnings) rather than a hard error.
+func validateFields(r Reader, sidecar *output.SidecarManifest, fields []string) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	schema := knownSchema(r, sidecar)
+	if schema == nil {
+		return nil // unknowable up front; handled as a warning later
+	}
+	known := make(map[string]bool, len(schema))
+	for _, c := range schema {
+		known[c] = true
+	}
+	for _, f := range fields {
+		if !known[f] {
+			return errUnknownField(f, schema)
+		}
+	}
+	return nil
+}
+
+// missingFieldWarnings reports requested --fields that never appeared in the
+// returned rows when the schema could not be validated up front. It is advisory:
+// without a full scan we cannot prove a field is absent from the whole file, so
+// this is a warning, not an error.
+func missingFieldWarnings(r Reader, sidecar *output.SidecarManifest, fields []string, rows []map[string]interface{}) []string {
+	if len(fields) == 0 || knownSchema(r, sidecar) != nil {
+		return nil
+	}
+	seen := make(map[string]bool)
+	for _, rec := range rows {
+		for k := range rec {
+			seen[k] = true
+		}
+	}
+	var missing []string
+	for _, f := range fields {
+		if !seen[f] {
+			missing = append(missing, f)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	return []string{"requested field(s) not present in the returned rows (the file has no schema header to validate against): " + joinColumns(missing)}
+}
+
+// knownSchema returns the authoritative up-front column set for --fields
+// validation: the reader's own schema first (Parquet/CSV), then the sidecar's
+// columns. nil means the schema is only knowable by scanning rows.
+func knownSchema(r Reader, sidecar *output.SidecarManifest) []string {
+	if cols := r.Columns(); cols != nil {
+		return cols
+	}
+	if sidecar != nil && len(sidecar.Columns) > 0 {
+		names := make([]string, len(sidecar.Columns))
+		for i, c := range sidecar.Columns {
+			names[i] = c.Name
+		}
+		return names
+	}
+	return nil
+}
+
+// schemaView trims full column stats to the schema-only fields (name, type, null
+// count) that --schema reports.
+func schemaView(cols []output.ColumnStats) []output.ColumnStats {
+	out := make([]output.ColumnStats, len(cols))
+	for i, c := range cols {
+		out[i] = output.ColumnStats{Name: c.Name, Type: c.Type, Nulls: c.Nulls, Basis: c.Basis}
+	}
+	return out
+}
+
+// selectColumns filters computed stats to the requested column names, preserving
+// the request order. An unknown name is an inspect_unknown_field error listing
+// the available columns.
+func selectColumns(cols []output.ColumnStats, want []string) ([]output.ColumnStats, error) {
+	byName := make(map[string]output.ColumnStats, len(cols))
+	available := make([]string, len(cols))
+	for i, c := range cols {
+		byName[c.Name] = c
+		available[i] = c.Name
+	}
+	out := make([]output.ColumnStats, 0, len(want))
+	for _, name := range want {
+		c, ok := byName[name]
+		if !ok {
+			return nil, errUnknownField(name, available)
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+// wrapReadError normalises a low-level read failure into an unreadable-file
+// error unless it is already a typed inspect error (readers may already wrap).
+func wrapReadError(err error) error {
+	if ie, ok := err.(*Error); ok {
+		return ie
+	}
+	return errUnreadable("", "", err)
+}

--- a/pkg/inspect/reader.go
+++ b/pkg/inspect/reader.go
@@ -41,7 +41,7 @@ func openReader(path, format, query string) (Reader, error) {
 
 	switch strings.ToLower(format) {
 	case "jsonl", "ndjson":
-		return newNDJSONReader(f), nil
+		return newNDJSONReader(f, path, query), nil
 	case "json":
 		r, rerr := newJSONReader(f, path, query)
 		if rerr != nil {

--- a/pkg/inspect/reader.go
+++ b/pkg/inspect/reader.go
@@ -1,0 +1,119 @@
+package inspect
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Reader streams records out of a spilled file one at a time, so a row-access
+// primitive reads only what it returns and memory never scales with the file
+// size. Row order is file order (= spill order = the DQL result order); a reader
+// never re-sorts (sorting is a query concern — push `| sort` into DQL, IN7).
+type Reader interface {
+	// Columns returns the column names when the format carries a cheap schema
+	// (Parquet footer, CSV header). It returns nil when the schema is only
+	// knowable by scanning rows (NDJSON / JSON), in which case the caller falls
+	// back to the sidecar schema or best-effort discovery.
+	Columns() []string
+	// Next returns the next record, or io.EOF when the stream is exhausted. The
+	// returned map is owned by the caller.
+	Next() (map[string]interface{}, error)
+	// Close releases the underlying file/handles.
+	Close() error
+}
+
+// openReader opens path with the reader for the given format. format is the
+// authoritative format from the sidecar when present, else inferred from the
+// extension by the caller. A missing file is reported as a not-found error and a
+// reader that cannot initialise (truncated/corrupt header) as unreadable, both
+// carrying the original query for a concrete re-query suggestion.
+func openReader(path, format, query string) (Reader, error) {
+	f, err := os.Open(path) //nolint:gosec // path is a user/agent-provided spill file by design
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errNotFound(path, query, err)
+		}
+		return nil, errUnreadable(path, query, err)
+	}
+
+	switch strings.ToLower(format) {
+	case "jsonl", "ndjson":
+		return newNDJSONReader(f), nil
+	case "json":
+		r, rerr := newJSONReader(f, path, query)
+		if rerr != nil {
+			_ = f.Close()
+			return nil, rerr
+		}
+		return r, nil
+	case "csv":
+		r, rerr := newCSVReader(f, path, query)
+		if rerr != nil {
+			_ = f.Close()
+			return nil, rerr
+		}
+		return r, nil
+	case "parquet":
+		r, rerr := newParquetReader(f, path, query)
+		if rerr != nil {
+			_ = f.Close()
+			return nil, rerr
+		}
+		return r, nil
+	default:
+		_ = f.Close()
+		return nil, errBadFlags("unsupported file format " + quote(format) + " (inspect reads jsonl, json, csv, or parquet)")
+	}
+}
+
+// formatFromExtension infers a spill format from a file extension. It is the
+// fallback when there is no sidecar to declare the format authoritatively.
+func formatFromExtension(path string) string {
+	switch strings.ToLower(strings.TrimPrefix(filepath.Ext(path), ".")) {
+	case "jsonl", "ndjson":
+		return "jsonl"
+	case "json":
+		return "json"
+	case "csv":
+		return "csv"
+	case "parquet":
+		return "parquet"
+	default:
+		return ""
+	}
+}
+
+// project returns a copy of rec limited to fields, preserving the requested
+// order semantics at the map level (maps are unordered; the printer/encoder
+// decides column order). A field absent from rec is simply omitted (it reads as
+// null downstream), matching DQL's `fields` behaviour. fields == nil returns rec
+// unchanged (no projection requested).
+func project(rec map[string]interface{}, fields []string) map[string]interface{} {
+	if len(fields) == 0 {
+		return rec
+	}
+	out := make(map[string]interface{}, len(fields))
+	for _, f := range fields {
+		if v, ok := rec[f]; ok {
+			out[f] = v
+		}
+	}
+	return out
+}
+
+// --- small shared string helpers -------------------------------------------
+
+func quote(s string) string { return strconv.Quote(s) }
+
+func joinColumns(cols []string) string {
+	if len(cols) == 0 {
+		return "(none)"
+	}
+	sorted := make([]string, len(cols))
+	copy(sorted, cols)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ", ")
+}

--- a/pkg/inspect/reader.go
+++ b/pkg/inspect/reader.go
@@ -2,10 +2,11 @@ package inspect
 
 import (
 	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
 )
 
 // Reader streams records out of a spilled file one at a time, so a row-access
@@ -70,20 +71,11 @@ func openReader(path, format, query string) (Reader, error) {
 }
 
 // formatFromExtension infers a spill format from a file extension. It is the
-// fallback when there is no sidecar to declare the format authoritatively.
+// fallback when there is no sidecar to declare the format authoritatively. It
+// delegates to the shared output.FormatForExt so the extension→format mapping
+// lives in one place.
 func formatFromExtension(path string) string {
-	switch strings.ToLower(strings.TrimPrefix(filepath.Ext(path), ".")) {
-	case "jsonl", "ndjson":
-		return "jsonl"
-	case "json":
-		return "json"
-	case "csv":
-		return "csv"
-	case "parquet":
-		return "parquet"
-	default:
-		return ""
-	}
+	return output.FormatForExt(path)
 }
 
 // project returns a copy of rec limited to fields, preserving the requested

--- a/pkg/inspect/reader_csv.go
+++ b/pkg/inspect/reader_csv.go
@@ -1,0 +1,65 @@
+package inspect
+
+import (
+	"encoding/csv"
+	"io"
+)
+
+// csvReader streams a CSV file written by the `-o csv` printer: a header row of
+// sorted column names followed by one row per record. CSV is all-strings, so
+// every cell is returned as a string and an empty cell as "" (CSV cannot
+// distinguish null from empty — a documented best-effort limitation, IN2). The
+// header gives the schema cheaply, so Columns() is authoritative for --fields
+// validation even without a sidecar.
+type csvReader struct {
+	c      io.Closer
+	r      *csv.Reader
+	header []string
+	path   string
+	q      string
+}
+
+func newCSVReader(rc io.ReadCloser, path, query string) (*csvReader, error) {
+	cr := csv.NewReader(rc)
+	cr.FieldsPerRecord = -1 // tolerate ragged rows rather than erroring the read
+	cr.ReuseRecord = true   // we copy what we keep; lets the reader reuse its buffer
+	header, err := cr.Read()
+	if err != nil {
+		if err == io.EOF {
+			// An empty CSV file (no header) is a valid empty result: no columns,
+			// no rows. Represent it as a reader that yields nothing.
+			return &csvReader{c: rc, r: cr, header: nil, path: path, q: query}, nil
+		}
+		return nil, errUnreadable(path, query, err)
+	}
+	// Copy the header out of the reader's reused buffer.
+	cols := make([]string, len(header))
+	copy(cols, header)
+	return &csvReader{c: rc, r: cr, header: cols, path: path, q: query}, nil
+}
+
+func (r *csvReader) Columns() []string { return r.header }
+
+func (r *csvReader) Next() (map[string]interface{}, error) {
+	if r.header == nil {
+		return nil, io.EOF
+	}
+	row, err := r.r.Read()
+	if err != nil {
+		if err == io.EOF {
+			return nil, io.EOF
+		}
+		return nil, errUnreadable(r.path, r.q, err)
+	}
+	rec := make(map[string]interface{}, len(r.header))
+	for i, col := range r.header {
+		if i < len(row) {
+			rec[col] = row[i]
+		} else {
+			rec[col] = "" // ragged short row → empty cell
+		}
+	}
+	return rec, nil
+}
+
+func (r *csvReader) Close() error { return r.c.Close() }

--- a/pkg/inspect/reader_json.go
+++ b/pkg/inspect/reader_json.go
@@ -1,0 +1,51 @@
+package inspect
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// jsonReader streams a JSON file written by the `-o json` printer: a single
+// top-level array of record objects. It reads elements one at a time with a
+// json.Decoder (read '[', then decode each element on demand) so peak memory is
+// one record rather than the whole array — important for a large spilled result.
+type jsonReader struct {
+	c    io.Closer
+	dec  *json.Decoder
+	path string
+	q    string
+	done bool
+}
+
+func newJSONReader(rc io.ReadCloser, path, query string) (*jsonReader, error) {
+	dec := json.NewDecoder(bufio.NewReaderSize(rc, 64*1024))
+	// Consume the opening '['. A JSON document that is not an array is not a
+	// shape inspect can stream as records → unreadable.
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, errUnreadable(path, query, err)
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '[' {
+		return nil, errUnreadable(path, query, fmt.Errorf("expected a JSON array of records, got %v", tok))
+	}
+	return &jsonReader{c: rc, dec: dec, path: path, q: query}, nil
+}
+
+// Columns returns nil: a JSON array exposes no schema header.
+func (r *jsonReader) Columns() []string { return nil }
+
+func (r *jsonReader) Next() (map[string]interface{}, error) {
+	if r.done || !r.dec.More() {
+		r.done = true
+		return nil, io.EOF
+	}
+	var rec map[string]interface{}
+	if err := r.dec.Decode(&rec); err != nil {
+		return nil, errUnreadable(r.path, r.q, err)
+	}
+	return rec, nil
+}
+
+func (r *jsonReader) Close() error { return r.c.Close() }

--- a/pkg/inspect/reader_ndjson.go
+++ b/pkg/inspect/reader_ndjson.go
@@ -13,12 +13,14 @@ import (
 // line — a log record with a large `content` field is common — is never
 // truncated by the scanner's token cap.
 type ndjsonReader struct {
-	c  io.Closer
-	br *bufio.Reader
+	c    io.Closer
+	br   *bufio.Reader
+	path string
+	q    string
 }
 
-func newNDJSONReader(rc io.ReadCloser) *ndjsonReader {
-	return &ndjsonReader{c: rc, br: bufio.NewReaderSize(rc, 64*1024)}
+func newNDJSONReader(rc io.ReadCloser, path, query string) *ndjsonReader {
+	return &ndjsonReader{c: rc, br: bufio.NewReaderSize(rc, 64*1024), path: path, q: query}
 }
 
 // Columns returns nil: NDJSON carries no schema header, so the column set is
@@ -33,7 +35,7 @@ func (r *ndjsonReader) Next() (map[string]interface{}, error) {
 			return nil, io.EOF
 		}
 		if err != nil && err != io.EOF {
-			return nil, err
+			return nil, errUnreadable(r.path, r.q, err)
 		}
 		trimmed := bytes.TrimSpace(line)
 		if len(trimmed) == 0 {
@@ -44,7 +46,7 @@ func (r *ndjsonReader) Next() (map[string]interface{}, error) {
 		}
 		var rec map[string]interface{}
 		if jerr := json.Unmarshal(trimmed, &rec); jerr != nil {
-			return nil, jerr
+			return nil, errUnreadable(r.path, r.q, jerr)
 		}
 		return rec, nil
 	}

--- a/pkg/inspect/reader_ndjson.go
+++ b/pkg/inspect/reader_ndjson.go
@@ -1,0 +1,61 @@
+package inspect
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// ndjsonReader streams an NDJSON / JSON Lines file (the default spill format,
+// D26): one JSON object per line. It reads line by line so peak memory is one
+// record, and uses a buffered reader (not bufio.Scanner) so an arbitrarily long
+// line — a log record with a large `content` field is common — is never
+// truncated by the scanner's token cap.
+type ndjsonReader struct {
+	c  io.Closer
+	br *bufio.Reader
+}
+
+func newNDJSONReader(rc io.ReadCloser) *ndjsonReader {
+	return &ndjsonReader{c: rc, br: bufio.NewReaderSize(rc, 64*1024)}
+}
+
+// Columns returns nil: NDJSON carries no schema header, so the column set is
+// only knowable by scanning rows. The engine falls back to the sidecar schema or
+// best-effort discovery for --fields validation.
+func (r *ndjsonReader) Columns() []string { return nil }
+
+func (r *ndjsonReader) Next() (map[string]interface{}, error) {
+	for {
+		line, err := r.readLine()
+		if err == io.EOF && len(line) == 0 {
+			return nil, io.EOF
+		}
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 {
+			if err == io.EOF {
+				return nil, io.EOF
+			}
+			continue // skip blank lines (e.g. a trailing newline)
+		}
+		var rec map[string]interface{}
+		if jerr := json.Unmarshal(trimmed, &rec); jerr != nil {
+			return nil, jerr
+		}
+		return rec, nil
+	}
+}
+
+// readLine reads a full line (including the trailing newline when present).
+// bufio.ReadBytes accumulates across buffer boundaries and grows as needed, so a
+// very long line is never truncated; the terminal line without a newline is
+// returned together with io.EOF.
+func (r *ndjsonReader) readLine() ([]byte, error) {
+	return r.br.ReadBytes('\n')
+}
+
+func (r *ndjsonReader) Close() error { return r.c.Close() }

--- a/pkg/inspect/reader_parquet.go
+++ b/pkg/inspect/reader_parquet.go
@@ -1,0 +1,179 @@
+package inspect
+
+import (
+	"io"
+	"os"
+	"time"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/format"
+)
+
+// parquetReader streams a Parquet file written by the `-o parquet` printer. It
+// reads row groups in bounded batches (parquet-go has no map-based generic
+// reader for an arbitrary schema, so it maps each leaf value back to its column
+// name itself), so peak memory is one batch, not the whole file.
+//
+// Timestamp columns are written as INT64 TIMESTAMP logical-type values
+// (nanoseconds); this reader converts them back to RFC3339 strings so they
+// round-trip to the same shape the other formats carry and the stats accumulator
+// recognises them as timestamps rather than as opaque longs.
+type parquetReader struct {
+	c      io.Closer
+	file   *parquet.File
+	names  []string      // leaf column index → name
+	tsMult map[int]int64 // leaf column index → ns multiplier for TIMESTAMP columns
+	path   string
+	q      string
+
+	rowGroups []parquet.RowGroup
+	rgIndex   int
+	rows      parquet.Rows
+	buf       []parquet.Row
+	pending   []parquet.Row // decoded rows not yet served
+	eof       bool
+}
+
+func newParquetReader(f *os.File, path, query string) (*parquetReader, error) {
+	info, err := f.Stat()
+	if err != nil {
+		return nil, errUnreadable(path, query, err)
+	}
+	pf, err := parquet.OpenFile(f, info.Size())
+	if err != nil {
+		return nil, errUnreadable(path, query, err)
+	}
+
+	cols := pf.Schema().Columns()
+	names := make([]string, len(cols))
+	for i, p := range cols {
+		names[i] = p[len(p)-1] // flat schema: one element per leaf path
+	}
+
+	// Detect TIMESTAMP logical-type columns and their unit so int64 values can be
+	// converted back to wall-clock strings.
+	tsMult := make(map[int]int64)
+	for i, p := range cols {
+		if leaf, ok := pf.Schema().Lookup(p...); ok {
+			if lt := leaf.Node.Type().LogicalType(); lt != nil && lt.Timestamp != nil {
+				tsMult[i] = nsMultiplier(lt.Timestamp.Unit)
+			}
+		}
+	}
+
+	return &parquetReader{
+		c:         f,
+		file:      pf,
+		names:     names,
+		tsMult:    tsMult,
+		path:      path,
+		q:         query,
+		rowGroups: pf.RowGroups(),
+		buf:       make([]parquet.Row, 64),
+	}, nil
+}
+
+// Columns returns the schema leaf names — authoritative for --fields validation
+// without needing a sidecar.
+func (r *parquetReader) Columns() []string { return r.names }
+
+func (r *parquetReader) Next() (map[string]interface{}, error) {
+	for len(r.pending) == 0 {
+		if err := r.fill(); err != nil {
+			return nil, err // io.EOF or a read error
+		}
+	}
+	row := r.pending[0]
+	r.pending = r.pending[1:]
+	return r.rowToMap(row), nil
+}
+
+// fill decodes the next batch of rows into r.pending, advancing across row
+// groups. It returns io.EOF when the whole file is exhausted.
+func (r *parquetReader) fill() error {
+	if r.eof {
+		return io.EOF
+	}
+	for {
+		if r.rows == nil {
+			if r.rgIndex >= len(r.rowGroups) {
+				r.eof = true
+				return io.EOF
+			}
+			r.rows = r.rowGroups[r.rgIndex].Rows()
+			r.rgIndex++
+		}
+		n, err := r.rows.ReadRows(r.buf)
+		if n > 0 {
+			r.pending = make([]parquet.Row, n)
+			for i := 0; i < n; i++ {
+				r.pending[i] = r.buf[i].Clone()
+			}
+		}
+		if err == io.EOF {
+			_ = r.rows.Close()
+			r.rows = nil
+			if n > 0 {
+				return nil
+			}
+			continue // exhausted this row group, try the next
+		}
+		if err != nil {
+			return errUnreadable(r.path, r.q, err)
+		}
+		if n > 0 {
+			return nil
+		}
+	}
+}
+
+func (r *parquetReader) rowToMap(row parquet.Row) map[string]interface{} {
+	m := make(map[string]interface{}, len(r.names))
+	for _, v := range row {
+		col := v.Column()
+		if col < 0 || col >= len(r.names) {
+			continue
+		}
+		name := r.names[col]
+		if v.IsNull() {
+			m[name] = nil
+			continue
+		}
+		switch v.Kind() {
+		case parquet.Boolean:
+			m[name] = v.Boolean()
+		case parquet.Int64:
+			if mult, ok := r.tsMult[col]; ok {
+				m[name] = time.Unix(0, v.Int64()*mult).UTC().Format(time.RFC3339Nano)
+			} else {
+				m[name] = v.Int64()
+			}
+		case parquet.Double:
+			m[name] = v.Double()
+		default:
+			m[name] = v.String()
+		}
+	}
+	return m
+}
+
+func (r *parquetReader) Close() error {
+	if r.rows != nil {
+		_ = r.rows.Close()
+	}
+	return r.c.Close()
+}
+
+// nsMultiplier maps a parquet TIMESTAMP unit to the multiplier that converts a
+// stored value to nanoseconds. The `-o parquet` writer always uses nanoseconds;
+// the others are handled for files written by other tooling.
+func nsMultiplier(unit format.TimeUnit) int64 {
+	switch {
+	case unit.Millis != nil:
+		return int64(time.Millisecond)
+	case unit.Micros != nil:
+		return int64(time.Microsecond)
+	default: // Nanos (and the writer's default)
+		return 1
+	}
+}

--- a/pkg/inspect/reader_parquet.go
+++ b/pkg/inspect/reader_parquet.go
@@ -2,6 +2,7 @@ package inspect
 
 import (
 	"io"
+	"math"
 	"os"
 	"time"
 
@@ -135,26 +136,64 @@ func (r *parquetReader) rowToMap(row parquet.Row) map[string]interface{} {
 			continue
 		}
 		name := r.names[col]
-		if v.IsNull() {
-			m[name] = nil
+		conv := r.convertValue(col, v)
+		// A REPEATED leaf (array column) emits multiple values that all report the
+		// same column index; accumulate them into a slice rather than letting the
+		// last value silently overwrite the earlier ones. (dtctl's own writer emits
+		// only flat OPTIONAL leaves, so this is for files from other tooling.)
+		if existing, ok := m[name]; ok {
+			if slice, isSlice := existing.([]interface{}); isSlice {
+				m[name] = append(slice, conv)
+			} else {
+				m[name] = []interface{}{existing, conv}
+			}
 			continue
 		}
-		switch v.Kind() {
-		case parquet.Boolean:
-			m[name] = v.Boolean()
-		case parquet.Int64:
-			if mult, ok := r.tsMult[col]; ok {
-				m[name] = time.Unix(0, v.Int64()*mult).UTC().Format(time.RFC3339Nano)
-			} else {
-				m[name] = v.Int64()
-			}
-		case parquet.Double:
-			m[name] = v.Double()
-		default:
-			m[name] = v.String()
-		}
+		m[name] = conv
 	}
 	return m
+}
+
+// convertValue maps a single parquet leaf value to its Go representation,
+// round-tripping the physical types the readers can encounter (booleans, 32/64-bit
+// integers, 32/64-bit floats, and TIMESTAMP-logical INT64s back to RFC3339). Types
+// outside this set (byte arrays, INT96, fixed-len) fall back to their string form.
+func (r *parquetReader) convertValue(col int, v parquet.Value) interface{} {
+	if v.IsNull() {
+		return nil
+	}
+	switch v.Kind() {
+	case parquet.Boolean:
+		return v.Boolean()
+	case parquet.Int32:
+		return int64(v.Int32())
+	case parquet.Int64:
+		if mult, ok := r.tsMult[col]; ok {
+			return formatTimestamp(v.Int64(), mult)
+		}
+		return v.Int64()
+	case parquet.Float:
+		return float64(v.Float())
+	case parquet.Double:
+		return v.Double()
+	default:
+		return v.String()
+	}
+}
+
+// formatTimestamp converts a stored timestamp value to an RFC3339 string,
+// guarding against int64 overflow of value*mult for far-future millis/micros
+// columns: on overflow the raw value is returned rather than a wrapped, garbage
+// wall-clock time.
+func formatTimestamp(value, mult int64) interface{} {
+	ns := value
+	if mult != 1 {
+		if value > math.MaxInt64/mult || value < math.MinInt64/mult {
+			return value // out of representable range; surface the raw value
+		}
+		ns = value * mult
+	}
+	return time.Unix(0, ns).UTC().Format(time.RFC3339Nano)
 }
 
 func (r *parquetReader) Close() error {

--- a/pkg/output/manifest.go
+++ b/pkg/output/manifest.go
@@ -18,6 +18,19 @@ const (
 	// KindSummaryOnly means the result was large but there was no writable
 	// filesystem; the manifest is returned without a path (stats + sample only).
 	KindSummaryOnly = "summary-only"
+	// KindFileSummary is emitted by Layer 2 `dtctl inspect` for the re-derived
+	// manifest primitives (--schema/--stats/--sample): the on-disk re-derivation
+	// of the schema/stats/sample shape from a spilled file (INSPECT IN5). It is a
+	// new kind, so a pre-inspect consumer treats it as opaque and falls back to
+	// context — non-breaking by construction (D31).
+	KindFileSummary = "file-summary"
+	// KindFileList is emitted by `dtctl inspect --list`: an enumeration of the
+	// spilled files visible in the active context's partition, each with its
+	// sidecar provenance. It lets an agent recover a file handle that has aged out
+	// of its context (the original spill envelope was trimmed/summarised) from disk
+	// rather than re-querying Grail. Another new kind, opaque to older consumers
+	// (D31).
+	KindFileList = "file-list"
 )
 
 // Stable spill-file error codes (D32). These are part of the versioned envelope

--- a/pkg/output/spill.go
+++ b/pkg/output/spill.go
@@ -178,6 +178,42 @@ func SidecarPathFor(dataPath string) string {
 	return filepath.Join(dir, stem+".manifest.json")
 }
 
+// FormatForExt maps a spilled-file extension to its spill format, or "" for a
+// missing/unrecognised extension. It is the single source of truth for the
+// extension→format mapping shared by the query spill path, `inspect`'s readers,
+// and the re-spill path (so the supported-format set cannot drift between them).
+func FormatForExt(path string) string {
+	switch strings.ToLower(strings.TrimPrefix(filepath.Ext(path), ".")) {
+	case "jsonl", "ndjson":
+		return "jsonl"
+	case "json":
+		return "json"
+	case "csv":
+		return "csv"
+	case "parquet":
+		return "parquet"
+	default:
+		return ""
+	}
+}
+
+// ExtForFormat maps a spill format to the file extension used on disk. It is the
+// inverse of FormatForExt and the single source of truth for the format→extension
+// mapping (shared by query and inspect re-spill); an unknown format defaults to
+// the jsonl extension to match the default spill format.
+func ExtForFormat(format string) string {
+	switch strings.ToLower(format) {
+	case "csv":
+		return "csv"
+	case "json":
+		return "json"
+	case "parquet":
+		return "parquet"
+	default:
+		return "jsonl"
+	}
+}
+
 // ReadSidecar reads and decodes the sidecar manifest next to a spilled data file
 // (D34). It returns (nil, nil) when no sidecar exists — an older spill or a
 // hand-copied bare file — so a caller can degrade gracefully (Layer 2 still does

--- a/pkg/output/spill.go
+++ b/pkg/output/spill.go
@@ -178,6 +178,73 @@ func SidecarPathFor(dataPath string) string {
 	return filepath.Join(dir, stem+".manifest.json")
 }
 
+// ReadSidecar reads and decodes the sidecar manifest next to a spilled data file
+// (D34). It returns (nil, nil) when no sidecar exists — an older spill or a
+// hand-copied bare file — so a caller can degrade gracefully (Layer 2 still does
+// row access and schema re-derivation without it, only losing provenance). A
+// present-but-corrupt sidecar returns an error.
+func ReadSidecar(dataPath string) (*SidecarManifest, error) {
+	data, err := os.ReadFile(SidecarPathFor(dataPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var sc SidecarManifest
+	if err := json.Unmarshal(data, &sc); err != nil {
+		return nil, fmt.Errorf("corrupt sidecar manifest: %w", err)
+	}
+	return &sc, nil
+}
+
+// ManagedContextFor reports whether path lies inside a managed spill cache tree
+// (D7) and, if so, the context-partition segment it sits under (D9). It does not
+// touch the filesystem or require the location to be writable — it is a pure
+// path comparison used by Layer 2 to refuse cross-context reads structurally,
+// before opening the file. ok is false for user-chosen paths (--spill-to /
+// DTCTL_SPILL_DIR), which opt out of partitioning (D25) and so carry no
+// structural context guarantee.
+func ManagedContextFor(path string) (contextName string, ok bool) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", false
+	}
+	for _, base := range managedBaseCandidates() {
+		baseAbs, err := filepath.Abs(base)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(baseAbs, abs)
+		if err != nil {
+			continue
+		}
+		// rel must descend into the tree: <context>/q-<hash>.<ext> ⇒ two segments,
+		// the first being the context partition. A rel that escapes the base
+		// (starts with "..") or is shallow is not a managed path.
+		if strings.HasPrefix(rel, "..") {
+			continue
+		}
+		parts := strings.Split(rel, string(filepath.Separator))
+		if len(parts) >= 2 && parts[0] != "" && parts[0] != ".." {
+			return parts[0], true
+		}
+	}
+	return "", false
+}
+
+// managedBaseCandidates returns the managed spill base dirs (D7) that
+// ManagedContextFor compares against, in resolution order. Unlike SpillBaseDir
+// it neither probes nor creates anything — it only needs the candidate roots.
+func managedBaseCandidates() []string {
+	var bases []string
+	if cache, err := os.UserCacheDir(); err == nil {
+		bases = append(bases, filepath.Join(cache, "dtctl", spillSubdir))
+	}
+	bases = append(bases, filepath.Join(os.TempDir(), "dtctl", spillSubdir))
+	return bases
+}
+
 // PruneOldSpills opportunistically deletes spilled files (and stray .tmp files,
 // D22) older than ttl, throttled to ~hourly via a marker so we never stat-storm
 // (D11). Errors are swallowed: pruning is best-effort and must never fail a

--- a/pkg/output/spill_list.go
+++ b/pkg/output/spill_list.go
@@ -1,0 +1,128 @@
+package output
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// SpillFileEntry describes one spilled result data file discovered in a spill
+// directory, enriched with its sidecar provenance (D34) when present. It is the
+// per-file element of a KindFileList listing — enough for an agent to recognise
+// a lost handle (the original query, row count, when it was spilled, whether it
+// was sampled) and inspect it by path, without re-querying Grail.
+type SpillFileEntry struct {
+	Path    string    `json:"path"`
+	Format  string    `json:"format"`
+	Bytes   int64     `json:"bytes"`
+	Created time.Time `json:"created"`
+	// Sidecar-derived provenance — empty/zero when the file has no manifest.
+	Query         string  `json:"query,omitempty"`
+	Rows          int     `json:"rows,omitempty"`
+	Sampled       bool    `json:"sampled,omitempty"`
+	SamplingRatio float64 `json:"sampling_ratio,omitempty"`
+	ContextName   string  `json:"context_name,omitempty"`
+	TenantID      string  `json:"tenant_id,omitempty"`
+	// SidecarMissing flags a bare data file with no manifest next to it: its
+	// provenance (query, sampling) is unknown, so a consumer must not trust the
+	// absence of `sampled` as proof the data is a full population.
+	SidecarMissing bool `json:"sidecar_missing,omitempty"`
+}
+
+// SpillList is the result payload for the KindFileList envelope (D2): the
+// spilled files visible in the directory that was listed. It carries the
+// directory and whether it is the managed cache (vs. a user-chosen --spill-dir
+// that opts out of the managed privacy guarantees, D25) so the listing is
+// self-describing.
+type SpillList struct {
+	Kind    string           `json:"kind"`
+	Dir     string           `json:"dir"`
+	Managed bool             `json:"managed"`
+	Files   []SpillFileEntry `json:"files"`
+}
+
+// spillDataExtensions is the closed set of data-file extensions a spill can
+// carry (mirrors the spill format set). Sidecars (.manifest.json), temp files
+// (.tmp), the prune marker (.last-prune) and probe files (.probe-*) are not in
+// this set and so are skipped by the listing.
+var spillDataExtensions = map[string]bool{
+	".jsonl":   true,
+	".json":    true,
+	".csv":     true,
+	".parquet": true,
+}
+
+// ListSpillFiles enumerates spilled result data files directly in dir (it does
+// not recurse — a managed listing is scoped to a single context partition by the
+// caller, D9), pairing each with its sidecar manifest when one is present. It
+// skips sidecar, temp, probe and prune-marker files. A non-existent dir is not
+// an error: it yields an empty list (nothing has been spilled in this context
+// yet). Entries are sorted most-recent-first — the order most useful for
+// recovering a handle that just aged out of context.
+func ListSpillFiles(dir string) ([]SpillFileEntry, error) {
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var out []SpillFileEntry
+	for _, de := range ents {
+		if de.IsDir() {
+			continue
+		}
+		name := de.Name()
+		// A sidecar ends with .manifest.json — exclude it before the extension
+		// check (its extension is .json, a data extension).
+		if strings.HasSuffix(name, ".manifest.json") || strings.HasSuffix(name, tmpSuffix) {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(name))
+		if !spillDataExtensions[ext] {
+			continue
+		}
+
+		path := filepath.Join(dir, name)
+		entry := SpillFileEntry{Path: path, Format: strings.TrimPrefix(ext, ".")}
+
+		if info, ierr := de.Info(); ierr == nil {
+			entry.Bytes = info.Size()
+			entry.Created = info.ModTime().UTC()
+		}
+
+		// Sidecar provenance wins over filesystem metadata where it exists: it is
+		// authoritative for created time, byte count and row count, and is the only
+		// source for query/sampling/tenant (D34).
+		sc, scerr := ReadSidecar(path)
+		switch {
+		case scerr != nil || sc == nil:
+			entry.SidecarMissing = true
+		default:
+			entry.Query = sc.Query
+			entry.Rows = sc.Rows
+			entry.Sampled = sc.Sampled
+			entry.SamplingRatio = sc.SamplingRatio
+			entry.ContextName = sc.ContextName
+			entry.TenantID = sc.TenantID
+			if sc.Format != "" {
+				entry.Format = sc.Format
+			}
+			if sc.Bytes > 0 {
+				entry.Bytes = sc.Bytes
+			}
+			if !sc.Created.IsZero() {
+				entry.Created = sc.Created.UTC()
+			}
+		}
+		out = append(out, entry)
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Created.After(out[j].Created)
+	})
+	return out, nil
+}

--- a/pkg/output/spill_list_test.go
+++ b/pkg/output/spill_list_test.go
@@ -1,0 +1,120 @@
+package output
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestListSpillFiles_MissingDirIsEmpty(t *testing.T) {
+	entries, err := ListSpillFiles(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("missing dir should not error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("missing dir should yield no entries, got %d", len(entries))
+	}
+}
+
+func TestListSpillFiles_ProvenanceAndSkips(t *testing.T) {
+	dir := t.TempDir()
+
+	// A spilled file WITH a sidecar.
+	withSidecar := filepath.Join(dir, "q-aaaa.jsonl")
+	if err := os.WriteFile(withSidecar, []byte("{\"a\":1}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	created := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	if err := WriteSidecar(withSidecar, &SidecarManifest{
+		EnvelopeVersion: EnvelopeVersion,
+		Format:          "jsonl",
+		Query:           "fetch logs | limit 10",
+		Rows:            10,
+		Sampled:         true,
+		SamplingRatio:   0.5,
+		ContextName:     "prod",
+		TenantID:        "abc12345",
+		Bytes:           4096,
+		Created:         created,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A bare spilled file with NO sidecar.
+	bare := filepath.Join(dir, "q-bbbb.csv")
+	if err := os.WriteFile(bare, []byte("a,b\n1,2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Noise that must be skipped: a stray temp file and the prune marker.
+	if err := os.WriteFile(filepath.Join(dir, "q-cccc.jsonl.tmp"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, pruneMarkerName), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ListSpillFiles(dir)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("want 2 data files (sidecar + bare), got %d: %+v", len(entries), entries)
+	}
+
+	byPath := map[string]SpillFileEntry{}
+	for _, e := range entries {
+		byPath[filepath.Base(e.Path)] = e
+	}
+
+	ws := byPath["q-aaaa.jsonl"]
+	if ws.Query != "fetch logs | limit 10" || ws.Rows != 10 || !ws.Sampled || ws.TenantID != "abc12345" {
+		t.Errorf("sidecar provenance not carried: %+v", ws)
+	}
+	if ws.Bytes != 4096 {
+		t.Errorf("sidecar Bytes should win over file size, got %d", ws.Bytes)
+	}
+	if !ws.Created.Equal(created) {
+		t.Errorf("sidecar Created should win, got %v want %v", ws.Created, created)
+	}
+	if ws.SidecarMissing {
+		t.Errorf("file with sidecar must not be flagged SidecarMissing")
+	}
+
+	bareEntry := byPath["q-bbbb.csv"]
+	if !bareEntry.SidecarMissing {
+		t.Errorf("bare file must be flagged SidecarMissing: %+v", bareEntry)
+	}
+	if bareEntry.Format != "csv" {
+		t.Errorf("bare file format should derive from extension, got %q", bareEntry.Format)
+	}
+	if bareEntry.Bytes == 0 {
+		t.Errorf("bare file should fall back to on-disk size")
+	}
+}
+
+func TestListSpillFiles_SortedMostRecentFirst(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(name string, age time.Duration) {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("{}\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_ = WriteSidecar(p, &SidecarManifest{Format: "jsonl", Created: time.Now().Add(-age).UTC()})
+	}
+	mk("q-old.jsonl", 3*time.Hour)
+	mk("q-new.jsonl", 1*time.Minute)
+	mk("q-mid.jsonl", 1*time.Hour)
+
+	entries, err := ListSpillFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"q-new.jsonl", "q-mid.jsonl", "q-old.jsonl"}
+	for i, w := range want {
+		if got := filepath.Base(entries[i].Path); got != w {
+			t.Errorf("position %d = %q, want %q (most-recent-first)", i, got, w)
+		}
+	}
+}

--- a/pkg/output/stats.go
+++ b/pkg/output/stats.go
@@ -129,52 +129,94 @@ func newColumnAccumulator(name string) *columnAccumulator {
 	}
 }
 
-// ComputeColumnStats computes the lean Layer-1 column profile over the buffered
-// records in a single pass (PR2 is buffered; the same accumulator shape is what
-// PR3 turns into online sketches). Columns are reported in deterministic
-// (alphabetical) order. When sampled is true every column carries
-// basis:"sample" per D23.
-func ComputeColumnStats(records []map[string]interface{}, sampled bool, topK, maxDistinct int) []ColumnStats {
+// StatsAccumulator folds records one at a time into per-column sketches and
+// finalises them to the lean Layer-1 column profile (D14/D20). Memory is
+// O(columns × distinct-bound), independent of the row count, so it profiles a
+// streamed file (Layer 2 `inspect --stats`) in a single bounded-memory pass as
+// well as the buffered query slice (via ComputeColumnStats). Reuse one
+// accumulator per file; it is not safe for concurrent use.
+type StatsAccumulator struct {
+	accs        map[string]*columnAccumulator
+	order       []string
+	rows        int
+	topK        int
+	maxDistinct int
+}
+
+// NewStatsAccumulator creates an accumulator with the given knobs; non-positive
+// values fall back to the package defaults (DefaultStatsTopK / DefaultStatsMaxDistinct).
+func NewStatsAccumulator(topK, maxDistinct int) *StatsAccumulator {
 	if topK <= 0 {
 		topK = DefaultStatsTopK
 	}
 	if maxDistinct <= 0 {
 		maxDistinct = DefaultStatsMaxDistinct
 	}
-
-	accs := make(map[string]*columnAccumulator)
-	var order []string
-	ensure := func(name string) *columnAccumulator {
-		acc, ok := accs[name]
-		if !ok {
-			acc = newColumnAccumulator(name)
-			accs[name] = acc
-			order = append(order, name)
-		}
-		return acc
+	return &StatsAccumulator{
+		accs:        make(map[string]*columnAccumulator),
+		topK:        topK,
+		maxDistinct: maxDistinct,
 	}
+}
 
-	for _, rec := range records {
-		for name, val := range rec {
-			ensure(name).observe(val, maxDistinct)
-		}
+// Observe folds a single record into the per-column sketches. A column absent
+// from a record is treated as null for that record (back-filled in Finalize
+// from the observed row count).
+func (s *StatsAccumulator) Observe(rec map[string]interface{}) {
+	s.rows++
+	for name, val := range rec {
+		s.ensure(name).observe(val, s.maxDistinct)
 	}
+}
+
+// Rows reports how many records have been observed.
+func (s *StatsAccumulator) Rows() int { return s.rows }
+
+func (s *StatsAccumulator) ensure(name string) *columnAccumulator {
+	acc, ok := s.accs[name]
+	if !ok {
+		acc = newColumnAccumulator(name)
+		s.accs[name] = acc
+		s.order = append(s.order, name)
+	}
+	return acc
+}
+
+// Finalize produces the per-column profiles in deterministic (alphabetical)
+// order. When sampled is true every column carries basis:"sample" (D23). It may
+// be called once after the last Observe.
+func (s *StatsAccumulator) Finalize(sampled bool) []ColumnStats {
 	// A record that lacks a column entirely counts as a null for that column.
 	// Back-fill those missing observations: a column seen in `count+nulls`
-	// records is implicitly null in the remaining `len(records)-(count+nulls)`.
-	for _, acc := range accs {
+	// records is implicitly null in the remaining `rows-(count+nulls)`.
+	for _, acc := range s.accs {
 		seen := acc.count + acc.nulls
-		if missing := len(records) - seen; missing > 0 {
+		if missing := s.rows - seen; missing > 0 {
 			acc.nulls += missing
 		}
 	}
 
+	order := make([]string, len(s.order))
+	copy(order, s.order)
 	sort.Strings(order)
 	out := make([]ColumnStats, 0, len(order))
 	for _, name := range order {
-		out = append(out, accs[name].finalize(sampled, topK))
+		out = append(out, s.accs[name].finalize(sampled, s.topK))
 	}
 	return out
+}
+
+// ComputeColumnStats computes the lean Layer-1 column profile over the buffered
+// records in a single pass (PR2 is buffered; the same accumulator powers the
+// streaming Layer 2 `inspect --stats` path). Columns are reported in
+// deterministic (alphabetical) order. When sampled is true every column carries
+// basis:"sample" per D23.
+func ComputeColumnStats(records []map[string]interface{}, sampled bool, topK, maxDistinct int) []ColumnStats {
+	acc := NewStatsAccumulator(topK, maxDistinct)
+	for _, rec := range records {
+		acc.Observe(rec)
+	}
+	return acc.Finalize(sampled)
 }
 
 func (a *columnAccumulator) observe(val interface{}, maxDistinct int) {

--- a/pkg/output/stats.go
+++ b/pkg/output/stats.go
@@ -141,6 +141,7 @@ type StatsAccumulator struct {
 	rows        int
 	topK        int
 	maxDistinct int
+	finalized   bool
 }
 
 // NewStatsAccumulator creates an accumulator with the given knobs; non-positive
@@ -183,17 +184,23 @@ func (s *StatsAccumulator) ensure(name string) *columnAccumulator {
 }
 
 // Finalize produces the per-column profiles in deterministic (alphabetical)
-// order. When sampled is true every column carries basis:"sample" (D23). It may
-// be called once after the last Observe.
+// order. When sampled is true every column carries basis:"sample" (D23). It is
+// idempotent: the null back-fill mutates accumulator state, so it runs only once
+// even if Finalize is called more than once (a second call returns the same
+// profile rather than double-counting back-filled nulls).
 func (s *StatsAccumulator) Finalize(sampled bool) []ColumnStats {
 	// A record that lacks a column entirely counts as a null for that column.
 	// Back-fill those missing observations: a column seen in `count+nulls`
-	// records is implicitly null in the remaining `rows-(count+nulls)`.
-	for _, acc := range s.accs {
-		seen := acc.count + acc.nulls
-		if missing := s.rows - seen; missing > 0 {
-			acc.nulls += missing
+	// records is implicitly null in the remaining `rows-(count+nulls)`. Guarded
+	// so a repeated Finalize does not back-fill twice.
+	if !s.finalized {
+		for _, acc := range s.accs {
+			seen := acc.count + acc.nulls
+			if missing := s.rows - seen; missing > 0 {
+				acc.nulls += missing
+			}
 		}
+		s.finalized = true
 	}
 
 	order := make([]string, len(s.order))

--- a/pkg/output/stats_test.go
+++ b/pkg/output/stats_test.go
@@ -217,6 +217,28 @@ func TestComputeColumnStats_TruncatesLongTopValues(t *testing.T) {
 	}
 }
 
+// TestStatsAccumulator_FinalizeIdempotent confirms that calling Finalize more
+// than once does not double-count the null back-fill (the back-fill mutates
+// accumulator state, so it must run only once).
+func TestStatsAccumulator_FinalizeIdempotent(t *testing.T) {
+	acc := NewStatsAccumulator(DefaultStatsTopK, DefaultStatsMaxDistinct)
+	// Row 1 has both columns; row 2 omits "b" → "b" is implicitly null once.
+	acc.Observe(map[string]interface{}{"a": "x", "b": "y"})
+	acc.Observe(map[string]interface{}{"a": "z"})
+
+	first := acc.Finalize(false)
+	second := acc.Finalize(false)
+
+	bFirst, _ := findCol(first, "b")
+	bSecond, _ := findCol(second, "b")
+	if bFirst.Nulls != 1 {
+		t.Fatalf("first Finalize: b nulls = %d, want 1", bFirst.Nulls)
+	}
+	if bSecond.Nulls != bFirst.Nulls {
+		t.Errorf("second Finalize: b nulls = %d, want %d (idempotent)", bSecond.Nulls, bFirst.Nulls)
+	}
+}
+
 func TestCapColumnsForEnvelope(t *testing.T) {
 	// 5 columns, descending population (a has fewest nulls, e the most).
 	cols := []ColumnStats{

--- a/skills/dtctl/SKILL.md
+++ b/skills/dtctl/SKILL.md
@@ -45,6 +45,7 @@ Resources and aliases are discoverable via `dtctl commands` (run at init). They 
 | apply / edit / delete | `dtctl apply -f wf.yaml --set env=prod` · `dtctl delete workflow <id>` |
 | exec | `dtctl exec function <id> --payload '{...}'` · `dtctl exec analyzer <id> --input '{...}'` (also workflow, copilot) |
 | query / wait | `dtctl query "fetch logs \| limit 10"` · `dtctl wait query ... --for=any` |
+| inspect | `dtctl inspect <file> --head 20` · `--tail`, `--page --offset N --limit M`, `--fields a,b`, `--schema`, `--stats`, `--sample N`, `--list` (row access over a spilled result file — no Grail re-query) |
 | logs / history / restore | `dtctl logs workflow-execution <id>` · `dtctl restore dashboard <id> --version 3` |
 | share / unshare | `dtctl share dashboard <id> --user a@example.com` |
 | find / open | `dtctl find intents --data trace.id=abc` · `dtctl open intent <app/intent> --data k=v` |
@@ -72,10 +73,10 @@ In agent mode `dtctl query` defaults to `--spill=auto`: large results spill to a
 | `result.kind` | Meaning → action |
 |---|---|
 | `records` | rows inline under `result.records` → use directly |
-| `result-file` | spilled: manifest with `path`, `format`, `rows`, `bytes`, column stats, `sample_rows` → read/filter the file locally, **don't re-query** |
+| `result-file` | spilled: manifest with `path`, `format`, `rows`, `bytes`, column stats, `sample_rows` → interrogate the file with `dtctl inspect <path>` (below), **don't re-query** |
 | `summary-only` | rows couldn't be written — manifest minus `path` → use stats/sample, or follow the cause-aware `context.suggestions` (`--spill=never` + a bound, or `--spill-to <path>`) |
 
-Treat an unknown `kind` as opaque and fall back to `context` (`decided`, `total`, `warnings`, `suggestions`). Sampled results put stats in a `sample_stats` block (`basis: "sample"`) — not population truth. Interrogate spilled files with local tools (`jq`, DuckDB), not by re-running the query.
+Treat an unknown `kind` as opaque and fall back to `context` (`decided`, `total`, `warnings`, `suggestions`). Sampled results put stats in a `sample_stats` block (`basis: "sample"`) — not population truth.
 
 ```bash
 dtctl query "fetch logs | limit 1000000" --agent     # auto-spills if large
@@ -84,12 +85,28 @@ dtctl query "fetch logs" --spill-to ./out.jsonl      # explicit path: jsonl|json
 dtctl query "fetch logs" --spill=auto --spill-threshold 100KB
 ```
 
+### Inspect a spilled file (no Grail re-query)
+
+`dtctl inspect <file>` reads the rows the summary left out — bounded, streaming, agent-context-friendly — so you never re-run the Grail scan. Pick exactly one primitive per call:
+
+```bash
+dtctl inspect <path> --head 20                          # first N rows (the manifest never carried rows)
+dtctl inspect <path> --tail 10                          # last N rows
+dtctl inspect <path> --page --offset 1000 --limit 50    # a window deep in the result (file order)
+dtctl inspect <path> --head 20 --fields timestamp,content  # project columns (composable)
+dtctl inspect <path> --schema                           # re-derive columns + types + null counts
+dtctl inspect <path> --stats                            # re-derive the per-column profile (or --stats=col,col)
+dtctl inspect --list                                    # lost the path? enumerate spilled files in this context
+```
+
+It is not a query engine — no filter/SQL/GROUP BY. For aggregates, push the work back into DQL (`… | summarize …`); for complex local analysis, hand the file to your preferred local analytics tooling. An oversized `inspect` window re-spills to a new file rather than flooding context, and refuses files from another context/tenant.
+
 ## Log pattern analysis (token-frugal)
 
 For free-text log triage, don't dump raw `content` — extract the taxonomy server-side, then drill:
 1. `dtctl exec analyzer dt.statistics.clustering.LogPatternExtractor --input '{"logQuery":"<DQL>","numberOfExamples":2}'` → DPL templates + match counts. `logQuery` is a **plain DQL string** (not an object) yielding `timestamp`+`content`. Projects well with `--jq` to `{patternExpression, numberOfMatches}`.
 2. Lift a `patternExpression` verbatim into `parse content, "..."` (rename captures `f_1`→meaningful), then `summarize … by:{field}` to extract/count at row scale. Unmatched lines yield null captures.
-3. Need raw rows? Drill with `fetch … --agent` and let it spill (above), then interrogate the file locally.
+3. Need raw rows? Drill with `fetch … --agent` and let it spill (above), then read them with `dtctl inspect <path> --head/--page` (above).
 
 ## Apply & templates
 


### PR DESCRIPTION
## Summary

Implements **`dtctl inspect`** — Layer 2 (PR4) of the result-spill design
([`INSPECT_DESIGN.md`](https://github.com/Dynatrace-Internal/dtctl-contrib/blob/main/dev/INSPECT_DESIGN.md)).
It is a small, fixed set of **pure-Go analytics primitives** over a file that
`dtctl query` spilled to disk, so an agent (or human) can interrogate the rows
**without re-querying Grail** and **without pulling the whole result back into
context**. The expensive Grail scan happens once; every `inspect` call reads only
what it needs and emits only the answer.

Builds directly on the Layer 1 spill/manifest/sidecar contract (PR2, #294).

## Command surface (choose exactly one primitive)

```
dtctl inspect <file> [primitive] [flags]

Row access — the reason inspect exists (the manifest never carried arbitrary rows):
  --head N                       first N rows
  --tail N                       last N rows
  --page --offset O --limit L    a paginated window (row order = result order)
  --fields a,b                   column projection (composable with the above)

Re-derive the summary for a file whose manifest is out of context:
  --schema                       columns + types + null counts
  --stats[=col,col]              per-column profile (bare = all columns)
  --sample N                     N representative (leading) rows

Recover a lost file handle:
  --list                         enumerate spilled files in the active context's
                                 partition, with their sidecar provenance

Shared: -o json|csv|toon|table   --jq <expr>   --agent   (+ the --spill* namespace)
```

`inspect` is **not** a query engine — no `--filter`, no SQL, no GROUP BY (D16).
Aggregate questions go back to DQL (`… | summarize …`); complex local analysis
goes to your preferred local analytics tooling.

## What's in the box

- **Streaming readers** for NDJSON / JSON / CSV / Parquet with **bounded memory
  independent of file size** — `head`/`page` are O(N), `tail` is an O(N) ring
  buffer, `--stats`/`--schema` are a single streaming pass via a reusable
  `output.StatsAccumulator` (refactored out of the Layer 1 buffered path).
  Parquet `TIMESTAMP` columns round-trip back to RFC3339.
- **`--list` handle recovery** — when the original spill envelope has aged out of
  context, `inspect --list` enumerates the spilled files in the active context's
  managed partition (most-recent-first), enriched with each file's sidecar
  provenance (original query, rows, sampled, created), so an agent can recover a
  handle from disk instead of re-querying Grail. It lists only the active
  context's partition — the read-side mirror of the D9 write partitioning — and
  flags bare data files with no manifest.
- **Envelope & UX consistency** — reuses the Layer 1 `Response` envelope,
  `envelope_version`, and sidecar (`output.ReadSidecar`). New `result.kind`
  values: `records` (row access), `file-summary` (re-derived manifest), and
  `file-list` (`--list`); all non-breaking by construction (unknown-kind opacity
  rule, D31).
- **Security** — structural cross-context/tenant refusal **before opening the
  file** (D9), plus the stale/missing-file error contract:
  `spill_file_not_found` / `spill_file_unreadable` / `spill_file_wrong_context`,
  and `inspect_bad_flags` / `inspect_unknown_field` (with the available-column
  list). Read errors mid-stream name the offending file across all four formats.
- **Re-spill (IN8)** — an oversized `inspect` row window re-spills to a *new*
  managed file instead of becoming a context hazard itself, honouring the same
  `--spill*` flags.
- **Closes the agent loop** — `query`'s spill suggestions now point at concrete
  `dtctl inspect … --head/--page/--fields` follow-ups now that Layer 2 ships.
- No third-party analytics project is named in any public help/suggestion (D28).

## Tests

- `pkg/inspect`: head/tail/page/fields round-trip across jsonl/json/csv and
  Parquet (incl. timestamp conversion and boolean/double kinds); stats/schema;
  sampling-unknown warning; wrong-context (managed path **and** user-path tenant
  mismatch); not-found. **Edge-case suite** (coverage 70%→88%): empty / blank-line
  / corrupt-mid-stream NDJSON, empty CSV, non-array JSON, corrupt Parquet,
  undeterminable format, extension-based format inference, `--stats` column
  selection + unknown-column error, deferred `--fields` validation warning on
  schemaless files, tail-larger-than-file and page-past-end boundaries, and
  mixed/complex/timestamp column classification.
- `pkg/output`: `ListSpillFiles` enumeration (sidecar pairing, missing-manifest
  flagging, sort order, exclusion of sidecar/tmp/probe/marker files).
- `cmd`: flag validation (one-primitive, `--offset` requires `--page`, bare
  `--fields` → head, `--stats=` selection, `--list` incompatibilities), re-spill
  inline-vs-spill, and `--list` rendering.
- Full `go build ./...`, `go vet`, `golangci-lint`, and the existing
  `cmd`/`exec`/`output` suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
