### PR TITLE
docs: document query parameters, auth status, ctx subcommands, and wait

### DIFF
--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -23,6 +23,7 @@ dtctl [verb] [resource-type] [resource-name] [flags]
 | `apply` | Apply configuration from file (create or update) |
 | `logs` | Print logs for a resource |
 | `query` | Execute a DQL query |
+| `wait` | Poll a DQL query until a record-count condition is met (tests/CI) |
 | `inspect` | Inspect a spilled query-result file locally (rows, schema, stats) without re-querying Grail |
 | `exec` | Execute a workflow, function, analyzer, or CoPilot skill |
 | `history` | Show version history (snapshots) of a document |
@@ -100,9 +101,14 @@ dtctl config describe-context <name>
 dtctl config delete-context <name>
 dtctl config view
 
-# Quick context switching
+# Quick context switching (shortcuts without the "config" prefix)
 dtctl ctx                          # List contexts
 dtctl ctx <name>                   # Switch context
+dtctl ctx current                  # Show current context name
+dtctl ctx describe <name>          # Show details of a context
+dtctl ctx set <name> --environment <url> [--token-ref <ref>]  # Create/update a context and switch to it
+dtctl ctx delete <name>            # Delete a context
+dtctl ctx token [<name>]           # Print the resolved token for a context
 
 # Credentials
 dtctl config set-credentials <ref> --token <token>
@@ -124,11 +130,20 @@ dtctl auth login --context <name> --environment <url>
 dtctl auth logout
 dtctl auth refresh
 
+# Session status: token presence, expiry, refresh token, granted scopes
+dtctl auth status
+dtctl auth status -o json
+
 # User identity
 dtctl auth whoami
 dtctl auth whoami --id-only
 dtctl auth whoami -o json
 ```
+
+`auth status` reports the OAuth session state for the current context — whether an
+access token is stored, when it expires, whether a refresh token is present (so
+the CLI can auto-refresh), and the granted scopes. For platform (non-OAuth)
+tokens it reports the auth type and skips the OAuth-specific fields.
 
 ## Query Commands
 
@@ -213,6 +228,24 @@ it emits. It composes with a single row-access window (`--head`/`--tail`/`--page
 which bounds the matches) and with `--fields` (which projects them), but is
 mutually exclusive with `--schema`/`--stats`/`--sample`. The program must emit
 objects; for free-form scalar extraction run `jq` over the file yourself.
