### PR TITLE
feat(query): surface scan-limit truncation and data-reduction advice in agent mode

### DIFF
--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -378,13 +378,13 @@ func classifyNotification(notificationType, message string) string {
 func getHintForNotification(notificationType, message string) string {
 	switch classifyNotification(notificationType, message) {
 	case notifScanLimit:
-		return "Result is PARTIAL (scan stopped early). Reduce data scanned — narrow the timeframe, restrict to specific buckets (bucket:{...}; use --include-contributions to find the heavy ones), filter early with == (not contains()), or sample logs/spans with --default-sampling-ratio. Raising --default-scan-limit-gbytes <value> works but costs more."
+		return "Result is PARTIAL (scan stopped early). Reduce data scanned — narrow the timeframe, restrict to specific buckets (bucket:{...}; use --include-contributions to find the heavy ones), filter early with == (not contains()), or sample logs/spans (add samplingRatio:1000 to the fetch, or pass --default-sampling-ratio). Raising --default-scan-limit-gbytes <value> works but costs more."
 	case notifResultLimit:
 		return "Result was truncated. Aggregate in DQL (| summarize ...) to shrink it, or raise --max-result-records / --max-result-bytes <value>."
 	case notifTimeout:
 		return "Fetch timed out (result may be incomplete). Narrow the timeframe or add filters, or raise --fetch-timeout-seconds <value>."
 	case notifSampling:
-		return "Results are sampled/extrapolated (approximate). Use --default-sampling-ratio 1 for exact values (higher scan cost)."
+		return "Results are sampled/extrapolated (approximate). For exact values remove samplingRatio from the fetch, or pass --default-sampling-ratio 1 (higher scan cost)."
 	case notifConsumption:
 		return "Query hit a consumption limit. Reduce the data scanned, or pass --enforce-query-consumption-limit=false to bypass."
 	}
@@ -405,7 +405,7 @@ func agentAdviceForNotification(notificationType, message string) []string {
 			"#   - restrict to the relevant bucket(s): fetch logs, bucket:{\"<bucket>\"}",
 			"#   - find which bucket dominates the scan: dtctl query --include-contributions --metadata=contributions -o json '<query>' and read matchedRecordsRatio per bucket",
 			"#   - filter early and prefer equality, e.g. | filter <field> == \"...\" (== scans far less than contains()/matchesPhrase())",
-			"#   - for logs/spans, sample with --default-sampling-ratio <N> (e.g. 1000) for approximate counts at a fraction of the scan",
+			"#   - for logs/spans, sample so only a fraction is scanned: add samplingRatio to the fetch, e.g. fetch logs, samplingRatio:1000 (DQL-native, portable) — or pass dtctl's --default-sampling-ratio 1000; extrapolate counts with sum(dt.system.sampling_ratio)",
 			"# only if you truly need the full scan: --default-scan-limit-gbytes <value> (higher cost & duration; -1 = unlimited)",
 		}
 	case notifResultLimit:
@@ -420,7 +420,7 @@ func agentAdviceForNotification(notificationType, message string) []string {
 		}
 	case notifSampling:
 		return []string{
-			"# results are sampled/extrapolated (approximate, not exact); re-run with --default-sampling-ratio 1 for exact values (higher scan cost)",
+			"# results are sampled/extrapolated (approximate, not exact); for exact values remove samplingRatio from the fetch (or pass --default-sampling-ratio 1) — higher scan cost",
 		}
 	case notifConsumption:
 		return []string{

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -333,32 +333,121 @@ func (e *DQLExecutor) VerifyQuery(query string, opts DQLVerifyOptions) (*DQLVeri
 	return handler.Verify(ctx, req)
 }
 
-// getHintForNotification returns a CLI hint for a given notification type or message
-func getHintForNotification(notificationType, message string) string {
-	hints := map[string]string{
-		"SCAN_LIMIT_GBYTES":       "Use --default-scan-limit-gbytes <value> to increase the limit (e.g., dtctl q '<query>' --default-scan-limit-gbytes 2000)",
-		"RESULT_LIMIT_RECORDS":    "Use --max-result-records <value> to increase the record limit",
-		"RESULT_LIMIT_BYTES":      "Use --max-result-bytes <value> to increase the result size limit",
-		"FETCH_TIMEOUT":           "Use --fetch-timeout-seconds <value> to increase the fetch timeout",
-		"SAMPLING_APPLIED":        "Use --default-sampling-ratio <value> to adjust sampling (1.0 = no sampling)",
-		"QUERY_CONSUMPTION_LIMIT": "Use --enforce-query-consumption-limit=false to disable consumption limits",
+// Notification categories. A query notification is mapped to one of these so a
+// single set of advice serves both the human stderr hint and the agent-envelope
+// suggestions. The empty string means "no specific advice".
+const (
+	notifScanLimit   = "scan_limit"
+	notifResultLimit = "result_limit"
+	notifTimeout     = "timeout"
+	notifSampling    = "sampling"
+	notifConsumption = "consumption"
+)
+
+// classifyNotification maps a query notification (by type, falling back to a
+// message pattern) to one of the notif* categories. The message fallback exists
+// because not every deployment tags notifications with a stable type.
+func classifyNotification(notificationType, message string) string {
+	switch notificationType {
+	case "SCAN_LIMIT_GBYTES":
+		return notifScanLimit
+	case "RESULT_LIMIT_RECORDS", "RESULT_LIMIT_BYTES":
+		return notifResultLimit
+	case "FETCH_TIMEOUT":
+		return notifTimeout
+	case "SAMPLING_APPLIED":
+		return notifSampling
+	case "QUERY_CONSUMPTION_LIMIT":
+		return notifConsumption
 	}
 
-	if hint, ok := hints[notificationType]; ok {
-		return hint
+	msg := strings.ToLower(message)
+	switch {
+	case strings.Contains(msg, "scan") && strings.Contains(msg, "gigabyte"):
+		return notifScanLimit
+	case strings.Contains(msg, "result has been limited") || strings.Contains(msg, "limited to"):
+		return notifResultLimit
 	}
-
-	if len(message) > 0 {
-		msgLower := strings.ToLower(message)
-		if strings.Contains(msgLower, "result has been limited") || strings.Contains(msgLower, "limited to") {
-			return "Use --max-result-records <value> to increase the record limit (e.g., dtctl q '<query>' --max-result-records 5000)"
-		}
-		if strings.Contains(msgLower, "scan") && strings.Contains(msgLower, "gigabyte") {
-			return "Use --default-scan-limit-gbytes <value> to increase the limit (e.g., dtctl q '<query>' --default-scan-limit-gbytes 2000)"
-		}
-	}
-
 	return ""
+}
+
+// getHintForNotification returns a concise CLI hint (a single line, for stderr)
+// for a given notification type or message. For a truncating notification it
+// leads with data-reduction advice — raising the limit is the expensive last
+// resort, not the first suggestion.
+func getHintForNotification(notificationType, message string) string {
+	switch classifyNotification(notificationType, message) {
+	case notifScanLimit:
+		return "Result is PARTIAL (scan stopped early). Prefer reducing data scanned — narrow the timeframe, add filters, sample logs/spans with --default-sampling-ratio, or aggregate in DQL. Raising --default-scan-limit-gbytes <value> works but costs more."
+	case notifResultLimit:
+		return "Result was truncated. Aggregate in DQL (| summarize ...) to shrink it, or raise --max-result-records / --max-result-bytes <value>."
+	case notifTimeout:
+		return "Fetch timed out (result may be incomplete). Narrow the timeframe or add filters, or raise --fetch-timeout-seconds <value>."
+	case notifSampling:
+		return "Results are sampled/extrapolated (approximate). Use --default-sampling-ratio 1 for exact values (higher scan cost)."
+	case notifConsumption:
+		return "Query hit a consumption limit. Reduce the data scanned, or pass --enforce-query-consumption-limit=false to bypass."
+	}
+	return ""
+}
+
+// agentAdviceForNotification returns agent-envelope suggestion lines (the "# ..."
+// style used across the spill envelope) for a notification. Unlike the one-line
+// human hint, it spells out the concrete alternatives an agent can act on and
+// leads with the fact that the result may be incomplete.
+func agentAdviceForNotification(notificationType, message string) []string {
+	switch classifyNotification(notificationType, message) {
+	case notifScanLimit:
+		return []string{
+			"# the scan limit was reached — this result is PARTIAL (the scan stopped early), not the full dataset",
+			"# prefer reducing the data scanned over raising the limit (raising it increases cost and duration):",
+			"#   - narrow the timeframe, e.g. from:now()-1h instead of a wide range",
+			"#   - add filters early to cut scanned data, e.g. | filter <field> == \"...\"",
+			"#   - for logs/spans, sample with --default-sampling-ratio <N> (e.g. 1000) for approximate counts at a fraction of the scan",
+			"#   - aggregate in DQL (| summarize ..., by:{...}) instead of fetching raw rows",
+			"# only if you truly need the full scan: --default-scan-limit-gbytes <value> (higher cost & duration; -1 = unlimited)",
+		}
+	case notifResultLimit:
+		return []string{
+			"# the result was truncated to the record/byte limit — rows are missing",
+			"# aggregate in DQL (| summarize ...) to shrink the result, or raise the cap with --max-result-records <N> / --max-result-bytes <N>",
+		}
+	case notifTimeout:
+		return []string{
+			"# the fetch timed out — this result may be incomplete",
+			"# narrow the timeframe or add filters to speed the query, or raise --fetch-timeout-seconds <N>",
+		}
+	case notifSampling:
+		return []string{
+			"# results are sampled/extrapolated (approximate, not exact); re-run with --default-sampling-ratio 1 for exact values (higher scan cost)",
+		}
+	case notifConsumption:
+		return []string{
+			"# the query hit a consumption limit and was stopped — this result may be incomplete",
+			"# reduce the data scanned (narrower timeframe/filters), or pass --enforce-query-consumption-limit=false to bypass",
+		}
+	}
+	return nil
+}
+
+// notificationAdvice converts query notifications into agent-envelope warnings
+// and suggestions. Unlike PrintNotifications (which writes to stderr for a
+// human), this surfaces the same information inside the JSON envelope on stdout,
+// so an agent parsing the result on stdout learns the result may be PARTIAL and
+// what to do next — otherwise a truncated scan looks like a complete answer.
+func notificationAdvice(notifications []QueryNotification) (warnings, suggestions []string) {
+	for _, n := range notifications {
+		switch strings.ToUpper(n.Severity) {
+		case "WARNING", "WARN", "ERROR":
+		default:
+			continue
+		}
+		if n.Message != "" {
+			warnings = append(warnings, n.Message)
+		}
+		suggestions = append(suggestions, agentAdviceForNotification(n.NotificationType, n.Message)...)
+	}
+	return warnings, suggestions
 }
 
 // PrintNotifications prints query notifications/warnings to stderr

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -378,7 +378,7 @@ func classifyNotification(notificationType, message string) string {
 func getHintForNotification(notificationType, message string) string {
 	switch classifyNotification(notificationType, message) {
 	case notifScanLimit:
-		return "Result is PARTIAL (scan stopped early). Prefer reducing data scanned — narrow the timeframe, add filters, sample logs/spans with --default-sampling-ratio, or aggregate in DQL. Raising --default-scan-limit-gbytes <value> works but costs more."
+		return "Result is PARTIAL (scan stopped early). Reduce data scanned — narrow the timeframe, restrict to specific buckets (bucket:{...}; use --include-contributions to find the heavy ones), filter early with == (not contains()), or sample logs/spans with --default-sampling-ratio. Raising --default-scan-limit-gbytes <value> works but costs more."
 	case notifResultLimit:
 		return "Result was truncated. Aggregate in DQL (| summarize ...) to shrink it, or raise --max-result-records / --max-result-bytes <value>."
 	case notifTimeout:
@@ -400,11 +400,12 @@ func agentAdviceForNotification(notificationType, message string) []string {
 	case notifScanLimit:
 		return []string{
 			"# the scan limit was reached — this result is PARTIAL (the scan stopped early), not the full dataset",
-			"# prefer reducing the data scanned over raising the limit (raising it increases cost and duration):",
-			"#   - narrow the timeframe, e.g. from:now()-1h instead of a wide range",
-			"#   - add filters early to cut scanned data, e.g. | filter <field> == \"...\"",
+			"# reduce the DATA SCANNED (aggregation alone does not help — it still scans everything). Raising the limit works but costs more and is slower:",
+			"#   - narrow the timeframe, e.g. from:now()-1h instead of a wide range (usually the biggest lever)",
+			"#   - restrict to the relevant bucket(s): fetch logs, bucket:{\"<bucket>\"}",
+			"#   - find which bucket dominates the scan: dtctl query --include-contributions --metadata=contributions -o json '<query>' and read matchedRecordsRatio per bucket",
+			"#   - filter early and prefer equality, e.g. | filter <field> == \"...\" (== scans far less than contains()/matchesPhrase())",
 			"#   - for logs/spans, sample with --default-sampling-ratio <N> (e.g. 1000) for approximate counts at a fraction of the scan",
-			"#   - aggregate in DQL (| summarize ..., by:{...}) instead of fetching raw rows",
 			"# only if you truly need the full scan: --default-scan-limit-gbytes <value> (higher cost & duration; -1 = unlimited)",
 		}
 	case notifResultLimit:

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -600,6 +600,74 @@ func TestGetHintForNotification(t *testing.T) {
 	}
 }
 
+func TestClassifyNotification(t *testing.T) {
+	tests := []struct {
+		name             string
+		notificationType string
+		message          string
+		want             string
+	}{
+		{"scan by type", "SCAN_LIMIT_GBYTES", "", notifScanLimit},
+		{"result records by type", "RESULT_LIMIT_RECORDS", "", notifResultLimit},
+		{"result bytes by type", "RESULT_LIMIT_BYTES", "", notifResultLimit},
+		{"timeout by type", "FETCH_TIMEOUT", "", notifTimeout},
+		{"sampling by type", "SAMPLING_APPLIED", "", notifSampling},
+		{"consumption by type", "QUERY_CONSUMPTION_LIMIT", "", notifConsumption},
+		{"scan by message", "", "stopped after 500 gigabytes were scanned", notifScanLimit},
+		{"result by message", "", "Your result has been limited to 1000.", notifResultLimit},
+		{"unknown", "SOMETHING_ELSE", "all good", ""},
+		{"empty", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyNotification(tt.notificationType, tt.message); got != tt.want {
+				t.Errorf("classifyNotification(%q, %q) = %q, want %q", tt.notificationType, tt.message, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentAdviceForNotification_ScanLimit(t *testing.T) {
+	got := agentAdviceForNotification("SCAN_LIMIT_GBYTES", "")
+	if len(got) == 0 {
+		t.Fatal("expected scan-limit advice, got none")
+	}
+	joined := strings.Join(got, "\n")
+	// The result must be flagged as PARTIAL and reduction advice must come
+	// before the (expensive) raise-the-limit escape hatch.
+	if !strings.Contains(joined, "PARTIAL") {
+		t.Errorf("scan-limit advice should flag the result as PARTIAL:\n%s", joined)
+	}
+	for _, want := range []string{"timeframe", "filter", "--default-sampling-ratio", "summarize"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("scan-limit advice missing %q:\n%s", want, joined)
+		}
+	}
+	reduceIdx := strings.Index(joined, "--default-sampling-ratio")
+	raiseIdx := strings.Index(joined, "--default-scan-limit-gbytes")
+	if raiseIdx < 0 || reduceIdx < 0 || reduceIdx > raiseIdx {
+		t.Errorf("reduction advice should precede the raise-the-limit hint:\n%s", joined)
+	}
+}
+
+func TestNotificationAdvice(t *testing.T) {
+	notifications := []QueryNotification{
+		{Severity: "WARNING", NotificationType: "SCAN_LIMIT_GBYTES", Message: "stopped after 500 gigabytes"},
+		{Severity: "INFO", NotificationType: "RESULT_LIMIT_RECORDS", Message: "informational, ignore me"},
+	}
+	warnings, suggestions := notificationAdvice(notifications)
+	if len(warnings) != 1 || warnings[0] != "stopped after 500 gigabytes" {
+		t.Errorf("expected only the WARNING message surfaced, got %v", warnings)
+	}
+	if len(suggestions) == 0 || !strings.Contains(strings.Join(suggestions, "\n"), "PARTIAL") {
+		t.Errorf("expected scan-limit suggestions, got %v", suggestions)
+	}
+	// The INFO notification must not contribute advice.
+	if strings.Contains(strings.Join(suggestions, "\n"), "record/byte limit") {
+		t.Errorf("INFO-severity notification should be ignored, got %v", suggestions)
+	}
+}
+
 func TestNewDQLExecutor(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -638,7 +638,7 @@ func TestAgentAdviceForNotification_ScanLimit(t *testing.T) {
 	if !strings.Contains(joined, "PARTIAL") {
 		t.Errorf("scan-limit advice should flag the result as PARTIAL:\n%s", joined)
 	}
-	for _, want := range []string{"timeframe", "filter", "--default-sampling-ratio", "summarize"} {
+	for _, want := range []string{"timeframe", "bucket", "contributions", "--default-sampling-ratio"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("scan-limit advice missing %q:\n%s", want, joined)
 		}

--- a/pkg/exec/spill_exec.go
+++ b/pkg/exec/spill_exec.go
@@ -188,6 +188,14 @@ func (e *DQLExecutor) buildSpillResponse(query string, result *DQLQueryResponse,
 		}
 	}
 
+	// Surface query notifications (scan-limit truncation, result caps, timeouts,
+	// sampling) into the envelope. Their advice leads the suggestions because a
+	// PARTIAL result is more consequential to an agent than the spill/inspect
+	// follow-ups — an agent parsing stdout must learn the result is incomplete.
+	notifWarnings, notifSuggestions := notificationAdvice(result.GetNotifications())
+	warnings = append(warnings, notifWarnings...)
+	suggestions = append(notifSuggestions, suggestions...)
+
 	total := len(records)
 	ctx := &output.ResponseContext{
 		Verb:             "query",
@@ -236,6 +244,11 @@ func (e *DQLExecutor) inlineRecordsResponse(query string, result *DQLQueryRespon
 		}
 	}
 
+	// Even an inline (small) result can be PARTIAL — a scan-limit stop can leave
+	// few rows. Surface the same notification advice so the agent isn't misled
+	// into treating a truncated scan as the complete answer.
+	notifWarnings, notifSuggestions := notificationAdvice(result.GetNotifications())
+
 	total := len(records)
 	ctx := &output.ResponseContext{
 		Verb:             "query",
@@ -245,6 +258,8 @@ func (e *DQLExecutor) inlineRecordsResponse(query string, result *DQLQueryRespon
 		ThresholdBytes:   opts.Spill.Threshold,
 		MeasuredBytes:    measured,
 		MeasuredEncoding: encoding,
+		Warnings:         notifWarnings,
+		Suggestions:      notifSuggestions,
 	}
 	return output.Response{
 		OK:              true,

--- a/pkg/exec/spill_test.go
+++ b/pkg/exec/spill_test.go
@@ -274,6 +274,69 @@ func TestBuildSpillResponse_InlineRecordsEnvelopeInAgentMode(t *testing.T) {
 	}
 }
 
+// resultWithNotification returns a small result carrying a query notification,
+// so the envelope-building paths can be exercised against truncation warnings.
+func resultWithNotification(n QueryNotification) (*DQLQueryResponse, []map[string]interface{}) {
+	resp, records := sampleResult(false)
+	resp.Metadata.Grail.Notifications = []QueryNotification{n}
+	return resp, records
+}
+
+func TestBuildSpillResponse_InlineSurfacesScanLimitNotification(t *testing.T) {
+	e := &DQLExecutor{}
+	result, records := resultWithNotification(QueryNotification{
+		Severity:         "WARNING",
+		NotificationType: "SCAN_LIMIT_GBYTES",
+		Message:          "Your execution was stopped after 500 gigabytes of data were scanned.",
+	})
+	opts := DQLExecuteOptions{
+		AgentMode: true,
+		Spill:     SpillOptions{Mode: SpillAuto, Threshold: 1 << 20, Dir: t.TempDir(), Format: "json"},
+	}
+	resp, handled, err := e.buildSpillResponse("fetch logs", result, records, "json", opts)
+	if err != nil || !handled {
+		t.Fatalf("buildSpillResponse: handled=%v err=%v", handled, err)
+	}
+	if resp.Context.Decided != "inline" {
+		t.Fatalf("decided = %q, want inline", resp.Context.Decided)
+	}
+	if len(resp.Context.Warnings) != 1 || !strings.Contains(resp.Context.Warnings[0], "500 gigabytes") {
+		t.Errorf("expected scan-limit warning in envelope, got %v", resp.Context.Warnings)
+	}
+	if !strings.Contains(strings.Join(resp.Context.Suggestions, "\n"), "PARTIAL") {
+		t.Errorf("expected PARTIAL scan-limit advice in envelope, got %v", resp.Context.Suggestions)
+	}
+}
+
+func TestBuildSpillResponse_SpilledSurfacesScanLimitNotificationFirst(t *testing.T) {
+	e := &DQLExecutor{}
+	result, records := resultWithNotification(QueryNotification{
+		Severity:         "WARNING",
+		NotificationType: "SCAN_LIMIT_GBYTES",
+		Message:          "Your execution was stopped after 500 gigabytes of data were scanned.",
+	})
+	opts := DQLExecuteOptions{
+		AgentMode: true,
+		Spill:     SpillOptions{Mode: SpillAlways, Threshold: 1 << 20, Dir: t.TempDir(), Format: "json"},
+	}
+	resp, spilled, err := e.buildSpillResponse("fetch logs", result, records, "json", opts)
+	if err != nil || !spilled {
+		t.Fatalf("buildSpillResponse: spilled=%v err=%v", spilled, err)
+	}
+	if len(resp.Context.Warnings) == 0 || !strings.Contains(strings.Join(resp.Context.Warnings, "\n"), "500 gigabytes") {
+		t.Errorf("expected scan-limit warning in spilled envelope, got %v", resp.Context.Warnings)
+	}
+	// Notification advice must lead the suggestions — a PARTIAL result matters
+	// more than the spill/inspect follow-ups.
+	if len(resp.Context.Suggestions) == 0 || !strings.Contains(resp.Context.Suggestions[0], "scan limit was reached") {
+		t.Errorf("scan-limit advice should lead the suggestions, got %v", resp.Context.Suggestions)
+	}
+	// The spill follow-ups (inspect hint) must still be present after it.
+	if !strings.Contains(strings.Join(resp.Context.Suggestions, "\n"), "dtctl inspect") {
+		t.Errorf("expected spill inspect follow-up to remain, got %v", resp.Context.Suggestions)
+	}
+}
+
 func TestBuildSpillResponse_NeverModeInlinesInAgentMode(t *testing.T) {
 	// --spill=never forces rows inline regardless of size; in agent mode that
 	// still means a self-describing kind:"records" envelope, never a table. Use


### PR DESCRIPTION
## Problem

When a DQL query hits the **scan limit** (or a result/timeout/consumption cap), the query still exits `0` and returns a **partial** result. In agent mode the truncation was only signalled on **stderr** — an agent parsing the JSON envelope on **stdout** saw a truncated scan as a complete answer. The single hint we did emit only said "raise `--default-scan-limit-gbytes`", which is the *expensive* move (higher cost + duration), not the sensible first step.

## Change

- **Surface query notifications into the agent envelope.** Both the inline and spilled paths now populate `context.warnings` (the raw API warning) and `context.suggestions` from the query's notifications, so an agent on stdout learns the result is **PARTIAL** and what to do next. Notification advice **leads** the suggestions.
- **Reduction-first, scanned-bytes-accurate advice.** For a scan-limit stop the suggestions lead with the true scanned-bytes reducers rather than raising the limit:
  - narrow the timeframe (usually the biggest lever)
  - restrict to the relevant bucket(s): `fetch logs, bucket:{"<bucket>"}`
  - find the heavy bucket: `dtctl query --include-contributions --metadata=contributions -o json '<query>'` → read `matchedRecordsRatio`
  - filter early with equality (`==` scans far less than `contains()`/`matchesPhrase()`)
  - sample logs/spans — **DQL-native `fetch logs, samplingRatio:1000`** (portable across any DQL client), or dtctl's `--default-sampling-ratio`; extrapolate counts with `sum(dt.system.sampling_ratio)`
  - raise `--default-scan-limit-gbytes` only as the expensive last resort

  These reducers are cross-checked against the `dt-dql-essentials` optimization guide. Note it also corrects a subtlety: **aggregation alone does not reduce the scan** (it still reads every record), so it's no longer listed as a scan reducer.
- **Sampling guidance distinguishes the two mechanisms.** `--default-sampling-ratio` maps to the request-level `defaultSamplingRatio` — a *fallback* the API applies only when the query has no `samplingRatio:` of its own — which is easy to mistake for the DQL fetch parameter. The advice therefore leads with `samplingRatio:<N>` in the fetch and treats the flag as a convenience alias. For exact values it steers to removing `samplingRatio:` from the fetch (the flag can't override an in-query ratio). Verified end-to-end: both cut a 500 GB scan to ~18 GB, but only the fetch parameter appears in `canonicalQuery`.
- Also covers `RESULT_LIMIT_*`, `FETCH_TIMEOUT`, `SAMPLING_APPLIED`, and `QUERY_CONSUMPTION_LIMIT` notifications, and rewords the human stderr hint the same way.

## Before / after (agent mode, scan limit hit)

Before — envelope gave no signal; warning only on stderr:
```json
"context": { "decided": "inline", "total": 1 }
```

After:
```json
"context": {
  "warnings": ["Your execution was stopped after N gigabytes of data were scanned. ..."],
  "suggestions": [
    "# the scan limit was reached — this result is PARTIAL (the scan stopped early), not the full dataset",
    "# reduce the DATA SCANNED (aggregation alone does not help — it still scans everything). ...",
    "#   - narrow the timeframe, e.g. from:now()-1h instead of a wide range (usually the biggest lever)",
    "#   - restrict to the relevant bucket(s): fetch logs, bucket:{\"<bucket>\"}",
    "#   - find which bucket dominates the scan: dtctl query --include-contributions --metadata=contributions -o json '<query>' and read matchedRecordsRatio per bucket",
    "#   - filter early and prefer equality, e.g. | filter <field> == \"...\" (== scans far less than contains()/matchesPhrase())",
    "#   - for logs/spans, sample so only a fraction is scanned: add samplingRatio to the fetch, e.g. fetch logs, samplingRatio:1000 (DQL-native, portable) — or pass dtctl's --default-sampling-ratio 1000; extrapolate counts with sum(dt.system.sampling_ratio)",
    "# only if you truly need the full scan: --default-scan-limit-gbytes <value> (higher cost & duration; -1 = unlimited)"
  ]
}
```

## Testing

- New unit tests: `classifyNotification`, `agentAdviceForNotification` (asserts PARTIAL flag + reduction advice precedes the raise-the-limit hint), `notificationAdvice` (ignores INFO severity).
- New integration tests: inline and spilled envelopes both carry the scan-limit warning + advice; on the spilled path the notification advice leads while the `dtctl inspect` follow-up is retained.
- `go test ./...` (both modules), `gofmt`, and `go vet` clean.
- Manually verified end-to-end against a live tenant (inline path, spill path, human stderr hint, and the two sampling mechanisms).
