### PR TITLE
feat(inspect): full-file predicate filtering via streaming --jq (re-spill guarded)

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -41,6 +41,19 @@ context (a stale spill, a file handed between sessions):
   --stats [col,col]        per-column profile (counts, null%, min/max, mean, top-K)
   --sample N               N representative (leading) rows
 
+For "give me only the matching rows", a --jq program runs as a streaming filter
+over the WHOLE file (per record, like jq over an NDJSON file) — not a dtctl
+predicate language, just jq as an opt-in post-processor:
+
+  --jq '<program>'         keep the objects the program emits, scanning every row
+
+The program is run on each record and only the objects it emits are collected,
+so 'select(.status == 500)' keeps matching rows and '{host, timestamp}' reshapes
+them. A row-access window bounds the result ('--jq … --head 20' = the first 20
+matches), and a bare '--jq …' over a large match set re-spills to a new file via
+the same --spill* guard as row access, so it never floods context. (The program
+must emit objects; for free-form scalar extraction, run jq on the file yourself.)
+
 And when the file handle itself is gone — the original spill envelope was
 trimmed or summarised out of context, but the file is still on disk — it can
 enumerate the spilled files in the active context and their provenance, so you
@@ -48,10 +61,11 @@ can recover a handle instead of re-querying Grail:
 
   --list                   list spilled files in the active context (query, rows, age)
 
-Choose exactly one primitive per call. 'inspect' is not a query engine: there is
-no filter, no SQL, no GROUP BY. For aggregate questions, push the work back into
-DQL and re-query ('… | summarize …'); for complex local analysis, hand the file
-to your preferred local analytics tooling.`,
+Choose exactly one primitive per call (--jq may add a bounding window and
+--fields). 'inspect' is not a query engine: there is no SQL, no GROUP BY, and no
+dtctl predicate language. For aggregate questions, push the work back into DQL
+and re-query ('… | summarize …'); for complex local analysis, hand the file to
+your preferred local analytics tooling.`,
 	Example: `  # First 20 rows of a spilled result
   dtctl inspect ~/.cache/dtctl/results/prod/q-7f3a9c.jsonl --head 20
 
@@ -60,6 +74,12 @@ to your preferred local analytics tooling.`,
 
   # The tail of the result
   dtctl inspect q-7f3a9c.jsonl --tail 10
+
+  # Keep only the matching rows (full-file streaming jq filter)
+  dtctl inspect q-7f3a9c.jsonl --jq 'select(.status == 500)'
+
+  # The first 20 matches, projected to two columns
+  dtctl inspect q-7f3a9c.jsonl --jq 'select(.status == 500)' --head 20 --fields host,timestamp
 
   # Re-derive the per-column profile for an out-of-context file
   dtctl inspect q-7f3a9c.jsonl --stats
