### PR TITLE
feat(breakpoint): add --filters to create breakpoint

### DIFF
--- a/cmd/breakpoint_helpers.go
+++ b/cmd/breakpoint_helpers.go
@@ -232,6 +232,19 @@ func parseFilters(input string) (map[string][]string, error) {
 	return filters, nil
 }
 
+// buildWorkspaceFilterSets parses a raw "key:value,key:value" filter string and
+// converts it into the GraphQL filter-set payload expected by
+// UpdateWorkspaceFilters. It is pure: no network calls and no side effects, so
+// callers (create and update) reuse it and run the network update at their own
+// call site.
+func buildWorkspaceFilterSets(raw string) ([]map[string]interface{}, error) {
+	parsed, err := parseFilters(raw)
+	if err != nil {
+		return nil, err
+	}
+	return livedebugger.BuildFilterSets(parsed), nil
+}
+
 func parseBreakpoint(input string) (string, int, error) {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {

--- a/cmd/breakpoint_helpers.go
+++ b/cmd/breakpoint_helpers.go
@@ -265,6 +265,17 @@ func formatFilters(parsed map[string][]string) string {
 	return strings.Join(pairs, ",")
 }
 
+// requireFiltersValue validates that a --filters flag which was provided also
+// carries a value. It is shared by create and update breakpoint so the
+// "empty --filters" error is identical (and greppable) in both commands. An
+// empty value means the flag was set but blank, e.g. --filters "".
+func requireFiltersValue(filters string) error {
+	if strings.TrimSpace(filters) == "" {
+		return fmt.Errorf("--filters provided without a value")
+	}
+	return nil
+}
+
 func parseBreakpoint(input string) (string, int, error) {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {

--- a/cmd/breakpoint_helpers.go
+++ b/cmd/breakpoint_helpers.go
@@ -276,6 +276,49 @@ func requireFiltersValue(filters string) error {
 	return nil
 }
 
+// countActiveWorkspaceBreakpoints returns how many enabled breakpoints currently
+// exist in the workspace. Disabled rules are excluded on purpose: a breakpoint
+// that reached its hit limit is auto-disabled by the runtime, so it should not
+// inflate the confirmation count shown before workspace filters are changed.
+func countActiveWorkspaceBreakpoints(handler *livedebugger.Handler, workspaceID string) (int, error) {
+	resp, err := handler.GetWorkspaceRules(workspaceID)
+	if err != nil {
+		return 0, err
+	}
+	return countActiveRules(resp)
+}
+
+// countActiveRules counts the enabled (non-disabled) breakpoint rules in a
+// GetWorkspaceRules GraphQL response. Split out from the network call so the
+// active-only counting logic can be unit tested without a live handler.
+func countActiveRules(resp map[string]interface{}) (int, error) {
+	rules, err := livedebugger.ExtractWorkspaceRules(resp)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for i := range rules {
+		if !rules[i].IsDisabled {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// filterChangeConfirmMessage builds the prompt shown before changing workspace
+// filters, which re-scopes every existing active breakpoint in the workspace.
+// creating indicates the same operation also creates a new breakpoint.
+func filterChangeConfirmMessage(count int, creating bool) string {
+	noun := "breakpoints"
+	if count == 1 {
+		noun = "breakpoint"
+	}
+	if creating {
+		return fmt.Sprintf("In addition to creating this breakpoint, this will change the workspace filters for %d active %s. Continue?", count, noun)
+	}
+	return fmt.Sprintf("This will change the workspace filters for %d active %s. Continue?", count, noun)
+}
+
 func parseBreakpoint(input string) (string, int, error) {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {

--- a/cmd/breakpoint_helpers.go
+++ b/cmd/breakpoint_helpers.go
@@ -245,6 +245,26 @@ func buildWorkspaceFilterSets(raw string) ([]map[string]interface{}, error) {
 	return livedebugger.BuildFilterSets(parsed), nil
 }
 
+// formatFilters renders parsed filters as a canonical, deterministic
+// "key:value,key:value" string. Keys are sorted (values are already sorted by
+// parseFilters), so dry-run previews show exactly what will be sent rather than
+// the raw, possibly unnormalized, user input (e.g. "ns : prod" -> "ns:prod").
+func formatFilters(parsed map[string][]string) string {
+	keys := make([]string, 0, len(parsed))
+	for key := range parsed {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0)
+	for _, key := range keys {
+		for _, value := range parsed[key] {
+			pairs = append(pairs, key+":"+value)
+		}
+	}
+	return strings.Join(pairs, ",")
+}
+
 func parseBreakpoint(input string) (string, int, error) {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {

--- a/cmd/breakpoint_helpers_test.go
+++ b/cmd/breakpoint_helpers_test.go
@@ -256,6 +256,104 @@ func TestRequireFiltersValue(t *testing.T) {
 	})
 }
 
+func TestCountActiveRules(t *testing.T) {
+	makeResp := func(rules []interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"data": map[string]interface{}{
+				"org": map[string]interface{}{
+					"workspace": map[string]interface{}{
+						"rules": rules,
+					},
+				},
+			},
+		}
+	}
+	rule := func(id string, disabled bool) map[string]interface{} {
+		return map[string]interface{}{"id": id, "is_disabled": disabled}
+	}
+
+	t.Run("counts only active (non-disabled) rules", func(t *testing.T) {
+		resp := makeResp([]interface{}{
+			rule("bp-1", false),
+			rule("bp-2", true), // hit-limit-reached, auto-disabled
+			rule("bp-3", false),
+		})
+		got, err := countActiveRules(resp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 2 {
+			t.Fatalf("expected 2 active rules, got %d", got)
+		}
+	})
+
+	t.Run("all disabled yields zero", func(t *testing.T) {
+		resp := makeResp([]interface{}{rule("bp-1", true), rule("bp-2", true)})
+		got, err := countActiveRules(resp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 0 {
+			t.Fatalf("expected 0 active rules, got %d", got)
+		}
+	})
+
+	t.Run("empty rules list yields zero", func(t *testing.T) {
+		got, err := countActiveRules(makeResp([]interface{}{}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 0 {
+			t.Fatalf("expected 0 active rules, got %d", got)
+		}
+	})
+
+	t.Run("malformed response returns error", func(t *testing.T) {
+		if _, err := countActiveRules(map[string]interface{}{}); err == nil {
+			t.Fatal("expected error for malformed response, got nil")
+		}
+	})
+}
+
+func TestFilterChangeConfirmMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		count    int
+		creating bool
+		want     string
+	}{
+		{
+			name:  "update singular",
+			count: 1,
+			want:  "This will change the workspace filters for 1 active breakpoint. Continue?",
+		},
+		{
+			name:  "update plural",
+			count: 3,
+			want:  "This will change the workspace filters for 3 active breakpoints. Continue?",
+		},
+		{
+			name:     "create singular",
+			count:    1,
+			creating: true,
+			want:     "In addition to creating this breakpoint, this will change the workspace filters for 1 active breakpoint. Continue?",
+		},
+		{
+			name:     "create plural",
+			count:    5,
+			creating: true,
+			want:     "In addition to creating this breakpoint, this will change the workspace filters for 5 active breakpoints. Continue?",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filterChangeConfirmMessage(tt.count, tt.creating); got != tt.want {
+				t.Fatalf("unexpected message:\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseBreakpoint(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/breakpoint_helpers_test.go
+++ b/cmd/breakpoint_helpers_test.go
@@ -206,6 +206,36 @@ func TestBuildWorkspaceFilterSets(t *testing.T) {
 	})
 }
 
+func TestFormatFilters(t *testing.T) {
+	t.Run("sorted deterministic output", func(t *testing.T) {
+		parsed := map[string][]string{
+			"ns":   {"prod", "staging"},
+			"host": {"HOST-1"},
+		}
+		got := formatFilters(parsed)
+		want := "host:HOST-1,ns:prod,ns:staging"
+		if got != want {
+			t.Fatalf("unexpected formatted filters: got %q want %q", got, want)
+		}
+	})
+
+	t.Run("normalizes raw input spacing", func(t *testing.T) {
+		parsed, err := parseFilters("ns : prod")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := formatFilters(parsed); got != "ns:prod" {
+			t.Fatalf("expected normalized 'ns:prod', got %q", got)
+		}
+	})
+
+	t.Run("empty map yields empty string", func(t *testing.T) {
+		if got := formatFilters(map[string][]string{}); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+}
+
 func TestParseBreakpoint(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/breakpoint_helpers_test.go
+++ b/cmd/breakpoint_helpers_test.go
@@ -151,6 +151,61 @@ func TestParseFilters(t *testing.T) {
 	}
 }
 
+func TestBuildWorkspaceFilterSets(t *testing.T) {
+	t.Run("valid single filter", func(t *testing.T) {
+		sets, err := buildWorkspaceFilterSets("k8s.namespace.name:prod")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(sets) != 1 {
+			t.Fatalf("expected 1 filter set, got %d", len(sets))
+		}
+
+		filtersField, ok := sets[0]["filters"].([]interface{})
+		if !ok || len(filtersField) != 0 {
+			t.Fatalf("expected empty filters slice, got %#v", sets[0]["filters"])
+		}
+
+		labels, ok := sets[0]["labels"].([]map[string]interface{})
+		if !ok || len(labels) != 1 {
+			t.Fatalf("expected 1 label, got %#v", sets[0]["labels"])
+		}
+		if labels[0]["field"] != "k8s.namespace.name" {
+			t.Fatalf("unexpected field: %#v", labels[0]["field"])
+		}
+		values, ok := labels[0]["values"].([]string)
+		if !ok || len(values) != 1 || values[0] != "prod" {
+			t.Fatalf("unexpected values: %#v", labels[0]["values"])
+		}
+	})
+
+	t.Run("multiple filters yield one set with multiple labels", func(t *testing.T) {
+		sets, err := buildWorkspaceFilterSets("k8s.namespace.name:prod,dt.entity.host:HOST-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(sets) != 1 {
+			t.Fatalf("expected 1 filter set, got %d", len(sets))
+		}
+		labels, ok := sets[0]["labels"].([]map[string]interface{})
+		if !ok || len(labels) != 2 {
+			t.Fatalf("expected 2 labels, got %#v", sets[0]["labels"])
+		}
+	})
+
+	t.Run("invalid format returns error", func(t *testing.T) {
+		if _, err := buildWorkspaceFilterSets("no-separator"); err == nil {
+			t.Fatalf("expected error for invalid filter format")
+		}
+	})
+
+	t.Run("empty input returns error", func(t *testing.T) {
+		if _, err := buildWorkspaceFilterSets(""); err == nil {
+			t.Fatalf("expected error for empty filter input")
+		}
+	})
+}
+
 func TestParseBreakpoint(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/breakpoint_helpers_test.go
+++ b/cmd/breakpoint_helpers_test.go
@@ -236,6 +236,26 @@ func TestFormatFilters(t *testing.T) {
 	})
 }
 
+func TestRequireFiltersValue(t *testing.T) {
+	t.Run("non-empty value passes", func(t *testing.T) {
+		if err := requireFiltersValue("ns:prod"); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("empty and whitespace-only values are rejected", func(t *testing.T) {
+		for _, in := range []string{"", "   ", "\t"} {
+			err := requireFiltersValue(in)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", in)
+			}
+			if !strings.Contains(err.Error(), "provided without a value") {
+				t.Fatalf("unexpected error message for %q: %v", in, err)
+			}
+		}
+	})
+}
+
 func TestParseBreakpoint(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/create_breakpoints.go
+++ b/cmd/create_breakpoints.go
@@ -54,8 +54,8 @@ Examples:
 		var filterSets []map[string]interface{}
 		var filterSummary string
 		if filtersChanged {
-			if strings.TrimSpace(filters) == "" {
-				return fmt.Errorf("--filters provided without a value")
+			if err := requireFiltersValue(filters); err != nil {
+				return err
 			}
 			parsed, err := parseFilters(filters)
 			if err != nil {

--- a/cmd/create_breakpoints.go
+++ b/cmd/create_breakpoints.go
@@ -62,16 +62,19 @@ Examples:
 			}
 		}
 
-		cfg, c, err := SetupWithSafety(safety.OperationCreate)
-		if err != nil {
-			return err
-		}
-
+		// Dry-run preview must not be blocked by the safety check (a readonly
+		// context should still show the preview), so it runs before
+		// SetupWithSafety. Matches create_workflows.go / create_buckets.go.
 		if dryRun {
 			if filtersChanged {
 				return printBreakpointMessage("create", fmt.Sprintf("Dry run: would set workspace filters (%s) and create breakpoint at %s:%d", strings.TrimSpace(filters), fileName, lineNumber))
 			}
 			return printBreakpointMessage("create", fmt.Sprintf("Dry run: would create breakpoint at %s:%d", fileName, lineNumber))
+		}
+
+		cfg, c, err := SetupWithSafety(safety.OperationCreate)
+		if err != nil {
+			return err
 		}
 
 		verbose := isDebugVerbose()

--- a/cmd/create_breakpoints.go
+++ b/cmd/create_breakpoints.go
@@ -16,12 +16,23 @@ var createBreakpointCmd = &cobra.Command{
 	Short:   "Create a Live Debugger breakpoint (experimental)",
 	Long: `Create a Live Debugger breakpoint in the current workspace.
 
+A breakpoint can only be created in a workspace that has filters configured.
+Set filters in the same step with --filters, or beforehand with
+'dtctl update breakpoint --filters key:value'. Filters are workspace-scoped and
+persist, so once set you can create more breakpoints without repeating them.
+
 Note: Live Debugger support is experimental. The underlying APIs and query
 behavior may change in future releases.
 
 Examples:
-  # Create a breakpoint
+  # Create a breakpoint (workspace must already have filters)
   dtctl create breakpoint OrderController.java:306
+
+  # Set workspace filters and create the breakpoint in one step
+  dtctl create breakpoint OrderController.java:306 --filters k8s.namespace.name:prod
+
+  # Multiple filters
+  dtctl create breakpoint OrderController.java:306 --filters k8s.namespace.name:prod,dt.entity.host:HOST-123
 
   # Dry run to preview
   dtctl create breakpoint OrderController.java:306 --dry-run
@@ -34,12 +45,32 @@ Examples:
 			return err
 		}
 
+		filters, _ := cmd.Flags().GetString("filters")
+		filtersChanged := cmd.Flags().Changed("filters")
+
+		// Validate --filters up front, before any config or network call, so
+		// format errors surface immediately. Filters are optional for create:
+		// only validate when the flag was actually provided.
+		var filterSets []map[string]interface{}
+		if filtersChanged {
+			if strings.TrimSpace(filters) == "" {
+				return fmt.Errorf("--filters provided without a value")
+			}
+			filterSets, err = buildWorkspaceFilterSets(filters)
+			if err != nil {
+				return err
+			}
+		}
+
 		cfg, c, err := SetupWithSafety(safety.OperationCreate)
 		if err != nil {
 			return err
 		}
 
 		if dryRun {
+			if filtersChanged {
+				return printBreakpointMessage("create", fmt.Sprintf("Dry run: would set workspace filters (%s) and create breakpoint at %s:%d", strings.TrimSpace(filters), fileName, lineNumber))
+			}
 			return printBreakpointMessage("create", fmt.Sprintf("Dry run: would create breakpoint at %s:%d", fileName, lineNumber))
 		}
 
@@ -68,12 +99,27 @@ Examples:
 			}
 		}
 
-		hasFilters, err := livedebugger.WorkspaceHasFilters(workspaceResp)
-		if err != nil {
-			return err
-		}
-		if !hasFilters {
-			return fmt.Errorf("no workspace filters configured; set filters first with:\n  dtctl update breakpoint --filters key:value\nthen retry creating the breakpoint")
+		if filtersChanged {
+			updateResp, err := handler.UpdateWorkspaceFilters(workspaceID, filterSets)
+			if err != nil {
+				if verbose {
+					_ = printGraphQLResponse("updateWorkspaceV2", updateResp)
+				}
+				return err
+			}
+			if verbose {
+				if err := printGraphQLResponse("updateWorkspaceV2", updateResp); err != nil {
+					return err
+				}
+			}
+		} else {
+			hasFilters, err := livedebugger.WorkspaceHasFilters(workspaceResp)
+			if err != nil {
+				return err
+			}
+			if !hasFilters {
+				return fmt.Errorf("no workspace filters configured; set filters first with:\n  dtctl update breakpoint --filters key:value\nor pass --filters when creating:\n  dtctl create breakpoint %s:%d --filters key:value", fileName, lineNumber)
+			}
 		}
 
 		createResp, err := handler.CreateBreakpoint(workspaceID, fileName, lineNumber)
@@ -91,4 +137,8 @@ Examples:
 
 		return printBreakpointMessage("create", fmt.Sprintf("Created breakpoint at %s:%d", fileName, lineNumber))
 	},
+}
+
+func init() {
+	createBreakpointCmd.Flags().String("filters", "", "workspace filters to set before creating the breakpoint (comma-separated key:value pairs)")
 }

--- a/cmd/create_breakpoints.go
+++ b/cmd/create_breakpoints.go
@@ -52,14 +52,17 @@ Examples:
 		// format errors surface immediately. Filters are optional for create:
 		// only validate when the flag was actually provided.
 		var filterSets []map[string]interface{}
+		var filterSummary string
 		if filtersChanged {
 			if strings.TrimSpace(filters) == "" {
 				return fmt.Errorf("--filters provided without a value")
 			}
-			filterSets, err = buildWorkspaceFilterSets(filters)
+			parsed, err := parseFilters(filters)
 			if err != nil {
 				return err
 			}
+			filterSets = livedebugger.BuildFilterSets(parsed)
+			filterSummary = formatFilters(parsed)
 		}
 
 		// Dry-run preview must not be blocked by the safety check (a readonly
@@ -67,7 +70,7 @@ Examples:
 		// SetupWithSafety. Matches create_workflows.go / create_buckets.go.
 		if dryRun {
 			if filtersChanged {
-				return printBreakpointMessage("create", fmt.Sprintf("Dry run: would set workspace filters (%s) and create breakpoint at %s:%d", strings.TrimSpace(filters), fileName, lineNumber))
+				return printBreakpointMessage("create", fmt.Sprintf("Dry run: would set workspace filters (%s) and create breakpoint at %s:%d", filterSummary, fileName, lineNumber))
 			}
 			return printBreakpointMessage("create", fmt.Sprintf("Dry run: would create breakpoint at %s:%d", fileName, lineNumber))
 		}

--- a/cmd/create_breakpoints.go
+++ b/cmd/create_breakpoints.go
@@ -122,8 +122,7 @@ Examples:
 					return err
 				}
 				if count > 0 && !prompt.Confirm(filterChangeConfirmMessage(count, true)) {
-					fmt.Println("Cancelled")
-					return nil
+					return printBreakpointMessage("create", "Cancelled")
 				}
 			}
 

--- a/cmd/create_breakpoints.go
+++ b/cmd/create_breakpoints.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtctl/pkg/prompt"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/livedebugger"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 )
@@ -20,6 +21,10 @@ A breakpoint can only be created in a workspace that has filters configured.
 Set filters in the same step with --filters, or beforehand with
 'dtctl update breakpoint --filters key:value'. Filters are workspace-scoped and
 persist, so once set you can create more breakpoints without repeating them.
+
+Because filters are workspace-scoped, changing them with --filters also re-scopes
+every existing breakpoint in the workspace. When active breakpoints would be
+affected you are asked to confirm; pass --yes (-y) to skip the prompt.
 
 Note: Live Debugger support is experimental. The underlying APIs and query
 behavior may change in future releases.
@@ -47,6 +52,7 @@ Examples:
 
 		filters, _ := cmd.Flags().GetString("filters")
 		filtersChanged := cmd.Flags().Changed("filters")
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
 
 		// Validate --filters up front, before any config or network call, so
 		// format errors surface immediately. Filters are optional for create:
@@ -70,7 +76,7 @@ Examples:
 		// SetupWithSafety. Matches create_workflows.go / create_buckets.go.
 		if dryRun {
 			if filtersChanged {
-				return printBreakpointMessage("create", fmt.Sprintf("Dry run: would set workspace filters (%s) and create breakpoint at %s:%d", filterSummary, fileName, lineNumber))
+				return printBreakpointMessage("create", fmt.Sprintf("Dry run: would set workspace filters (%s) and create breakpoint at %s:%d (note: changing filters also re-scopes existing breakpoints in the workspace)", filterSummary, fileName, lineNumber))
 			}
 			return printBreakpointMessage("create", fmt.Sprintf("Dry run: would create breakpoint at %s:%d", fileName, lineNumber))
 		}
@@ -106,6 +112,21 @@ Examples:
 		}
 
 		if filtersChanged {
+			// Changing workspace filters re-scopes every existing active
+			// breakpoint in the workspace, not just the one being created.
+			// Confirm first, unless --yes or a non-interactive (--plain/agent)
+			// context. The extra read is only paid when we might prompt.
+			if !skipConfirm && !plainMode {
+				count, err := countActiveWorkspaceBreakpoints(handler, workspaceID)
+				if err != nil {
+					return err
+				}
+				if count > 0 && !prompt.Confirm(filterChangeConfirmMessage(count, true)) {
+					fmt.Println("Cancelled")
+					return nil
+				}
+			}
+
 			updateResp, err := handler.UpdateWorkspaceFilters(workspaceID, filterSets)
 			if err != nil {
 				if verbose {
@@ -147,4 +168,5 @@ Examples:
 
 func init() {
 	createBreakpointCmd.Flags().String("filters", "", "workspace filters to set before creating the breakpoint (comma-separated key:value pairs)")
+	createBreakpointCmd.Flags().BoolP("yes", "y", false, "skip the confirmation prompt when changing workspace filters affects existing breakpoints")
 }

--- a/cmd/create_breakpoints_test.go
+++ b/cmd/create_breakpoints_test.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestCreateBreakpointCommandRegistration(t *testing.T) {
 	createCmd, _, err := rootCmd.Find([]string{"create"})
@@ -18,4 +21,52 @@ func TestCreateBreakpointCommandRegistration(t *testing.T) {
 	if breakpointCmd == nil || breakpointCmd.Name() != "breakpoint" {
 		t.Fatalf("expected create breakpoint command to exist")
 	}
+}
+
+func TestCreateBreakpointFiltersFlagRegistered(t *testing.T) {
+	if createBreakpointCmd.Flags().Lookup("filters") == nil {
+		t.Fatalf("expected --filters flag to be registered on create breakpoint")
+	}
+}
+
+// TestCreateBreakpointFiltersValidation exercises the early --filters validation
+// that runs before any config or network call, so no client/config setup is
+// required. The flag state is saved and restored to avoid leaking into other tests.
+func TestCreateBreakpointFiltersValidation(t *testing.T) {
+	cmd := createBreakpointCmd
+	flag := cmd.Flags().Lookup("filters")
+	if flag == nil {
+		t.Fatalf("expected --filters flag to be registered on create breakpoint")
+	}
+
+	originalValue := flag.Value.String()
+	originalChanged := flag.Changed
+	defer func() {
+		_ = flag.Value.Set(originalValue)
+		flag.Changed = originalChanged
+	}()
+
+	t.Run("empty value", func(t *testing.T) {
+		if err := flag.Value.Set(""); err != nil {
+			t.Fatalf("failed to set flag: %v", err)
+		}
+		flag.Changed = true
+
+		err := cmd.RunE(cmd, []string{"OrderController.java:306"})
+		if err == nil || !strings.Contains(err.Error(), "provided without a value") {
+			t.Fatalf("expected 'provided without a value' error, got %v", err)
+		}
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		if err := flag.Value.Set("no-separator"); err != nil {
+			t.Fatalf("failed to set flag: %v", err)
+		}
+		flag.Changed = true
+
+		err := cmd.RunE(cmd, []string{"OrderController.java:306"})
+		if err == nil || !strings.Contains(err.Error(), "invalid filter") {
+			t.Fatalf("expected invalid filter error, got %v", err)
+		}
+	})
 }

--- a/cmd/create_breakpoints_test.go
+++ b/cmd/create_breakpoints_test.go
@@ -29,6 +29,19 @@ func TestCreateBreakpointFiltersFlagRegistered(t *testing.T) {
 	}
 }
 
+func TestCreateBreakpointYesFlagRegistered(t *testing.T) {
+	flag := createBreakpointCmd.Flags().Lookup("yes")
+	if flag == nil {
+		t.Fatalf("expected --yes flag to be registered on create breakpoint")
+	}
+	if flag.Shorthand != "y" {
+		t.Fatalf("expected --yes shorthand 'y', got %q", flag.Shorthand)
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("expected --yes default 'false', got %q", flag.DefValue)
+	}
+}
+
 // TestCreateBreakpointFiltersValidation exercises the early --filters validation
 // that runs before any config or network call, so no client/config setup is
 // required. The flag state is saved and restored to avoid leaking into other tests.

--- a/cmd/update_breakpoints.go
+++ b/cmd/update_breakpoints.go
@@ -60,8 +60,8 @@ Examples:
 		}
 
 		if filtersChanged {
-			if strings.TrimSpace(filters) == "" {
-				return fmt.Errorf("--filters is required")
+			if err := requireFiltersValue(filters); err != nil {
+				return err
 			}
 			if conditionChanged || enabledChanged {
 				return fmt.Errorf("--filters cannot be combined with --condition or --enabled")

--- a/cmd/update_breakpoints.go
+++ b/cmd/update_breakpoints.go
@@ -115,12 +115,12 @@ Examples:
 				}
 			}
 
-			parsedFilters, err := parseFilters(filters)
+			filterSets, err := buildWorkspaceFilterSets(filters)
 			if err != nil {
 				return err
 			}
 
-			updateResp, err := handler.UpdateWorkspaceFilters(workspaceID, livedebugger.BuildFilterSets(parsedFilters))
+			updateResp, err := handler.UpdateWorkspaceFilters(workspaceID, filterSets)
 			if err != nil {
 				if verbose {
 					_ = printGraphQLResponse("updateWorkspaceV2", updateResp)

--- a/cmd/update_breakpoints.go
+++ b/cmd/update_breakpoints.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtctl/pkg/prompt"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/livedebugger"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 )
@@ -25,6 +26,10 @@ var updateBreakpointCmd = &cobra.Command{
 	Short:   "Update Live Debugger breakpoints and workspace filters (experimental)",
 	Long: `Update Live Debugger breakpoints by mutable rule ID or source location,
 or update workspace filters for the current project.
+
+Filters are workspace-scoped, so updating them with --filters also re-scopes
+every existing breakpoint in the workspace. When active breakpoints would be
+affected you are asked to confirm; pass --yes (-y) to skip the prompt.
 
 Note: Live Debugger support is experimental. The underlying APIs and query
 behavior may change in future releases.
@@ -48,6 +53,7 @@ Examples:
 		verbose := isDebugVerbose()
 		filters, _ := cmd.Flags().GetString("filters")
 		filtersChanged := cmd.Flags().Changed("filters")
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
 		trailingArgs := []string{}
 		if len(args) > 1 {
 			trailingArgs = args[1:]
@@ -89,7 +95,7 @@ Examples:
 			}
 
 			if dryRun {
-				return printBreakpointMessage("update", fmt.Sprintf("Dry run: would update Live Debugger workspace filters (%s)", strings.TrimSpace(filters)))
+				return printBreakpointMessage("update", fmt.Sprintf("Dry run: would update Live Debugger workspace filters (%s) (note: this also re-scopes existing breakpoints in the workspace)", strings.TrimSpace(filters)))
 			}
 
 			c, err := NewClientFromConfig(cfg)
@@ -118,6 +124,21 @@ Examples:
 			filterSets, err := buildWorkspaceFilterSets(filters)
 			if err != nil {
 				return err
+			}
+
+			// Changing workspace filters re-scopes every existing active
+			// breakpoint in the workspace. Confirm first, unless --yes or a
+			// non-interactive (--plain/agent) context. The extra read is only
+			// paid when we might prompt.
+			if !skipConfirm && !plainMode {
+				count, err := countActiveWorkspaceBreakpoints(handler, workspaceID)
+				if err != nil {
+					return err
+				}
+				if count > 0 && !prompt.Confirm(filterChangeConfirmMessage(count, false)) {
+					fmt.Println("Cancelled")
+					return nil
+				}
 			}
 
 			updateResp, err := handler.UpdateWorkspaceFilters(workspaceID, filterSets)
@@ -539,5 +560,6 @@ func init() {
 	updateBreakpointCmd.Flags().String("condition", "", "Condition expression for the breakpoint")
 	updateBreakpointCmd.Flags().String("enabled", "", "Enable or disable the breakpoint")
 	updateBreakpointCmd.Flags().String("filters", "", "workspace filters to apply (comma-separated key:value pairs)")
+	updateBreakpointCmd.Flags().BoolP("yes", "y", false, "skip the confirmation prompt when changing workspace filters affects existing breakpoints")
 	updateBreakpointCmd.Flags().Lookup("enabled").NoOptDefVal = "true"
 }

--- a/cmd/update_breakpoints.go
+++ b/cmd/update_breakpoints.go
@@ -95,7 +95,11 @@ Examples:
 			}
 
 			if dryRun {
-				return printBreakpointMessage("update", fmt.Sprintf("Dry run: would update Live Debugger workspace filters (%s) (note: this also re-scopes existing breakpoints in the workspace)", strings.TrimSpace(filters)))
+				parsed, err := parseFilters(filters)
+				if err != nil {
+					return err
+				}
+				return printBreakpointMessage("update", fmt.Sprintf("Dry run: would update Live Debugger workspace filters (%s) (note: this also re-scopes existing breakpoints in the workspace)", formatFilters(parsed)))
 			}
 
 			c, err := NewClientFromConfig(cfg)
@@ -136,8 +140,7 @@ Examples:
 					return err
 				}
 				if count > 0 && !prompt.Confirm(filterChangeConfirmMessage(count, false)) {
-					fmt.Println("Cancelled")
-					return nil
+					return printBreakpointMessage("update", "Cancelled")
 				}
 			}
 

--- a/cmd/update_breakpoints_test.go
+++ b/cmd/update_breakpoints_test.go
@@ -37,6 +37,19 @@ func TestUpdateBreakpointCommandRegistration(t *testing.T) {
 	}
 }
 
+func TestUpdateBreakpointYesFlagRegistered(t *testing.T) {
+	flag := updateBreakpointCmd.Flags().Lookup("yes")
+	if flag == nil {
+		t.Fatalf("expected --yes flag to be registered on update breakpoint")
+	}
+	if flag.Shorthand != "y" {
+		t.Fatalf("expected --yes shorthand 'y', got %q", flag.Shorthand)
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("expected --yes default 'false', got %q", flag.DefValue)
+	}
+}
+
 func TestUpdateBreakpointFilters_NoIdentifier_NoPanic(t *testing.T) {
 	viper.Reset()
 

--- a/docs/LIVE_DEBUGGER.md
+++ b/docs/LIVE_DEBUGGER.md
@@ -62,10 +62,24 @@ Create a breakpoint by file and line number:
 dtctl create breakpoint OrderController.java:306
 ```
 
+A breakpoint can only be created in a workspace that already has filters
+configured. Either configure them first (see step 1), or set them in the same
+step with `--filters`:
+
+```bash
+dtctl create breakpoint OrderController.java:306 --filters k8s.namespace.name:prod
+```
+
+Filters are workspace-scoped and persist, so once set you can create additional
+breakpoints (in other files) without repeating `--filters`.
+
 ### Rules
 
 - the expected format is `File.java:line`
 - the line number must be a positive integer
+- `--filters` is optional and accepts comma-separated `key:value` (or `key=value`) pairs
+- when `--filters` is provided, the workspace filters are updated before the breakpoint is created
+- when `--filters` is omitted, the workspace must already have filters configured
 - `--dry-run` is supported
 
 Example:

--- a/docs/LIVE_DEBUGGER.md
+++ b/docs/LIVE_DEBUGGER.md
@@ -47,11 +47,26 @@ dtctl update breakpoints --filters k8s.namespace.name:prod,dt.entity.host:HOST-1
 dtctl update breakpoint --filters k8s.namespace.name=prod,dt.entity.host=HOST-123
 ```
 
+Filters are workspace-scoped: a single filter set applies to **every** breakpoint
+in the workspace. Changing the filters therefore re-scopes all existing
+breakpoints, not just ones you create afterwards. Because of this, `dtctl` counts
+the active breakpoints that would be affected and prompts for confirmation before
+applying the change. Pass `--yes` (`-y`) to skip the prompt, for example in
+scripts:
+
+```bash
+dtctl update breakpoint --filters k8s.namespace.name:prod --yes
+```
+
 ### Notes
 
 - `--filters` is required for `dtctl update breakpoint`
 - filter values are mapped to the Live Debugger workspace filter set payload
 - repeated keys are supported
+- changing filters re-scopes all existing breakpoints, so you are prompted to
+  confirm unless you pass `--yes` (`-y`); auto-disabled breakpoints (for example
+  after reaching their hit limit) are not counted, and non-interactive contexts
+  (`--plain` or agent mode) skip the prompt
 - in verbose/debug mode, raw GraphQL responses are printed for troubleshooting
 
 ## 2. Create a breakpoint
@@ -71,7 +86,9 @@ dtctl create breakpoint OrderController.java:306 --filters k8s.namespace.name:pr
 ```
 
 Filters are workspace-scoped and persist, so once set you can create additional
-breakpoints (in other files) without repeating `--filters`.
+breakpoints (in other files) without repeating `--filters`. Because filters are
+shared across the workspace, passing `--filters` here also re-scopes any existing
+breakpoints, so `dtctl` prompts for confirmation unless you pass `--yes` (`-y`).
 
 ### Rules
 
@@ -79,6 +96,7 @@ breakpoints (in other files) without repeating `--filters`.
 - the line number must be a positive integer
 - `--filters` is optional and accepts comma-separated `key:value` (or `key=value`) pairs
 - when `--filters` is provided, the workspace filters are updated before the breakpoint is created
+- when `--filters` changes the workspace filters, existing breakpoints are re-scoped too, so you are prompted to confirm unless you pass `--yes` (`-y`)
 - when `--filters` is omitted, the workspace must already have filters configured
 - `--dry-run` is supported
 
@@ -241,6 +259,7 @@ Live Debugger mutating commands follow `dtctl` safety conventions:
 - edit operations use update safety checks
 - delete operations use delete safety checks
 - destructive delete operations support confirmation bypass with `-y`
+- filter changes prompt for confirmation because they re-scope existing breakpoints; bypass with `-y`/`--yes`
 - supported mutating commands provide `--dry-run`
 
 ## Example workflow

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -3157,6 +3157,12 @@ dtctl update breakpoints --filters k8s.namespace.name:prod,dt.entity.host:HOST-1
 dtctl update breakpoint --filters k8s.namespace.name=prod,dt.entity.host=HOST-123
 ```
 
+Filters are workspace-scoped, so changing them re-scopes **all** existing breakpoints, not just new ones. `dtctl` prompts for confirmation before applying the change; pass `--yes` (`-y`) to skip it (for example in scripts):
+
+```bash
+dtctl update breakpoint --filters k8s.namespace.name:prod --yes
+```
+
 ### Breakpoint lifecycle
 
 ```bash

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -3160,7 +3160,10 @@ dtctl update breakpoint --filters k8s.namespace.name=prod,dt.entity.host=HOST-12
 ### Breakpoint lifecycle
 
 ```bash
-# Create
+# Create and set workspace filters in one step
+dtctl create breakpoint OrderController.java:306 --filters k8s.namespace.name:prod
+
+# Create (workspace must already have filters)
 dtctl create breakpoint OrderController.java:306
 
 # List

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -1868,10 +1868,11 @@ This flag is composable with any output format (`-o json`, `-o yaml`, `-o table`
 Live Debugger follows the standard verb-noun grammar and avoids introducing a separate command tree:
 
 ```bash
-dtctl update breakpoint --filters key:value[,key:value...]     # configure workspace filters
+dtctl create breakpoint File.java:line --filters key:value     # set workspace filters + create a breakpoint in one step
 dtctl create breakpoint File.java:line                         # create breakpoint
+dtctl update breakpoint --filters key:value[,key:value...]     # configure workspace filters
 dtctl get breakpoints                                          # list breakpoints
-dtctl describe <breakpoint-id|filename:line>                   # describe breakpoint rollout/status
+dtctl describe breakpoint <breakpoint-id|filename:line>                   # describe breakpoint rollout/status
 dtctl update breakpoint <id|filename:line> --condition "..."   # update condition
 dtctl update breakpoint <id|filename:line> --enabled true|false # enable/disable
 dtctl delete breakpoint <id|filename:line|--all>               # delete breakpoints
@@ -1882,6 +1883,7 @@ dtctl delete breakpoint <id|filename:line|--all>               # delete breakpoi
 Design notes:
 - `dtctl describe` keeps existing resource-subcommand behavior; breakpoint describe is only routed for breakpoint-like identifiers.
 - Mutating operations (`update` filter update, `create`, `update`, `delete`) must run safety checks, including in dry-run mode.
+- `--filters` is optional on `create`. Filters are workspace-scoped and sticky: once set (via `update breakpoint --filters` or `create breakpoint ... --filters`), they persist for subsequent breakpoints until changed. When `--filters` is supplied on `create`, the workspace filters are updated first, then the breakpoint is created; otherwise `create` requires that workspace filters were already configured.
 
 ## Examples
 

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -1883,7 +1883,7 @@ dtctl delete breakpoint <id|filename:line|--all>               # delete breakpoi
 Design notes:
 - `dtctl describe` keeps existing resource-subcommand behavior; breakpoint describe is only routed for breakpoint-like identifiers.
 - Mutating operations (`update` filter update, `create`, `update`, `delete`) must run safety checks, including in dry-run mode.
-- `--filters` is optional on `create`. Filters are workspace-scoped and sticky: once set (via `update breakpoint --filters` or `create breakpoint ... --filters`), they persist for subsequent breakpoints until changed. When `--filters` is supplied on `create`, the workspace filters are updated first, then the breakpoint is created; otherwise `create` requires that workspace filters were already configured.
+- `--filters` is optional on `create`. Filters are workspace-scoped and sticky: once set (via `update breakpoint --filters` or `create breakpoint ... --filters`), they persist for subsequent breakpoints until changed. Because a single filter set applies to the whole workspace, changing the filters re-scopes all existing breakpoints (not just new ones); `create`/`update` count the active breakpoints affected and prompt for confirmation before applying the change, bypassable with `--yes` (`-y`) and skipped in non-interactive contexts (`--plain`/agent mode). When `--filters` is supplied on `create`, the workspace filters are updated first, then the breakpoint is created; otherwise `create` requires that workspace filters were already configured.
 
 ## Examples
 

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -287,7 +287,7 @@ This document tracks the current implementation status of dtctl. For future plan
 
 ### Live Debugger Features (Experimental)
 - [x] Configure workspace filters: `dtctl update breakpoint --filters key:value[,key:value...]` (also supports `key=value`)
-- [x] Create breakpoint: `dtctl create breakpoint File.java:line`
+- [x] Create breakpoint: `dtctl create breakpoint File.java:line` (optional `--filters key:value[,...]` sets workspace filters in the same step)
 - [x] List breakpoints: `dtctl get breakpoints`
 - [x] Describe breakpoint status by ID or location: `dtctl describe <id|filename:line>`
 - [x] Update breakpoint condition/enabled state: `dtctl update breakpoint <id|filename:line> --condition ... --enabled ...`

--- a/docs/site/_docs/live-debugger.md
+++ b/docs/site/_docs/live-debugger.md
@@ -23,10 +23,12 @@ dtctl auth login
 
 ## Configure Workspace Filters
 
-Workspace filters let you scope which monitored processes are eligible for breakpoints. This is important in large environments to avoid unnecessary overhead.
+Workspace filters scope which monitored processes are eligible for breakpoints, which is important in large environments to avoid unnecessary overhead. Filters are workspace-scoped and sticky: once set, they apply to every breakpoint you create until you change them.
+
+You can set filters in the same step as creating a breakpoint (see [Create a Breakpoint](#create-a-breakpoint)), so a separate filter command is not required. Use the standalone command when you want to set or change filters without creating a breakpoint:
 
 ```bash
-# Set a workspace filter to target a specific Kubernetes namespace
+# Set workspace filters (e.g. target a specific Kubernetes namespace)
 dtctl update breakpoint --filters k8s.namespace.name:prod
 ```
 
@@ -35,8 +37,11 @@ dtctl update breakpoint --filters k8s.namespace.name:prod
 ### Create a Breakpoint
 
 ```bash
-# Create a breakpoint at a specific source location
-dtctl create breakpoint --file com/example/MyService.java --line 42
+# Create a breakpoint at a specific source location (file:line)
+dtctl create breakpoint com/example/MyService.java:42
+
+# Set workspace filters and create the breakpoint in one step
+dtctl create breakpoint com/example/MyService.java:42 --filters k8s.namespace.name:prod
 ```
 
 ### List Breakpoints
@@ -69,8 +74,8 @@ dtctl update breakpoint bp-abc123 --enabled=false
 # Delete a single breakpoint by ID
 dtctl delete breakpoint bp-abc123
 
-# Delete all breakpoints at a specific source location
-dtctl delete breakpoint --file com/example/MyService.java --line 42
+# Delete all breakpoints at a specific source location (file:line)
+dtctl delete breakpoint com/example/MyService.java:42
 
 # Delete all breakpoints in the workspace
 dtctl delete breakpoint --all
@@ -92,7 +97,7 @@ By default, `--decode-snapshots` produces a simplified view that shows variable 
 ```bash
 # Full decoding with complete object graphs
 dtctl query "fetch application.snapshots | limit 5" \
-  --decode-snapshots --full
+  --decode-snapshots=full
 ```
 
 ## Safety and Dry-Run
@@ -101,7 +106,7 @@ Live Debugger commands that modify state (create, update, delete) support safety
 
 ```bash
 # Preview what would be created without actually creating it
-dtctl create breakpoint --file com/example/MyService.java --line 42 --dry-run
+dtctl create breakpoint com/example/MyService.java:42 --dry-run
 
 # Safety checks prevent accidental modifications in read-only contexts
 ```
@@ -112,22 +117,19 @@ dtctl create breakpoint --file com/example/MyService.java --line 42 --dry-run
 # 1. Log in with OAuth
 dtctl auth login
 
-# 2. Set workspace filters to target production
-dtctl update breakpoint --filters k8s.namespace.name:prod
+# 2. Create a breakpoint on a suspect line, setting workspace filters in the same step
+dtctl create breakpoint com/example/PaymentService.java:87 --filters k8s.namespace.name:prod
 
-# 3. Create a breakpoint on a suspect line
-dtctl create breakpoint --file com/example/PaymentService.java --line 87
-
-# 4. List breakpoints to confirm
+# 3. List breakpoints to confirm
 dtctl get breakpoints
 
-# 5. Wait for the breakpoint to be hit, then query snapshots
+# 4. Wait for the breakpoint to be hit, then query snapshots
 dtctl query "fetch application.snapshots \
   | filter source.file == 'com/example/PaymentService.java' \
   | limit 5" --decode-snapshots
 
-# 6. Inspect the decoded variables to diagnose the issue
+# 5. Inspect the decoded variables to diagnose the issue
 
-# 7. Clean up — delete the breakpoint
-dtctl delete breakpoint --file com/example/PaymentService.java --line 87
+# 6. Clean up — delete the breakpoint
+dtctl delete breakpoint com/example/PaymentService.java:87
 ```

--- a/docs/site/_docs/live-debugger.md
+++ b/docs/site/_docs/live-debugger.md
@@ -23,7 +23,7 @@ dtctl auth login
 
 ## Configure Workspace Filters
 
-Workspace filters scope which monitored processes are eligible for breakpoints, which is important in large environments to avoid unnecessary overhead. Filters are workspace-scoped and sticky: once set, they apply to every breakpoint you create until you change them.
+Workspace filters scope which monitored processes are eligible for breakpoints, which is important in large environments to avoid unnecessary overhead. Filters are workspace-scoped: a single filter set applies to **every** breakpoint in the workspace. Because of this, changing the filters re-scopes not only breakpoints you create afterwards but **all existing breakpoints** in the workspace as well.
 
 You can set filters in the same step as creating a breakpoint (see [Create a Breakpoint](#create-a-breakpoint)), so a separate filter command is not required. Use the standalone command when you want to set or change filters without creating a breakpoint:
 
@@ -31,6 +31,20 @@ You can set filters in the same step as creating a breakpoint (see [Create a Bre
 # Set workspace filters (e.g. target a specific Kubernetes namespace)
 dtctl update breakpoint --filters k8s.namespace.name:prod
 ```
+
+Because changing filters re-scopes existing breakpoints, `dtctl` counts the active breakpoints that would be affected and asks you to confirm before applying the change:
+
+```text
+This will change the workspace filters for 3 active breakpoints. Continue? [y/N]:
+```
+
+Pass `--yes` (`-y`) to skip the prompt, e.g. in scripts:
+
+```bash
+dtctl update breakpoint --filters k8s.namespace.name:prod --yes
+```
+
+> **Note:** Breakpoints that have auto-disabled (for example after reaching their hit limit) are not counted. In non-interactive contexts (`--plain` or auto-detected agent mode) the change proceeds without prompting.
 
 ## Breakpoint Lifecycle
 
@@ -43,6 +57,8 @@ dtctl create breakpoint com/example/MyService.java:42
 # Set workspace filters and create the breakpoint in one step
 dtctl create breakpoint com/example/MyService.java:42 --filters k8s.namespace.name:prod
 ```
+
+When `--filters` changes the workspace filters, it also re-scopes existing breakpoints (see [Configure Workspace Filters](#configure-workspace-filters)), so you are prompted to confirm unless you pass `--yes`.
 
 ### List Breakpoints
 


### PR DESCRIPTION
## Summary
Add an optional `--filters` flag to `dtctl create breakpoint`, so workspace
filters can be set and a breakpoint created in a single command (previously
filters had to be configured beforehand via `update breakpoint --filters`).
Because filters are **workspace-scoped**, a single filter set applies to every
breakpoint in the workspace — so changing filters re-scopes **all existing
breakpoints**, not just the one being created. To make that side effect explicit
and safe, `create`/`update breakpoint --filters` now count the active breakpoints
that would be affected and prompt for confirmation before applying the change,
with a `--yes`/`-y` flag to skip it.
## What changed
### `--filters` on `create breakpoint`
- `create breakpoint` accepts `--filters key:value[,key:value...]`; when
  provided, workspace filters are updated before the breakpoint is created.
- `--filters` is validated up front (before any network call); it stays
  optional and sticky for create.
- Shared `buildWorkspaceFilterSets` helper reused by `update breakpoint`.
### Confirmation guard for filter re-scoping (new)
- `create breakpoint --filters` and `update breakpoint --filters` prompt for
  confirmation before changing workspace filters, since the change re-scopes all
  existing breakpoints in the workspace.
- Only **active** breakpoints are counted — auto-disabled ones (e.g. after
  reaching their hit limit) are excluded so they don't inflate the count.
- The prompt only appears when at least one active breakpoint would be affected;
  the extra read is only paid when we might actually prompt.
- `--yes` (`-y`) skips the prompt for scripts/automation.
- Non-interactive contexts (`--plain` or auto-detected agent mode) proceed
  without prompting.
- `--dry-run` notes that the change also re-scopes existing breakpoints (no
  network read is performed in dry-run).
### Review-finding fixes
- Dry-run preview runs **before** the safety check, so a readonly context still
  shows the preview.
- Dry-run shows **normalized** filters (e.g. `ns : prod` → `ns:prod`) so the
  preview matches exactly what will be sent.
- Shared empty-`--filters` guard message between create and update.
### Docs
- Documented workspace-scoped re-scoping, the confirmation prompt, and `--yes`
  across the Live Debugger site guide, `LIVE_DEBUGGER.md`, `QUICK_START.md`, and
  the `API_DESIGN.md` design note.
- Updated `IMPLEMENTATION_STATUS.md`.
- Fixed pre-existing invalid examples in the Live Debugger site docs
  (`--file/--line` → positional `file:line`, `--decode-snapshots=full`) and
  documented that workspace filters are no longer a required prerequisite.
## Testing
- `go build ./...`, `go vet`, `gofmt`/`goimports` clean; `golangci-lint` 0 issues
- New unit tests: active-only rule counting, confirmation message wording, and
  `--yes` flag registration on both `create` and `update breakpoint`
- `go test ./...` (cmd, golden, integration) and SDK tests pass