### PR TITLE
feat(query): expose metadata.metrics for timeseries queries via --metadata=metrics

### DIFF
--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -764,7 +764,7 @@ func TestMetadataFlagCompletion_Empty(t *testing.T) {
 		t.Error("expected ShellCompDirectiveNoSpace to be set")
 	}
 
-	// Should include "all" plus all 13 field names
+	// Should include "all" plus all valid field names
 	allFields := output.ValidMetadataFieldNames()
 	expectedCount := len(allFields) + 1 // +1 for "all"
 	if len(suggestions) != expectedCount {
@@ -816,9 +816,10 @@ func TestMetadataFlagCompletion_AfterComma(t *testing.T) {
 		}
 	}
 
-	// Should have 12 suggestions (all fields minus queryId)
-	if len(suggestions) != 12 {
-		t.Errorf("got %d suggestions, want 12", len(suggestions))
+	// Should have one suggestion per field minus the already-selected queryId
+	want := len(output.ValidMetadataFieldNames()) - 1
+	if len(suggestions) != want {
+		t.Errorf("got %d suggestions, want %d", len(suggestions), want)
 	}
 }
 
@@ -854,9 +855,10 @@ func TestMetadataFlagCompletion_MultipleSelected(t *testing.T) {
 		}
 	}
 
-	// 13 total fields - 2 selected = 11
-	if len(suggestions) != 11 {
-		t.Errorf("got %d suggestions, want 11", len(suggestions))
+	// All fields minus the 2 already-selected (queryId, sampled)
+	want := len(output.ValidMetadataFieldNames()) - 2
+	if len(suggestions) != want {
+		t.Errorf("got %d suggestions, want %d", len(suggestions), want)
 	}
 }
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -746,7 +746,7 @@ func init() {
 bare --metadata or -M shows all fields; --metadata=field1,field2 selects specific fields
 available: executionTimeMilliseconds,scannedRecords,scannedBytes,scannedDataPoints,
 sampled,queryId,dqlVersion,query,canonicalQuery,timezone,locale,
-analysisTimeframe,contributions`)
+analysisTimeframe,contributions,metrics`)
 	queryCmd.Flags().Lookup("metadata").NoOptDefVal = "all"
 
 	// Snapshot decode flag

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1182,7 +1182,7 @@ dtctl query "fetch logs | filter status='ERROR'" \
 - `--timezone`: Query timezone (e.g., 'UTC', 'Europe/Paris', 'America/New_York')
 
 **Metadata Parameters:**
-- `--metadata`, `-M`: Include query execution metadata in output. Use bare `--metadata` for all fields, or select specific fields with `--metadata=field1,field2`. Valid fields: `analysisTimeframe`, `canonicalQuery`, `contributions`, `dqlVersion`, `executionTimeMilliseconds`, `locale`, `query`, `queryId`, `sampled`, `scannedBytes`, `scannedDataPoints`, `scannedRecords`, `timezone`
+- `--metadata`, `-M`: Include query execution metadata in output. Use bare `--metadata` for all fields, or select specific fields with `--metadata=field1,field2`. Valid fields: `analysisTimeframe`, `canonicalQuery`, `contributions`, `dqlVersion`, `executionTimeMilliseconds`, `locale`, `metrics`, `query`, `queryId`, `sampled`, `scannedBytes`, `scannedDataPoints`, `scannedRecords`, `timezone`
 - `--include-contributions`: Include bucket contribution details in metadata (requires API support)
 
 **Note:** All parameters are sent in the DQL query request body and work with both immediate responses and long-running queries that require polling.

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -536,56 +536,61 @@ func columnTypeMappings(result *DQLQueryResponse) []output.ColumnTypeMapping {
 }
 
 // extractQueryMetadata converts DQL response metadata to the output-layer QueryMetadata type.
