### PR TITLE
feat(exec): add profile command for code-level analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ dtctl query "fetch logs | limit 10"           # Run DQL queries
 dtctl apply -f workflow.yaml --set env=prod   # Declarative configuration
 dtctl get dashboards -o json                  # Structured output for automation
 dtctl exec copilot nl2dql "error logs from last hour"
+dtctl exec profile --kind hotspots --entity SERVICE-ABC123 --last 1h  # Code-level profiling
 ```
 
 ![dtctl dashboard workflow demo](docs/assets/dtctl-1.gif)
@@ -83,6 +84,7 @@ Token-based authentication and multi-environment configuration are covered in th
 | Extensions 2.0 | get, describe, apply monitoring configs |
 | Hub Extensions | get, describe, list releases, filter by keyword |
 | App Functions & Intents | get, describe, execute, find, open (deep linking) |
+| Code Profiling | hotspots, threads, memory, memory-details — via `dtctl exec profile` |
 | Davis AI | analyzers, CoPilot chat, NL-to-DQL, document search |
 | Cloud Integrations | AWS, Azure & GCP connections and monitoring (get, describe, create, delete, apply, update, enable) |
 | EdgeConnect | get, describe, create, delete |

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -18,7 +18,8 @@ Available operations:
   function (fn, func)     Invoke an app function or run ad-hoc JavaScript
   analyzer (az)           Run a Davis AI analyzer
   slo                     Evaluate a service-level objective
-  copilot (cp, chat)      Chat with Davis CoPilot interactively`,
+  copilot (cp, chat)      Chat with Davis CoPilot interactively
+  profile                 Run a code-level profiling analysis (hotspots, threads, memory)`,
 	Example: `  # Execute a workflow and wait for completion
   dtctl exec workflow <workflow-id>
 
@@ -45,4 +46,5 @@ func init() {
 	execCmd.AddCommand(execAnalyzerCmd)
 	execCmd.AddCommand(execCopilotCmd)
 	execCmd.AddCommand(execSLOCmd)
+	execCmd.AddCommand(execProfileCmd)
 }