@@ -136,6 +156,18 @@ func buildInspectRequest(cmd *cobra.Command, path string) (inspect.Request, erro
 	offsetChanged := f.Changed("offset")
 	limitChanged := f.Changed("limit")
 
+	// A --jq program turns the call into a full-file streaming filter (PrimFilter):
+	// every record is run through jq and the emitted objects are collected,
+	// re-spill-guarded. The row-access window (--head/--tail/--page) then *bounds*
+	// that output rather than selecting a primitive of its own, so it is handled
+	// here before the one-primitive-per-call check below (which counts windows as
+	// primitives). It deliberately does not introduce a dtctl predicate language —
+	// jq is a general post-processor the caller opts into (D16).
+	if jqFilter != "" {
+		return buildInspectFilterRequest(path, fields, hasSchema, hasStats, hasSample,
+			hasHead, hasTail, hasPage, offsetChanged, limitChanged, cmd)
+	}
+
 	if len(selected) > 1 {
 		return inspect.Request{}, inspect.BadFlags(
 			fmt.Sprintf("choose exactly one primitive, not %d (%s)", len(selected), strings.Join(dashify(selected), ", ")),
@@ -192,6 +224,70 @@ func buildInspectRequest(cmd *cobra.Command, path string) (inspect.Request, erro
 		// (the engine honours an explicit count, including 0, verbatim).
 		req.Primitive = inspect.PrimHead
 		req.N = inspect.DefaultRowCount
+	}
+	return req, nil
+}
+
+// buildInspectFilterRequest builds a full-file streaming-filter request (--jq,
+// PrimFilter). --jq selects rows; an optional row-access window bounds the
+// output. It is mutually exclusive with the re-derivation primitives
+// (--schema/--stats/--sample): those summarise the whole file, and "filter then
+// summarise" is a two-step that belongs in DQL or a re-spill, not a single
+// inspect call.
+func buildInspectFilterRequest(
+	path string, fields []string,
+	hasSchema, hasStats, hasSample, hasHead, hasTail, hasPage bool,
+	offsetChanged, limitChanged bool,
+	cmd *cobra.Command,
+) (inspect.Request, error) {
+	f := cmd.Flags()
+
+	if hasSchema || hasStats || hasSample {
+		return inspect.Request{}, inspect.BadFlags(
+			"--jq filters rows and cannot be combined with --schema/--stats/--sample",
+			"filter first, then summarise the result — push the aggregate into DQL ('… | summarize …'), or re-spill the filtered rows and run --stats on that file",
+		)
+	}
+
+	windows := 0
+	for _, on := range []bool{hasHead, hasTail, hasPage} {
+		if on {
+			windows++
+		}
+	}
+	if windows > 1 {
+		return inspect.Request{}, inspect.BadFlags(
+			"--jq accepts at most one bounding window (--head, --tail, or --page)",
+			"e.g. dtctl inspect "+path+" --jq 'select(.status == 500)' --head 20",
+		)
+	}
+	if (offsetChanged || limitChanged) && !hasPage {
+		return inspect.Request{}, inspect.BadFlags(
+			"--offset/--limit require --page",
+			"e.g. dtctl inspect "+path+" --jq 'select(.status == 500)' --page --offset 1000 --limit 50",
+		)
+	}
+
+	req := inspect.Request{Path: path, Fields: fields, Filter: jqFilter}
+	switch {
+	case hasHead:
+		req.Primitive = inspect.PrimHead
+		req.N, _ = f.GetInt("head")
+	case hasTail:
+		req.Primitive = inspect.PrimTail
+		req.N, _ = f.GetInt("tail")
+	case hasPage:
+		req.Primitive = inspect.PrimPage
+		req.Offset, _ = f.GetInt("offset")
+		if limitChanged {
+			req.Limit, _ = f.GetInt("limit")
+		} else {
+			req.Limit = inspect.DefaultRowCount
+		}
+	default:
+		// No window: the whole-file form. Its output is unbounded, so the re-spill
+		// guard (maybeRespill / IN8) is what keeps it context-safe.
+		req.Primitive = inspect.PrimFilter
 	}
 	return req, nil
 }

--- a/cmd/inspect_output.go
+++ b/cmd/inspect_output.go
@@ -22,10 +22,12 @@ func emitInspectResult(cmd *cobra.Command, cfg *config.Config, req inspect.Reque
 	return emitInspectRecords(cmd, cfg, req, res)
 }
 
-// emitInspectRecords renders a row-access result. In agent mode it first checks
-// whether the rows are themselves a context hazard and re-spills if so (IN8),
-// otherwise emits a self-describing kind:records envelope (or, when a --jq /
-// non-JSON encoding owns the shape, the standard agent printer).
+// emitInspectRecords renders a row-access or filtered (--jq) result. Both produce
+// the same kind:records shape: a --jq filter is applied per record IN THE ENGINE
+// (full-file streaming, PrimFilter), so by the time records reach here they are
+// already the filtered objects — the printer must NOT re-apply jq, and the output
+// format stays the caller's choice (filtered rows are ordinary records, not
+// arbitrary jq scalars). In agent mode an oversized result re-spills first (IN8).
 func emitInspectRecords(cmd *cobra.Command, cfg *config.Config, req inspect.Request, res *inspect.Result) error {
 	records := res.Records
 
@@ -38,13 +40,12 @@ func emitInspectRecords(cmd *cobra.Command, cfg *config.Config, req inspect.Requ
 			return output.EncodeEnvelope(os.Stdout, *spilled)
 		}
 
-		// --jq or a non-JSON result encoding owns the output shape; defer to the
-		// standard agent printer (mirrors `query`'s inline path).
-		if jqFilter != "" || output.NormalizeMeasureEncoding(outputFormat) != "json" {
+		// A non-JSON result encoding (-o csv/parquet/toon) owns the output shape;
+		// defer to the standard agent printer (mirrors `query`'s inline path).
+		if output.NormalizeMeasureEncoding(outputFormat) != "json" {
 			ctx := inspectContext(req, res, len(records))
 			ap := output.NewAgentPrinter(os.Stdout, ctx)
 			ap.SetResultFormat(outputFormat)
-			ap.SetJQFilter(jqFilter)
 			return ap.PrintList(records)
 		}
 
@@ -61,15 +62,13 @@ func emitInspectRecords(cmd *cobra.Command, cfg *config.Config, req inspect.Requ
 	// Human / scripted output: print the rows in the chosen format, warnings to
 	// stderr so they never corrupt a piped result.
 	printInspectWarnings(res.Warnings)
-	format := outputFormat
-	if jqFilter != "" {
-		format = output.NormalizeJQOutputFormat(format)
-	}
-	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: format, Writer: os.Stdout, JQFilter: jqFilter})
+	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: outputFormat, Writer: os.Stdout})
 	return p.PrintList(records)
 }
 
 // emitInspectSummary renders a re-derived file-summary (--schema/--stats/--sample).