+// Grail metadata (execution stats, query text, ...) and Metrics (timeseries metric descriptors)
+// are independent siblings of the response's metadata section, so either one being present is
+// enough to produce a non-nil result — gating on Grail alone would silently drop Metrics for
+// responses that populate metadata.metrics without metadata.grail.
 func extractQueryMetadata(result *DQLQueryResponse) *output.QueryMetadata {
 	g := result.GetMetadata()
-	if g == nil {
+	metrics := result.GetMetrics()
+	if g == nil && len(metrics) == 0 {
 		return nil
 	}
 
-	meta := &output.QueryMetadata{
-		ExecutionTimeMilliseconds: g.ExecutionTimeMilliseconds,
-		ScannedRecords:            g.ScannedRecords,
-		ScannedBytes:              g.ScannedBytes,
-		ScannedDataPoints:         g.ScannedDataPoints,
-		Sampled:                   g.Sampled,
-		QueryID:                   g.QueryID,
-		DQLVersion:                g.DQLVersion,
-		Query:                     g.Query,
-		CanonicalQuery:            g.CanonicalQuery,
-		Timezone:                  g.Timezone,
-		Locale:                    g.Locale,
-	}
+	meta := &output.QueryMetadata{}
 
-	if g.AnalysisTimeframe != nil {
-		meta.AnalysisTimeframe = &output.MetadataTimeframe{
-			Start: g.AnalysisTimeframe.Start,
-			End:   g.AnalysisTimeframe.End,
+	if g != nil {
+		meta.ExecutionTimeMilliseconds = g.ExecutionTimeMilliseconds
+		meta.ScannedRecords = g.ScannedRecords
+		meta.ScannedBytes = g.ScannedBytes
+		meta.ScannedDataPoints = g.ScannedDataPoints
+		meta.Sampled = g.Sampled
+		meta.QueryID = g.QueryID
+		meta.DQLVersion = g.DQLVersion
+		meta.Query = g.Query
+		meta.CanonicalQuery = g.CanonicalQuery
+		meta.Timezone = g.Timezone
+		meta.Locale = g.Locale
+
+		if g.AnalysisTimeframe != nil {
+			meta.AnalysisTimeframe = &output.MetadataTimeframe{
+				Start: g.AnalysisTimeframe.Start,
+				End:   g.AnalysisTimeframe.End,
+			}
+		}
+
+		if g.Contributions != nil && len(g.Contributions.Buckets) > 0 {
+			contribs := &output.MetadataContribs{}
+			for _, b := range g.Contributions.Buckets {
+				contribs.Buckets = append(contribs.Buckets, output.MetadataBucket{
+					Name:                b.Name,
+					Table:               b.Table,
+					ScannedBytes:        b.ScannedBytes,
+					MatchedRecordsRatio: b.MatchedRecordsRatio,
+				})
+			}
+			meta.Contributions = contribs
 		}
 	}
 
-	if g.Contributions != nil && len(g.Contributions.Buckets) > 0 {
-		contribs := &output.MetadataContribs{}
-		for _, b := range g.Contributions.Buckets {
-			contribs.Buckets = append(contribs.Buckets, output.MetadataBucket{
-				Name:                b.Name,
-				Table:               b.Table,
-				ScannedBytes:        b.ScannedBytes,
-				MatchedRecordsRatio: b.MatchedRecordsRatio,
-			})
-		}
-		meta.Contributions = contribs
-	}
-
-	if metrics := result.GetMetrics(); len(metrics) > 0 {
-		for _, m := range metrics {
-			meta.Metrics = append(meta.Metrics, output.MetricInfo{
-				MetricKey:   m.MetricKey,
-				FieldName:   m.FieldName,
-				Aggregation: m.Aggregation,
-				DisplayName: m.DisplayName,
-				Unit:        m.Unit,
-			})
-		}
+	for _, m := range metrics {
+		meta.Metrics = append(meta.Metrics, output.MetricInfo{
+			MetricKey:   m.MetricKey,
+			FieldName:   m.FieldName,
+			Aggregation: m.Aggregation,
+			DisplayName: m.DisplayName,
+			Unit:        m.Unit,
+		})
 	}
 
 	return meta

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -30,6 +30,7 @@ type (
 	BucketContribution    = sdkquery.BucketContribution
 	QueryNotification     = sdkquery.Notification
 	AnalysisTimeframe     = sdkquery.AnalysisTimeframe
+	MetricInfo            = sdkquery.MetricInfo
 	DQLVerifyRequest      = sdkquery.VerifyRequest
 	DQLVerifyResponse     = sdkquery.VerifyResponse
 	MetadataNotification  = sdkquery.VerifyNotification
@@ -573,6 +574,18 @@ func extractQueryMetadata(result *DQLQueryResponse) *output.QueryMetadata {
 			})
 		}
 		meta.Contributions = contribs
+	}
+
+	if metrics := result.GetMetrics(); len(metrics) > 0 {
+		for _, m := range metrics {
+			meta.Metrics = append(meta.Metrics, output.MetricInfo{
+				MetricKey:   m.MetricKey,
+				FieldName:   m.FieldName,
+				Aggregation: m.Aggregation,
+				DisplayName: m.DisplayName,
+				Unit:        m.Unit,
+			})
+		}
 	}
 
 	return meta

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -1632,6 +1632,38 @@ func TestExtractQueryMetadata_NilMetadata_PrintPath(t *testing.T) {
 	}
 }
 
+// TestExtractQueryMetadata_MetricsWithoutGrail verifies that Metrics (timeseries
+// metric descriptors) are extracted even when Grail metadata is absent — the two
+// are independent siblings of the response's metadata section, and a response
+// with metadata.metrics but no metadata.grail must not have its metrics dropped.
+func TestExtractQueryMetadata_MetricsWithoutGrail(t *testing.T) {
+	resp := &DQLQueryResponse{
+		State:   "SUCCEEDED",
+		Records: []map[string]interface{}{{"timestamp": "2026-03-09T12:15:00Z"}},
+		Metadata: &DQLMetadata{
+			Grail: nil,
+			Metrics: []MetricInfo{
+				{MetricKey: "dt.host.cpu.usage", FieldName: "avg(dt.host.cpu.usage)", Aggregation: "avg"},
+			},
+		},
+	}
+
+	meta := extractQueryMetadata(resp)
+	if meta == nil {
+		t.Fatal("expected metadata for response with Metrics but no Grail, got nil")
+	}
+	if len(meta.Metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(meta.Metrics))
+	}
+	if meta.Metrics[0].MetricKey != "dt.host.cpu.usage" {
+		t.Errorf("expected MetricKey=dt.host.cpu.usage, got %q", meta.Metrics[0].MetricKey)
+	}
+	// Grail-derived fields must remain zero-valued since Grail was absent.
+	if meta.QueryID != "" || meta.ExecutionTimeMilliseconds != 0 {
+		t.Errorf("expected zero-valued Grail fields, got QueryID=%q ExecutionTimeMilliseconds=%d", meta.QueryID, meta.ExecutionTimeMilliseconds)
+	}
+}
+
 func TestExtractQueryMetadata_ResultMetadataPrecedence(t *testing.T) {
 	// When both result.Metadata and top-level Metadata exist,
 	// result.Metadata should take precedence

--- a/pkg/output/golden_test.go
+++ b/pkg/output/golden_test.go
@@ -1861,6 +1861,10 @@ func metadataFixture() *QueryMetadata {
 				},
 			},
 		},