+
+## Wait Commands
+
+`dtctl wait query` polls a DQL query with exponential backoff until a record-count
+condition is met — built for tests and CI/CD that must wait for data to land. See
+[Waiting for Query Conditions](dql-queries#waiting-for-query-conditions) for the
+full condition list, polling controls, and exit codes.
+
+```bash
+# Wait for exactly one matching record (default timeout 5m)
+dtctl wait query "fetch spans | filter test_id == 'test-123'" --for=count=1
+
+# Wait for any error logs, with a custom timeout
+dtctl wait query "fetch logs | filter status == 'ERROR'" --for=any --timeout 2m
+
+# Conditions: count=N | count-gte=N | count-gt=N | count-lte=N | count-lt=N | any | none
+# Polling:    --timeout --max-attempts --initial-delay --min-interval --max-interval --backoff-multiplier
+```
 
 ## Execution Commands
 

--- a/docs/site/_docs/configuration.md
+++ b/docs/site/_docs/configuration.md
@@ -81,6 +81,18 @@ dtctl ctx dev
 dtctl ctx
 ```
 
+The `ctx` command is a shorthand for the common `config` operations. With no
+argument it lists contexts; with a name it switches. It also has subcommands:
+
+```bash
+dtctl ctx current                 # Show the current context name
+dtctl ctx describe prod           # Show details of a context
+dtctl ctx set staging \           # Create or update a context and switch to it
+  --environment "https://staging.apps.dynatrace.com" --token-ref staging-token
+dtctl ctx delete old-env          # Delete a context
+dtctl ctx token prod              # Print the resolved token for a context (defaults to current)
+```
+
 ### One-Time Context Override
 
 Run a single command against a different context without switching:

--- a/docs/site/_docs/dql-queries.md
+++ b/docs/site/_docs/dql-queries.md
@@ -251,24 +251,116 @@ Both `--segment` and `--segments-file` can be combined. If the same segment ID a
 
 ## Additional Parameters
 
-Fine-tune query execution with these options:
+Fine-tune query execution with these options.
+
+### Timeframe, Timezone, and Locale
 
 ```bash
-# Specify a time frame
-dtctl query "fetch logs | limit 10" --timeframe "now()-2h"
+# Default timeframe applied when the query does not set its own (ISO-8601/RFC3339)
+dtctl query "fetch logs | limit 10" \
+  --default-timeframe-start "2024-01-01T00:00:00Z" \
+  --default-timeframe-end   "2024-01-02T00:00:00Z"
 
-# Set timezone and locale
+# Set timezone and locale (affect time bucketing and formatting)
 dtctl query "fetch logs | limit 10" --timezone "America/New_York" --locale "en_US"
+```
 
-# Enable sampling for faster results on large datasets
-dtctl query "fetch logs" --sampling-ratio 0.1
+`--default-timeframe-start` / `--default-timeframe-end` only fill in a timeframe
+when the query itself does not specify one (e.g. via a `from`/`to` in the query).
+There is no `--timeframe` flag — express relative ranges in DQL instead
+(e.g. `fetch logs, from:now()-2h`).
 
-# Fetch execution metadata alongside results
+### Sampling and Preview
+
+```bash
+# Enable sampling for faster results on large log/span datasets
+# (normalized to a power of 10, e.g. 1000 samples 1/1000 of matching records)
+dtctl query "fetch logs" --default-sampling-ratio 1000
+
+# Request preview (partial) results if they are available within the timeout
+dtctl query "fetch logs | limit 10" --enable-preview
+```
+
+There is no `--sampling-ratio` or `--preview` flag — use `--default-sampling-ratio`
+and `--enable-preview`.
+
+### Execution Limits
+
+```bash
+# Cap how long Grail spends fetching data
+dtctl query "fetch logs" --fetch-timeout-seconds 30
+
+# Enforce the tenant's query consumption limit (fail instead of over-consuming)
+dtctl query "fetch logs" --enforce-query-consumption-limit
+```
+
+See [Large Dataset Downloads](#large-dataset-downloads) for `--max-result-records`,
+`--max-result-bytes`, and `--default-scan-limit-gbytes`.
+
+### Metadata, Types, and Contributions
+
+```bash
+# Fetch execution metadata alongside results (bare flag = all fields)
 dtctl query "fetch logs | limit 10" --metadata
 
-# Preview mode (faster, approximate results)
-dtctl query "fetch logs | limit 10" --preview
+# Select specific metadata fields
+dtctl query "fetch logs | limit 10" --metadata=scannedRecords,scannedBytes,executionTimeMilliseconds
+
+# Include DQL column type information in the result
+dtctl query "fetch logs | limit 10" --include-types
+
+# Include Grail bucket contribution information
+dtctl query "fetch logs | limit 10" --include-contributions
 ```
+
+Available `--metadata` fields: `executionTimeMilliseconds`, `scannedRecords`,
+`scannedBytes`, `scannedDataPoints`, `sampled`, `queryId`, `dqlVersion`, `query`,
+`canonicalQuery`, `timezone`, `locale`, `analysisTimeframe`, `contributions`,
+`metrics`.
+
+### Caller Context
+
+```bash
+# Declare the caller's intent in the dt-client-context request header
+# (useful for AI agents / scripts to tag why a query ran)
+dtctl query "fetch logs | limit 10" --client-context "root-cause-analysis"
+```
+
+### Chart Rendering
+
+When rendering to a terminal chart (`-o chart`, `sparkline`, `barchart`,
+`braille`), control the drawing area:
+
+```bash
+dtctl query "timeseries avg(dt.host.cpu.usage)" -o chart --width 120 --height 20
+dtctl query "timeseries avg(dt.host.cpu.usage)" -o chart --fullscreen  # use full terminal size
+```
+
+### Full Parameter Reference
+
+| Flag | Purpose |
+|------|---------|
+| `--default-timeframe-start` / `--default-timeframe-end` | Default query timeframe (ISO-8601/RFC3339) used when the query omits one |
+| `--timezone` | Query timezone (e.g. `UTC`, `Europe/Paris`) |
+| `--locale` | Query locale (e.g. `en_US`, `de_DE`) |
+| `--default-sampling-ratio` | Sampling ratio for faster approximate results (normalized to a power of 10) |
+| `--enable-preview` | Return preview results if available within the timeout |
+| `--fetch-timeout-seconds` | Time limit for fetching data (seconds) |
+| `--enforce-query-consumption-limit` | Enforce the tenant query consumption limit |
+| `--max-result-records` | Maximum number of result records |
+| `--max-result-bytes` | Maximum result payload size in bytes |
+| `--default-scan-limit-gbytes` | Cap on how much data Grail scans (GB) |
+| `--metadata`, `-M` | Include execution metadata (bare = all, or `=field1,field2`) |
+| `--include-types` | Include DQL column type information |
+| `--include-contributions` | Include Grail bucket contribution information |
+| `--client-context` | Set the `dt-client-context` request header (caller intent) |
+| `--width` / `--height` / `--fullscreen` | Terminal chart dimensions (chart output formats) |
+| `--decode-snapshots` | Decode Live Debugger snapshot payloads (see [Live Debugger](live-debugger)) |
+| `--spill*` | Spill large results to a file (see [above](#spilling-large-results-to-a-file)) |
+| `-S` / `--segment`, `-V` / `--segment-var`, `--segments-file` | Apply filter segments (see [above](#filter-segments)) |
+| `--live` / `--interval` | Live mode with periodic refresh (see [below](#live-mode)) |
+| `--set` | Set a template variable (`key=value`) |
+| `-f` / `--file` | Read the query from a file (`-` for stdin) |
 
 ## Live Mode
 
@@ -281,6 +373,68 @@ dtctl query "fetch logs | filter loglevel == 'ERROR' | sort timestamp desc | lim
 ```
 
 Press `Ctrl+C` to stop live mode.
+
+## Waiting for Query Conditions
+
+`dtctl wait query` repeatedly runs a DQL query until a **condition on the record
+count** is met (or a timeout is reached), using exponential backoff between
+attempts. It is built for tests and CI/CD — waiting for instrumented data to land
+before making assertions.
+
+```bash
+# Wait until exactly one matching span arrives
+dtctl wait query "fetch spans | filter test_id == 'test-123'" --for=count=1
+
+# Wait for any error logs, up to 2 minutes
+dtctl wait query "fetch logs | filter status == 'ERROR'" --for=any --timeout 2m
+
+# Template variables and file-based queries work here too
+dtctl wait query -f query.dql --set test_id=my-test --for=count-gte=1
+
+# Tune the backoff (e.g. for CI)
+dtctl wait query "..." --for=any --min-interval 500ms --max-interval 15s --backoff-multiplier 2
+
+# Capture the result once the condition is met
+dtctl wait query "..." --for=count=1 -o json > result.json
+```
+
+### Conditions (`--for`, required)
+
+| Condition | Meets when |
+|-----------|-----------|
+| `count=N` | Exactly N records |
+| `count-gte=N` | At least N records (`>=`) |
+| `count-gt=N` | More than N records (`>`) |
+| `count-lte=N` | At most N records (`<=`) |
+| `count-lt=N` | Fewer than N records (`<`) |
+| `any` | Any records returned (count > 0) |
+| `none` | No records returned (count == 0) |
+
+### Polling Controls
+
+| Flag | Purpose |
+|------|---------|
+| `--timeout` | Maximum time to wait (default `5m`, `0` = unlimited) |
+| `--max-attempts` | Maximum number of attempts (`0` = unlimited) |
+| `--initial-delay` | Delay before the first attempt |
+| `--min-interval` / `--max-interval` | Backoff bounds (defaults `1s` / `10s`) |
+| `--backoff-multiplier` | Exponential backoff multiplier (must be `> 1.0`, default `2`) |
+| `-q, --quiet` | Suppress progress messages |
+
+`wait query` also accepts the standard query tuning flags (`--timezone`,
+`--locale`, `--default-timeframe-start/-end`, `--default-sampling-ratio`,
+`--max-result-records`, etc.).
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Condition met |
+| `1` | Timeout reached |
+| `2` | Max attempts exceeded |
+| `3` | Query execution error |
+| `4` | Invalid condition syntax |
+| `5` | Invalid arguments |
 
 ## Cancelling Queries
 

--- a/docs/site/_docs/live-debugger.md
+++ b/docs/site/_docs/live-debugger.md
@@ -87,12 +87,12 @@ dtctl query "fetch application.snapshots | limit 10" --decode-snapshots
 
 ### Full vs Simplified Decoding
 
-By default, `--decode-snapshots` produces a simplified view that shows variable names and values in a human-readable format. For the full raw snapshot data (including nested objects and metadata), use:
+By default, `--decode-snapshots` (equivalent to `--decode-snapshots=simplified`) produces a simplified view that shows variable names and values in a human-readable format. For the full decoded tree (including nested objects and type annotations), use `--decode-snapshots=full`:
 
 ```bash
 # Full decoding with complete object graphs
 dtctl query "fetch application.snapshots | limit 5" \
-  --decode-snapshots --full
+  --decode-snapshots=full
 ```
 
 ## Safety and Dry-Run


### PR DESCRIPTION
## Summary

Audits the GitHub Pages docs (`docs/site/`) against the actual `dtctl` CLI surface and closes gaps on the query and reference pages. Every flag name and behavior below was verified against a freshly built binary.

Scope agreed with maintainer: **`auth status`, `ctx` subcommands, `wait`, and full query-parameter coverage.** (Deliberately excludes IAM, classic-pipelines-translation, notifications, token migration, and SDK — out of scope for this PR.)

## Changes

**`dql-queries.md`**
- Rewrote **Additional Parameters** to document *every* query flag, grouped, with a full reference table. Newly documented: `--client-context`, `--fetch-timeout-seconds`, `--enforce-query-consumption-limit`, `--include-types`, `--include-contributions`, `--metadata=<field>` selection (with the field list), and chart flags `--width` / `--height` / `--fullscreen`.
- **Fixed three documented-but-nonexistent flags** (real doc bugs): `--timeframe` → `--default-timeframe-start`/`--default-timeframe-end`, `--sampling-ratio` → `--default-sampling-ratio`, `--preview` → `--enable-preview`.
- Added a **Waiting for Query Conditions** section for `dtctl wait query` (conditions, polling controls, exit codes).

**`command-reference.md`**
- Added `wait` to the Core Verbs table.
- Added `auth status` to Authentication Commands.
- Expanded the `ctx` block with all subcommands (`current`, `describe`, `set`, `delete`, `token`).
- Added a **Wait Commands** section.

**`configuration.md`**
- Documented the full `ctx` subcommand set.

**`live-debugger.md`**
- **Fixed** `--decode-snapshots --full` → `--decode-snapshots=full` (the `--full` flag does not exist).

## Testing

- All flag names verified against the built `dtctl` binary.
- Front matter (YAML), Liquid `raw`/`endraw` balance, and code-fence balance validated for all four files.
- A full local Jekyll render was **not** possible in this environment: the pinned `github-pages`/Jekyll 3.6.2 stack fails identically on *every* file (including untouched ones) under Ruby 3.3.5 (rexml/Psych removed from default gems). This is a local toolchain mismatch, not a content issue — GitHub Pages CI builds on a compatible Ruby.