### PR TITLE
feat(extension): add --feature-set-metrics flag to describe extension

### DIFF
--- a/cmd/describe_extensions.go
+++ b/cmd/describe_extensions.go
@@ -229,9 +229,12 @@ Examples:
 					if featureSetMetrics {
 						if detail, ok := details.FeatureSetDetails[fs]; ok {
 							for _, m := range detail.Metrics {
-								if m.Metadata.DisplayName != "" {
+								switch {
+								case m.Metadata != nil && m.Metadata.DisplayName != "" && m.Metadata.Unit != "":
 									fmt.Printf("      %s - %s (%s)\n", m.Key, m.Metadata.DisplayName, m.Metadata.Unit)
-								} else {
+								case m.Metadata != nil && m.Metadata.DisplayName != "":
+									fmt.Printf("      %s - %s\n", m.Key, m.Metadata.DisplayName)
+								default:
 									fmt.Printf("      %s\n", m.Key)
 								}
 							}
@@ -284,22 +287,6 @@ Examples:
 			return nil
 		}
 
-		// For other formats (JSON, YAML, etc.), use the printer.
-		// Without --feature-set-metrics: featureSets is a plain list of names.
-		// With --feature-set-metrics: featureSets is a map of name → full metric objects (key + metadata).
-		var featureSets interface{} = details.FeatureSets
-		if featureSetMetrics {
-			fsMap := make(map[string][]extension.FeatureSetMetric)
-			for _, fs := range details.FeatureSets {
-				metrics := details.FeatureSetDetails[fs].Metrics
-				if metrics == nil {
-					metrics = []extension.FeatureSetMetric{}
-				}
-				fsMap[fs] = metrics
-			}
-			featureSets = fsMap
-		}
-
 		var availableVersions []string
 		for _, v := range versions.Items {
 			availableVersions = append(availableVersions, v.Version)
@@ -313,7 +300,7 @@ Examples:
 			MinEECVersion:       details.MinEECVersion,
 			FileHash:            details.FileHash,
 			DataSources:         details.DataSources,
-			FeatureSets:         featureSets,
+			FeatureSets:         buildFeatureSetsOutput(details, featureSetMetrics),
 			Variables:           details.Variables,
 			ActiveVersion:       activeVersion,
 			AvailableVersions:   availableVersions,
@@ -323,6 +310,33 @@ Examples:
 		enrichAgent(printer, "describe", "extension")
 		return printer.Print(desc)
 	},
+}
+
+// buildFeatureSetsOutput shapes the featureSets field for JSON/YAML output.
+//
+// Without --feature-set-metrics it returns a plain []string of feature-set names;
+// with the flag it returns a map of name → metric objects (key + metadata).
+//
+// It returns an untyped nil when the extension has no feature sets so that the
+// `omitempty` tag actually drops the field: a non-nil empty slice or map boxed
+// into an interface{} is NOT considered empty by encoding/json and would
+// otherwise serialize as "featureSets": null / {} instead of being omitted.
+func buildFeatureSetsOutput(details *extension.ExtensionDetails, withMetrics bool) interface{} {
+	if len(details.FeatureSets) == 0 {
+		return nil
+	}
+	if !withMetrics {
+		return details.FeatureSets
+	}
+	fsMap := make(map[string][]extension.FeatureSetMetric, len(details.FeatureSets))
+	for _, fs := range details.FeatureSets {
+		metrics := details.FeatureSetDetails[fs].Metrics
+		if metrics == nil {
+			metrics = []extension.FeatureSetMetric{}
+		}
+		fsMap[fs] = metrics
+	}
+	return fsMap
 }
 
 func init() {

--- a/cmd/describe_extensions.go
+++ b/cmd/describe_extensions.go
@@ -11,7 +11,9 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/resources/extension"
 )
 
-// extensionDescription is a rich struct for JSON/YAML output of describe extension
+// extensionDescription is a rich struct for JSON/YAML output of describe extension.
+// FeatureSets is []string (names only) by default; map[string][]string (names → metric keys)
+// when --feature-set-metrics is set.
 type extensionDescription struct {
 	Name                string                        `json:"name" yaml:"name"`
 	Version             string                        `json:"version" yaml:"version"`
@@ -20,7 +22,7 @@ type extensionDescription struct {
 	MinEECVersion       string                        `json:"minEECVersion,omitempty" yaml:"minEECVersion,omitempty"`
 	FileHash            string                        `json:"fileHash,omitempty" yaml:"fileHash,omitempty"`
 	DataSources         []string                      `json:"dataSources,omitempty" yaml:"dataSources,omitempty"`
-	FeatureSets         map[string][]string           `json:"featureSets,omitempty" yaml:"featureSets,omitempty"`
+	FeatureSets         interface{}                   `json:"featureSets,omitempty" yaml:"featureSets,omitempty"`
 	Variables           []extension.ExtensionVariable `json:"variables,omitempty" yaml:"variables,omitempty"`
 	ActiveVersion       string                        `json:"activeVersion,omitempty" yaml:"activeVersion,omitempty"`
 	AvailableVersions   []string                      `json:"availableVersions,omitempty" yaml:"availableVersions,omitempty"`
@@ -62,6 +64,7 @@ Examples:
 		monConfigSchema, _ := cmd.Flags().GetBool("monitoring-configuration-schema")
 		activeGateGroups, _ := cmd.Flags().GetBool("active-gate-groups")
 		noFluff, _ := cmd.Flags().GetBool("no-fluff")
+		featureSetMetrics, _ := cmd.Flags().GetBool("feature-set-metrics")
 
 		if monConfigSchema && activeGateGroups {
 			return fmt.Errorf("--monitoring-configuration-schema and --active-gate-groups are mutually exclusive")
@@ -223,9 +226,15 @@ Examples:
 				output.DescribeSection("Feature Sets:")
 				for _, fs := range details.FeatureSets {
 					fmt.Printf("  - %s\n", fs)
-					if detail, ok := details.FeatureSetDetails[fs]; ok && len(detail.Metrics) > 0 {
-						for _, m := range detail.Metrics {
-							fmt.Printf("      %s\n", m.Key)
+					if featureSetMetrics {
+						if detail, ok := details.FeatureSetDetails[fs]; ok {
+							for _, m := range detail.Metrics {
+								if m.Metadata.DisplayName != "" {
+									fmt.Printf("      %s - %s (%s)\n", m.Key, m.Metadata.DisplayName, m.Metadata.Unit)
+								} else {
+									fmt.Printf("      %s\n", m.Key)
+								}
+							}
 						}
 					}
 				}
@@ -275,16 +284,20 @@ Examples:
 			return nil
 		}
 
-		// For other formats (JSON, YAML, etc.), use the printer
-		featureSets := make(map[string][]string)
-		for _, fs := range details.FeatureSets {
-			var metrics []string
-			if detail, ok := details.FeatureSetDetails[fs]; ok {
-				for _, m := range detail.Metrics {
-					metrics = append(metrics, m.Key)
+		// For other formats (JSON, YAML, etc.), use the printer.
+		// Without --feature-set-metrics: featureSets is a plain list of names.
+		// With --feature-set-metrics: featureSets is a map of name → full metric objects (key + metadata).
+		var featureSets interface{} = details.FeatureSets
+		if featureSetMetrics {
+			fsMap := make(map[string][]extension.FeatureSetMetric)
+			for _, fs := range details.FeatureSets {
+				metrics := details.FeatureSetDetails[fs].Metrics
+				if metrics == nil {
+					metrics = []extension.FeatureSetMetric{}
 				}
+				fsMap[fs] = metrics
 			}
-			featureSets[fs] = metrics
+			featureSets = fsMap
 		}
 
 		var availableVersions []string
@@ -317,4 +330,5 @@ func init() {
 	describeExtensionCmd.Flags().Bool("monitoring-configuration-schema", false, "Output only the monitoring configuration schema for this extension version")
 	describeExtensionCmd.Flags().Bool("active-gate-groups", false, "List active gate groups available for this extension version")
 	describeExtensionCmd.Flags().Bool("no-fluff", false, "Strip documentation, customMessage, and displayName fields from schema output (use with --monitoring-configuration-schema)")
+	describeExtensionCmd.Flags().Bool("feature-set-metrics", false, "Show metrics available in each feature set")
 }

--- a/cmd/describe_extensions_integration_test.go
+++ b/cmd/describe_extensions_integration_test.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+)
+
+// describeExtensionMux serves the endpoints `describe extension` touches for the
+// JSON/YAML path: the version list, the version details, and the (empty)
+// monitoring-configuration list. The details payload uses the raw API field
+// names (featureSetsDetails, metadata, ...) so the whole command path — HTTP →
+// unmarshal → buildFeatureSetsOutput → printer — is exercised end to end.
+func describeExtensionMux() *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// Extension with feature sets and metric metadata.
+	mux.HandleFunc("/platform/extensions/v2/extensions/com.example.with-fs", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":      []map[string]any{{"version": "1.2.3", "extensionName": "com.example.with-fs", "active": true}},
+			"totalCount": 1,
+		})
+	})
+	mux.HandleFunc("/platform/extensions/v2/extensions/com.example.with-fs/1.2.3", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"extensionName": "com.example.with-fs",
+			"version": "1.2.3",
+			"featureSets": ["default", "advanced"],
+			"featureSetsDetails": {
+				"default": {
+					"metrics": [
+						{"key": "ext.uptime", "metadata": {"displayName": "Instance uptime", "unit": "Second"}},
+						{"key": "ext.bare"}
+					]
+				},
+				"advanced": {"metrics": []}
+			}
+		}`))
+	})
+
+	// Extension with no feature sets at all.
+	mux.HandleFunc("/platform/extensions/v2/extensions/com.example.no-fs", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":      []map[string]any{{"version": "1.0.0", "extensionName": "com.example.no-fs", "active": true}},
+			"totalCount": 1,
+		})
+	})
+	mux.HandleFunc("/platform/extensions/v2/extensions/com.example.no-fs/1.0.0", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"extensionName": "com.example.no-fs", "version": "1.0.0"}`))
+	})
+
+	// Monitoring configurations: empty for every extension.
+	mux.HandleFunc("/platform/extensions/v2/extensions/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}, "totalCount": 0})
+	})
+
+	return mux
+}
+
+// runDescribeExtensionJSON drives the real describe extension command against
+// srv and returns the parsed JSON output.
+func runDescribeExtensionJSON(t *testing.T, srv *httptest.Server, name string, featureSetMetrics bool) map[string]any {
+	t.Helper()
+
+	t.Setenv("DTCTL_DISABLE_KEYRING", "1")
+	t.Setenv(config.EnvTokenStorage, "file")
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config")
+
+	originalCfgFile := cfgFile
+	origFormat, origAgent := outputFormat, agentMode
+	t.Cleanup(func() {
+		cfgFile = originalCfgFile
+		outputFormat, agentMode = origFormat, origAgent
+		_ = describeExtensionCmd.Flags().Set("feature-set-metrics", "false")
+		_ = describeExtensionCmd.Flags().Set("version", "")
+	})
+	cfgFile = configPath
+	outputFormat = "json"
+	agentMode = false
+
+	cfg := config.NewConfig()
+	cfg.SetContext("test", srv.URL, "test-token")
+	if err := cfg.SetToken("test-token", "dt0c01.ST.test-token-value.test-secret"); err != nil {
+		t.Fatalf("failed to set token: %v", err)
+	}
+	cfg.CurrentContext = "test"
+	if err := cfg.SaveTo(configPath); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	if featureSetMetrics {
+		_ = describeExtensionCmd.Flags().Set("feature-set-metrics", "true")
+	}
+
+	out := captureExtStdout(t, func() {
+		if err := describeExtensionCmd.RunE(describeExtensionCmd, []string{name}); err != nil {
+			t.Fatalf("describe extension failed: %v", err)
+		}
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	return got
+}
+
+func captureExtStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+func TestDescribeExtension_FeatureSets_Integration(t *testing.T) {
+	srv := httptest.NewServer(describeExtensionMux())
+	defer srv.Close()
+
+	t.Run("without --feature-set-metrics: featureSets is a name array", func(t *testing.T) {
+		got := runDescribeExtensionJSON(t, srv, "com.example.with-fs", false)
+
+		fs, ok := got["featureSets"].([]any)
+		if !ok {
+			t.Fatalf("featureSets = %T (%v), want []any", got["featureSets"], got["featureSets"])
+		}
+		if len(fs) != 2 || fs[0] != "default" || fs[1] != "advanced" {
+			t.Errorf("featureSets = %v, want [default advanced]", fs)
+		}
+	})
+
+	t.Run("with --feature-set-metrics: featureSets is a map with metadata", func(t *testing.T) {
+		got := runDescribeExtensionJSON(t, srv, "com.example.with-fs", true)
+
+		fs, ok := got["featureSets"].(map[string]any)
+		if !ok {
+			t.Fatalf("featureSets = %T (%v), want map", got["featureSets"], got["featureSets"])
+		}
+		metrics, ok := fs["default"].([]any)
+		if !ok || len(metrics) != 2 {
+			t.Fatalf("featureSets[default] = %v, want 2 metrics", fs["default"])
+		}
+
+		// First metric carries metadata (proves the featureSetsDetails tag is correct).
+		m0 := metrics[0].(map[string]any)
+		md, ok := m0["metadata"].(map[string]any)
+		if !ok {
+			t.Fatalf("metrics[0].metadata missing; got %v", m0)
+		}
+		if md["displayName"] != "Instance uptime" || md["unit"] != "Second" {
+			t.Errorf("metadata = %v, want displayName=Instance uptime unit=Second", md)
+		}
+
+		// Second metric has no metadata: the field must be omitted, not "metadata": {}.
+		m1 := metrics[1].(map[string]any)
+		if _, present := m1["metadata"]; present {
+			t.Errorf("metrics[1] should omit empty metadata, got %v", m1)
+		}
+	})
+
+	t.Run("extension with no feature sets omits the field", func(t *testing.T) {
+		got := runDescribeExtensionJSON(t, srv, "com.example.no-fs", false)
+
+		if v, present := got["featureSets"]; present {
+			t.Errorf("featureSets should be omitted for an extension with none, got %v (%T)", v, v)
+		}
+	})
+}

--- a/cmd/describe_extensions_test.go
+++ b/cmd/describe_extensions_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
 	"testing"
 
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/extension"
 )
 
@@ -122,6 +125,76 @@ func TestStripSchemaFluff_NoFluffKeys(t *testing.T) {
 	after, _ := json.Marshal(result)
 	if string(before) != string(after) {
 		t.Errorf("expected no change when no fluff keys present\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+// describeExtensionFixture returns a synthetic extensionDescription for golden tests.
+// withMetrics controls whether FeatureSets is a plain []string (false) or a
+// map[string][]extension.FeatureSetMetric with full metadata (true).
+func describeExtensionFixture(withMetrics bool) *extensionDescription {
+	enabled := true
+	base := &extensionDescription{
+		Name:                "com.example.test-extension",
+		Version:             "1.2.3",
+		Author:              "Example Corp",
+		MinDynatraceVersion: "1.300.0",
+		MinEECVersion:       "1.299.0",
+		FileHash:            "abc123def456",
+		DataSources:         []string{"sqlPostgres"},
+		Variables: []extension.ExtensionVariable{
+			{Name: "endpoint", Type: "text", DisplayName: "Endpoint"},
+		},
+		ActiveVersion:     "1.2.3",
+		AvailableVersions: []string{"1.0.0", "1.2.3"},
+		MonitoringConfigs: []monitoringConfigSummary{
+			{
+				ObjectID:    "obj-a1b2c3d4",
+				Scope:       "host:HOST-001",
+				Enabled:     &enabled,
+				Description: "Production monitoring",
+			},
+		},
+	}
+	if withMetrics {
+		base.FeatureSets = map[string][]extension.FeatureSetMetric{
+			"default": {
+				{
+					Key: "ext.uptime",
+					Metadata: extension.FeatureSetMetricMetadata{
+						DisplayName: "Instance uptime",
+						Description: "Time since instance started",
+						Unit:        "Second",
+					},
+				},
+			},
+			"advanced": {},
+		}
+	} else {
+		base.FeatureSets = []string{"default", "advanced"}
+	}
+	return base
+}
+
+func TestGolden_DescribeExtension(t *testing.T) {
+	formats := map[string]string{
+		"json": "json",
+		"yaml": "yaml",
+	}
+	cases := map[string]bool{
+		"no-metrics":   false,
+		"with-metrics": true,
+	}
+	for caseName, withMetrics := range cases {
+		for fmtName, format := range formats {
+			t.Run(caseName+"-"+fmtName, func(t *testing.T) {
+				var buf bytes.Buffer
+				printer := output.NewPrinterWithWriter(format, &buf)
+				if err := printer.Print(describeExtensionFixture(withMetrics)); err != nil {
+					t.Fatalf("Print failed: %v", err)
+				}
+				testutil.AssertGolden(t, "describe/extension-description-"+caseName+"-"+fmtName, buf.String())
+			})
+		}
 	}
 }
 

--- a/cmd/describe_extensions_test.go
+++ b/cmd/describe_extensions_test.go
@@ -160,7 +160,7 @@ func describeExtensionFixture(withMetrics bool) *extensionDescription {
 			"default": {
 				{
 					Key: "ext.uptime",
-					Metadata: extension.FeatureSetMetricMetadata{
+					Metadata: &extension.FeatureSetMetricMetadata{
 						DisplayName: "Instance uptime",
 						Description: "Time since instance started",
 						Unit:        "Second",

--- a/cmd/testdata/golden/describe/extension-description-no-metrics-json.golden
+++ b/cmd/testdata/golden/describe/extension-description-no-metrics-json.golden
@@ -1,0 +1,35 @@
+{
+  "name": "com.example.test-extension",
+  "version": "1.2.3",
+  "author": "Example Corp",
+  "minDynatraceVersion": "1.300.0",
+  "minEECVersion": "1.299.0",
+  "fileHash": "abc123def456",
+  "dataSources": [
+    "sqlPostgres"
+  ],
+  "featureSets": [
+    "default",
+    "advanced"
+  ],
+  "variables": [
+    {
+      "name": "endpoint",
+      "type": "text",
+      "displayName": "Endpoint"
+    }
+  ],
+  "activeVersion": "1.2.3",
+  "availableVersions": [
+    "1.0.0",
+    "1.2.3"
+  ],
+  "monitoringConfigurations": [
+    {
+      "objectId": "obj-a1b2c3d4",
+      "scope": "host:HOST-001",
+      "enabled": true,
+      "description": "Production monitoring"
+    }
+  ]
+}

--- a/cmd/testdata/golden/describe/extension-description-no-metrics-yaml.golden
+++ b/cmd/testdata/golden/describe/extension-description-no-metrics-yaml.golden
@@ -1,0 +1,24 @@
+name: com.example.test-extension
+version: 1.2.3
+author: Example Corp
+minDynatraceVersion: 1.300.0
+minEECVersion: 1.299.0
+fileHash: abc123def456
+dataSources:
+  - sqlPostgres
+featureSets:
+  - default
+  - advanced
+variables:
+  - name: endpoint
+    type: text
+    displayname: Endpoint
+activeVersion: 1.2.3
+availableVersions:
+  - 1.0.0
+  - 1.2.3
+monitoringConfigurations:
+  - objectId: obj-a1b2c3d4
+    scope: host:HOST-001
+    enabled: true
+    description: Production monitoring

--- a/cmd/testdata/golden/describe/extension-description-with-metrics-json.golden
+++ b/cmd/testdata/golden/describe/extension-description-with-metrics-json.golden
@@ -1,0 +1,44 @@
+{
+  "name": "com.example.test-extension",
+  "version": "1.2.3",
+  "author": "Example Corp",
+  "minDynatraceVersion": "1.300.0",
+  "minEECVersion": "1.299.0",
+  "fileHash": "abc123def456",
+  "dataSources": [
+    "sqlPostgres"
+  ],
+  "featureSets": {
+    "advanced": [],
+    "default": [
+      {
+        "key": "ext.uptime",
+        "metadata": {
+          "displayName": "Instance uptime",
+          "description": "Time since instance started",
+          "unit": "Second"
+        }
+      }
+    ]
+  },
+  "variables": [
+    {
+      "name": "endpoint",
+      "type": "text",
+      "displayName": "Endpoint"
+    }
+  ],
+  "activeVersion": "1.2.3",
+  "availableVersions": [
+    "1.0.0",
+    "1.2.3"
+  ],
+  "monitoringConfigurations": [
+    {
+      "objectId": "obj-a1b2c3d4",
+      "scope": "host:HOST-001",
+      "enabled": true,
+      "description": "Production monitoring"
+    }
+  ]
+}

--- a/cmd/testdata/golden/describe/extension-description-with-metrics-yaml.golden
+++ b/cmd/testdata/golden/describe/extension-description-with-metrics-yaml.golden
@@ -1,0 +1,29 @@
+name: com.example.test-extension
+version: 1.2.3
+author: Example Corp
+minDynatraceVersion: 1.300.0
+minEECVersion: 1.299.0
+fileHash: abc123def456
+dataSources:
+  - sqlPostgres
+featureSets:
+  advanced: []
+  default:
+    - key: ext.uptime
+      metadata:
+        displayname: Instance uptime
+        description: Time since instance started
+        unit: Second
+variables:
+  - name: endpoint
+    type: text
+    displayname: Endpoint
+activeVersion: 1.2.3
+availableVersions:
+  - 1.0.0
+  - 1.2.3
+monitoringConfigurations:
+  - objectId: obj-a1b2c3d4
+    scope: host:HOST-001
+    enabled: true
+    description: Production monitoring

--- a/pkg/resources/extension/extension.go
+++ b/pkg/resources/extension/extension.go
@@ -180,6 +180,7 @@ type (
 	ExtensionAuthor               = sdkext.ExtensionAuthor
 	FeatureSetDetail              = sdkext.FeatureSetDetail
 	FeatureSetMetric              = sdkext.FeatureSetMetric
+	FeatureSetMetricMetadata      = sdkext.FeatureSetMetricMetadata
 	ExtensionVariable             = sdkext.ExtensionVariable
 	MonitoringConfigurationCreate = sdkext.MonitoringConfigurationCreate
 	ExtensionEnvironmentConfig    = sdkext.ExtensionEnvironmentConfig

--- a/sdk/api/extension/extension.go
+++ b/sdk/api/extension/extension.go
@@ -78,7 +78,7 @@ type FeatureSetDetail struct {
 
 // FeatureSetMetric represents a metric within a feature set
 type FeatureSetMetric struct {
-	Key      string                  `json:"key"`
+	Key      string                   `json:"key"`
 	Metadata FeatureSetMetricMetadata `json:"metadata,omitempty"`
 }
 

--- a/sdk/api/extension/extension.go
+++ b/sdk/api/extension/extension.go
@@ -78,8 +78,11 @@ type FeatureSetDetail struct {
 
 // FeatureSetMetric represents a metric within a feature set
 type FeatureSetMetric struct {
-	Key      string                   `json:"key"`
-	Metadata FeatureSetMetricMetadata `json:"metadata,omitempty"`
+	Key string `json:"key"`
+	// Metadata is a pointer so that omitempty actually drops the field for metrics
+	// that carry no metadata. encoding/json does NOT treat a zero-valued struct as
+	// empty, so a value type here would always serialize as "metadata": {}.
+	Metadata *FeatureSetMetricMetadata `json:"metadata,omitempty"`
 }
 
 // FeatureSetMetricMetadata holds display information for a feature set metric

--- a/sdk/api/extension/extension.go
+++ b/sdk/api/extension/extension.go
@@ -58,7 +58,7 @@ type ExtensionDetails struct {
 	Author              ExtensionAuthor             `json:"author,omitempty"`
 	DataSources         []string                    `json:"dataSources,omitempty"`
 	FeatureSets         []string                    `json:"featureSets,omitempty"`
-	FeatureSetDetails   map[string]FeatureSetDetail `json:"featureSetDetails,omitempty"`
+	FeatureSetDetails   map[string]FeatureSetDetail `json:"featureSetsDetails,omitempty"`
 	FileHash            string                      `json:"fileHash,omitempty"`
 	MinDynatraceVersion string                      `json:"minDynatraceVersion,omitempty"`
 	MinEECVersion       string                      `json:"minEECVersion,omitempty"`
@@ -72,12 +72,21 @@ type ExtensionAuthor struct {
 
 // FeatureSetDetail represents a feature set of an extension
 type FeatureSetDetail struct {
-	Metrics []FeatureSetMetric `json:"metrics,omitempty"`
+	IsRecommended bool               `json:"isRecommended,omitempty"`
+	Metrics       []FeatureSetMetric `json:"metrics,omitempty"`
 }
 
 // FeatureSetMetric represents a metric within a feature set
 type FeatureSetMetric struct {
-	Key string `json:"key"`
+	Key      string                  `json:"key"`
+	Metadata FeatureSetMetricMetadata `json:"metadata,omitempty"`
+}
+
+// FeatureSetMetricMetadata holds display information for a feature set metric
+type FeatureSetMetricMetadata struct {
+	DisplayName string `json:"displayName,omitempty"`
+	Description string `json:"description,omitempty"`
+	Unit        string `json:"unit,omitempty"`
 }
 
 // ExtensionVariable represents a variable defined in an extension

--- a/sdk/api/extension/extension_test.go
+++ b/sdk/api/extension/extension_test.go
@@ -118,6 +118,84 @@ func TestGetVersion(t *testing.T) {
 	}
 }
 
+// TestGetVersion_FeatureSetsDetails guards the wire contract for feature-set
+// metrics. It serves a raw payload using the *exact* field names the Extensions
+// 2.0 API returns (featureSetsDetails, isRecommended, metadata.displayName, ...)
+// so that a regression in any json tag — e.g. reverting featureSetsDetails back
+// to featureSetDetails — fails here instead of silently producing empty metrics.
+func TestGetVersion_FeatureSetsDetails(t *testing.T) {
+	const raw = `{
+		"extensionName": "com.example.test-extension",
+		"version": "1.2.3",
+		"featureSets": ["default", "advanced"],
+		"featureSetsDetails": {
+			"default": {
+				"isRecommended": true,
+				"metrics": [
+					{
+						"key": "ext.uptime",
+						"metadata": {
+							"displayName": "Instance uptime",
+							"description": "Time since instance started",
+							"unit": "Second"
+						}
+					},
+					{"key": "ext.bare"}
+				]
+			},
+			"advanced": {"metrics": []}
+		}
+	}`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/extensions/v2/extensions/com.example.test-extension/1.2.3", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(raw))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.GetVersion(context.Background(), "com.example.test-extension", "1.2.3")
+	if err != nil {
+		t.Fatalf("GetVersion() error: %v", err)
+	}
+
+	detail, ok := result.FeatureSetDetails["default"]
+	if !ok {
+		t.Fatalf("FeatureSetDetails missing \"default\"; the featureSetsDetails json tag likely does not match the API. Got keys: %v", keysOf(result.FeatureSetDetails))
+	}
+	if !detail.IsRecommended {
+		t.Errorf("IsRecommended = false, want true (isRecommended tag mismatch)")
+	}
+	if len(detail.Metrics) != 2 {
+		t.Fatalf("got %d metrics, want 2", len(detail.Metrics))
+	}
+
+	// Metric with full metadata.
+	m0 := detail.Metrics[0]
+	if m0.Key != "ext.uptime" {
+		t.Errorf("Metrics[0].Key = %q, want %q", m0.Key, "ext.uptime")
+	}
+	if m0.Metadata == nil {
+		t.Fatalf("Metrics[0].Metadata = nil, want populated metadata")
+	}
+	if m0.Metadata.DisplayName != "Instance uptime" || m0.Metadata.Unit != "Second" {
+		t.Errorf("Metrics[0].Metadata = %+v, want displayName=%q unit=%q", *m0.Metadata, "Instance uptime", "Second")
+	}
+
+	// Metric without metadata: the pointer must stay nil so omitempty can drop it.
+	if m1 := detail.Metrics[1]; m1.Metadata != nil {
+		t.Errorf("Metrics[1].Metadata = %+v, want nil for a metric with no metadata", *m1.Metadata)
+	}
+}
+
+func keysOf(m map[string]FeatureSetDetail) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 func TestDeleteMonitoringConfiguration(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/platform/extensions/v2/extensions/com.dynatrace.extension.host/monitoring-configurations/config-1", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes #323

## Summary

- Add `--feature-set-metrics` flag to `dtctl describe extension`; without it, feature sets show only names (default behaviour, table shows a plain list, JSON/YAML shows a string array)
- Fix SDK JSON tag `featureSetDetails` → `featureSetsDetails` to match the actual API response field name (root cause of metrics never populating)
- Extend `FeatureSetDetail` with `IsRecommended` and `FeatureSetMetric` with `Metadata` (displayName, description, unit)
- Table output with the flag renders `key - DisplayName (Unit)` per metric
- JSON/YAML with the flag: `featureSets` becomes a map of name → full metric objects including metadata

> **Breaking change**: default JSON/YAML output for `featureSets` changes from `{"name": []}` (map) to `["name"]` (array). dtctl is pre-1.0 (currently v0.31).

## Test plan

- [ ] `dtctl describe extension com.dynatrace.extension.postgres --version 3.0.102` — feature sets listed, no metrics
- [ ] `dtctl describe extension com.dynatrace.extension.postgres --version 3.0.102 --feature-set-metrics` — metrics shown with display name and unit
- [ ] `-o json` and `-o yaml` variants of both cases
- [ ] `make test` passes (golden tests for `extensionDescription` added for no-metrics and with-metrics × json/yaml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)