+		Metrics: []MetricInfo{
+			{MetricKey: "process.cpu.utilization", FieldName: "avg(process.cpu.utilization)", Aggregation: "avg", Unit: "Percent", DisplayName: "Process CPU Utilization"},
+			{MetricKey: "process.memory.usage", FieldName: "sum(process.memory.usage)", Aggregation: "sum", Unit: "Byte", DisplayName: "Process Memory Usage"},
+		},
 	}
 }
 

--- a/pkg/output/metadata.go
+++ b/pkg/output/metadata.go
@@ -22,6 +22,7 @@ var allMetadataFields = map[string]bool{
 	"locale":                    true,
 	"analysisTimeframe":         true,
 	"contributions":             true,
+	"metrics":                   true,
 }
 
 // QueryMetadata holds DQL query execution metadata for output formatting.
@@ -40,6 +41,18 @@ type QueryMetadata struct {
 	Locale                    string             `json:"locale,omitempty" yaml:"locale,omitempty"`
 	AnalysisTimeframe         *MetadataTimeframe `json:"analysisTimeframe,omitempty" yaml:"analysisTimeframe,omitempty"`
 	Contributions             *MetadataContribs  `json:"contributions,omitempty" yaml:"contributions,omitempty"`
+	Metrics                   []MetricInfo       `json:"metrics,omitempty" yaml:"metrics,omitempty"`
+}
+
+// MetricInfo describes a single metric referenced in a timeseries query result.
+// It maps the DQL column name (FieldName) to the underlying metric descriptor.
+// DisplayName and Unit are present only when the API returns metric catalogue data.
+type MetricInfo struct {
+	MetricKey   string `json:"metric.key,omitempty" yaml:"metric.key,omitempty"`
+	FieldName   string `json:"fieldName,omitempty" yaml:"fieldName,omitempty"`
+	Aggregation string `json:"aggregation,omitempty" yaml:"aggregation,omitempty"`
+	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Unit        string `json:"unit,omitempty" yaml:"unit,omitempty"`
 }
 
 // MetadataTimeframe represents the analysis timeframe for a query.
