### PR TITLE
feat(query): request metric-metadata enrichment so timeseries metrics expose displayName/description/unit

### DIFF
--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -209,8 +209,24 @@ func buildExecuteRequest(query string, opts DQLExecuteOptions) sdkquery.ExecuteR
 	if len(opts.Segments) > 0 {
 		req.FilterSegments = opts.Segments
 	}
+	// Request metric-catalogue enrichment (displayName/description/unit on
+	// metadata.metrics[]) only when the caller actually wants metrics metadata.
+	if wantsMetricsMetadata(opts.MetadataFields) {
+		req.EnrichMetricMetadata = true
+	}
 
 	return req
+}
+
+// wantsMetricsMetadata reports whether the requested metadata fields include
+// metric metadata — either explicitly ("metrics") or via the "all" selector.
+func wantsMetricsMetadata(fields []string) bool {
+	for _, f := range fields {
+		if f == "all" || f == "metrics" {
+			return true
+		}
+	}
+	return false
 }
 
 // Execute executes a DQL query
@@ -589,6 +605,7 @@ func extractQueryMetadata(result *DQLQueryResponse) *output.QueryMetadata {
 			FieldName:   m.FieldName,
 			Aggregation: m.Aggregation,
 			DisplayName: m.DisplayName,
+			Description: m.Description,
 			Unit:        m.Unit,
 		})
 	}

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -1636,6 +1636,28 @@ func TestExtractQueryMetadata_NilMetadata_PrintPath(t *testing.T) {
 // metric descriptors) are extracted even when Grail metadata is absent — the two
 // are independent siblings of the response's metadata section, and a response
 // with metadata.metrics but no metadata.grail must not have its metrics dropped.
+func TestBuildExecuteRequest_EnrichMetricMetadataGating(t *testing.T) {
+	cases := []struct {
+		name   string
+		fields []string
+		want   bool
+	}{
+		{"no metadata", nil, false},
+		{"unrelated field", []string{"scannedRecords"}, false},
+		{"metrics selected", []string{"metrics"}, true},
+		{"metrics among others", []string{"scannedRecords", "metrics"}, true},
+		{"all selector", []string{"all"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := buildExecuteRequest("timeseries avg(dt.host.cpu.user)", DQLExecuteOptions{MetadataFields: tc.fields})
+			if req.EnrichMetricMetadata != tc.want {
+				t.Errorf("EnrichMetricMetadata = %v, want %v", req.EnrichMetricMetadata, tc.want)
+			}
+		})
+	}
+}
+
 func TestExtractQueryMetadata_MetricsWithoutGrail(t *testing.T) {
 	resp := &DQLQueryResponse{
 		State:   "SUCCEEDED",
@@ -1643,7 +1665,7 @@ func TestExtractQueryMetadata_MetricsWithoutGrail(t *testing.T) {
 		Metadata: &DQLMetadata{
 			Grail: nil,
 			Metrics: []MetricInfo{
-				{MetricKey: "dt.host.cpu.usage", FieldName: "avg(dt.host.cpu.usage)", Aggregation: "avg"},
+				{MetricKey: "dt.host.cpu.usage", FieldName: "avg(dt.host.cpu.usage)", Aggregation: "avg", DisplayName: "CPU usage", Description: "Average CPU usage across all cores", Unit: "Percent"},
 			},
 		},
 	}
@@ -1657,6 +1679,16 @@ func TestExtractQueryMetadata_MetricsWithoutGrail(t *testing.T) {
 	}
 	if meta.Metrics[0].MetricKey != "dt.host.cpu.usage" {
 		t.Errorf("expected MetricKey=dt.host.cpu.usage, got %q", meta.Metrics[0].MetricKey)
+	}
+	// Descriptor fields (displayName/description/unit) must be carried through the conversion.
+	if meta.Metrics[0].DisplayName != "CPU usage" {
+		t.Errorf("expected DisplayName=CPU usage, got %q", meta.Metrics[0].DisplayName)
+	}
+	if meta.Metrics[0].Description != "Average CPU usage across all cores" {
+		t.Errorf("expected Description to be carried through, got %q", meta.Metrics[0].Description)
+	}
+	if meta.Metrics[0].Unit != "Percent" {
+		t.Errorf("expected Unit=Percent, got %q", meta.Metrics[0].Unit)
 	}
 	// Grail-derived fields must remain zero-valued since Grail was absent.
 	if meta.QueryID != "" || meta.ExecutionTimeMilliseconds != 0 {

--- a/pkg/output/metadata.go
+++ b/pkg/output/metadata.go
@@ -46,12 +46,14 @@ type QueryMetadata struct {
 
 // MetricInfo describes a single metric referenced in a timeseries query result.
 // It maps the DQL column name (FieldName) to the underlying metric descriptor.
-// DisplayName and Unit are present only when the API returns metric catalogue data.
+// DisplayName, Description, and Unit are present only when the API returns metric
+// catalogue data.
 type MetricInfo struct {
 	MetricKey   string `json:"metric.key,omitempty" yaml:"metric.key,omitempty"`
 	FieldName   string `json:"fieldName,omitempty" yaml:"fieldName,omitempty"`
 	Aggregation string `json:"aggregation,omitempty" yaml:"aggregation,omitempty"`
 	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	Unit        string `json:"unit,omitempty" yaml:"unit,omitempty"`
 }
 
@@ -306,6 +308,9 @@ func FormatMetadataFooter(m *QueryMetadata, fields []string) string {
 			b.WriteString(line)
 			if mi.DisplayName != "" {
 				b.WriteString(fmt.Sprintf("    %s\n", mi.DisplayName))
+			}
+			if mi.Description != "" {
+				b.WriteString(fmt.Sprintf("    %s\n", mi.Description))
 			}
 		}
 	}

--- a/pkg/output/metadata_test.go
+++ b/pkg/output/metadata_test.go
@@ -919,7 +919,7 @@ func TestValidMetadataFieldNames_Sorted(t *testing.T) {
 func TestFormatMetadataFooter_Metrics(t *testing.T) {
 	meta := &QueryMetadata{
 		Metrics: []MetricInfo{
-			{MetricKey: "process.cpu.utilization", FieldName: "avg(process.cpu.utilization)", Aggregation: "avg", Unit: "Percent", DisplayName: "Process CPU Utilization"},
+			{MetricKey: "process.cpu.utilization", FieldName: "avg(process.cpu.utilization)", Aggregation: "avg", Unit: "Percent", DisplayName: "Process CPU Utilization", Description: "Percentage of CPU time consumed by the process"},
 			{MetricKey: "process.cpu.utilization", FieldName: "sum(process.cpu.utilization)", Aggregation: "sum"},
 		},
 	}
@@ -936,6 +936,9 @@ func TestFormatMetadataFooter_Metrics(t *testing.T) {
 	}
 	if !strings.Contains(result, "Process CPU Utilization") {
 		t.Errorf("expected display name, got:\n%s", result)
+	}
+	if !strings.Contains(result, "Percentage of CPU time consumed by the process") {
+		t.Errorf("expected description, got:\n%s", result)
 	}
 	// Without unit
 	if !strings.Contains(result, "sum(process.cpu.utilization) → process.cpu.utilization [sum]") {
@@ -999,7 +1002,7 @@ func TestMetadataToMap_Metrics(t *testing.T) {
 	meta := &QueryMetadata{
 		QueryID: "test-id",
 		Metrics: []MetricInfo{
-			{MetricKey: "process.cpu.utilization", FieldName: "avg(process.cpu.utilization)", Aggregation: "avg", Unit: "Percent"},
+			{MetricKey: "process.cpu.utilization", FieldName: "avg(process.cpu.utilization)", Aggregation: "avg", Unit: "Percent", Description: "Percentage of CPU time consumed by the process"},
 		},
 	}
 
@@ -1018,6 +1021,9 @@ func TestMetadataToMap_Metrics(t *testing.T) {
 	}
 	if len(metrics) != 1 || metrics[0].Unit != "Percent" {
 		t.Errorf("unexpected metrics value: %+v", metrics)
+	}
+	if metrics[0].Description != "Percentage of CPU time consumed by the process" {
+		t.Errorf("expected description to be preserved, got: %q", metrics[0].Description)
 	}
 
 	// When nil Metrics and "metrics" is selected, map must contain metrics:null

--- a/sdk/api/query/query.go
+++ b/sdk/api/query/query.go
@@ -76,7 +76,17 @@ type ExecuteRequest struct {
 	Locale                       string             `json:"locale,omitempty"`
 	Timezone                     string             `json:"timezone,omitempty"`
 	FilterSegments               []FilterSegmentRef `json:"filterSegments,omitempty"`
+
+	// EnrichMetricMetadata requests metric-catalogue enrichment of the response's
+	// metadata.metrics[] entries (displayName, description, unit). It is sent as the
+	// `enrich=metric-metadata` query-string parameter on both query:execute and
+	// query:poll — not in the request body — hence json:"-".
+	EnrichMetricMetadata bool `json:"-"`
 }
+
+// enrichMetricMetadataParam is the query-string value that asks the Grail query
+// API to enrich metadata.metrics[] with metric-catalogue fields.
+const enrichMetricMetadataParam = "metric-metadata"
 
 // Response represents a DQL query response from execute or poll.
 type Response struct {
@@ -113,13 +123,14 @@ type ColumnType struct {
 
 // MetricInfo describes a single metric referenced in a timeseries query result.
 // It maps the DQL column name (FieldName) to the underlying metric descriptor.
-// DisplayName and Unit are present only when the API returns metric catalogue data;
-// they are absent for tenants or queries that do not populate them.
+// DisplayName, Description, and Unit are present only when the API returns metric
+// catalogue data; they are absent for tenants or queries that do not populate them.
 type MetricInfo struct {
 	MetricKey   string `json:"metric.key,omitempty"`
 	FieldName   string `json:"fieldName,omitempty"`
 	Aggregation string `json:"aggregation,omitempty"`
 	DisplayName string `json:"displayName,omitempty"`
+	Description string `json:"description,omitempty"`
 	Unit        string `json:"unit,omitempty"`
 }
 
@@ -246,6 +257,9 @@ func (h *Handler) Execute(ctx context.Context, req ExecuteRequest) (*Response, e
 		SetHeader("Content-Type", "application/json").
 		SetBody(req).
 		SetResult(&result)
+	if req.EnrichMetricMetadata {
+		httpReq.SetQueryParam("enrich", enrichMetricMetadataParam)
+	}
 	h.applyHeaders(httpReq)
 
 	resp, err := httpReq.Post(basePath + ":execute")
@@ -266,14 +280,20 @@ func (h *Handler) Execute(ctx context.Context, req ExecuteRequest) (*Response, e
 }
 
 // Poll polls for the results of an asynchronous query. The server holds the
-// connection for up to timeoutMs milliseconds before returning.
-func (h *Handler) Poll(ctx context.Context, requestToken string, timeoutMs int64) (*Response, error) {
+// connection for up to timeoutMs milliseconds before returning. When enrich is
+// true, the poll requests metric-metadata enrichment so the final SUCCEEDED
+// response carries displayName/description/unit — it must match the enrichment
+// requested on the originating execute call.
+func (h *Handler) Poll(ctx context.Context, requestToken string, timeoutMs int64, enrich bool) (*Response, error) {
 	var result Response
 
 	httpReq := h.client.HTTP().R().SetContext(ctx).
 		SetQueryParam("request-token", requestToken).
 		SetQueryParam("request-timeout-milliseconds", fmt.Sprintf("%d", timeoutMs)).
 		SetResult(&result)
+	if enrich {
+		httpReq.SetQueryParam("enrich", enrichMetricMetadataParam)
+	}
 	h.applyHeaders(httpReq)
 
 	resp, err := httpReq.Get(basePath + ":poll")
@@ -384,7 +404,7 @@ func (h *Handler) ExecuteAndPoll(ctx context.Context, req ExecuteRequest, onUnau
 		default:
 		}
 
-		pollResult, pollErr := h.Poll(pollCtx, result.RequestToken, pollRequestTimeoutMs)
+		pollResult, pollErr := h.Poll(pollCtx, result.RequestToken, pollRequestTimeoutMs, req.EnrichMetricMetadata)
 		if pollErr != nil {
 			// On 401, try the onUnauthorized callback once per consecutive failure.
 			var apiErr *httpclient.APIError

--- a/sdk/api/query/query_test.go
+++ b/sdk/api/query/query_test.go
@@ -65,6 +65,65 @@ func TestExecute_Synchronous(t *testing.T) {
 	}
 }
 
+func TestExecuteAndPoll_EnrichMetricMetadata(t *testing.T) {
+	var execEnrich, pollEnrich string
+	var polled atomic.Bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/storage/query/v1/query:execute", func(w http.ResponseWriter, r *http.Request) {
+		execEnrich = r.URL.Query().Get("enrich")
+		resp := Response{State: "RUNNING", RequestToken: "tok-enrich"}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/platform/storage/query/v1/query:poll", func(w http.ResponseWriter, r *http.Request) {
+		pollEnrich = r.URL.Query().Get("enrich")
+		polled.Store(true)
+		resp := Response{
+			State: "SUCCEEDED",
+			Result: &Result{
+				Metadata: &Metadata{Metrics: []MetricInfo{{MetricKey: "dt.host.cpu.user", Unit: "%"}}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.ExecuteAndPoll(context.Background(), ExecuteRequest{Query: "timeseries avg(dt.host.cpu.user)", EnrichMetricMetadata: true}, nil)
+	if err != nil {
+		t.Fatalf("ExecuteAndPoll() error: %v", err)
+	}
+	if !polled.Load() {
+		t.Fatal("expected poll to be invoked")
+	}
+	if execEnrich != "metric-metadata" {
+		t.Errorf("execute enrich = %q, want metric-metadata", execEnrich)
+	}
+	if pollEnrich != "metric-metadata" {
+		t.Errorf("poll enrich = %q, want metric-metadata", pollEnrich)
+	}
+}
+
+func TestExecute_NoEnrichByDefault(t *testing.T) {
+	var execEnrich string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/storage/query/v1/query:execute", func(w http.ResponseWriter, r *http.Request) {
+		execEnrich = r.URL.Query().Get("enrich")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Response{State: "SUCCEEDED", Result: &Result{}})
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.Execute(context.Background(), ExecuteRequest{Query: "fetch logs | limit 1"}); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if execEnrich != "" {
+		t.Errorf("enrich param = %q, want empty when EnrichMetricMetadata is false", execEnrich)
+	}
+}
+
 func TestExecute_AsyncWithPoll(t *testing.T) {
 	var pollCount atomic.Int32
 
@@ -129,7 +188,7 @@ func TestPoll_Success(t *testing.T) {
 	})
 
 	h := NewHandler(newTestClient(t, mux))
-	result, err := h.Poll(context.Background(), "tok-abc", 5000)
+	result, err := h.Poll(context.Background(), "tok-abc", 5000, false)
 	if err != nil {
 		t.Fatalf("Poll() error: %v", err)
 	}
@@ -146,7 +205,7 @@ func TestPoll_ErrorReturnsAPIError(t *testing.T) {
 	})
 
 	h := NewHandler(newTestClient(t, mux))
-	_, err := h.Poll(context.Background(), "tok-abc", 5000)
+	_, err := h.Poll(context.Background(), "tok-abc", 5000, false)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -431,6 +490,54 @@ func TestResponse_GetMetadata(t *testing.T) {
 	}
 	if m.QueryID != "q-123" {
 		t.Errorf("QueryID = %q, want q-123", m.QueryID)
+	}
+}
+
+func TestMetricInfo_UnmarshalFromAPI(t *testing.T) {
+	// Mirrors the metadata.metrics[] shape the DQL API returns for timeseries
+	// queries. All descriptor fields must survive unmarshalling.
+	const raw = `{
+		"records": [],
+		"metadata": {
+			"metrics": [
+				{
+					"metric.key": "dt.host.cpu.user",
+					"displayName": "CPU user",
+					"description": "Average CPU time when CPU was running in user mode",
+					"unit": "%",
+					"fieldName": "sum(dt.host.cpu.user)",
+					"aggregation": "sum"
+				}
+			]
+		}
+	}`
+
+	var r Response
+	if err := json.Unmarshal([]byte(raw), &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	metrics := r.GetMetrics()
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+	m := metrics[0]
+	if m.MetricKey != "dt.host.cpu.user" {
+		t.Errorf("MetricKey = %q, want dt.host.cpu.user", m.MetricKey)
+	}
+	if m.DisplayName != "CPU user" {
+		t.Errorf("DisplayName = %q, want CPU user", m.DisplayName)
+	}
+	if m.Description != "Average CPU time when CPU was running in user mode" {
+		t.Errorf("Description = %q, want the API description", m.Description)
+	}
+	if m.Unit != "%" {
+		t.Errorf("Unit = %q, want %%", m.Unit)
+	}
+	if m.FieldName != "sum(dt.host.cpu.user)" {
+		t.Errorf("FieldName = %q, want sum(dt.host.cpu.user)", m.FieldName)
+	}
+	if m.Aggregation != "sum" {
+		t.Errorf("Aggregation = %q, want sum", m.Aggregation)
 	}
 }
 
@@ -765,7 +872,7 @@ func TestWithHeaders_PropagatedToAllEndpoints(t *testing.T) {
 	h := NewHandler(newTestClient(t, mux)).WithHeaders(map[string]string{"x-custom": "test-value"})
 
 	h.Execute(context.Background(), ExecuteRequest{Query: "q"})
-	h.Poll(context.Background(), "tok", 1000)
+	h.Poll(context.Background(), "tok", 1000, false)
 	h.Cancel(context.Background(), "tok")
 	h.Verify(context.Background(), VerifyRequest{Query: "q"})
 

--- a/test/integration/query_metric_metadata_test.go
+++ b/test/integration/query_metric_metadata_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	sdkquery "github.com/dynatrace-oss/dtctl/sdk/api/query"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+// TestQueryMetricMetadataEnrichment verifies that requesting metric-metadata
+// enrichment (the `enrich=metric-metadata` query-string parameter on
+// query:execute / query:poll) causes the DQL API to populate the catalogue
+// fields displayName / description / unit on metadata.metrics[], and that
+// omitting it leaves those fields empty.
+//
+// This is the end-to-end guard for the bug where dtctl never requested
+// enrichment, so units/displayName/description were always missing.
+func TestQueryMetricMetadataEnrichment(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	env := SetupIntegration(t)
+	handler := sdkquery.NewHandler(httpclient.Wrap(env.Client.HTTP()))
+
+	// A built-in host metric that carries catalogue metadata on any Grail tenant
+	// that has ingested host data. Matches the metric used by other e2e tests.
+	const query = "timeseries avg(dt.host.cpu.usage), from: -2h"
+
+	// Enriched request: must return at least one metric with catalogue fields.
+	enriched, err := handler.ExecuteAndPoll(
+		context.Background(),
+		sdkquery.ExecuteRequest{Query: query, EnrichMetricMetadata: true},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("enriched query failed: %v", err)
+	}
+
+	metrics := enriched.GetMetrics()
+	if len(metrics) == 0 {
+		t.Skipf("tenant returned no metrics metadata for %q (metric likely absent); cannot verify enrichment", query)
+	}
+
+	var m sdkquery.MetricInfo
+	found := false
+	for _, mi := range metrics {
+		if mi.MetricKey == "dt.host.cpu.usage" {
+			m = mi
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a metrics entry for dt.host.cpu.usage, got %+v", metrics)
+	}
+
+	t.Logf("enriched metric: key=%q displayName=%q unit=%q description=%q",
+		m.MetricKey, m.DisplayName, m.Unit, m.Description)
+
+	// Enrichment must populate the catalogue fields. Unit and DisplayName are
+	// reliably set for built-in metrics; Description may be empty for some, so
+	// require the two stable ones and log the third.
+	if m.Unit == "" {
+		t.Errorf("expected non-empty unit for dt.host.cpu.usage when enrichment is requested")
+	}
+	if m.DisplayName == "" {
+		t.Errorf("expected non-empty displayName for dt.host.cpu.usage when enrichment is requested")
+	}
+
+	// Contrast request: without enrichment the catalogue fields must be absent,
+	// proving it is the enrich parameter — not the tenant — that drives it.
+	plain, err := handler.ExecuteAndPoll(
+		context.Background(),
+		sdkquery.ExecuteRequest{Query: query, EnrichMetricMetadata: false},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("plain query failed: %v", err)
+	}
+	for _, mi := range plain.GetMetrics() {
+		if mi.MetricKey != "dt.host.cpu.usage" {
+			continue
+		}
+		if mi.DisplayName != "" || mi.Description != "" || mi.Unit != "" {
+			t.Errorf("expected no catalogue fields without enrichment, got displayName=%q description=%q unit=%q",
+				mi.DisplayName, mi.Description, mi.Unit)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`dtctl query "timeseries …" --metadata=metrics` returned metric metadata with only `metric.key`, `fieldName`, and `aggregation`. The catalogue fields shown in the Dynatrace UI — `displayName`, `description`, `unit` — were always missing.

**Root cause:** the Grail query API only enriches `metadata.metrics[]` with catalogue fields when the request includes the query-string parameter `?enrich=metric-metadata` on **both** `query:execute` and `query:poll`. dtctl never sent it. (The response structs added in #326 partially modelled `displayName`/`unit`, but they were effectively dead code since nothing requested enrichment; `description` was missing entirely.)

Verified empirically: before the fix, no tenant returned the enriched fields via dtctl; after it, they all do.

## Changes

- **SDK** (`sdk/api/query`): new `ExecuteRequest.EnrichMetricMetadata`, sent as `enrich=metric-metadata` on `Execute` and `Poll`; added the missing `Description` field to `MetricInfo`.
- **exec** (`pkg/exec/dql.go`): copy `Description` through; request enrichment **only** when the caller wants metrics metadata (`--metadata=metrics` or bare `--metadata`/`all`) — no overhead on other queries.
- **output** (`pkg/output/metadata.go`): carry `Description` and render it in the human-readable metadata footer. (Left out of the comma-joined CSV comment line, consistent with `displayName`.)

## Tests

- SDK: JSON-unmarshal round-trip, enrich-param-sent (execute + poll), no-enrich-by-default.
- exec: enrichment gating table; conversion carries displayName/description/unit.
- output: footer + map assertions include description.
- **Integration** (`test/integration/query_metric_metadata_test.go`): end-to-end — asserts enrichment populates the catalogue fields and that omitting it leaves them empty.

Ran the integration test against a live tenant:

```
enriched metric: key="dt.host.cpu.usage" displayName="CPU usage %" unit="%" description="Percentage of CPU time when CPU was utilized…"
--- PASS: TestQueryMetricMetadataEnrichment
```

Unit + golden suites green; both modules build; `go vet` clean.

## Example (after)

```json
"metrics": [{
  "metric.key": "dt.host.cpu.user",
  "fieldName": "sum(dt.host.cpu.user)",
  "aggregation": "sum",
  "displayName": "CPU user",
  "description": "Average CPU time when CPU was running in user mode",
  "unit": "%"
}]
```