### PR TITLE
feat(get): align classic-pipelines-translation flag defaults with API v1.41.0

### DIFF
--- a/cmd/get_classic_pipelines_translation.go
+++ b/cmd/get_classic_pipelines_translation.go
@@ -130,7 +130,7 @@ func printValueAsJSON(v any) error {
 }
 
 func init() {
-	getClassicPipelinesTranslationCmd.Flags().Bool("include-sample-data", false, "Include processor sample data in the translation")
-	getClassicPipelinesTranslationCmd.Flags().Bool("skip-disabled-rules", true, "Skip disabled rules during translation")
-	getClassicPipelinesTranslationCmd.Flags().Bool("skip-builtin-processing-rules", false, "Skip built-in processing rules during translation")
+	getClassicPipelinesTranslationCmd.Flags().Bool("include-sample-data", true, "Include processor sample data in the translation")
+	getClassicPipelinesTranslationCmd.Flags().Bool("skip-disabled-rules", false, "Skip disabled rules during translation")
+	getClassicPipelinesTranslationCmd.Flags().Bool("skip-builtin-processing-rules", true, "Skip built-in processing rules during translation")
 }

--- a/cmd/get_classic_pipelines_translation.go
+++ b/cmd/get_classic_pipelines_translation.go
@@ -40,8 +40,8 @@ Examples:
   # Print the translated pipeline as JSON
   dtctl get classic-pipelines-translation logs -o json
 
-  # Keep disabled rules in the translation
-  dtctl get classic-pipelines-translation logs --skip-disabled-rules=false`,
+  # Skip disabled rules in the translation (overrides the server default)
+  dtctl get classic-pipelines-translation logs --skip-disabled-rules=true`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		scope := args[0]

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2015,8 +2015,8 @@ dtctl get classic-pipelines-translation bizevents -o yaml > reference-pipeline.y
 # Print the translated pipeline as JSON
 dtctl get classic-pipelines-translation logs -o json
 
-# Keep disabled rules in the translation (overrides the server default)
-dtctl get classic-pipelines-translation logs --skip-disabled-rules=false
+# Skip disabled rules in the translation (overrides the server default)
+dtctl get classic-pipelines-translation logs --skip-disabled-rules=true
 ```
 
 The scope is a positional argument and must be `logs` or `bizevents`. Every output format emits the translated pipeline document directly (no `{value, withWarning}` wrapper), so the exported file is applyable as-is. The translation is deterministic where possible; when a processing rule's definition script could not be translated automatically (`withWarning=true`), a warning is printed to stderr (and carried in the agent envelope under `-A`) and that part needs a manual rewrite. Apply the reviewed result with `dtctl create settings --schema builtin:openpipeline.<scope>.pipelines -f <file>`.

--- a/sdk/api/classicpipelinestranslate/classicpipelinestranslate.go
+++ b/sdk/api/classicpipelinestranslate/classicpipelinestranslate.go
@@ -36,18 +36,18 @@ func NewHandler(c *httpclient.Client) *Handler {
 // Configuration is the scope to translate (e.g. "logs" or "bizevents") and is
 // required. The three booleans mirror the endpoint's query parameters; they are
 // always sent explicitly so a caller can override the server-side defaults
-// (notably SkipDisabledRules, which the server defaults to true).
+// (notably SkipDisabledRules, which the server defaults to false).
 type TranslateOptions struct {
 	// Configuration is the classic pipeline scope to translate (required).
 	Configuration string
 	// IncludeSampleData includes processor sample data in the translation
-	// (API default: false).
+	// (API default: true).
 	IncludeSampleData bool
 	// SkipDisabledRules skips disabled rules during translation
-	// (API default: true).
+	// (API default: false).
 	SkipDisabledRules bool
 	// SkipBuiltinProcessingRules skips built-in processing rules during
-	// translation (API default: false).
+	// translation (API default: true).
 	SkipBuiltinProcessingRules bool
 }
 
@@ -71,8 +71,8 @@ func (h *Handler) Translate(ctx context.Context, opts TranslateOptions) (*Transl
 
 	resp, err := h.client.HTTP().R().SetContext(ctx).
 		// All four parameters are sent explicitly (rather than relying on
-		// server defaults) so that, for example, --skip-disabled-rules=false
-		// can override the server's true default.
+		// server defaults) so that, for example, --skip-disabled-rules=true
+		// can override the server's false default.
 		SetQueryParam("configuration", opts.Configuration).
 		SetQueryParam("includeSampleData", strconv.FormatBool(opts.IncludeSampleData)).
 		SetQueryParam("skipDisabledRules", strconv.FormatBool(opts.SkipDisabledRules)).


### PR DESCRIPTION
## Description

Adjusts CLI flag defaults for `get classic-pipelines-translation` to match the defaults introduced in API v1.41.0:

- `--include-sample-data`: `true`
- `--skip-disabled-rules`: `false`
- `--skip-builtin-processing-rules`: `true`

## Related Issues

-

## Testing

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)