+// These primitives never carry a --jq filter (it is rejected as mutually
+// exclusive at flag-validation time), so there is no per-record jq to apply here.
 func emitInspectSummary(req inspect.Request, res *inspect.Result) error {
 	total := 0
 	if res.Summary != nil {
@@ -78,12 +77,6 @@ func emitInspectSummary(req inspect.Request, res *inspect.Result) error {
 
 	if agentMode {
 		ctx := inspectContext(req, res, total)
-		if jqFilter != "" {
-			ap := output.NewAgentPrinter(os.Stdout, ctx)
-			ap.SetResultFormat(outputFormat)
-			ap.SetJQFilter(jqFilter)
-			return ap.Print(res.Summary)
-		}
 		resp := output.Response{
 			OK:              true,
 			EnvelopeVersion: output.EnvelopeVersion,
@@ -97,14 +90,11 @@ func emitInspectSummary(req inspect.Request, res *inspect.Result) error {
 	// pretty JSON; honour an explicit structured format otherwise.
 	printInspectWarnings(res.Warnings)
 	format := outputFormat
-	if jqFilter != "" {
-		format = output.NormalizeJQOutputFormat(format)
-	}
 	switch format {
 	case "", "table", "wide":
 		format = "json"
 	}
-	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: format, Writer: os.Stdout, JQFilter: jqFilter})
+	p := output.NewPrinterWithOpts(output.PrinterOptions{Format: format, Writer: os.Stdout})
 	return p.Print(res.Summary)
 }
 

--- a/cmd/inspect_spill.go
+++ b/cmd/inspect_spill.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -120,11 +121,11 @@ func maybeRespill(cmd *cobra.Command, cfg *config.Config, req inspect.Request, r
 	// Carry forward any engine warnings (e.g. sampling-unknown) onto the spill.
 	warnings = append(res.Warnings, warnings...)
 
-	// A --jq transform cannot be applied to a re-spilled result (the rows went to
-	// a file, not through the inline jq path), so warn rather than silently drop
-	// the filter — mirroring the query spill path's behaviour.
-	if jqFilter != "" {
-		warnings = append(warnings, "--jq was not applied to the re-spilled result; the file holds the full untransformed rows — apply your filter to the file locally")
+	// Note when the re-spilled file is the OUTPUT of a --jq filter (the engine
+	// applied jq per record over the whole source file, IN-filter), so a reader
+	// knows the file already holds the filtered/transformed rows — not the source.
+	if req.Filter != "" {
+		warnings = append(warnings, "this file holds the rows matched by --jq, not the full source result")
 	}
 
 	suggestions := []string{}
@@ -212,6 +213,11 @@ func describeInspectCall(req inspect.Request) string {
 	var b strings.Builder
 	b.WriteString("inspect ")
 	b.WriteString(req.Path)
+	// A --jq filter (PrimFilter, or any primitive with req.Filter set) carries the
+	// window as a bound, not a primitive, so record both the filter and the bound.
+	if req.Filter != "" {
+		fmt.Fprintf(&b, " --jq %s", strconv.Quote(req.Filter))
+	}
 	switch req.Primitive {
 	case inspect.PrimHead:
 		fmt.Fprintf(&b, " --head %d", req.N)

--- a/cmd/inspect_test.go
+++ b/cmd/inspect_test.go
@@ -103,6 +103,87 @@ func TestBuildInspectRequest_Errors(t *testing.T) {
 	}
 }
 
+// withJQ sets the package-level jqFilter (bound to the persistent --jq flag at
+// runtime) for the duration of a test, since buildInspectRequest reads it there.
+func withJQ(t *testing.T, filter string) {
+	t.Helper()
+	orig := jqFilter
+	t.Cleanup(func() { jqFilter = orig })
+	jqFilter = filter
+}
+
+func TestBuildInspectRequest_FilterModes(t *testing.T) {
+	withJQ(t, "select(.status == 500)")
+
+	t.Run("whole-file", func(t *testing.T) {
+		c := newInspectTestCmd(t)
+		req, err := buildInspectRequest(c, "f.jsonl")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if req.Primitive != inspect.PrimFilter || req.Filter == "" {
+			t.Errorf("req = %+v, want PrimFilter with a filter", req)
+		}
+	})
+
+	t.Run("head-bound", func(t *testing.T) {
+		c := newInspectTestCmd(t, "--head", "20")
+		req, err := buildInspectRequest(c, "f.jsonl")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if req.Primitive != inspect.PrimHead || req.N != 20 || req.Filter == "" {
+			t.Errorf("req = %+v, want head-bounded filter", req)
+		}
+	})
+
+	t.Run("page-bound", func(t *testing.T) {
+		c := newInspectTestCmd(t, "--page", "--offset", "5", "--limit", "3")
+		req, err := buildInspectRequest(c, "f.jsonl")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if req.Primitive != inspect.PrimPage || req.Offset != 5 || req.Limit != 3 || req.Filter == "" {
+			t.Errorf("req = %+v, want page-bounded filter", req)
+		}
+	})
+
+	t.Run("fields-compose", func(t *testing.T) {
+		c := newInspectTestCmd(t, "--fields", "host,ts")
+		req, err := buildInspectRequest(c, "f.jsonl")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if req.Primitive != inspect.PrimFilter || len(req.Fields) != 2 {
+			t.Errorf("req = %+v, want filter with 2 fields", req)
+		}
+	})
+}
+
+func TestBuildInspectRequest_FilterErrors(t *testing.T) {
+	withJQ(t, "select(.status == 500)")
+	cases := []struct {
+		name string
+		argv []string
+	}{
+		{"with-schema", []string{"--schema"}},
+		{"with-stats", []string{"--stats"}},
+		{"with-sample", []string{"--sample", "5"}},
+		{"two-windows", []string{"--head", "5", "--tail", "5"}},
+		{"offset-without-page", []string{"--offset", "5"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newInspectTestCmd(t, tc.argv...)
+			_, err := buildInspectRequest(c, "f.jsonl")
+			ie, ok := err.(*inspect.Error)
+			if !ok || ie.Code != "inspect_bad_flags" {
+				t.Fatalf("err = %v, want inspect_bad_flags", err)
+			}
+		})
+	}
+}
+
 // writeRecords writes records to path using the jsonl printer (mirrors a spill).
 func writeRecords(t *testing.T, path string, records []map[string]interface{}) {
 	t.Helper()
@@ -173,37 +254,46 @@ func TestMaybeRespill_SpillsAboveThreshold(t *testing.T) {
 	}
 }
 
-// TestMaybeRespill_WarnsJQDropped confirms that a --jq filter set when a row
-// window re-spills produces a warning rather than being silently dropped (parity
-// with the query spill path).
-func TestMaybeRespill_WarnsJQDropped(t *testing.T) {
+// TestMaybeRespill_WarnsFilteredOutput confirms that when a --jq filter result
+// re-spills, the envelope notes the file holds the FILTERED rows (the engine
+// applied jq per record over the whole source file before the re-spill) rather
+// than warning the filter was dropped — the jq output went to the file, not the
+// inline path.
+func TestMaybeRespill_WarnsFilteredOutput(t *testing.T) {
 	origAgent, origJQ := agentMode, jqFilter
 	defer func() { agentMode, jqFilter = origAgent, origJQ }()
 	agentMode = true
-	jqFilter = ".[].host"
+	jqFilter = "select(.status == 500)"
 
 	dir := t.TempDir()
-	c := newInspectTestCmd(t, "--head", "100", "--spill=auto", "--spill-threshold", "10", "--spill-to", filepath.Join(dir, "out.jsonl"))
+	c := newInspectTestCmd(t, "--spill=auto", "--spill-threshold", "10", "--spill-to", filepath.Join(dir, "out.jsonl"))
 
+	// The records here are the FILTERED output the engine already produced.
 	records := []map[string]interface{}{
-		{"host": "web-01", "status": float64(200)},
 		{"host": "web-02", "status": float64(500)},
 	}
 	res := &inspect.Result{Kind: output.KindRecords, Records: records, Format: "jsonl"}
-	resp, err := maybeRespill(c, &config.Config{}, inspect.Request{Path: "src.jsonl", Primitive: inspect.PrimHead, N: 100}, res)
+	req := inspect.Request{Path: "src.jsonl", Primitive: inspect.PrimFilter, Filter: "select(.status == 500)"}
+	resp, err := maybeRespill(c, &config.Config{}, req, res)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if resp == nil {
 		t.Fatal("expected a re-spill response")
 	}
-	var found bool
+	var foundFiltered, foundDropped bool
 	for _, w := range resp.Context.Warnings {
+		if strings.Contains(w, "holds the rows matched by --jq") {
+			foundFiltered = true
+		}
 		if strings.Contains(w, "--jq was not applied") {
-			found = true
+			foundDropped = true
 		}
 	}
-	if !found {
-		t.Errorf("expected a --jq-not-applied warning, got %v", resp.Context.Warnings)
+	if !foundFiltered {
+		t.Errorf("expected a filtered-output note, got %v", resp.Context.Warnings)
+	}
+	if foundDropped {
+		t.Errorf("must not warn the filter was dropped — the engine applied it: %v", resp.Context.Warnings)
 	}
 }

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -41,7 +41,7 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] `exec` - Execute workflows, analyzers, copilot, functions, SLOs
 - [x] `logs` - View execution logs
 - [x] `query` - Execute DQL queries
-- [x] `inspect` - Local row access / schema / stats over a spilled query-result file (no Grail re-query); `--list` enumerates spilled files in the active context to recover a lost handle
+- [x] `inspect` - Local row access / schema / stats over a spilled query-result file (no Grail re-query); `--jq` filters the whole file per record (re-spill-guarded); `--list` enumerates spilled files in the active context to recover a lost handle
 - [x] `wait` - Wait for conditions on resources (polling with exponential backoff)
 - [x] `history` - Show version history (snapshots)
 - [x] `restore` - Restore to previous version
@@ -143,6 +143,7 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] Query metadata output: `--metadata` / `-M` with field selection
 - [x] Spill large results to a local file with a summary envelope: `--spill[=auto|always|never]`, `--spill-to`, `--spill-format`, `--spill-threshold`
 - [x] Local inspection of a spilled file (no Grail re-query): `dtctl inspect <file> --head/--tail/--page/--fields/--schema/--stats/--sample`
+- [x] Full-file predicate filtering via a streaming `--jq` program (per record over the whole file, re-spill-guarded): `dtctl inspect <file> --jq 'select(.status == 500)'`
 - [x] Recover a lost file handle by listing spilled files in the active context: `dtctl inspect --list`
 
 ### SLO Features

--- a/docs/site/_docs/ai-agent-mode.md
+++ b/docs/site/_docs/ai-agent-mode.md
@@ -72,7 +72,9 @@ regardless of how big the result was. There are three kinds:
 
 On a `result-file` result the rows are on disk, so read them with
 [`dtctl inspect <path>`](command-reference#inspect-commands) — `--head`/`--tail`/
-`--page`/`--fields` for bounded row access, `--schema`/`--stats` to re-derive the
+`--page`/`--fields` for bounded row access, `--jq '<program>'` to keep only the
+matching rows (a streaming filter over the whole file; a large match set
+re-spills via the same `--spill*` guard), `--schema`/`--stats` to re-derive the
 profile, `--list` to recover a path that has aged out of context — instead of
 re-querying Grail. On a `summary-only` result the rows are not on disk, so
 `context.suggestions` carries the right next step for *why* the spill degraded: a

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -176,8 +176,8 @@ dtctl verify query -f query.dql --canonical --fail-on-warn
 [Spilling Large Results](dql-queries#spilling-large-results-to-a-file)) — without
 re-querying Grail and without pulling the whole result back into context. Its
 primary capability is **row access**, which the spill summary never carried.
-Choose exactly one primitive per call; it is not a query engine (no filter, no
-SQL, no GROUP BY — push aggregates back into DQL).
+Choose exactly one primitive per call; it is not a query engine (no SQL, no
+GROUP BY, no dtctl predicate language — push aggregates back into DQL).
 
 ```bash
 # Row access
@@ -185,6 +185,11 @@ dtctl inspect q-7f3a9c.jsonl --head 20            # first N rows
 dtctl inspect q-7f3a9c.jsonl --tail 10            # last N rows
 dtctl inspect q-7f3a9c.jsonl --page --offset 1000 --limit 50   # a paginated window (result order)
 dtctl inspect q-7f3a9c.jsonl --head 20 --fields timestamp,content  # column projection (composable)
+
+# Keep only the matching rows — a streaming jq filter over the WHOLE file
+dtctl inspect q-7f3a9c.jsonl --jq 'select(.status == 500)'         # every matching row
+dtctl inspect q-7f3a9c.jsonl --jq 'select(.status == 500)' --head 20  # first 20 matches (window bounds it)
+dtctl inspect q-7f3a9c.jsonl --jq '{host, timestamp}'             # reshape each row to an object
 
 # Re-derive the summary for a file whose manifest is out of context
 dtctl inspect q-7f3a9c.jsonl --schema             # columns + types + null counts
@@ -196,9 +201,18 @@ dtctl inspect --list                              # spilled files in the active 
 ```
 
 Reads jsonl, json, csv, and parquet. Honours the shared `--spill*` flags: an
-oversized inspect window re-spills to a new managed file instead of flooding
-output. It lists/reads only the active context's partition and refuses a file
-that belongs to a different context or tenant.
+oversized inspect window — or a `--jq` filter that matches a large number of rows —
+re-spills to a new managed file instead of flooding output. It lists/reads only
+the active context's partition and refuses a file that belongs to a different
+context or tenant.
+
+`--jq` on `inspect` is a **full-file** filter: unlike elsewhere in dtctl (where
+`--jq` post-processes the in-memory result), here it is run **per record** over
+the whole spilled file — like `jq` over an NDJSON file — and collects the objects
+it emits. It composes with a single row-access window (`--head`/`--tail`/`--page`,
+which bounds the matches) and with `--fields` (which projects them), but is
+mutually exclusive with `--schema`/`--stats`/`--sample`. The program must emit
+objects; for free-form scalar extraction run `jq` over the file yourself.
 
 ## Execution Commands
 

--- a/docs/site/_docs/dql-queries.md
+++ b/docs/site/_docs/dql-queries.md
@@ -166,13 +166,17 @@ needs and emits only the answer, without re-querying. Its primary capability is
 dtctl inspect ./out.jsonl --head 20                       # first 20 rows
 dtctl inspect ./out.jsonl --page --offset 1000 --limit 50 # a window deep in the result
 dtctl inspect ./out.jsonl --tail 10 --fields timestamp,content  # last rows, projected
+dtctl inspect ./out.jsonl --jq 'select(.status == 500)'   # keep only matching rows (streaming, whole-file)
 dtctl inspect ./out.jsonl --schema                        # re-derive columns + types + null counts
 dtctl inspect ./out.jsonl --stats                         # re-derive the per-column profile
 dtctl inspect --list                                      # lost the path? list spilled files in this context
 ```
 
-`inspect` is not a query engine — for aggregate questions push the work back into
-DQL (`… | summarize …`) and re-query. See the
+`--jq` here is a **full-file** filter run per record (like `jq` over NDJSON), so
+it returns "only the matching rows" without re-querying Grail — a large match set
+re-spills via the same `--spill*` guard. `inspect` is not a query engine, though —
+for aggregate questions push the work back into DQL (`… | summarize …`) and
+re-query. See the
 [Inspect Commands](command-reference#inspect-commands) reference for the full flag
 set.
 

--- a/pkg/inspect/filter.go
+++ b/pkg/inspect/filter.go
@@ -1,0 +1,184 @@
+package inspect
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// runFilter streams every record in the file through the compiled --jq program
+// and collects the objects it emits (PrimFilter). This is full-file predicate
+// filtering — the "give me only the matching rows" capability that row access
+// alone could not provide — expressed with jq rather than a bespoke dtctl
+// predicate language (D16).
+//
+// The output is bounded one of two ways, and both matter because a full-file
+// filter can match unboundedly many rows:
+//   - A row-access window carried in req.Primitive (PrimHead/PrimTail/PrimPage)
+//     bounds the *matched* output here, and --head/--page additionally stop the
+//     scan early once enough matches are collected.
+//   - The unbounded whole-file form (PrimFilter, no window) collects every match;
+//     the command layer's re-spill guard (maybeRespill / IN8) is what keeps that
+//     from becoming the context blow-up the spill feature exists to prevent.
+//
+// jq runs per record (like `jq` over an NDJSON file), so the program is a
+// predicate/transform over a single object — e.g. `select(.status == 500)` or
+// `{host, timestamp}` — not an array program. Only objects are collected: a
+// program that emits a scalar/array has no place in the record-oriented pipeline
+// (re-spill, stats, envelope all assume records), so that is a typed usage error
+// pointing the caller at an object-producing form.
+func runFilter(r Reader, req Request, res *Result) error {
+	prog, err := output.CompileJQ(req.Filter)
+	if err != nil {
+		return errBadFlags(err.Error(),
+			"give --jq a valid jq program, e.g. --jq 'select(.status == 500)'")
+	}
+
+	c := newFilterCollector(req)
+	for {
+		rec, rerr := r.Next()
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			return wrapReadError(rerr)
+		}
+
+		emitted, jerr := prog.RunRecord(rec)
+		if jerr != nil {
+			return errBadFlags(jerr.Error(),
+				"the --jq program failed on a record; check it against the file's schema (dtctl inspect "+req.Path+" --schema)")
+		}
+		for _, v := range emitted {
+			obj, ok := v.(map[string]interface{})
+			if !ok {
+				return errFilterNonObject(v)
+			}
+			if c.add(project(obj, req.Fields)) {
+				// The window is satisfied and the rest of the file cannot change the
+				// answer (head/page): stop scanning early.
+				res.Kind = output.KindRecords
+				res.Records = c.rows()
+				return nil
+			}
+		}
+	}
+
+	res.Kind = output.KindRecords
+	res.Records = c.rows()
+	return nil
+}
+
+// filterCollector bounds the rows a streaming filter keeps, mirroring the
+// row-access primitives so a windowed filter has the same shape as a windowed
+// read: PrimHead keeps the first N, PrimPage keeps [offset, offset+limit),
+// PrimTail keeps the last N (ring buffer), and PrimFilter keeps everything
+// (the re-spill guard, not this collector, bounds that form).
+type filterCollector struct {
+	prim   Primitive
+	out    []map[string]interface{}
+	skip   int // remaining rows to skip before collecting (page offset)
+	limit  int // max rows to collect; <0 means unbounded
+	tailN  int // ring size for PrimTail
+	ring   []map[string]interface{}
+	tailCt int
+}
+
+func newFilterCollector(req Request) *filterCollector {
+	c := &filterCollector{prim: req.Primitive, limit: -1}
+	switch req.Primitive {
+	case PrimHead:
+		c.limit = rowCount(req.N)
+	case PrimPage:
+		if req.Offset > 0 {
+			c.skip = req.Offset
+		}
+		c.limit = pageLimit(req.Limit)
+	case PrimTail:
+		c.tailN = rowCount(req.N)
+	}
+	if c.limit >= 0 {
+		c.out = make([]map[string]interface{}, 0, prealloc(c.limit))
+	}
+	return c
+}
+
+// add records one matched row and reports whether the bounded window is now
+// complete (so the caller can stop scanning). It never reports completion for
+// the tail or unbounded forms, which must read to EOF.
+func (c *filterCollector) add(row map[string]interface{}) (done bool) {
+	if c.prim == PrimTail {
+		if c.tailN <= 0 {
+			return false
+		}
+		if len(c.ring) < c.tailN {
+			c.ring = append(c.ring, row)
+		} else {
+			c.ring[c.tailCt%c.tailN] = row
+		}
+		c.tailCt++
+		return false
+	}
+
+	if c.skip > 0 {
+		c.skip--
+		return false
+	}
+	if c.limit >= 0 && len(c.out) >= c.limit {
+		return true // already full (e.g. --head 0 / --limit 0)
+	}
+	c.out = append(c.out, row)
+	return c.limit >= 0 && len(c.out) >= c.limit
+}
+
+// rows returns the collected rows, materialising the tail ring in arrival order.
+func (c *filterCollector) rows() []map[string]interface{} {
+	if c.prim != PrimTail {
+		if c.out == nil {
+			return []map[string]interface{}{}
+		}
+		return c.out
+	}
+	size := c.tailN
+	if c.tailCt < size {
+		size = c.tailCt
+	}
+	out := make([]map[string]interface{}, 0, size)
+	start := c.tailCt - size
+	for i := start; i < c.tailCt; i++ {
+		out = append(out, c.ring[i%c.tailN])
+	}
+	return out
+}
+
+// errFilterNonObject reports a --jq program that emitted a non-object value. The
+// record-oriented pipeline (re-spill, stats, the kind:records envelope) only
+// carries objects, so a scalar/array output is a usage error rather than a
+// silently dropped or mangled row.
+func errFilterNonObject(v interface{}) *Error {
+	return errBadFlags(
+		fmt.Sprintf("--jq must emit objects (records), but it emitted a %s", jsonTypeName(v)),
+		"wrap the projection in an object, e.g. --jq 'select(.status == 500)' or --jq '{host, timestamp}'",
+		"for free-form extraction into scalars, run jq over the spilled file directly with your own tooling",
+	)
+}
+
+// jsonTypeName names the JSON kind of a value emitted by gojq, for an actionable
+// "filter emitted a <type>" message.
+func jsonTypeName(v interface{}) string {
+	switch v.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case int, float64:
+		return "number"
+	case string:
+		return "string"
+	case []interface{}:
+		return "array"
+	default:
+		return fmt.Sprintf("%T", v)
+	}
+}

--- a/pkg/inspect/filter_test.go
+++ b/pkg/inspect/filter_test.go
@@ -1,0 +1,177 @@
+package inspect
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// hostsOf collects the "host" column from a row set for order-sensitive asserts.
+func hostsOf(rows []map[string]interface{}) []string {
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		if h, ok := r["host"].(string); ok {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+func TestRunFilter_PredicateWholeFile(t *testing.T) {
+	dir := t.TempDir()
+	for _, format := range []string{"jsonl", "json", "csv"} {
+		t.Run(format, func(t *testing.T) {
+			path := writeSpill(t, dir, format, sampleRecords(), &output.SidecarManifest{
+				Format: format, Rows: 4, ContextName: "prod",
+			})
+
+			// status is a number in jsonl/json but a string in csv; compare as a
+			// string via tostring so one predicate works across formats.
+			res, err := Run(Request{Path: path, Primitive: PrimFilter, Filter: `select((.status|tostring) == "200")`})
+			if err != nil {
+				t.Fatalf("filter: %v", err)
+			}
+			if res.Kind != output.KindRecords {
+				t.Fatalf("kind = %q, want records", res.Kind)
+			}
+			if got := hostsOf(res.Records); strings.Join(got, ",") != "web-01,web-03" {
+				t.Errorf("hosts = %v, want [web-01 web-03]", got)
+			}
+		})
+	}
+}
+
+func TestRunFilter_NoMatchesIsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), nil)
+
+	res, err := Run(Request{Path: path, Primitive: PrimFilter, Filter: `select(.status == 999)`})
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if res.Records == nil {
+		t.Fatalf("records should be non-nil empty slice, got nil")
+	}
+	if len(res.Records) != 0 {
+		t.Errorf("want 0 rows, got %d", len(res.Records))
+	}
+}
+
+func TestRunFilter_HeadBoundsMatches(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), nil)
+
+	// Two rows match; --head 1 keeps the first match in file order.
+	res, err := Run(Request{Path: path, Primitive: PrimHead, N: 1, Filter: `select(.status == 200)`})
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if got := hostsOf(res.Records); strings.Join(got, ",") != "web-01" {
+		t.Errorf("hosts = %v, want [web-01]", got)
+	}
+}
+
+func TestRunFilter_TailBoundsMatches(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), nil)
+
+	res, err := Run(Request{Path: path, Primitive: PrimTail, N: 1, Filter: `select(.status == 200)`})
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if got := hostsOf(res.Records); strings.Join(got, ",") != "web-03" {
+		t.Errorf("hosts = %v, want [web-03] (last match)", got)
+	}
+}
+
+func TestRunFilter_PageBoundsMatches(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), nil)
+
+	// Both 200s match; offset 1, limit 1 → the second match.
+	res, err := Run(Request{Path: path, Primitive: PrimPage, Offset: 1, Limit: 1, Filter: `select(.status == 200)`})
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if got := hostsOf(res.Records); strings.Join(got, ",") != "web-03" {
+		t.Errorf("hosts = %v, want [web-03]", got)
+	}
+}
+
+func TestRunFilter_FieldsProjectMatchedRows(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), nil)
+
+	res, err := Run(Request{Path: path, Primitive: PrimFilter, Fields: []string{"host"}, Filter: `select(.status == 500)`})
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if len(res.Records) != 1 {
+		t.Fatalf("want 1 row, got %d", len(res.Records))
+	}
+	row := res.Records[0]
+	if _, ok := row["status"]; ok {
+		t.Errorf("status should be projected away, row = %v", row)
+	}
+	if row["host"] != "web-02" {
+		t.Errorf("host = %v, want web-02", row["host"])
+	}
+}
+
+func TestRunFilter_TransformToObject(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), nil)
+
+	// Reshaping to a new object is allowed (still record-shaped).
+	res, err := Run(Request{Path: path, Primitive: PrimFilter, Filter: `select(.status == 500) | {h: .host}`})
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if len(res.Records) != 1 || res.Records[0]["h"] != "web-02" {
+		t.Errorf("records = %v, want [{h: web-02}]", res.Records)
+	}
+}
+
+func TestRunFilter_NonObjectOutputIsError(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), nil)
+
+	// `.host` emits scalars, which the record-oriented pipeline cannot carry.
+	_, err := Run(Request{Path: path, Primitive: PrimFilter, Filter: `.host`})
+	ie, ok := err.(*Error)
+	if !ok || ie.Code != codeBadFlags {
+		t.Fatalf("err = %v, want inspect_bad_flags", err)
+	}
+	if !strings.Contains(ie.Message, "must emit objects") {
+		t.Errorf("message = %q, want it to mention emitting objects", ie.Message)
+	}
+}
+
+func TestRunFilter_InvalidProgramIsError(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSpill(t, dir, "jsonl", sampleRecords(), nil)
+
+	_, err := Run(Request{Path: path, Primitive: PrimFilter, Filter: `select(`})
+	ie, ok := err.(*Error)
+	if !ok || ie.Code != codeBadFlags {
+		t.Fatalf("err = %v, want inspect_bad_flags", err)
+	}
+}
+
+func TestRunFilter_MultipleEmitsPerRecord(t *testing.T) {
+	dir := t.TempDir()
+	records := []map[string]interface{}{
+		{"items": []interface{}{map[string]interface{}{"host": "a"}, map[string]interface{}{"host": "b"}}},
+	}
+	path := writeSpill(t, dir, "jsonl", records, nil)
+
+	// One source record fans out to two emitted objects.
+	res, err := Run(Request{Path: path, Primitive: PrimFilter, Filter: `.items[]`})
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if got := hostsOf(res.Records); strings.Join(got, ",") != "a,b" {
+		t.Errorf("hosts = %v, want [a b]", got)
+	}
+}

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -25,6 +25,16 @@ const (
 	PrimSchema Primitive = "schema" // columns + types + null counts
 	PrimStats  Primitive = "stats"  // per-column profile
 	PrimSample Primitive = "sample" // N representative (leading) rows
+
+	// PrimFilter streams every record in the file through a caller-supplied jq
+	// program and collects the objects it emits — full-file predicate filtering
+	// (the missing "give me only the matching rows" capability) without a bespoke
+	// query language (D16: jq is a general post-processor the caller opts into,
+	// not dtctl's own DQL alternative). It is selected by --jq; a row-access
+	// window (--head/--tail/--page) carried in the request bounds the output, and
+	// the whole-file no-window form is mandatory-guarded by the re-spill machinery
+	// because its output is otherwise unbounded.
+	PrimFilter Primitive = "filter"
 )
 
 // DefaultRowCount is the row cap applied to head/tail/sample (and a bare
@@ -48,6 +58,12 @@ type Request struct {
 	Fields []string
 	// StatsColumns restricts PrimStats to these columns. Empty means all.
 	StatsColumns []string
+
+	// Filter is a jq program run per record over the WHOLE file (PrimFilter). When
+	// non-empty it takes precedence over the row-access switch and turns the call
+	// into a streaming filter; Primitive then carries the optional bounding window
+	// (PrimHead/PrimTail/PrimPage) or PrimFilter for the unbounded whole-file form.
+	Filter string
 
 	// ActiveContext / ActiveTenant are the live dtctl context name and tenant id,
 	// used for the structural cross-context/tenant refusal (D9/D32).
@@ -114,13 +130,20 @@ func Run(req Request) (*Result, error) {
 
 	res := &Result{Format: format, Sidecar: sidecar}
 
+	// A --jq program turns the call into a full-file streaming filter regardless
+	// of the row-access window, which it carries in Primitive as a bound. Checked
+	// before the switch so the window flags select a bound, not a primitive.
+	if req.Filter != "" {
+		return res, runFilter(r, req, res)
+	}
+
 	switch req.Primitive {
 	case PrimHead, PrimTail, PrimPage:
 		return res, runRowAccess(r, req, sidecar, res)
 	case PrimSchema, PrimStats, PrimSample:
 		return res, runSummary(r, req, sidecar, res)
 	default:
-		return nil, errBadFlags("no primitive selected (choose one of --head, --tail, --page, --schema, --stats, --sample, or --fields)")
+		return nil, errBadFlags("no primitive selected (choose one of --head, --tail, --page, --schema, --stats, --sample, --jq, or --fields)")
 	}
 }
 

--- a/pkg/output/jq.go
+++ b/pkg/output/jq.go
@@ -68,3 +68,56 @@ func ApplyJQ(filter string, input interface{}) (interface{}, error) {
 		return results, nil
 	}
 }
+
+// CompiledJQ is a jq program parsed and compiled once for repeated, per-record
+// execution in a streaming filter (e.g. `dtctl inspect --jq` over a whole
+// spilled file). ApplyJQ re-parses and re-compiles on every call, which is fine
+// for a one-shot post-filter but quadratic when run over millions of records;
+// CompiledJQ pays that cost once.
+type CompiledJQ struct {
+	code *gojq.Code
+}
+
+// CompileJQ parses and compiles a jq program for streaming, per-record use. The
+// returned *CompiledJQ is safe to reuse across records (gojq does not mutate the
+// compiled code). A parse/compile failure is reported as an invalid-filter error.
+func CompileJQ(filter string) (*CompiledJQ, error) {
+	query, err := gojq.Parse(filter)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --jq filter: %w", err)
+	}
+	code, err := gojq.Compile(query)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --jq filter: %w", err)
+	}
+	return &CompiledJQ{code: code}, nil
+}
+
+// RunRecord runs the compiled program over a single record and returns every
+// value it emits, in order. A record that yields no output — a `select(...)`
+// that does not match, or `empty` — returns an empty slice: that is exactly how
+// filtering drops a row. A runtime error from the program (e.g. a type error)
+// is returned so the caller can surface it rather than silently skipping rows.
+//
+// The record is normalised through encoding/json first so values produced by any
+// reader (Parquet/CSV typed columns, time values) run cleanly through gojq, which
+// only accepts nil/bool/int/float64/string/[]any/map[string]any inputs.
+func (c *CompiledJQ) RunRecord(rec map[string]interface{}) ([]interface{}, error) {
+	generic, err := toGeneric(rec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply --jq filter: %w", err)
+	}
+	iter := c.code.Run(generic)
+	var out []interface{}
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if runErr, ok := v.(error); ok {
+			return nil, fmt.Errorf("failed to apply --jq filter: %w", runErr)
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}

--- a/pkg/output/jq_test.go
+++ b/pkg/output/jq_test.go
@@ -48,6 +48,60 @@ func TestApplyJQ_InvalidFilter(t *testing.T) {
 	}
 }
 
+func TestCompileJQ_RunRecord(t *testing.T) {
+	prog, err := CompileJQ(`select(.status == 500)`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	// Matching record passes through.
+	out, err := prog.RunRecord(map[string]interface{}{"host": "web-02", "status": 500})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 emitted value, got %d (%#v)", len(out), out)
+	}
+
+	// Non-matching record is dropped (empty output is how filtering works).
+	out, err = prog.RunRecord(map[string]interface{}{"host": "web-01", "status": 200})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("want 0 emitted values for a non-match, got %#v", out)
+	}
+}
+
+func TestCompileJQ_Invalid(t *testing.T) {
+	if _, err := CompileJQ(`select(`); err == nil {
+		t.Fatal("expected a compile error for an invalid program")
+	} else if !strings.Contains(err.Error(), "invalid --jq filter") {
+		t.Fatalf("err = %v, want invalid --jq filter", err)
+	}
+}
+
+func TestCompileJQ_RunRecord_Reusable(t *testing.T) {
+	// A compiled program must be safe to run over many records in sequence.
+	prog, err := CompileJQ(`{h: .host}`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	for _, host := range []string{"a", "b", "c"} {
+		out, err := prog.RunRecord(map[string]interface{}{"host": host})
+		if err != nil {
+			t.Fatalf("run %s: %v", host, err)
+		}
+		if len(out) != 1 {
+			t.Fatalf("host %s: want 1 value, got %#v", host, out)
+		}
+		obj, ok := out[0].(map[string]interface{})
+		if !ok || obj["h"] != host {
+			t.Fatalf("host %s: got %#v", host, out[0])
+		}
+	}
+}
+
 func TestNormalizeJQOutputFormat(t *testing.T) {
 	tests := []struct {
 		in   string


### PR DESCRIPTION
Implements #313.

## What

On `dtctl inspect`, `--jq` now runs as a **streaming filter over the whole spilled file** (per record, like `jq` over an NDJSON file) instead of post-filtering the already-windowed rows. This gives a sandboxed agent — no shell, no external analytics tool — the "give me only the matching rows" capability it was missing, **without** re-querying Grail (which bills another scan and can return *different* data, breaking the spill-once snapshot) and **without** introducing a bespoke dtctl predicate language (D16 — jq is a general post-processor the caller opts into).

```bash
dtctl inspect q.jsonl --jq 'select(.status == 500)'                 # every matching row
dtctl inspect q.jsonl --jq 'select(.status == 500)' --head 20       # first 20 matches (window bounds it)
dtctl inspect q.jsonl --jq 'select(.status == 500)' --fields host,ts # matches, projected
dtctl inspect q.jsonl --jq '{host, timestamp}'                       # reshape each row
```

## Design decisions

The issue flagged two interaction questions; resolved as:

- **`--jq` selects, a window bounds.** `--jq` streams the whole file; an optional `--head`/`--tail`/`--page` bounds the *matched* output (and `--head`/`--page` stop the scan early). A bare `--jq` is the unbounded whole-file form.
- **`--jq` is exclusive to row filtering** — mutually exclusive with `--schema`/`--stats`/`--sample` (filter-then-summarise belongs in DQL or a re-spill, not one call). On `inspect`, `--jq` is run **per record** (NDJSON semantics), which differs from its array-input meaning elsewhere in dtctl; this is the intuitive model for a file and is documented in the command help.
- **Object output only.** The program must emit objects (records); a scalar/array output is a typed `inspect_bad_flags` error pointing at an object-producing form. This keeps the record-oriented re-spill/stats/envelope pipeline coherent and matches the "predicate filtering" framing.

## The catch (designed in)

A full-file filter has unbounded output, so it flows through the **same byte-budget re-spill guard** (`maybeRespill` / IN8) the row-access path already uses: over threshold → re-spill to a new managed file + summary envelope; under → inline. The re-spilled file holds the **filtered** rows, its provenance records the `--jq` program, and sampling provenance (IN3) is preserved. The old "`--jq` was not applied to the re-spilled result" warning is replaced by a note that the file holds the matched rows.

## Tests

- `pkg/output`: `CompileJQ`/`RunRecord` (match, drop-on-no-match, reusable across records, invalid program).
- `pkg/inspect`: whole-file predicate across jsonl/json/csv, head/tail/page bounds, `--fields` projection, object-reshape, fan-out (multiple emits per record), non-object error, invalid program, empty result.
- `cmd`: `buildInspectRequest` filter-mode parsing + mutual-exclusion validation; re-spill of filtered output carries the right note.

Docs updated: command reference, DQL queries, AI agent mode, implementation status, and the command's `--help`.