--- a/cmd/exec_profile.go
+++ b/cmd/exec_profile.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/profile"
@@ -15,7 +17,7 @@ import (
 var execProfileCmd = &cobra.Command{
 	Use:   "profile",
 	Short: "Run a code-level profiling analysis on a Dynatrace entity",
-	Long: `Run a code-level profiling analysis via the dynatrace.profiling app function.
+	Long: `Run a code-level profiling analysis via the Dynatrace code-level analysis API.
 
 The analysis is asynchronous server-side; this command polls until it completes.
 
@@ -87,8 +89,6 @@ Examples:
 		allocType, _ := cmd.Flags().GetString("type")
 		method, _ := cmd.Flags().GetString("method")
 
-		appID, _ := cmd.Flags().GetString("app")
-
 		_, c, err := SetupClient()
 		if err != nil {
 			return err
@@ -96,7 +96,7 @@ Examples:
 
 		handler := profile.NewHandler(c)
 		stopSpinner := startSpinner(fmt.Sprintf("running %s analysis", kindShort))
-		result, err := handler.Run(cmd.Context(), appID, profile.Payload{
+		resp, err := handler.Run(cmd.Context(), profile.Payload{
 			Kind:            apiKind,
 			EntityID:        entityID,
 			From:            from,
@@ -116,6 +116,11 @@ Examples:
 			return err
 		}
 
+		// Marshal resp to a generic map so enrich/compact helpers see the
+		// expected envelope shape: {"status":..., "result":{...}, ...}
+		b, _ := json.Marshal(resp)
+		var result interface{}
+		_ = json.Unmarshal(b, &result)
 		full, _ := cmd.Flags().GetBool("full")
 		if !full {
 			result = compactResult(result)
@@ -126,9 +131,57 @@ Examples:
 		if outputFormat == "" {
 			outputFormat = "json"
 		}
+		if outputFormat == "stacktree" {
+			w, _, err := term.GetSize(int(os.Stdout.Fd()))
+			if err != nil || w <= 0 {
+				w = 120
+			}
+			depth, _ := cmd.Flags().GetInt("depth")
+			appOnly, _ := cmd.Flags().GetBool("app-only")
+			if s := profile.ToStackTree(apiKind, result, w, depth, appOnly); s != "" {
+				fmt.Print(s)
+				return nil
+			}
+			outputFormat = "json"
+		}
+		if outputFormat == "tree" {
+			w, _, err := term.GetSize(int(os.Stdout.Fd()))
+			if err != nil || w <= 0 {
+				w = 120
+			}
+			if s := profile.ToTree(apiKind, result, w); s != "" {
+				fmt.Print(s)
+				return nil
+			}
+			outputFormat = "json"
+		}
+		if outputFormat == "bars" {
+			w, _, err := term.GetSize(int(os.Stdout.Fd()))
+			if err != nil || w <= 0 {
+				w = 120
+			}
+			top, _ := cmd.Flags().GetInt("top")
+			if s := profile.ToBars(apiKind, result, w, top); s != "" {
+				fmt.Print(s)
+				return nil
+			}
+			outputFormat = "json"
+		}
+		if outputFormat == "flamegraph" {
+			w, _, err := term.GetSize(int(os.Stdout.Fd()))
+			if err != nil || w <= 0 {
+				w = 120
+			}
+			if fg := profile.ToFlamegraph(apiKind, result, w); fg != "" {
+				fmt.Print(fg)
+				return nil
+			}
+			outputFormat = "json"
+		}
 		if outputFormat == "table" {
 			if rows := profile.ToTableRows(apiKind, result); rows != nil {
-				return output.NewPrinter("table").PrintList(rows)
+				top, _ := cmd.Flags().GetInt("top")
+				return output.NewPrinter("table").PrintList(profile.LimitRows(rows, top))
 			}
 			outputFormat = "json"
 		}
@@ -148,7 +201,6 @@ func parseProfileTimestamp(s string) (int64, error) {
 }
 
 func init() {
-	execProfileCmd.Flags().String("app", profile.DefaultAppID, "app ID to invoke (override for dev/custom deployments)")
 	execProfileCmd.Flags().StringP("kind", "k", "", "analysis kind: hotspots, threads, memory, memory-details (required)")
 	execProfileCmd.Flags().StringP("entity", "e", "", "entity ID (SERVICE-xxx or PROCESS_GROUP-xxx) (required)")
 	execProfileCmd.Flags().String("last", "", "time window relative to now, e.g. 1h, 30m (max 2h)")
@@ -171,6 +223,9 @@ func init() {
 	execProfileCmd.Flags().String("method", "", "method to drill into (memory-details)")
 
 	execProfileCmd.Flags().Bool("full", false, "include raw timeseries dataPoints (stripped by default)")
+	execProfileCmd.Flags().Int("top", 0, "limit table output to top N rows by running samples (0 = all)")
+	execProfileCmd.Flags().Int("depth", 0, "limit stacktree output to N levels deep (0 = all)")
+	execProfileCmd.Flags().Bool("app-only", false, "stacktree: show only com.dynatrace.* frames")
 
 	_ = execProfileCmd.MarkFlagRequired("kind")
 	_ = execProfileCmd.MarkFlagRequired("entity")

--- a/cmd/exec_profile.go
+++ b/cmd/exec_profile.go
@@ -138,7 +138,8 @@ Examples:
 			}
 			depth, _ := cmd.Flags().GetInt("depth")
 			appOnly, _ := cmd.Flags().GetBool("app-only")
-			if s := profile.ToStackTree(apiKind, result, w, depth, appOnly); s != "" {
+			abbrev, _ := cmd.Flags().GetBool("abbrev")
+			if s := profile.ToStackTree(apiKind, result, w, depth, appOnly, abbrev); s != "" {
 				fmt.Print(s)
 				return nil
 			}
@@ -226,6 +227,7 @@ func init() {
 	execProfileCmd.Flags().Int("top", 0, "limit table output to top N rows by running samples (0 = all)")
 	execProfileCmd.Flags().Int("depth", 0, "limit stacktree output to N levels deep (0 = all)")
 	execProfileCmd.Flags().Bool("app-only", false, "stacktree: show only com.dynatrace.* frames")
+	execProfileCmd.Flags().Bool("abbrev", false, "stacktree: abbreviate package segments to first letter (e.g. com.example → c.e)")
 
 	_ = execProfileCmd.MarkFlagRequired("kind")
 	_ = execProfileCmd.MarkFlagRequired("entity")

--- a/cmd/exec_profile.go
+++ b/cmd/exec_profile.go
@@ -1,0 +1,241 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/profile"
+)
+
+var execProfileCmd = &cobra.Command{
+	Use:   "profile",
+	Short: "Run a code-level profiling analysis on a Dynatrace entity",
+	Long: `Run a code-level profiling analysis via the dynatrace.profiling app function.
+
+The analysis is asynchronous server-side; this command polls until it completes.
+
+Kinds:
+  hotspots        Method hotspots for a SERVICE entity
+  threads         Thread analysis for a SERVICE entity
+  memory          Memory allocation analysis for a PROCESS_GROUP or PGI entity
+  memory-details  Drill-down into a specific type/method (requires --type and --method)
+
+Examples:
+  # Method hotspots for the last hour
+  dtctl exec profile --kind hotspots --entity SERVICE-ABC123 --last 1h
+
+  # Thread analysis with a 30-minute window
+  dtctl exec profile --kind threads --entity SERVICE-ABC123 --last 30m
+
+  # Memory allocation, survivors only
+  dtctl exec profile --kind memory --entity PROCESS_GROUP-DEF456 --last 1h --survivors-only
+
+  # Memory drill-down
+  dtctl exec profile --kind memory-details --entity PROCESS_GROUP-DEF456 --last 1h \
+    --type java.lang.String --method "java.lang.String.intern()"
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		kindShort, _ := cmd.Flags().GetString("kind")
+		entityID, _ := cmd.Flags().GetString("entity")
+		lastStr, _ := cmd.Flags().GetString("last")
+		fromStr, _ := cmd.Flags().GetString("from")
+		toStr, _ := cmd.Flags().GetString("to")
+
+		apiKind, ok := profile.Kind[kindShort]
+		if !ok {
+			return fmt.Errorf("unknown kind %q: use hotspots, threads, memory, or memory-details", kindShort)
+		}
+		if entityID == "" {
+			return fmt.Errorf("--entity is required")
+		}
+
+		var from, to int64
+		if lastStr != "" {
+			last, err := time.ParseDuration(lastStr)
+			if err != nil {
+				return fmt.Errorf("invalid --last value %q: %w", lastStr, err)
+			}
+			now := time.Now()
+			from, to = now.Add(-last).UnixMilli(), now.UnixMilli()
+		} else {
+			if fromStr == "" || toStr == "" {
+				return fmt.Errorf("provide --last <duration> or both --from and --to")
+			}
+			var err error
+			from, err = parseProfileTimestamp(fromStr)
+			if err != nil {
+				return err
+			}
+			to, err = parseProfileTimestamp(toStr)
+			if err != nil {
+				return err
+			}
+		}
+
+		serviceFilter, _ := cmd.Flags().GetString("service-filter")
+		showWaiting, _ := cmd.Flags().GetBool("show-waiting")
+		problemID, _ := cmd.Flags().GetString("problem-id")
+		survivorsOnly, _ := cmd.Flags().GetBool("survivors-only")
+		typeFilter, _ := cmd.Flags().GetString("type-filter")
+		apiFilter, _ := cmd.Flags().GetString("api-filter")
+		methodFQNFilter, _ := cmd.Flags().GetString("method-fqn-filter")
+		allocType, _ := cmd.Flags().GetString("type")
+		method, _ := cmd.Flags().GetString("method")
+
+		appID, _ := cmd.Flags().GetString("app")
+
+		_, c, err := SetupClient()
+		if err != nil {
+			return err
+		}
+
+		handler := profile.NewHandler(c)
+		stopSpinner := startSpinner(fmt.Sprintf("running %s analysis", kindShort))
+		result, err := handler.Run(cmd.Context(), appID, profile.Payload{
+			Kind:            apiKind,
+			EntityID:        entityID,
+			From:            from,
+			To:              to,
+			ServiceFilter:   serviceFilter,
+			ShowWaiting:     showWaiting,
+			ProblemID:       problemID,
+			SurvivorsOnly:   survivorsOnly,
+			TypeFilter:      typeFilter,
+			APIFilter:       apiFilter,
+			MethodFQNFilter: methodFQNFilter,
+			Type:            allocType,
+			Method:          method,
+		})
+		stopSpinner()
+		if err != nil {
+			return err
+		}
+
+		full, _ := cmd.Flags().GetBool("full")
+		if !full {
+			result = compactResult(result)
+		}
+		result = profile.EnrichResult(apiKind, result)
+
+		outputFormat, _ := cmd.Flags().GetString("output")
+		if outputFormat == "" {
+			outputFormat = "json"
+		}
+		if outputFormat == "table" {
+			if rows := profile.ToTableRows(apiKind, result); rows != nil {
+				return output.NewPrinter("table").PrintList(rows)
+			}
+			outputFormat = "json"
+		}
+		return output.NewPrinter(outputFormat).Print(result)
+	},
+}
+
+func parseProfileTimestamp(s string) (int64, error) {
+	if ms, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return ms, nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse time %q: use RFC3339 or epoch millis", s)
+	}
+	return t.UnixMilli(), nil
+}
+
+func init() {
+	execProfileCmd.Flags().String("app", profile.DefaultAppID, "app ID to invoke (override for dev/custom deployments)")
+	execProfileCmd.Flags().StringP("kind", "k", "", "analysis kind: hotspots, threads, memory, memory-details (required)")
+	execProfileCmd.Flags().StringP("entity", "e", "", "entity ID (SERVICE-xxx or PROCESS_GROUP-xxx) (required)")
+	execProfileCmd.Flags().String("last", "", "time window relative to now, e.g. 1h, 30m (max 2h)")
+	execProfileCmd.Flags().String("from", "", "window start — RFC3339 or epoch millis")
+	execProfileCmd.Flags().String("to", "", "window end — RFC3339 or epoch millis")
+
+	// hotspots / threads only
+	execProfileCmd.Flags().String("service-filter", "", "service call filter (hotspots/threads)")
+	execProfileCmd.Flags().Bool("show-waiting", false, "include waiting (non-running) samples (hotspots/threads)")
+
+	// memory* only
+	execProfileCmd.Flags().String("problem-id", "", "scope to a problem ID (memory*)")
+	execProfileCmd.Flags().Bool("survivors-only", false, "restrict to surviving allocations (memory*)")
+	execProfileCmd.Flags().String("type-filter", "", "`;`-separated allocated-type filter (memory*)")
+	execProfileCmd.Flags().String("api-filter", "", "`;`-separated API filter (memory*)")
+	execProfileCmd.Flags().String("method-fqn-filter", "", "`;`-separated method FQN filter (memory*)")
+
+	// memory-details only
+	execProfileCmd.Flags().String("type", "", "allocated type to drill into (memory-details)")
+	execProfileCmd.Flags().String("method", "", "method to drill into (memory-details)")
+
+	execProfileCmd.Flags().Bool("full", false, "include raw timeseries dataPoints (stripped by default)")
+
+	_ = execProfileCmd.MarkFlagRequired("kind")
+	_ = execProfileCmd.MarkFlagRequired("entity")
+}
+
+// startSpinner writes an animated spinner to stderr while work is in progress.
+// Call the returned function to stop it and clear the line.
+// Skipped in plain/agent mode (non-TTY) to keep output machine-readable.
+func startSpinner(label string) func() {
+	if agentMode || plainMode || !output.ColorEnabled() {
+		return func() {}
+	}
+	frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		i := 0
+		for {
+			select {
+			case <-done:
+				fmt.Fprintf(os.Stderr, "\r\033[K") // clear line
+				return
+			case <-ticker.C:
+				fmt.Fprintf(os.Stderr, "\r%s %s", frames[i%len(frames)], label)
+				i++
+			}
+		}
+	}()
+	return func() { close(done) }
+}
+
+// visualOnlyKeys are fields that carry UI rendering metadata with no analytical value.
+var visualOnlyKeys = map[string]bool{
+	"color":    true, // hex colour for charts
+	"uuid":     true, // internal render ID
+	"fileName": true, // usually null in profiling results
+	"filePath": true, // usually null in profiling results
+}
+
+// compactResult strips timeseries dataPoints and visual-only fields so agents
+// receive signal without chart/render noise.
+func compactResult(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, child := range val {
+			if visualOnlyKeys[k] {
+				continue
+			}
+			if k == "dataPoints" {
+				if arr, ok := child.([]interface{}); ok {
+					out["dataPointsCount"] = len(arr)
+					continue
+				}
+			}
+			out[k] = compactResult(child)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(val))
+		for i, item := range val {
+			out[i] = compactResult(item)
+		}
+		return out
+	}
+	return v
+}

--- a/cmd/exec_profile_test.go
+++ b/cmd/exec_profile_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestParseProfileTimestamp(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantMs  int64
+		wantErr bool
+	}{
+		{"1700000000000", 1700000000000, false},
+		{"2023-11-14T22:13:20Z", 1700000000000, false},
+		{"not-a-time", 0, true},
+		{"", 0, true},
+	}
+
+	for _, tc := range cases {
+		got, err := parseProfileTimestamp(tc.input)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("parseProfileTimestamp(%q) error = %v, wantErr %v", tc.input, err, tc.wantErr)
+			continue
+		}
+		if !tc.wantErr && got != tc.wantMs {
+			t.Errorf("parseProfileTimestamp(%q) = %d, want %d", tc.input, got, tc.wantMs)
+		}
+	}
+}

--- a/demo-pizza-slowness.md
+++ b/demo-pizza-slowness.md
@@ -1,0 +1,20 @@
+# Demo: agent diagnoses pizza service slowness
+
+## Prompt to give the fresh agent
+
+> My pizza service is slow. The process group instance is
+> `PROCESS_GROUP_INSTANCE-82CBCAA0F214B356` on environment `hzi4275d`.
+> I have `dtctl` available. Figure out why.
+
+## What the agent should do (without any hints)
+
+1. Run `dtctl exec --help` or `dtctl commands --brief -o json` to discover available commands
+2. Notice `exec profile` and read its help
+3. Run:
+   ```
+   dtctl exec profile -k hotspots \
+     -e PROCESS_GROUP_INSTANCE-82CBCAA0F214B356 \
+     --last 1h \
+     --app my.dynatrace.profiling.timur.berdiev
+   ```
+4. Read `hotPaths` in the response and identify the root cause

--- a/pkg/auth/resource_scopes.go
+++ b/pkg/auth/resource_scopes.go
@@ -105,6 +105,9 @@ var ResourceScopes = map[string]AccessScopes{
 	// (/platform/app-engine/function-executor/v1/sdk-versions).
 	"sdk-version": {Read: []string{"app-engine:apps:run"}},
 
+	// Code-level analysis (/platform-reserved/codelevelanalysis/v0.1)
+	"profile": {Run: []string{"storage:entities:read"}},
+
 	// Davis AI
 	"analyzer": {Read: []string{"davis:analyzers:read"}, Run: []string{"davis:analyzers:execute"}},
 	"copilot":  {Run: []string{"davis-copilot:conversations:execute"}},

--- a/pkg/resources/profile/bars.go
+++ b/pkg/resources/profile/bars.go
@@ -1,0 +1,103 @@
+package profile
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+type barTypeSpec struct {
+	name  string
+	color string // ANSI 256-color index
+	get   func(HotspotRow) int
+}
+
+var barTypes = []barTypeSpec{
+	{"R", "39", func(r HotspotRow) int { return r.Running }},
+	{"L", "196", func(r HotspotRow) int { return r.Lock }},
+	{"N", "226", func(r HotspotRow) int { return r.NetIO }},
+	{"D", "46", func(r HotspotRow) int { return r.DiskIO }},
+	{"W", "244", func(r HotspotRow) int { return r.Wait }},
+}
+
+const miniBarWidth = 8
+const nameColWidth = 38
+
+// ToBars renders per-type horizontal mini-bars for each hotspot method.
+func ToBars(kind string, raw interface{}, width int, top int) string {
+	if kind != "methodHotspots" && kind != "threadAnalysis" {
+		return ""
+	}
+	topMap, ok := raw.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	result, _ := topMap["result"].(map[string]interface{})
+	rows := hotspotRows(result)
+	if len(rows) == 0 {
+		return ""
+	}
+
+	n := 20
+	if top > 0 && top < n {
+		n = top
+	}
+	if len(rows) < n {
+		n = len(rows)
+	}
+	rows = rows[:n]
+
+	// Per-type max across visible rows (for independent normalization).
+	maxPerType := make([]int, len(barTypes))
+	for _, row := range rows {
+		for i, t := range barTypes {
+			if v := t.get(row); v > maxPerType[i] {
+				maxPerType[i] = v
+			}
+		}
+	}
+
+	colorOn := output.ColorEnabled()
+	var sb strings.Builder
+
+	// Legend
+	labels := []string{"Running", "Lock", "Net I/O", "Disk I/O", "Wait"}
+	if colorOn {
+		for i, t := range barTypes {
+			if maxPerType[i] > 0 {
+				fmt.Fprintf(&sb, "\033[38;5;%sm█ %s\033[0m  ", t.color, labels[i])
+			}
+		}
+		sb.WriteString("\n\n")
+	} else {
+		for i, t := range barTypes {
+			if maxPerType[i] > 0 {
+				fmt.Fprintf(&sb, "%s=%s  ", t.name, labels[i])
+			}
+		}
+		sb.WriteString("\n\n")
+	}
+
+	for _, row := range rows {
+		name := truncate(row.Class+"."+row.Method, nameColWidth)
+		sb.WriteString(name)
+		sb.WriteString(strings.Repeat(" ", nameColWidth-len([]rune(name))+1))
+
+		for i, t := range barTypes {
+			if maxPerType[i] == 0 {
+				continue
+			}
+			v := t.get(row)
+			filled := int(float64(v) / float64(maxPerType[i]) * float64(miniBarWidth))
+			bar := strings.Repeat("█", filled) + strings.Repeat("░", miniBarWidth-filled)
+			if colorOn {
+				fmt.Fprintf(&sb, "\033[38;5;%sm%s\033[0m %5d  ", t.color, bar, v)
+			} else {
+				fmt.Fprintf(&sb, "%s:%s %5d  ", t.name, bar, v)
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}

--- a/pkg/resources/profile/enrich.go
+++ b/pkg/resources/profile/enrich.go
@@ -1,0 +1,296 @@
+package profile
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// HotspotRow is the table representation of a single method hotspot.
+type HotspotRow struct {
+	Class   string `json:"class"   table:"CLASS"`
+	Method  string `json:"method"  table:"METHOD"`
+	Running int    `json:"running" table:"RUNNING"`
+	Lock    int    `json:"lock"    table:"LOCK"`
+	NetIO   int    `json:"netIO"   table:"NET_IO"`
+	DiskIO  int    `json:"diskIO"  table:"DISK_IO"`
+	Wait    int    `json:"wait"    table:"WAIT"`
+}
+
+// MemoryTypeRow is the table representation of a single allocated type.
+type MemoryTypeRow struct {
+	Type          string `json:"type"          table:"TYPE"`
+	AllocCount    int    `json:"allocCount"    table:"ALLOC COUNT"`
+	AllocSize     int    `json:"allocSize"     table:"ALLOC SIZE"`
+	SurvivorCount int    `json:"survivorCount" table:"SURVIVOR COUNT"`
+	SurvivorSize  int    `json:"survivorSize"  table:"SURVIVOR SIZE"`
+}
+
+// EnrichResult injects analytical summaries (hotPaths for CPU kinds,
+// topTypes for memory kinds) that agents and users can consume directly.
+func EnrichResult(kind string, raw interface{}) interface{} {
+	top, ok := raw.(map[string]interface{})
+	if !ok {
+		return raw
+	}
+	result, ok := top["result"].(map[string]interface{})
+	if !ok {
+		return raw
+	}
+
+	switch kind {
+	case "methodHotspots", "threadAnalysis":
+		if paths := buildHotPaths(result); len(paths) > 0 {
+			top["hotPaths"] = paths
+		}
+	}
+	return top
+}
+
+// ToTableRows converts a profile result to a slice of table-renderable rows.
+// Returns nil if the kind/data isn't suited for table display.
+func ToTableRows(kind string, raw interface{}) interface{} {
+	top, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	result, _ := top["result"].(map[string]interface{})
+
+	switch kind {
+	case "methodHotspots", "threadAnalysis":
+		return hotspotRows(result)
+	case "memoryAllocation", "memoryAllocationDetails":
+		return memoryTypeRows(result)
+	}
+	return nil
+}
+
+// --- hotspots / thread analysis ---
+
+func hotspotRows(result map[string]interface{}) []HotspotRow {
+	nodes := dataNodes(result)
+	if len(nodes) == 0 {
+		return nil
+	}
+	// skip the virtual root (empty label)
+	var rows []HotspotRow
+	for _, raw := range nodes {
+		n, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		label := nodeLabel(n)
+		if label == "" {
+			continue
+		}
+		s := nodeSamples(n)
+		rows = append(rows, HotspotRow{
+			Class:   nodeClass(n),
+			Method:  nodeMethod(n),
+			Running: s["RUNNING"],
+			Lock:    s["LOCK"],
+			NetIO:   s["NET_IO"],
+			DiskIO:  s["DISK_IO"],
+			Wait:    s["WAIT"],
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Running > rows[j].Running })
+	return rows
+}
+
+// --- memory ---
+
+func memoryTypeRows(result map[string]interface{}) []MemoryTypeRow {
+	ar, _ := result["analysisResult"].(map[string]interface{})
+	if ar == nil {
+		return nil
+	}
+	typesRaw, _ := ar["types"].([]interface{})
+	if len(typesRaw) == 0 {
+		return nil
+	}
+	rows := make([]MemoryTypeRow, 0, len(typesRaw))
+	for _, t := range typesRaw {
+		tm, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rows = append(rows, MemoryTypeRow{
+			Type:          strVal(tm, "typeName"),
+			AllocCount:    intVal(tm, "allocationCount"),
+			AllocSize:     intVal(tm, "allocationSize"),
+			SurvivorCount: intVal(tm, "survivorCount"),
+			SurvivorSize:  intVal(tm, "survivorSize"),
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].AllocSize > rows[j].AllocSize })
+	return rows
+}
+
+// --- hotPaths builder ---
+
+type nodeInfo struct {
+	id       string
+	label    string
+	childIDs []string
+	running  int
+}
+
+func buildHotPaths(result map[string]interface{}) []map[string]interface{} {
+	nodes := dataNodes(result)
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	nodeMap := make(map[string]*nodeInfo, len(nodes))
+	parentOf := make(map[string]string, len(nodes))
+	rootID := nodeIDStr(result["dataRootNodeId"])
+
+	for _, n := range nodes {
+		nm, ok := n.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id := nodeIDStr(nm["id"])
+		info := &nodeInfo{
+			id:      id,
+			label:   nodeLabel(nm),
+			running: nodeSamples(nm)["RUNNING"],
+		}
+		if cids, ok := nm["childIds"].([]interface{}); ok {
+			for _, c := range cids {
+				if s, ok := c.(string); ok {
+					info.childIDs = append(info.childIDs, s)
+					parentOf[s] = id
+				}
+			}
+		}
+		nodeMap[id] = info
+	}
+
+	// Total = max running count across all nodes (root often has 0; top real node has the max).
+	totalSamples := 0
+	for _, n := range nodeMap {
+		if n.running > totalSamples {
+			totalSamples = n.running
+		}
+	}
+
+	// Find leaves sorted by running samples.
+	var leaves []*nodeInfo
+	for _, n := range nodeMap {
+		if len(n.childIDs) == 0 && n.label != "" {
+			leaves = append(leaves, n)
+		}
+	}
+	sort.Slice(leaves, func(i, j int) bool { return leaves[i].running > leaves[j].running })
+	if len(leaves) > 5 {
+		leaves = leaves[:5]
+	}
+
+	paths := make([]map[string]interface{}, 0, len(leaves))
+	for _, leaf := range leaves {
+		chain := traceToRoot(leaf.id, rootID, nodeMap, parentOf)
+		pct := 0.0
+		if totalSamples > 0 {
+			pct = float64(leaf.running) / float64(totalSamples) * 100
+		}
+		paths = append(paths, map[string]interface{}{
+			"path":           strings.Join(chain, " → "),
+			"runningSamples": leaf.running,
+			"pct":            fmt.Sprintf("%.1f%%", pct),
+		})
+	}
+	return paths
+}
+
+func traceToRoot(leafID, rootID string, nodes map[string]*nodeInfo, parentOf map[string]string) []string {
+	var chain []string
+	cur := leafID
+	for cur != "" && cur != rootID {
+		n := nodes[cur]
+		if n == nil {
+			break
+		}
+		if n.label != "" {
+			chain = append(chain, n.label)
+		}
+		cur = parentOf[cur]
+	}
+	// reverse: root → leaf
+	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
+		chain[i], chain[j] = chain[j], chain[i]
+	}
+	return chain
+}
+
+// --- helpers ---
+
+func dataNodes(result map[string]interface{}) []interface{} {
+	if result == nil {
+		return nil
+	}
+	nodes, _ := result["dataNodes"].([]interface{})
+	return nodes
+}
+
+func nodeLabel(n map[string]interface{}) string {
+	cp, _ := n["classPath"].(string)
+	cn, _ := n["className"].(string)
+	mn, _ := n["methodName"].(string)
+	if cn == "" || mn == "" {
+		return ""
+	}
+	if cp != "" {
+		return cp + "." + cn + "." + mn + "()"
+	}
+	return cn + "." + mn + "()"
+}
+
+func nodeClass(n map[string]interface{}) string {
+	cp, _ := n["classPath"].(string)
+	cn, _ := n["className"].(string)
+	if cp != "" {
+		return cp + "." + cn
+	}
+	return cn
+}
+
+func nodeMethod(n map[string]interface{}) string {
+	mn, _ := n["methodName"].(string)
+	return mn + "()"
+}
+
+func nodeSamples(n map[string]interface{}) map[string]int {
+	out := map[string]int{"RUNNING": 0, "LOCK": 0, "NET_IO": 0, "DISK_IO": 0, "WAIT": 0}
+	s, ok := n["samples"].(map[string]interface{})
+	if !ok {
+		return out
+	}
+	for k := range out {
+		if v, ok := s[k].(float64); ok {
+			out[k] = int(v)
+		}
+	}
+	return out
+}
+
+func nodeIDStr(v interface{}) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case float64:
+		return fmt.Sprintf("%g", x)
+	}
+	return ""
+}
+
+func strVal(m map[string]interface{}, key string) string {
+	v, _ := m[key].(string)
+	return v
+}
+
+func intVal(m map[string]interface{}, key string) int {
+	v, _ := m[key].(float64)
+	return int(v)
+}

--- a/pkg/resources/profile/enrich.go
+++ b/pkg/resources/profile/enrich.go
@@ -47,6 +47,24 @@ func EnrichResult(kind string, raw interface{}) interface{} {
 	return top
 }
 
+// LimitRows truncates rows to n if n > 0.
+func LimitRows(rows interface{}, n int) interface{} {
+	if n <= 0 {
+		return rows
+	}
+	switch v := rows.(type) {
+	case []HotspotRow:
+		if n < len(v) {
+			return v[:n]
+		}
+	case []MemoryTypeRow:
+		if n < len(v) {
+			return v[:n]
+		}
+	}
+	return rows
+}
+
 // ToTableRows converts a profile result to a slice of table-renderable rows.
 // Returns nil if the kind/data isn't suited for table display.
 func ToTableRows(kind string, raw interface{}) interface{} {

--- a/pkg/resources/profile/flamegraph.go
+++ b/pkg/resources/profile/flamegraph.go
@@ -1,0 +1,203 @@
+package profile
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+const minBlockWidth = 3 // blocks narrower than this are skipped
+
+// ToFlamegraph renders a Unicode flamegraph for hotspot/thread kinds.
+// Returns an empty string for unsupported kinds or missing data.
+func ToFlamegraph(kind string, raw interface{}, width int) string {
+	if kind != "methodHotspots" && kind != "threadAnalysis" {
+		return ""
+	}
+	top, ok := raw.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	result, _ := top["result"].(map[string]interface{})
+	nodes := dataNodes(result)
+	if len(nodes) == 0 {
+		return ""
+	}
+
+	rootID := nodeIDStr(result["dataRootNodeId"])
+
+	type fgNode struct {
+		id       string
+		label    string
+		running  int
+		children []*fgNode
+		startX   int
+		endX     int
+		depth    int
+	}
+
+	nodeMap := make(map[string]*fgNode, len(nodes))
+	for _, n := range nodes {
+		nm, ok := n.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id := nodeIDStr(nm["id"])
+		nodeMap[id] = &fgNode{
+			id:      id,
+			label:   fgLabel(nm),
+			running: nodeSamples(nm)["RUNNING"],
+		}
+	}
+	for _, n := range nodes {
+		nm, ok := n.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		parent := nodeMap[nodeIDStr(nm["id"])]
+		if cids, ok := nm["childIds"].([]interface{}); ok {
+			for _, c := range cids {
+				if s, ok := c.(string); ok {
+					if child := nodeMap[s]; child != nil {
+						parent.children = append(parent.children, child)
+					}
+				}
+			}
+		}
+	}
+
+	root := nodeMap[rootID]
+	if root == nil {
+		return ""
+	}
+
+	total := root.running
+	if total == 0 {
+		for _, c := range root.children {
+			total += c.running
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+
+	// Assign x positions recursively; children share parent's range proportionally.
+	var assignX func(n *fgNode, depth int)
+	assignX = func(n *fgNode, depth int) {
+		n.depth = depth
+		sort.Slice(n.children, func(i, j int) bool {
+			return n.children[i].running > n.children[j].running
+		})
+		x := n.startX
+		for _, child := range n.children {
+			w := int(float64(child.running) / float64(total) * float64(width))
+			if w < 1 && child.running > 0 {
+				w = 1
+			}
+			child.startX = x
+			child.endX = x + w
+			x += w
+			assignX(child, depth+1)
+		}
+	}
+	root.startX = 0
+	root.endX = width
+	assignX(root, 0)
+
+	// Collect nodes by depth level; skip virtual root (empty label) and too-narrow blocks.
+	maxDepth := 0
+	for _, n := range nodeMap {
+		if n.depth > maxDepth {
+			maxDepth = n.depth
+		}
+	}
+	levels := make([][]*fgNode, maxDepth+1)
+	for _, n := range nodeMap {
+		if n.label == "" {
+			continue
+		}
+		if n.endX-n.startX < minBlockWidth {
+			continue
+		}
+		levels[n.depth] = append(levels[n.depth], n)
+	}
+
+	// Render bottom-up (root level at bottom, leaves at top).
+	var sb strings.Builder
+	colorOn := output.ColorEnabled()
+	for d := maxDepth; d >= 0; d-- {
+		level := levels[d]
+		if len(level) == 0 {
+			continue
+		}
+		sort.Slice(level, func(i, j int) bool { return level[i].startX < level[j].startX })
+
+		cursor := 0
+		for _, n := range level {
+			w := n.endX - n.startX
+			if n.startX > cursor {
+				sb.WriteString(strings.Repeat(" ", n.startX-cursor))
+			}
+			label := centerLabel(n.label, w)
+			heat := float64(n.running) / float64(total)
+			if colorOn {
+				fmt.Fprintf(&sb, "\033[%sm%s\033[0m", heatColor(heat), label)
+			} else {
+				sb.WriteString(label)
+			}
+			cursor = n.endX
+		}
+		if cursor < width {
+			sb.WriteString(strings.Repeat(" ", width-cursor))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func truncate(s string, width int) string {
+	runes := []rune(s)
+	if len(runes) <= width {
+		return s
+	}
+	if width <= 1 {
+		return string(runes[:width])
+	}
+	return string(runes[:width-1]) + "…"
+}
+
+// centerLabel produces a block of exactly `width` runes: label centered, padded with █.
+func centerLabel(label string, width int) string {
+	runes := []rune(label)
+	if len(runes) > width {
+		if width <= 1 {
+			return strings.Repeat("█", width)
+		}
+		runes = append(runes[:width-1], '…')
+	}
+	pad := width - len(runes)
+	left := pad / 2
+	right := pad - left
+	return strings.Repeat("█", left) + string(runes) + strings.Repeat("█", right)
+}
+
+// heatColor returns an ANSI 256-color fg code for a 0..1 heat value (blue → red).
+func heatColor(heat float64) string {
+	stops := []int{21, 33, 39, 46, 82, 226, 214, 208, 202, 196}
+	idx := int(heat * float64(len(stops)-1))
+	if idx >= len(stops) {
+		idx = len(stops) - 1
+	}
+	return fmt.Sprintf("38;5;%d", stops[idx])
+}
+
+func fgLabel(n map[string]interface{}) string {
+	cn, _ := n["className"].(string)
+	mn, _ := n["methodName"].(string)
+	if cn == "" || mn == "" {
+		return ""
+	}
+	return cn + "." + mn + "()"
+}

--- a/pkg/resources/profile/profile.go
+++ b/pkg/resources/profile/profile.go
@@ -1,0 +1,76 @@
+package profile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	sdkae "github.com/dynatrace-oss/dtctl/sdk/api/appengine"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+const (
+	DefaultAppID = "dynatrace.profiling"
+	functionName = "codeLevelAnalysis"
+)
+
+// Kind maps user-facing shorthand to the API kind strings.
+var Kind = map[string]string{
+	"hotspots":       "methodHotspots",
+	"threads":        "threadAnalysis",
+	"memory":         "memoryAllocation",
+	"memory-details": "memoryAllocationDetails",
+}
+
+type Payload struct {
+	Kind            string `json:"kind"`
+	EntityID        string `json:"entityId"`
+	From            int64  `json:"from"`
+	To              int64  `json:"to"`
+	ServiceFilter   string `json:"serviceFilter,omitempty"`
+	ShowWaiting     bool   `json:"showWaiting,omitempty"`
+	ProblemID       string `json:"problemId,omitempty"`
+	SurvivorsOnly   bool   `json:"survivorsOnly,omitempty"`
+	TypeFilter      string `json:"typeFilter,omitempty"`
+	APIFilter       string `json:"apiFilter,omitempty"`
+	MethodFQNFilter string `json:"methodFqnFilter,omitempty"`
+	Type            string `json:"type,omitempty"`
+	Method          string `json:"method,omitempty"`
+}
+
+type Handler struct {
+	fn *sdkae.FunctionHandler
+}
+
+func NewHandler(c *client.Client) *Handler {
+	return &Handler{fn: sdkae.NewFunctionHandler(httpclient.Wrap(c.HTTP()))}
+}
+
+func (h *Handler) Run(ctx context.Context, appID string, p Payload) (interface{}, error) {
+	body, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("profile: marshal payload: %w", err)
+	}
+
+	resp, err := h.fn.InvokeFunction(ctx, &sdkae.FunctionInvokeRequest{
+		Method:       "POST",
+		AppID:        appID,
+		FunctionName: functionName,
+		Payload:      string(body),
+		Headers:      map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("profile: %w", err)
+	}
+
+	if resp.RawBody != nil {
+		return resp.RawBody, nil
+	}
+	var result interface{}
+	if err := json.Unmarshal([]byte(resp.Body), &result); err != nil {
+		return resp.Body, nil
+	}
+	return result, nil
+}
+

--- a/pkg/resources/profile/profile.go
+++ b/pkg/resources/profile/profile.go
@@ -2,75 +2,29 @@ package profile
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
-	sdkae "github.com/dynatrace-oss/dtctl/sdk/api/appengine"
+	sdkcla "github.com/dynatrace-oss/dtctl/sdk/api/codelevelanalysis"
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
 )
 
-const (
-	DefaultAppID = "dynatrace.profiling"
-	functionName = "codeLevelAnalysis"
-)
+// Kind maps user-facing shorthand to API kind strings.
+var Kind = sdkcla.Kind
 
-// Kind maps user-facing shorthand to the API kind strings.
-var Kind = map[string]string{
-	"hotspots":       "methodHotspots",
-	"threads":        "threadAnalysis",
-	"memory":         "memoryAllocation",
-	"memory-details": "memoryAllocationDetails",
-}
+// Payload is the analysis request; re-exported from the SDK for CLI use.
+type Payload = sdkcla.Payload
 
-type Payload struct {
-	Kind            string `json:"kind"`
-	EntityID        string `json:"entityId"`
-	From            int64  `json:"from"`
-	To              int64  `json:"to"`
-	ServiceFilter   string `json:"serviceFilter,omitempty"`
-	ShowWaiting     bool   `json:"showWaiting,omitempty"`
-	ProblemID       string `json:"problemId,omitempty"`
-	SurvivorsOnly   bool   `json:"survivorsOnly,omitempty"`
-	TypeFilter      string `json:"typeFilter,omitempty"`
-	APIFilter       string `json:"apiFilter,omitempty"`
-	MethodFQNFilter string `json:"methodFqnFilter,omitempty"`
-	Type            string `json:"type,omitempty"`
-	Method          string `json:"method,omitempty"`
-}
+// Response is the analysis result; re-exported from the SDK for CLI use.
+type Response = sdkcla.Response
 
 type Handler struct {
-	fn *sdkae.FunctionHandler
+	sdk *sdkcla.Handler
 }
 
 func NewHandler(c *client.Client) *Handler {
-	return &Handler{fn: sdkae.NewFunctionHandler(httpclient.Wrap(c.HTTP()))}
+	return &Handler{sdk: sdkcla.NewHandler(httpclient.Wrap(c.HTTP()))}
 }
 
-func (h *Handler) Run(ctx context.Context, appID string, p Payload) (interface{}, error) {
-	body, err := json.Marshal(p)
-	if err != nil {
-		return nil, fmt.Errorf("profile: marshal payload: %w", err)
-	}
-
-	resp, err := h.fn.InvokeFunction(ctx, &sdkae.FunctionInvokeRequest{
-		Method:       "POST",
-		AppID:        appID,
-		FunctionName: functionName,
-		Payload:      string(body),
-		Headers:      map[string]string{"Content-Type": "application/json"},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("profile: %w", err)
-	}
-
-	if resp.RawBody != nil {
-		return resp.RawBody, nil
-	}
-	var result interface{}
-	if err := json.Unmarshal([]byte(resp.Body), &result); err != nil {
-		return resp.Body, nil
-	}
-	return result, nil
+func (h *Handler) Run(ctx context.Context, p Payload) (*Response, error) {
+	return h.sdk.Run(ctx, p)
 }
-

--- a/pkg/resources/profile/stacktree.go
+++ b/pkg/resources/profile/stacktree.go
@@ -1,0 +1,265 @@
+package profile
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// ToStackTree renders the full call tree with resolved labels and per-node sample counts.
+// Unlike -o tree it applies no threshold filtering and shows all sample types.
+// appPrefix is the only package root shown when --app-only is set.
+const appPrefix = "com.dynatrace."
+
+func isSystemFrame(label string) bool {
+	return !strings.HasPrefix(label, appPrefix)
+}
+
+// commonDotPrefix returns the longest shared dot-segment prefix across all labels.
+func commonDotPrefix(labels []string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	segs := strings.Split(labels[0], ".")
+	for _, l := range labels[1:] {
+		ls := strings.Split(l, ".")
+		i := 0
+		for i < len(segs) && i < len(ls) && segs[i] == ls[i] {
+			i++
+		}
+		segs = segs[:i]
+	}
+	// Keep only package segments (drop the last segment if it looks like a Class).
+	// A segment is a package part if it's all lowercase.
+	end := len(segs)
+	for end > 0 && len(segs[end-1]) > 0 && segs[end-1][0] >= 'A' && segs[end-1][0] <= 'Z' {
+		end--
+	}
+	segs = segs[:end]
+	if len(segs) == 0 {
+		return ""
+	}
+	return strings.Join(segs, ".") + "."
+}
+
+func ToStackTree(kind string, raw interface{}, width, maxDepth int, appOnly bool) string {
+	if kind != "methodHotspots" && kind != "threadAnalysis" {
+		return ""
+	}
+	top, ok := raw.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	result, _ := top["result"].(map[string]interface{})
+	nodes := dataNodes(result)
+	if len(nodes) == 0 {
+		return ""
+	}
+
+	rootID := nodeIDStr(result["dataRootNodeId"])
+
+	type stNode struct {
+		id       string
+		label    string
+		samples  map[string]int
+		children []*stNode
+	}
+
+	nodeMap := make(map[string]*stNode, len(nodes))
+	for _, n := range nodes {
+		nm, ok := n.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id := nodeIDStr(nm["id"])
+		nodeMap[id] = &stNode{
+			id:      id,
+			label:   nodeLabel(nm),
+			samples: nodeSamples(nm),
+		}
+	}
+	for _, n := range nodes {
+		nm, ok := n.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		parent := nodeMap[nodeIDStr(nm["id"])]
+		if cids, ok := nm["childIds"].([]interface{}); ok {
+			for _, c := range cids {
+				if s, ok := c.(string); ok {
+					if child := nodeMap[s]; child != nil {
+						parent.children = append(parent.children, child)
+					}
+				}
+			}
+		}
+	}
+
+	root := nodeMap[rootID]
+	if root == nil {
+		return ""
+	}
+
+	total := root.samples["RUNNING"]
+	if total == 0 {
+		for _, c := range root.children {
+			total += c.samples["RUNNING"]
+		}
+	}
+
+	var sortChildren func(n *stNode)
+	sortChildren = func(n *stNode) {
+		sort.Slice(n.children, func(i, j int) bool {
+			return n.children[i].samples["RUNNING"] > n.children[j].samples["RUNNING"]
+		})
+		for _, c := range n.children {
+			sortChildren(c)
+		}
+	}
+	sortChildren(root)
+
+	colorOn := output.ColorEnabled()
+
+	// sample type display order with colors matching bars.go
+	type sampleDef struct{ key, short, color string }
+	sampleDefs := []sampleDef{
+		{"RUNNING", "R", "39"},
+		{"LOCK", "L", "196"},
+		{"NET_IO", "N", "226"},
+		{"DISK_IO", "D", "46"},
+		{"WAIT", "W", "244"},
+	}
+
+	formatSamples := func(s map[string]int) string {
+		var parts []string
+		for _, def := range sampleDefs {
+			v := s[def.key]
+			if v == 0 {
+				continue
+			}
+			if colorOn {
+				parts = append(parts, fmt.Sprintf("\033[38;5;%sm%s\033[0m:%d", def.color, def.short, v))
+			} else {
+				parts = append(parts, fmt.Sprintf("%s:%d", def.short, v))
+			}
+		}
+		if len(parts) == 0 {
+			return ""
+		}
+		return "  [" + strings.Join(parts, "  ") + "]"
+	}
+
+	// Collect visible labels to find the longest common package prefix to strip.
+	var visibleLabels []string
+	var collectLabels func(n *stNode)
+	collectLabels = func(n *stNode) {
+		if n.label != "" && n.id != rootID && !(appOnly && isSystemFrame(n.label)) {
+			visibleLabels = append(visibleLabels, n.label)
+		}
+		for _, c := range n.children {
+			collectLabels(c)
+		}
+	}
+	collectLabels(root)
+	stripPrefix := commonDotPrefix(visibleLabels)
+
+	var sb strings.Builder
+	if stripPrefix != "" {
+		if colorOn {
+			fmt.Fprintf(&sb, "\033[2m[%s]\033[0m\n", stripPrefix)
+		} else {
+			fmt.Fprintf(&sb, "[%s]\n", stripPrefix)
+		}
+	}
+
+	// dfs(n, prefix, connector):
+	//   prefix   — continuation lines already established by ancestors
+	//   connector — "├─ ", "└─ ", or "↳  " (always 3 visible chars wide)
+	//
+	// Single-child chains use "↳  " and do NOT grow the prefix, so indentation
+	// only increases at real forks.
+	var dfs func(n *stNode, prefix, connector string, depth int)
+	dfs = func(n *stNode, prefix, connector string, depth int) {
+		if maxDepth > 0 && depth > maxDepth {
+			return
+		}
+		// skip virtual root
+		if n.label == "" && n.id == rootID {
+			for i, c := range n.children {
+				conn := "├─ "
+				if i == len(n.children)-1 {
+					conn = "└─ "
+				}
+				dfs(c, "", conn, depth+1)
+			}
+			return
+		}
+
+		if appOnly && isSystemFrame(n.label) {
+			// transparent: pass children through without rendering this node
+			switch len(n.children) {
+			case 1:
+				dfs(n.children[0], prefix, connector, depth)
+			default:
+				var childBase string
+				if connector == "├─ " {
+					childBase = prefix + "│  "
+				} else {
+					childBase = prefix + "   "
+				}
+				for i, c := range n.children {
+					conn := "├─ "
+					if i == len(n.children)-1 {
+						conn = "└─ "
+					}
+					dfs(c, childBase, conn, depth)
+				}
+			}
+			return
+		}
+
+		label := strings.TrimPrefix(n.label, stripPrefix)
+		samples := formatSamples(n.samples)
+
+		fmt.Fprintf(&sb, "%s%s%s%s\n", prefix, connector, label, samples)
+
+		switch len(n.children) {
+		case 0:
+			// leaf
+		case 1:
+			// single child: no new indent, use ↳ — but still advance the
+			// prefix for the parent's branch line if this was a non-last fork arm.
+			var childPrefix string
+			switch connector {
+			case "├─ ":
+				childPrefix = prefix + "│  "
+			case "└─ ":
+				childPrefix = prefix + "   "
+			default: // "↳  " — already collapsed, prefix stays put
+				childPrefix = prefix
+			}
+			dfs(n.children[0], childPrefix, "↳  ", depth+1)
+		default:
+			// real fork: indent under this node
+			var childBase string
+			switch connector {
+			case "├─ ":
+				childBase = prefix + "│  "
+			default: // "└─ " or "↳  "
+				childBase = prefix + "   "
+			}
+			for i, c := range n.children {
+				conn := "├─ "
+				if i == len(n.children)-1 {
+					conn = "└─ "
+				}
+				dfs(c, childBase, conn, depth+1)
+			}
+		}
+	}
+
+	dfs(root, "", "", 0)
+	return sb.String()
+}

--- a/pkg/resources/profile/stacktree.go
+++ b/pkg/resources/profile/stacktree.go
@@ -8,8 +8,6 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 )
 
-// ToStackTree renders the full call tree with resolved labels and per-node sample counts.
-// Unlike -o tree it applies no threshold filtering and shows all sample types.
 // appPrefix is the only package root shown when --app-only is set.
 const appPrefix = "com.dynatrace."
 
@@ -17,34 +15,26 @@ func isSystemFrame(label string) bool {
 	return !strings.HasPrefix(label, appPrefix)
 }
 
-// commonDotPrefix returns the longest shared dot-segment prefix across all labels.
-func commonDotPrefix(labels []string) string {
-	if len(labels) == 0 {
-		return ""
-	}
-	segs := strings.Split(labels[0], ".")
-	for _, l := range labels[1:] {
-		ls := strings.Split(l, ".")
-		i := 0
-		for i < len(segs) && i < len(ls) && segs[i] == ls[i] {
-			i++
+// abbreviateLabel shortens each lowercase package segment to its first character,
+// leaving class names (uppercase-initial) and the method suffix intact.
+// e.g. com.dynatrace.easytravel.business.webservice.JourneyService.findJourneys()
+//   →  c.d.e.b.w.JourneyService.findJourneys()
+func abbreviateLabel(label string) string {
+	segs := strings.Split(label, ".")
+	out := make([]string, 0, len(segs))
+	for _, s := range segs {
+		if len(s) > 0 && s[0] >= 'a' && s[0] <= 'z' {
+			out = append(out, string(s[0]))
+		} else {
+			out = append(out, s)
 		}
-		segs = segs[:i]
 	}
-	// Keep only package segments (drop the last segment if it looks like a Class).
-	// A segment is a package part if it's all lowercase.
-	end := len(segs)
-	for end > 0 && len(segs[end-1]) > 0 && segs[end-1][0] >= 'A' && segs[end-1][0] <= 'Z' {
-		end--
-	}
-	segs = segs[:end]
-	if len(segs) == 0 {
-		return ""
-	}
-	return strings.Join(segs, ".") + "."
+	return strings.Join(out, ".")
 }
 
-func ToStackTree(kind string, raw interface{}, width, maxDepth int, appOnly bool) string {
+// ToStackTree renders the full call tree with resolved labels and per-node sample counts.
+// Unlike -o tree it applies no threshold filtering and shows all sample types.
+func ToStackTree(kind string, raw interface{}, width, maxDepth int, appOnly, abbrev bool) string {
 	if kind != "methodHotspots" && kind != "threadAnalysis" {
 		return ""
 	}
@@ -102,13 +92,6 @@ func ToStackTree(kind string, raw interface{}, width, maxDepth int, appOnly bool
 		return ""
 	}
 
-	total := root.samples["RUNNING"]
-	if total == 0 {
-		for _, c := range root.children {
-			total += c.samples["RUNNING"]
-		}
-	}
-
 	var sortChildren func(n *stNode)
 	sortChildren = func(n *stNode) {
 		sort.Slice(n.children, func(i, j int) bool {
@@ -122,7 +105,6 @@ func ToStackTree(kind string, raw interface{}, width, maxDepth int, appOnly bool
 
 	colorOn := output.ColorEnabled()
 
-	// sample type display order with colors matching bars.go
 	type sampleDef struct{ key, short, color string }
 	sampleDefs := []sampleDef{
 		{"RUNNING", "R", "39"},
@@ -135,14 +117,12 @@ func ToStackTree(kind string, raw interface{}, width, maxDepth int, appOnly bool
 	formatSamples := func(s map[string]int) string {
 		var parts []string
 		for _, def := range sampleDefs {
-			v := s[def.key]
-			if v == 0 {
-				continue
-			}
-			if colorOn {
-				parts = append(parts, fmt.Sprintf("\033[38;5;%sm%s\033[0m:%d", def.color, def.short, v))
-			} else {
-				parts = append(parts, fmt.Sprintf("%s:%d", def.short, v))
+			if v := s[def.key]; v != 0 {
+				if colorOn {
+					parts = append(parts, fmt.Sprintf("\033[38;5;%sm%s\033[0m:%d", def.color, def.short, v))
+				} else {
+					parts = append(parts, fmt.Sprintf("%s:%d", def.short, v))
+				}
 			}
 		}
 		if len(parts) == 0 {
@@ -151,41 +131,15 @@ func ToStackTree(kind string, raw interface{}, width, maxDepth int, appOnly bool
 		return "  [" + strings.Join(parts, "  ") + "]"
 	}
 
-	// Collect visible labels to find the longest common package prefix to strip.
-	var visibleLabels []string
-	var collectLabels func(n *stNode)
-	collectLabels = func(n *stNode) {
-		if n.label != "" && n.id != rootID && !(appOnly && isSystemFrame(n.label)) {
-			visibleLabels = append(visibleLabels, n.label)
-		}
-		for _, c := range n.children {
-			collectLabels(c)
-		}
-	}
-	collectLabels(root)
-	stripPrefix := commonDotPrefix(visibleLabels)
-
 	var sb strings.Builder
-	if stripPrefix != "" {
-		if colorOn {
-			fmt.Fprintf(&sb, "\033[2m[%s]\033[0m\n", stripPrefix)
-		} else {
-			fmt.Fprintf(&sb, "[%s]\n", stripPrefix)
-		}
-	}
 
-	// dfs(n, prefix, connector):
-	//   prefix   — continuation lines already established by ancestors
-	//   connector — "├─ ", "└─ ", or "↳  " (always 3 visible chars wide)
-	//
-	// Single-child chains use "↳  " and do NOT grow the prefix, so indentation
-	// only increases at real forks.
 	var dfs func(n *stNode, prefix, connector string, depth int)
 	dfs = func(n *stNode, prefix, connector string, depth int) {
 		if maxDepth > 0 && depth > maxDepth {
 			return
 		}
-		// skip virtual root
+
+		// Virtual root: recurse directly into children.
 		if n.label == "" && n.id == rootID {
 			for i, c := range n.children {
 				conn := "├─ "
@@ -197,8 +151,8 @@ func ToStackTree(kind string, raw interface{}, width, maxDepth int, appOnly bool
 			return
 		}
 
+		// System frame passthrough (appOnly mode).
 		if appOnly && isSystemFrame(n.label) {
-			// transparent: pass children through without rendering this node
 			switch len(n.children) {
 			case 1:
 				dfs(n.children[0], prefix, connector, depth)
@@ -220,34 +174,30 @@ func ToStackTree(kind string, raw interface{}, width, maxDepth int, appOnly bool
 			return
 		}
 
-		label := strings.TrimPrefix(n.label, stripPrefix)
-		samples := formatSamples(n.samples)
-
-		fmt.Fprintf(&sb, "%s%s%s%s\n", prefix, connector, label, samples)
+		label := n.label
+		if abbrev {
+			label = abbreviateLabel(label)
+		}
+		fmt.Fprintf(&sb, "%s%s%s%s\n", prefix, connector, label, formatSamples(n.samples))
 
 		switch len(n.children) {
 		case 0:
-			// leaf
 		case 1:
-			// single child: no new indent, use ↳ — but still advance the
-			// prefix for the parent's branch line if this was a non-last fork arm.
 			var childPrefix string
 			switch connector {
 			case "├─ ":
 				childPrefix = prefix + "│  "
 			case "└─ ":
 				childPrefix = prefix + "   "
-			default: // "↳  " — already collapsed, prefix stays put
+			default: // "↳  "
 				childPrefix = prefix
 			}
 			dfs(n.children[0], childPrefix, "↳  ", depth+1)
 		default:
-			// real fork: indent under this node
 			var childBase string
-			switch connector {
-			case "├─ ":
+			if connector == "├─ " {
 				childBase = prefix + "│  "
-			default: // "└─ " or "↳  "
+			} else {
 				childBase = prefix + "   "
 			}
 			for i, c := range n.children {

--- a/pkg/resources/profile/tree.go
+++ b/pkg/resources/profile/tree.go
@@ -1,0 +1,150 @@
+package profile
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+const treeMinPct = 0.5 // skip nodes below this % of total
+
+// ToTree renders an indented call-tree for hotspot/thread kinds.
+func ToTree(kind string, raw interface{}, width int) string {
+	if kind != "methodHotspots" && kind != "threadAnalysis" {
+		return ""
+	}
+	top, ok := raw.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	result, _ := top["result"].(map[string]interface{})
+	nodes := dataNodes(result)
+	if len(nodes) == 0 {
+		return ""
+	}
+
+	rootID := nodeIDStr(result["dataRootNodeId"])
+
+	type tNode struct {
+		id       string
+		label    string
+		running  int
+		children []*tNode
+	}
+
+	nodeMap := make(map[string]*tNode, len(nodes))
+	for _, n := range nodes {
+		nm, ok := n.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id := nodeIDStr(nm["id"])
+		nodeMap[id] = &tNode{
+			id:      id,
+			label:   fgLabel(nm),
+			running: nodeSamples(nm)["RUNNING"],
+		}
+	}
+	for _, n := range nodes {
+		nm, ok := n.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		parent := nodeMap[nodeIDStr(nm["id"])]
+		if cids, ok := nm["childIds"].([]interface{}); ok {
+			for _, c := range cids {
+				if s, ok := c.(string); ok {
+					if child := nodeMap[s]; child != nil {
+						parent.children = append(parent.children, child)
+					}
+				}
+			}
+		}
+	}
+
+	root := nodeMap[rootID]
+	if root == nil {
+		return ""
+	}
+
+	total := root.running
+	if total == 0 {
+		for _, c := range root.children {
+			total += c.running
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+
+	var sortChildren func(n *tNode)
+	sortChildren = func(n *tNode) {
+		sort.Slice(n.children, func(i, j int) bool {
+			return n.children[i].running > n.children[j].running
+		})
+		for _, c := range n.children {
+			sortChildren(c)
+		}
+	}
+	sortChildren(root)
+
+	colorOn := output.ColorEnabled()
+	const nameWidth = 45
+	const miniBar = 10
+
+	var sb strings.Builder
+	var dfs func(n *tNode, prefix string, isLast bool)
+	dfs = func(n *tNode, prefix string, isLast bool) {
+		// virtual root: skip to children
+		if n.label == "" && n.id == rootID {
+			for i, c := range n.children {
+				dfs(c, "", i == len(n.children)-1)
+			}
+			return
+		}
+
+		pct := float64(n.running) / float64(total) * 100
+		if pct < treeMinPct {
+			return
+		}
+
+		connector := "├─ "
+		if isLast {
+			connector = "└─ "
+		}
+
+		label := truncate(n.label, nameWidth)
+		labelPad := nameWidth - len([]rune(label))
+		filled := int(pct / 100 * float64(miniBar))
+		bar := strings.Repeat("█", filled) + strings.Repeat("░", miniBar-filled)
+
+		if colorOn {
+			heat := pct / 100
+			fmt.Fprintf(&sb, "%s%s%s%s  %5d  %5.1f%%  \033[%sm%s\033[0m\n",
+				prefix, connector, label, strings.Repeat(" ", labelPad),
+				n.running, pct,
+				heatColor(heat), bar,
+			)
+		} else {
+			fmt.Fprintf(&sb, "%s%s%s%s  %5d  %5.1f%%  %s\n",
+				prefix, connector, label, strings.Repeat(" ", labelPad),
+				n.running, pct, bar,
+			)
+		}
+
+		childPrefix := prefix
+		if isLast {
+			childPrefix += "   "
+		} else {
+			childPrefix += "│  "
+		}
+		for i, c := range n.children {
+			dfs(c, childPrefix, i == len(n.children)-1)
+		}
+	}
+
+	dfs(root, "", true)
+	return sb.String()
+}

--- a/sdk/api/codelevelanalysis/codelevelanalysis.go
+++ b/sdk/api/codelevelanalysis/codelevelanalysis.go
@@ -1,0 +1,205 @@
+package codelevelanalysis
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+const (
+	basePath        = "/platform-reserved/codelevelanalysis/v0.1"
+	pollInterval    = 1500 * time.Millisecond
+	maxPollAttempts = 40
+	maxPollErrors   = 40
+)
+
+// Kind maps user-facing shorthand to the API kind strings.
+var Kind = map[string]string{
+	"hotspots":       "methodHotspots",
+	"threads":        "threadAnalysis",
+	"memory":         "memoryAllocation",
+	"memory-details": "memoryAllocationDetails",
+}
+
+type Payload struct {
+	Kind            string `json:"kind"`
+	EntityID        string `json:"entityId"`
+	From            int64  `json:"from"`
+	To              int64  `json:"to"`
+	ServiceFilter   string `json:"serviceFilter,omitempty"`
+	ShowWaiting     bool   `json:"showWaiting,omitempty"`
+	ProblemID       string `json:"problemId,omitempty"`
+	SurvivorsOnly   bool   `json:"survivorsOnly,omitempty"`
+	TypeFilter      string `json:"typeFilter,omitempty"`
+	APIFilter       string `json:"apiFilter,omitempty"`
+	MethodFQNFilter string `json:"methodFqnFilter,omitempty"`
+	Type            string `json:"type,omitempty"`
+	Method          string `json:"method,omitempty"`
+}
+
+type Response struct {
+	Status    string      `json:"status"` // "completed" | "no-data"
+	Kind      string      `json:"kind"`
+	EntityID  string      `json:"entityId"`
+	PollCount int         `json:"pollCount"`
+	Result    interface{} `json:"result"`
+}
+
+type progressToken struct {
+	Token string `json:"token"`
+}
+
+type Handler struct {
+	client *httpclient.Client
+}
+
+func NewHandler(c *httpclient.Client) *Handler {
+	return &Handler{client: c}
+}
+
+func (h *Handler) Run(ctx context.Context, p Payload) (*Response, error) {
+	if err := validate(p); err != nil {
+		return nil, err
+	}
+
+	submitPath := buildSubmitPath(p)
+	resp, err := h.client.HTTP().R().SetContext(ctx).Get(submitPath)
+	if err != nil {
+		return nil, fmt.Errorf("codelevelanalysis: submit: %w", err)
+	}
+	if err := httpclient.CheckResponse(resp); err != nil {
+		// Allow 202 through — CheckResponse only errors on 4xx/5xx
+		// so this path is only hit on genuine errors.
+		return nil, fmt.Errorf("codelevelanalysis: submit: %w", err)
+	}
+
+	if resp.StatusCode() == 200 {
+		return parseResult(p, 0, resp.Body())
+	}
+
+	// 202: async task started — extract token and poll
+	var pt progressToken
+	if err := json.Unmarshal(resp.Body(), &pt); err != nil || pt.Token == "" {
+		return nil, fmt.Errorf("codelevelanalysis: submit returned 202 without a progress token")
+	}
+	return h.poll(ctx, p, pt.Token)
+}
+
+func (h *Handler) poll(ctx context.Context, p Payload, token string) (*Response, error) {
+	resultPath := fmt.Sprintf("%s/result?token=%s", basePath, url.QueryEscape(token))
+	errCount := 0
+
+	for attempt := 1; attempt <= maxPollAttempts; attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(pollInterval):
+		}
+
+		resp, err := h.client.HTTP().R().SetContext(ctx).Get(resultPath)
+		if err != nil {
+			errCount++
+			if errCount >= maxPollErrors {
+				return nil, fmt.Errorf("codelevelanalysis: poll failed %d times (token %s): %w", maxPollErrors, token, err)
+			}
+			continue
+		}
+
+		sc := resp.StatusCode()
+		if sc != 200 && sc != 202 && sc != 204 {
+			errCount++
+			if errCount >= maxPollErrors {
+				return nil, fmt.Errorf("codelevelanalysis: poll returned %d %d times (token %s)", sc, maxPollErrors, token)
+			}
+			continue
+		}
+
+		if sc == 204 {
+			return &Response{Status: "no-data", Kind: p.Kind, EntityID: p.EntityID, PollCount: attempt}, nil
+		}
+		if sc == 200 {
+			return parseResult(p, attempt, resp.Body())
+		}
+		// 202: still running
+	}
+
+	return nil, fmt.Errorf("codelevelanalysis: analysis did not complete within %ds (token %s)",
+		int(maxPollAttempts*pollInterval/time.Second), token)
+}
+
+func parseResult(p Payload, pollCount int, body []byte) (*Response, error) {
+	var result interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("codelevelanalysis: parse result: %w", err)
+	}
+	return &Response{Status: "completed", Kind: p.Kind, EntityID: p.EntityID, PollCount: pollCount, Result: result}, nil
+}
+
+func validate(p Payload) error {
+	if p.EntityID == "" {
+		return fmt.Errorf("codelevelanalysis: entityId is required")
+	}
+	if p.From == 0 || p.To == 0 || p.To <= p.From {
+		return fmt.Errorf("codelevelanalysis: from/to must be epoch-millis with to > from")
+	}
+	if p.To-p.From > 2*60*60*1000 {
+		return fmt.Errorf("codelevelanalysis: timeframe must not exceed 2 hours")
+	}
+	if p.Kind == "memoryAllocationDetails" && (p.Type == "" || p.Method == "") {
+		return fmt.Errorf("codelevelanalysis: memoryAllocationDetails requires type and method")
+	}
+	return nil
+}
+
+func buildSubmitPath(p Payload) string {
+	params := url.Values{}
+	params.Set("from", fmt.Sprintf("%d", p.From))
+	params.Set("to", fmt.Sprintf("%d", p.To))
+	entity := url.PathEscape(p.EntityID)
+
+	setIfTrue := func(key string, v bool) {
+		if v {
+			params.Set(key, "true")
+		}
+	}
+	setIfSet := func(key, v string) {
+		if v != "" {
+			params.Set(key, v)
+		}
+	}
+
+	switch p.Kind {
+	case "methodHotspots", "threadAnalysis":
+		setIfSet("servicefilter", p.ServiceFilter)
+		setIfTrue("showWaiting", p.ShowWaiting)
+		path := "methodhotspots"
+		if p.Kind == "threadAnalysis" {
+			path = "threadanalysis"
+		}
+		return fmt.Sprintf("%s/%s/%s?%s", basePath, path, entity, params.Encode())
+
+	case "memoryAllocation":
+		setIfSet("problemId", p.ProblemID)
+		setIfTrue("survivorsOnly", p.SurvivorsOnly)
+		setIfSet("typeFilter", p.TypeFilter)
+		setIfSet("apiFilter", p.APIFilter)
+		setIfSet("methodFqnFilter", p.MethodFQNFilter)
+		return fmt.Sprintf("%s/memoryallocation/%s?%s", basePath, entity, params.Encode())
+
+	case "memoryAllocationDetails":
+		setIfSet("problemId", p.ProblemID)
+		setIfSet("type", p.Type)
+		setIfSet("method", p.Method)
+		setIfTrue("survivorsOnly", p.SurvivorsOnly)
+		setIfSet("typeFilter", p.TypeFilter)
+		setIfSet("apiFilter", p.APIFilter)
+		setIfSet("methodFqnFilter", p.MethodFQNFilter)
+		return fmt.Sprintf("%s/memoryallocationdetails/%s?%s", basePath, entity, params.Encode())
+	}
+
+	panic(fmt.Sprintf("codelevelanalysis: unsupported kind %q", p.Kind))
+}


### PR DESCRIPTION
## Summary

- Adds `dtctl exec profile` command for code-level profiling analysis via the Dynatrace code-level analysis API
- Supports four analysis kinds: `hotspots`, `threads`, `memory`, `memory-details`
- Polls asynchronously until analysis completes, with a spinner in TTY mode

## Output formats

| Flag | Description |
|------|-------------|
| `-o table` | Hotspot rows sorted by running samples; `--top N` to limit |
| `-o flamegraph` | Unicode flamegraph, bottom-up, heat-colored |
| `-o tree` | Indented call tree with % and mini-bar |
| `-o bars` | Per-type horizontal bars (running / lock / net / disk / wait) |
| `-o stacktree` | Full raw call tree with resolved labels and sample counts |

### `stacktree` flags

| Flag | Description |
|------|-------------|
| `--depth N` | Limit tree to N levels deep |
| `--app-only` | Show only `com.dynatrace.*` frames |
| `--abbrev` | Log4j-style package abbreviation (`com.example` → `c.e`) |

Single-child chains collapse with `↳` (no extra indent); indentation only grows at real forks.

## Test plan

- [ ] `dtctl exec profile --kind hotspots --entity SERVICE-xxx --last 1h`
- [ ] `-o flamegraph`, `-o tree`, `-o bars`, `-o stacktree`
- [ ] `--app-only --abbrev --depth 10` on stacktree
- [ ] `--top 10` on table output
- [ ] Memory kinds with `--survivors-only`, `--type`, `--method`

🤖 Generated with [Claude Code](https://claude.com/claude-code)