### PR TITLE
docs: document exec function ad-hoc mode & --data/--defer; fix --data @ help

### DIFF
--- a/cmd/exec_functions.go
+++ b/cmd/exec_functions.go
@@ -26,8 +26,8 @@ Examples:
   # Execute with POST and payload
   dtctl exec function myapp/myfunction --method POST --payload '{"key":"value"}'
 
-  # Execute with payload from file
-  dtctl exec function myapp/myfunction --method POST --data @payload.json
+  # Execute with payload from file (use - to read the payload from stdin)
+  dtctl exec function myapp/myfunction --method POST --data payload.json
 
   # Defer execution (async, for resumable functions)
   dtctl exec function myapp/myfunction --defer
@@ -87,7 +87,7 @@ func init() {
 	// Function flags
 	execFunctionCmd.Flags().String("method", "GET", "HTTP method for app function (GET, POST, PUT, PATCH, DELETE)")
 	execFunctionCmd.Flags().String("payload", "", "request payload (JSON string)")
-	execFunctionCmd.Flags().String("data", "", "read payload from file (use @filename or - for stdin)")
+	execFunctionCmd.Flags().String("data", "", "read payload from file (or - for stdin)")
 	execFunctionCmd.Flags().String("code", "", "JavaScript code to execute (for ad-hoc execution)")
 	execFunctionCmd.Flags().StringP("file", "f", "", "read JavaScript code from file (for ad-hoc execution)")
 	execFunctionCmd.Flags().Bool("defer", false, "defer execution (async, for resumable functions)")

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -663,12 +663,15 @@ dtctl describe function <app-id>/<function-name> -o json  # JSON output
 # Execute functions
 dtctl exec function <app-id>/<function-name>     # Execute function (GET)
 dtctl exec function <app-id>/<function-name> --method POST --payload '{"key":"value"}'
-dtctl exec function <app-id>/<function-name> --method POST --data @payload.json
+dtctl exec function <app-id>/<function-name> --method POST --data payload.json  # payload from file (- for stdin)
 dtctl exec function <app-id>/<function-name> -o json  # JSON output
 
-# Deferred (async) execution for resumable functions (not implemented yet)
-# dtctl exec function <app-id>/<function-name> --defer
-# dtctl get deferred-executions                    # List deferred executions
+# Deferred (async) execution for resumable functions
+dtctl exec function <app-id>/<function-name> --defer
+
+# Ad-hoc JavaScript execution (no app deployment)
+dtctl exec function --code 'export default async function() { return "hello" }'
+dtctl exec function -f script.js --payload '{"input":"data"}'  # -f - reads code from stdin
 # dtctl describe deferred-execution <execution-id> # Execution details
 
 # Function Executor (ad-hoc code execution)

--- a/docs/site/_docs/apps.md
+++ b/docs/site/_docs/apps.md
@@ -38,14 +38,72 @@ dtctl describe function dynatrace.automations/execute-dql-query
 
 ### Execute a Function
 
+`dtctl exec function` has **two modes**:
+
+1. **App function** — invoke a function exposed by an installed app (`app-id/function-name`).
+2. **Ad-hoc JavaScript** — run JavaScript directly, without deploying an app.
+
+The mode is chosen by the flags you pass: if `--code` or `-f`/`--file` is
+present, dtctl runs in **ad-hoc mode** (and ignores any `app-id/function-name`
+argument, `--method`, and `--defer`). Otherwise it runs in **app-function mode**.
+
+The command has aliases `fn` and `func`.
+
+#### App Functions
+
 ```bash
-# Execute a function with a JSON payload
+# GET (default method, no payload)
+dtctl exec function dynatrace.automations/execute-dql-query
+
+# POST with an inline JSON payload
 dtctl exec function dynatrace.automations/execute-dql-query \
   --method POST \
   --payload '{"query":"fetch logs | limit 5"}'
+
+# Payload from a file, or from stdin with "-"
+dtctl exec function dynatrace.automations/execute-dql-query --method POST --data payload.json
+cat payload.json | dtctl exec function dynatrace.automations/execute-dql-query --method POST --data -
+
+# Defer execution (async, for resumable functions) — returns a handle instead of the result
+dtctl exec function dynatrace.automations/long-running --method POST --payload '{}' --defer
 ```
 
+`--method` accepts `GET` (default), `POST`, `PUT`, `PATCH`, or `DELETE`.
+`--payload` takes an inline JSON string; `--data` reads the same payload from a
+file (or `-` for stdin). Pass at most one of the two.
+
 **Payload discovery:** If you're unsure what fields a function expects, try executing it with an empty payload (`--payload '{}'`). The error response will typically list the required fields and their types.
+
+#### Ad-hoc JavaScript
+
+Run a function's worth of JavaScript without publishing an app — useful for
+quick platform automation and for prototyping app functions:
+
+```bash
+# Inline code
+dtctl exec function --code 'export default async function () { return "hello" }'
+
+# Code from a file (use -f - to read the code from stdin)
+dtctl exec function -f script.js
+
+# Code from a file, with an input payload passed to the function
+dtctl exec function -f script.js --payload '{"input":"data"}'
+dtctl exec function -f script.js --data payload.json
+```
+
+In ad-hoc mode `--payload` / `--data` supply the input passed to the code; the
+`--method` and `--defer` flags do not apply.
+
+#### Flag Reference
+
+| Flag | Mode | Purpose |
+|------|------|---------|
+| `--method` | app function | HTTP method: `GET` (default), `POST`, `PUT`, `PATCH`, `DELETE` |
+| `--payload` | both | Inline JSON payload / input |
+| `--data` | both | Read the payload / input from a file (`-` = stdin) |
+| `--defer` | app function | Defer execution (async, for resumable functions) |
+| `--code` | ad-hoc | JavaScript source to execute inline (selects ad-hoc mode) |
+| `-f`, `--file` | ad-hoc | Read JavaScript source from a file (`-` = stdin; selects ad-hoc mode) |
 
 ### Common Functions
 

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -262,6 +262,12 @@ dtctl exec analyzer <analyzer-id> --query "timeseries avg(dt.host.cpu.usage)"
 
 # App Functions
 dtctl exec function <app-id>/<function-name> --method POST --payload '{...}'
+dtctl exec function <app-id>/<function-name> --method POST --data payload.json   # payload from file (- = stdin)
+dtctl exec function <app-id>/<function-name> --defer                             # async / resumable
+
+# Ad-hoc JavaScript (no app deployment; --code or -f selects this mode)
+dtctl exec function --code 'export default async function () { return "hi" }'
+dtctl exec function -f script.js --payload '{"input":"data"}'                    # -f - reads code from stdin
 
 # Davis CoPilot
 dtctl exec copilot "What is DQL?" --stream


### PR DESCRIPTION
## Summary

Follow-up to the docs audit. `dtctl exec function` has **two execution modes**, but the docs only covered one — prompted by the question "is the `-f` case documented?" (it wasn't).

## What was missing

`exec function` selects its mode from the flags:
- **App function** — `exec function app-id/fn --method … --payload …`
- **Ad-hoc JavaScript** — `exec function --code …` or `exec function -f script.js` (runs JS with no app deployment; `--code`/`-f` switch to this mode and cause any positional arg, `--method`, and `--defer` to be ignored)

Only app-function mode was documented in `apps.md` and `command-reference.md`. Undocumented before this PR: the entire ad-hoc mode (`--code`, `-f`/`--file`, incl. `-f -` for stdin), `--data` (payload from file/stdin), `--defer` (async/resumable), and the mode-selection semantics.

## Help/behavior bug fixed 🐞

`exec function --help` and its examples told users to pass a payload file as `--data @payload.json` (curl-style). But `ReadFileOrStdin` does a plain `os.Open` with **no `@` stripping**, so `--data @payload.json` tries to open a file literally named `@payload.json` and fails. Per maintainer decision, the **behavior is kept** and the **help/examples are corrected** to the working form: `--data payload.json` or `--data -` (stdin).

## Changes

- **`cmd/exec_functions.go`** — fix the `--data` flag usage string and the `@payload.json` example.
- **`docs/site/_docs/apps.md`** — rewrite *Execute a Function* into **App Functions** + **Ad-hoc JavaScript** subsections, with mode-selection notes and a flag-reference table.
- **`docs/site/_docs/command-reference.md`** — add `--data`, `--defer`, and ad-hoc examples to the exec block.
- **`docs/dev/API_DESIGN.md`** — fix the `--data @` example; `--defer` was marked "not implemented yet" but is implemented; add ad-hoc examples.

## Testing

- Verified every flag/example against the built binary; confirmed `--help` no longer mentions `@filename`.
- `go build`, `go vet`, and `go test ./cmd/ ./pkg/exec/ ./pkg/resources/appengine/` all pass.
- Markdown front matter / code-fence balance validated. (Full local Jekyll render remains blocked by the Ruby 3.3 toolchain mismatch noted in the previous PR — environment, not content.)