@@ -195,6 +208,9 @@ func MetadataToMap(meta *QueryMetadata, fields []string) interface{} {
 	if set["contributions"] {
 		m["contributions"] = meta.Contributions
 	}
+	if set["metrics"] {
+		m["metrics"] = meta.Metrics
+	}
 
 	return m
 }
@@ -278,6 +294,22 @@ func FormatMetadataFooter(m *QueryMetadata, fields []string) string {
 		}
 	}
 
+	// Metrics (timeseries queries only)
+	if hasField("metrics", fields) && len(m.Metrics) > 0 {
+		b.WriteString("Metrics:\n")
+		for _, mi := range m.Metrics {
+			line := fmt.Sprintf("  %s → %s [%s", mi.FieldName, mi.MetricKey, mi.Aggregation)
+			if mi.Unit != "" {
+				line += ", " + mi.Unit
+			}
+			line += "]\n"
+			b.WriteString(line)
+			if mi.DisplayName != "" {
+				b.WriteString(fmt.Sprintf("    %s\n", mi.DisplayName))
+			}
+		}
+	}
+
 	return b.String()
 }
 
@@ -338,6 +370,16 @@ func FormatMetadataCSVComments(m *QueryMetadata, fields []string) string {
 		for _, bucket := range m.Contributions.Buckets {
 			b.WriteString(fmt.Sprintf("# contribution: %s (%s, %d bytes, %.1f%% matched)\n",
 				bucket.Name, bucket.Table, bucket.ScannedBytes, bucket.MatchedRecordsRatio*100))
+		}
+	}
+
+	if hasField("metrics", fields) && len(m.Metrics) > 0 {
+		for _, mi := range m.Metrics {
+			parts := []string{mi.FieldName, mi.MetricKey, mi.Aggregation}
+			if mi.Unit != "" {
+				parts = append(parts, mi.Unit)
+			}
+			b.WriteString(fmt.Sprintf("# metric: %s\n", strings.Join(parts, ", ")))
 		}
 	}
 

--- a/pkg/output/metadata_test.go
+++ b/pkg/output/metadata_test.go
@@ -129,6 +129,9 @@ func TestFormatMetadataFooter(t *testing.T) {
 				},
 			},
 		},
+		Metrics: []MetricInfo{
+			{MetricKey: "process.cpu.utilization", FieldName: "avg(process.cpu.utilization)", Aggregation: "avg"},
+		},
 	}
 
 	// Disable color for predictable test output
@@ -154,6 +157,8 @@ func TestFormatMetadataFooter(t *testing.T) {
 		"Sampled:            no",
 		"custom_sen_low_logs_platform_service_shared (logs)",
 		"scanned: 2.8 MB, matched: 100.0%",
+		"Metrics:",
+		"avg(process.cpu.utilization) → process.cpu.utilization [avg]",
 	}
 
 	for _, exp := range expectations {
@@ -212,6 +217,9 @@ func TestFormatMetadataCSVComments(t *testing.T) {
 				},
 			},
 		},
+		Metrics: []MetricInfo{
+			{MetricKey: "process.cpu.utilization", FieldName: "avg(process.cpu.utilization)", Aggregation: "avg"},
+		},
 	}
 
 	result := FormatMetadataCSVComments(meta, nil)
@@ -238,6 +246,7 @@ func TestFormatMetadataCSVComments(t *testing.T) {
 		"# analysis_start: 2026-03-09T10:16:39.973805659Z",
 		"# analysis_end: 2026-03-09T12:16:39.973805659Z",
 		"# contribution: custom_sen_low_logs_platform_service_shared (logs, 2982690 bytes, 100.0% matched)",
+		"# metric: avg(process.cpu.utilization), process.cpu.utilization, avg",
 	}
 
 	for _, exp := range expectations {
@@ -867,11 +876,11 @@ func TestYAMLPrinter_MetadataToMap(t *testing.T) {
 }
 
 // TestValidMetadataFieldNames_Sorted verifies that ValidMetadataFieldNames
-// returns all 13 fields in sorted order.
+// returns all 14 fields in sorted order.
 func TestValidMetadataFieldNames_Sorted(t *testing.T) {
 	names := ValidMetadataFieldNames()
-	if len(names) != 13 {
-		t.Fatalf("expected 13 valid field names, got %d: %v", len(names), names)
+	if len(names) != 14 {
+		t.Fatalf("expected 14 valid field names, got %d: %v", len(names), names)
 	}
 	// Verify sorted
 	for i := 1; i < len(names); i++ {
@@ -894,6 +903,7 @@ func TestValidMetadataFieldNames_Sorted(t *testing.T) {
 		"locale":                    true,
 		"analysisTimeframe":         true,
 		"contributions":             true,
+		"metrics":                   true,
 	}
 	for _, n := range names {
 		if !expected[n] {
@@ -903,5 +913,122 @@ func TestValidMetadataFieldNames_Sorted(t *testing.T) {
 	}
 	for missing := range expected {
 		t.Errorf("missing field name: %q", missing)
+	}
+}
+
+func TestFormatMetadataFooter_Metrics(t *testing.T) {
+	meta := &QueryMetadata{
+		Metrics: []MetricInfo{
+			{MetricKey: "process.cpu.utilization", FieldName: "avg(process.cpu.utilization)", Aggregation: "avg", Unit: "Percent", DisplayName: "Process CPU Utilization"},
+			{MetricKey: "process.cpu.utilization", FieldName: "sum(process.cpu.utilization)", Aggregation: "sum"},
+		},
+	}
+
+	ResetColorCache()
+	SetPlainMode(true)
+	defer ResetColorCache()
+
+	result := FormatMetadataFooter(meta, nil)
+
+	// With unit and display name
+	if !strings.Contains(result, "avg(process.cpu.utilization) → process.cpu.utilization [avg, Percent]") {
+		t.Errorf("expected metric line with unit, got:\n%s", result)
+	}
+	if !strings.Contains(result, "Process CPU Utilization") {
+		t.Errorf("expected display name, got:\n%s", result)
+	}
+	// Without unit
+	if !strings.Contains(result, "sum(process.cpu.utilization) → process.cpu.utilization [sum]") {
+		t.Errorf("expected metric line without unit, got:\n%s", result)
+	}
+}
+
+func TestFormatMetadataFooter_Metrics_FilteredField(t *testing.T) {
+	meta := &QueryMetadata{
+		ExecutionTimeMilliseconds: 47,
+		QueryID:                   "test-id",
+		Metrics: []MetricInfo{
+			{MetricKey: "process.cpu.utilization", FieldName: "avg(process.cpu.utilization)", Aggregation: "avg", Unit: "Percent"},
+		},
+	}
+
+	ResetColorCache()
+	SetPlainMode(true)
+	defer ResetColorCache()
+
+	result := FormatMetadataFooter(meta, []string{"metrics"})
+
+	if !strings.Contains(result, "Metrics:") {
+		t.Error("expected 'Metrics:' heading")
+	}
+	if !strings.Contains(result, "avg(process.cpu.utilization) → process.cpu.utilization [avg, Percent]") {
+		t.Errorf("expected metric line, got:\n%s", result)
+	}
+	// Other fields must be absent
+	if strings.Contains(result, "Execution time:") {
+		t.Error("'Execution time' should not appear when filtered to metrics only")
+	}
+	if strings.Contains(result, "Query ID:") {
+		t.Error("'Query ID' should not appear when filtered to metrics only")
+	}
+}
+
+func TestFormatMetadataCSVComments_Metrics(t *testing.T) {
+	meta := &QueryMetadata{
+		Metrics: []MetricInfo{
+			{MetricKey: "process.cpu.utilization", FieldName: "avg(process.cpu.utilization)", Aggregation: "avg", Unit: "Percent"},
+			{MetricKey: "process.cpu.utilization", FieldName: "sum(process.cpu.utilization)", Aggregation: "sum"},
+		},
+	}
+
+	result := FormatMetadataCSVComments(meta, nil)
+
+	if !strings.Contains(result, "# metric: avg(process.cpu.utilization), process.cpu.utilization, avg, Percent") {
+		t.Errorf("expected metric line with unit, got:\n%s", result)
+	}
+	if !strings.Contains(result, "# metric: sum(process.cpu.utilization), process.cpu.utilization, sum") {
+		t.Errorf("expected metric line without unit, got:\n%s", result)
+	}
+	// Must not have a trailing comma when unit is absent
+	if strings.Contains(result, "sum,\n") {
+		t.Errorf("metric line without unit should not have trailing comma, got:\n%s", result)
+	}
+}
+
+func TestMetadataToMap_Metrics(t *testing.T) {
+	meta := &QueryMetadata{
+		QueryID: "test-id",
+		Metrics: []MetricInfo{
+			{MetricKey: "process.cpu.utilization", FieldName: "avg(process.cpu.utilization)", Aggregation: "avg", Unit: "Percent"},
+		},
+	}
+
+	// When "metrics" is selected, the slice must appear in the map
+	result := MetadataToMap(meta, []string{"metrics"})
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map, got %T", result)
+	}
+	if len(m) != 1 {
+		t.Fatalf("expected 1 key, got %d: %v", len(m), m)
+	}
+	metrics, ok := m["metrics"].([]MetricInfo)
+	if !ok {
+		t.Fatalf("expected []MetricInfo, got %T", m["metrics"])
+	}
+	if len(metrics) != 1 || metrics[0].Unit != "Percent" {
+		t.Errorf("unexpected metrics value: %+v", metrics)
+	}
+
+	// When nil Metrics and "metrics" is selected, map must contain metrics:null
+	emptyMeta := &QueryMetadata{}
+	result2 := MetadataToMap(emptyMeta, []string{"metrics"})
+	m2, ok := result2.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map, got %T", result2)
+	}
+	jsonOut, _ := json.Marshal(m2)
+	if !strings.Contains(string(jsonOut), `"metrics":null`) {
+		t.Errorf("expected metrics:null for empty slice, got: %s", jsonOut)
 	}
 }

--- a/pkg/output/testdata/golden/query/dql-metadata-csv.golden
+++ b/pkg/output/testdata/golden/query/dql-metadata-csv.golden
@@ -13,6 +13,8 @@
 # locale: und
 # sampled: false
 # contribution: default_logs (logs, 2982690 bytes, 100.0% matched)
+# metric: avg(process.cpu.utilization), process.cpu.utilization, avg, Percent
+# metric: sum(process.memory.usage), process.memory.usage, sum, Byte
 content,host.name,status,timestamp
 Connection timeout to database,web-server-01,ERROR,2025-03-15T10:30:00Z
 High memory usage detected,web-server-02,WARN,2025-03-15T10:29:55Z

--- a/pkg/output/testdata/golden/query/dql-metadata-json.golden
+++ b/pkg/output/testdata/golden/query/dql-metadata-json.golden
@@ -22,7 +22,23 @@
           "matchedRecordsRatio": 1
         }
       ]
-    }
+    },
+    "metrics": [
+      {
+        "metric.key": "process.cpu.utilization",
+        "fieldName": "avg(process.cpu.utilization)",
+        "aggregation": "avg",
+        "displayName": "Process CPU Utilization",
+        "unit": "Percent"
+      },
+      {
+        "metric.key": "process.memory.usage",
+        "fieldName": "sum(process.memory.usage)",
+        "aggregation": "sum",
+        "displayName": "Process Memory Usage",
+        "unit": "Byte"
+      }
+    ]
   },
   "records": [
     {

--- a/pkg/output/testdata/golden/query/dql-metadata-table.golden
+++ b/pkg/output/testdata/golden/query/dql-metadata-table.golden
@@ -19,3 +19,8 @@ Sampled:            no
 Contributions:
   default_logs (logs)
     scanned: 2.8 MB, matched: 100.0%
+Metrics:
+  avg(process.cpu.utilization) → process.cpu.utilization [avg, Percent]
+    Process CPU Utilization
+  sum(process.memory.usage) → process.memory.usage [sum, Byte]
+    Process Memory Usage

--- a/pkg/output/testdata/golden/query/dql-metadata-toon.golden
+++ b/pkg/output/testdata/golden/query/dql-metadata-toon.golden
@@ -9,6 +9,9 @@ metadata:
   dqlVersion: V1_0
   executionTimeMilliseconds: 47
   locale: und
+  metrics[#2]{aggregation,displayName,fieldName,metric.key,unit}:
+    avg,Process CPU Utilization,avg(process.cpu.utilization),process.cpu.utilization,Percent
+    sum,Process Memory Usage,sum(process.memory.usage),process.memory.usage,Byte
   query: "fetch logs | limit 3 | fields timestamp, host.name, status, content"
   queryId: 27c4daf9-2619-4ba1-b1ad-9e276c75a351
   scannedBytes: 2982690

--- a/pkg/output/testdata/golden/query/dql-metadata-wide.golden
+++ b/pkg/output/testdata/golden/query/dql-metadata-wide.golden
@@ -19,3 +19,8 @@ Sampled:            no
 Contributions:
   default_logs (logs)
     scanned: 2.8 MB, matched: 100.0%
+Metrics:
+  avg(process.cpu.utilization) → process.cpu.utilization [avg, Percent]
+    Process CPU Utilization
+  sum(process.memory.usage) → process.memory.usage [sum, Byte]
+    Process Memory Usage

--- a/pkg/output/testdata/golden/query/dql-metadata-yaml.golden
+++ b/pkg/output/testdata/golden/query/dql-metadata-yaml.golden
@@ -20,6 +20,17 @@ metadata:
         table: logs
         scannedBytes: 2982690
         matchedRecordsRatio: 1
+  metrics:
+    - metric.key: process.cpu.utilization
+      fieldName: avg(process.cpu.utilization)
+      aggregation: avg
+      displayName: Process CPU Utilization
+      unit: Percent
+    - metric.key: process.memory.usage
+      fieldName: sum(process.memory.usage)
+      aggregation: sum
+      displayName: Process Memory Usage
+      unit: Byte
 records:
   - content: Connection timeout to database
     host.name: web-server-01

--- a/sdk/api/query/query.go
+++ b/sdk/api/query/query.go
@@ -111,9 +111,22 @@ type ColumnType struct {
 	Type string `json:"type"`
 }
 
+// MetricInfo describes a single metric referenced in a timeseries query result.
+// It maps the DQL column name (FieldName) to the underlying metric descriptor.
+// DisplayName and Unit are present only when the API returns metric catalogue data;
+// they are absent for tenants or queries that do not populate them.
+type MetricInfo struct {
+	MetricKey   string `json:"metric.key,omitempty"`
+	FieldName   string `json:"fieldName,omitempty"`
+	Aggregation string `json:"aggregation,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	Unit        string `json:"unit,omitempty"`
+}
+
 // Metadata represents the metadata section of a DQL response.
 type Metadata struct {
-	Grail *GrailMetadata `json:"grail,omitempty"`
+	Grail   *GrailMetadata `json:"grail,omitempty"`
+	Metrics []MetricInfo   `json:"metrics,omitempty"`
 }
 
 // GrailMetadata represents Grail-specific query execution metadata.
@@ -448,6 +461,19 @@ func (r *Response) GetMetadata() *GrailMetadata {
 	}
 	if r.Metadata != nil && r.Metadata.Grail != nil {
 		return r.Metadata.Grail
+	}
+	return nil
+}
+
+// GetMetrics returns the metrics array from the response, checking both
+// result-level and top-level metadata. Returns nil when no metrics are present
+// (e.g., for non-timeseries queries).
+func (r *Response) GetMetrics() []MetricInfo {
+	if r.Result != nil && r.Result.Metadata != nil && len(r.Result.Metadata.Metrics) > 0 {
+		return r.Result.Metadata.Metrics
+	}
+	if r.Metadata != nil && len(r.Metadata.Metrics) > 0 {
+		return r.Metadata.Metrics
 	}
 	return nil
 }

--- a/sdk/api/query/query_test.go
+++ b/sdk/api/query/query_test.go
@@ -434,6 +434,58 @@ func TestResponse_GetMetadata(t *testing.T) {
 	}
 }
 
+func TestResponse_GetMetrics(t *testing.T) {
+	t.Run("from top-level metadata", func(t *testing.T) {
+		r := &Response{
+			Metadata: &Metadata{
+				Metrics: []MetricInfo{{MetricKey: "dt.host.cpu.usage", FieldName: "avg(dt.host.cpu.usage)", Aggregation: "avg"}},
+			},
+		}
+		metrics := r.GetMetrics()
+		if len(metrics) != 1 || metrics[0].MetricKey != "dt.host.cpu.usage" {
+			t.Errorf("got %+v, want one metric for dt.host.cpu.usage", metrics)
+		}
+	})
+
+	t.Run("from result metadata", func(t *testing.T) {
+		r := &Response{
+			Result: &Result{
+				Metadata: &Metadata{
+					Metrics: []MetricInfo{{MetricKey: "dt.host.mem.usage", FieldName: "sum(dt.host.mem.usage)", Aggregation: "sum"}},
+				},
+			},
+		}
+		metrics := r.GetMetrics()
+		if len(metrics) != 1 || metrics[0].MetricKey != "dt.host.mem.usage" {
+			t.Errorf("got %+v, want one metric for dt.host.mem.usage", metrics)
+		}
+	})
+
+	t.Run("metrics without grail", func(t *testing.T) {
+		// The DQL API may return metadata.metrics independently of metadata.grail
+		// (they are unrelated siblings of Metadata) — GetMetrics must not depend
+		// on Grail being present.
+		r := &Response{
+			Metadata: &Metadata{
+				Metrics: []MetricInfo{{MetricKey: "dt.host.cpu.usage"}},
+			},
+		}
+		if r.GetMetadata() != nil {
+			t.Fatal("expected nil Grail metadata for this fixture")
+		}
+		if len(r.GetMetrics()) != 1 {
+			t.Errorf("expected metrics to be returned even when Grail metadata is absent, got %+v", r.GetMetrics())
+		}
+	})
+
+	t.Run("no metrics", func(t *testing.T) {
+		r := &Response{Metadata: &Metadata{}}
+		if metrics := r.GetMetrics(); metrics != nil {
+			t.Errorf("expected nil metrics, got %+v", metrics)
+		}
+	})
+}
+
 // helpers to avoid importing errors in test
 func errorAsAPIError(err error, target **httpclient.APIError) bool {
 	for err != nil {


### PR DESCRIPTION
## Summary

- The DQL API returns a `metadata.metrics` array for `timeseries` queries describing each referenced metric (key, DQL field alias, aggregation function, and optionally display name and unit). dtctl was silently dropping it because `Metadata` had no `Metrics` field.
- Adds `MetricInfo` to the SDK response types and threads it all the way to the `--metadata` flag output, including human-readable table footer and CSV comment rendering.
- `metrics` is now a valid field name for `--metadata=metrics` (or included automatically with bare `--metadata`).

## Changes

| Layer | What changed |
|---|---|
| `sdk/api/query` | Added `MetricInfo` struct + `Metrics []MetricInfo` to `Metadata`; added `GetMetrics()` helper (mirrors `GetMetadata()`) |
| `pkg/exec/dql` | Re-exported `MetricInfo` alias; populated `meta.Metrics` from `result.GetMetrics()` in `extractQueryMetadata()` |
| `pkg/output/metadata` | Added `MetricInfo` + `MetricInfo []MetricInfo` to `QueryMetadata`; registered `"metrics"` as a valid field; table footer renders `field → key [agg, unit]` + display name; CSV renders `# metric: field, key, agg[, unit]` |
| `cmd/query` | Added `metrics` to the `--metadata` flag help text |

## Test plan

- [ ] `go test ./...` (main module) — all pass
- [ ] `go test ./...` (sdk module) — all pass
- [ ] `go vet ./...` — clean
- [ ] Golden files regenerated and reviewed: only the "all" variants gain the `metrics` block; filtered variants are unchanged
- [ ] `TestValidMetadataFieldNames_Sorted` updated: 13 → 14 fields
- [ ] New unit tests: `TestFormatMetadataFooter_Metrics`, `TestFormatMetadataFooter_Metrics_FilteredField`, `TestFormatMetadataCSVComments_Metrics`, `TestMetadataToMap_Metrics`