### PR TITLE
feat(query): live progress bar for long-running queries

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -392,7 +392,10 @@ Examples:
 			Spill:                        spillOpts,
 			TenantID:                     spillTenantID,
 			ContextName:                  spillContextName,
-			NoProgress:                   noProgress,
+			// The progress bar is a user-facing affordance of the `query`
+			// command only; opt in here (subject to --no-progress) so internal
+			// query callers stay silent by default.
+			ShowProgress: !noProgress,
 		}
 
 		// Handle live mode
@@ -419,8 +422,8 @@ Examples:
 			}
 
 			// Live mode owns the terminal via its own printer; a per-fetch
-			// progress bar would fight it, so suppress it.
-			opts.NoProgress = true
+			// progress bar would fight it, so keep it off.
+			opts.ShowProgress = false
 
 			// Create printer options for live mode (needed for resize support)
 			printerOpts := output.PrinterOptions{

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -241,6 +241,19 @@ Examples:
 		defaultSamplingRatio, _ := cmd.Flags().GetFloat64("default-sampling-ratio")
 		fetchTimeoutSeconds, _ := cmd.Flags().GetInt32("fetch-timeout-seconds")
 		enablePreview, _ := cmd.Flags().GetBool("enable-preview")
+		progressMode, _ := cmd.Flags().GetString("progress")
+		switch progressMode {
+		case output.ProgressAuto, output.ProgressAlways, output.ProgressNever:
+		default:
+			return fmt.Errorf("unsupported --progress value %q (use \"auto\", \"always\", or \"never\")", progressMode)
+		}
+		// The (preview: N rows) counter is only meaningful when previews are
+		// requested. If the user asked for progress but not previews, enable them
+		// so the counter has data — the backend attaches previews to poll
+		// responses, which the reporter surfaces without changing final output.
+		if progressMode == output.ProgressAlways && !cmd.Flags().Changed("enable-preview") {
+			enablePreview = true
+		}
 		enforceQueryConsumptionLimit, _ := cmd.Flags().GetBool("enforce-query-consumption-limit")
 		includeTypes, _ := cmd.Flags().GetBool("include-types")
 		// Parquet derives its column schema from DQL types, so request them even
@@ -391,6 +404,7 @@ Examples:
 			Spill:                        spillOpts,
 			TenantID:                     spillTenantID,
 			ContextName:                  spillContextName,
+			ProgressMode:                 progressMode,
 		}
 
 		// Handle live mode
@@ -415,6 +429,10 @@ Examples:
 			if interval == 0 {
 				interval = output.DefaultLiveInterval
 			}
+
+			// Live mode owns the terminal via its own printer; a per-fetch
+			// progress bar would fight it, so suppress it.
+			opts.ProgressMode = output.ProgressNever
 
 			// Create printer options for live mode (needed for resize support)
 			printerOpts := output.PrinterOptions{
@@ -729,6 +747,7 @@ func init() {
 	queryCmd.Flags().Float64("default-sampling-ratio", 0, "default sampling ratio (0 = use default, normalized to power of 10 <= 100000)")
 	queryCmd.Flags().Int32("fetch-timeout-seconds", 0, "time limit for fetching data in seconds (0 = use default)")
 	queryCmd.Flags().Bool("enable-preview", false, "request preview results if available within timeout")
+	queryCmd.Flags().String("progress", "auto", "show a live progress bar on stderr for long queries: auto|always|never")
 	queryCmd.Flags().Bool("enforce-query-consumption-limit", false, "enforce query consumption limit")
 	queryCmd.Flags().Bool("include-types", false, "include type information in query results")
 	queryCmd.Flags().Bool("include-contributions", false, "include bucket contribution information in query results")

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -241,19 +241,7 @@ Examples:
 		defaultSamplingRatio, _ := cmd.Flags().GetFloat64("default-sampling-ratio")
 		fetchTimeoutSeconds, _ := cmd.Flags().GetInt32("fetch-timeout-seconds")
 		enablePreview, _ := cmd.Flags().GetBool("enable-preview")
-		progressMode, _ := cmd.Flags().GetString("progress")
-		switch progressMode {
-		case output.ProgressAuto, output.ProgressAlways, output.ProgressNever:
-		default:
-			return fmt.Errorf("unsupported --progress value %q (use \"auto\", \"always\", or \"never\")", progressMode)
-		}
-		// The (preview: N rows) counter is only meaningful when previews are
-		// requested. If the user asked for progress but not previews, enable them
-		// so the counter has data — the backend attaches previews to poll
-		// responses, which the reporter surfaces without changing final output.
-		if progressMode == output.ProgressAlways && !cmd.Flags().Changed("enable-preview") {
-			enablePreview = true
-		}
+		noProgress, _ := cmd.Flags().GetBool("no-progress")
 		enforceQueryConsumptionLimit, _ := cmd.Flags().GetBool("enforce-query-consumption-limit")
 		includeTypes, _ := cmd.Flags().GetBool("include-types")
 		// Parquet derives its column schema from DQL types, so request them even
@@ -404,7 +392,7 @@ Examples:
 			Spill:                        spillOpts,
 			TenantID:                     spillTenantID,
 			ContextName:                  spillContextName,
-			ProgressMode:                 progressMode,
+			NoProgress:                   noProgress,
 		}
 
 		// Handle live mode
@@ -432,7 +420,7 @@ Examples:
 
 			// Live mode owns the terminal via its own printer; a per-fetch
 			// progress bar would fight it, so suppress it.
-			opts.ProgressMode = output.ProgressNever
+			opts.NoProgress = true
 
 			// Create printer options for live mode (needed for resize support)
 			printerOpts := output.PrinterOptions{
@@ -747,7 +735,7 @@ func init() {
 	queryCmd.Flags().Float64("default-sampling-ratio", 0, "default sampling ratio (0 = use default, normalized to power of 10 <= 100000)")
 	queryCmd.Flags().Int32("fetch-timeout-seconds", 0, "time limit for fetching data in seconds (0 = use default)")
 	queryCmd.Flags().Bool("enable-preview", false, "request preview results if available within timeout")
-	queryCmd.Flags().String("progress", "auto", "show a live progress bar on stderr for long queries: auto|always|never")
+	queryCmd.Flags().Bool("no-progress", false, "disable the live progress bar shown on stderr for long queries")
 	queryCmd.Flags().Bool("enforce-query-consumption-limit", false, "enforce query consumption limit")
 	queryCmd.Flags().Bool("include-types", false, "include type information in query results")
 	queryCmd.Flags().Bool("include-contributions", false, "include bucket contribution information in query results")

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -182,6 +182,10 @@ Examples:
 			DefaultTimeframeEnd:    defaultTimeframeEnd,
 			Locale:                 locale,
 			Timezone:               timezone,
+			// The waiter drives its own per-attempt progress output on stderr; a
+			// per-query progress bar (plus a completion summary per attempt) would
+			// fight it, so suppress it — same reasoning as --live in query.go.
+			NoProgress: true,
 		}
 
 		// Create wait config

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -182,10 +182,9 @@ Examples:
 			DefaultTimeframeEnd:    defaultTimeframeEnd,
 			Locale:                 locale,
 			Timezone:               timezone,
-			// The waiter drives its own per-attempt progress output on stderr; a
-			// per-query progress bar (plus a completion summary per attempt) would
-			// fight it, so suppress it — same reasoning as --live in query.go.
-			NoProgress: true,
+			// ShowProgress is left false: the waiter drives its own per-attempt
+			// progress output on stderr, and a per-query progress bar (plus a
+			// completion summary per attempt) would fight it.
 		}
 
 		// Create wait config

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1172,7 +1172,7 @@ dtctl query "fetch logs | filter status='ERROR'" \
 - `--enable-preview`: Request preview results if available within timeout
 - `--enforce-query-consumption-limit`: Enforce query consumption limit
 - `--include-types`: Include type information in query results
-- `--progress`: Live progress bar on stderr for long queries — `auto` (default), `always`, or `never`
+- `--no-progress`: Disable the live progress bar shown on stderr for long queries (shown by default on interactive terminals)
 
 **Timeframe Parameters:**
 - `--default-timeframe-start`: Query timeframe start timestamp (ISO-8601/RFC3339, e.g., '2022-04-20T12:10:04.123Z')

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1172,6 +1172,7 @@ dtctl query "fetch logs | filter status='ERROR'" \
 - `--enable-preview`: Request preview results if available within timeout
 - `--enforce-query-consumption-limit`: Enforce query consumption limit
 - `--include-types`: Include type information in query results
+- `--progress`: Live progress bar on stderr for long queries — `auto` (default), `always`, or `never`
 
 **Timeframe Parameters:**
 - `--default-timeframe-start`: Query timeframe start timestamp (ISO-8601/RFC3339, e.g., '2022-04-20T12:10:04.123Z')

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -140,6 +140,7 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] Watch mode with incremental updates: `--watch`, `--interval`
 - [x] Customizable chart dimensions: `--width`, `--height`, `--fullscreen`
 - [x] Custom record/byte/scan limits
+- [x] Live progress bar on stderr for long queries (scan volume, records, elapsed): `--progress[=auto|always|never]`
 - [x] Query metadata output: `--metadata` / `-M` with field selection
 - [x] Spill large results to a local file with a summary envelope: `--spill[=auto|always|never]`, `--spill-to`, `--spill-format`, `--spill-threshold`
 - [x] Local inspection of a spilled file (no Grail re-query): `dtctl inspect <file> --head/--tail/--page/--fields/--schema/--stats/--sample`

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -140,7 +140,7 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] Watch mode with incremental updates: `--watch`, `--interval`
 - [x] Customizable chart dimensions: `--width`, `--height`, `--fullscreen`
 - [x] Custom record/byte/scan limits
-- [x] Live progress bar on stderr for long queries (scan volume, records, elapsed): `--progress[=auto|always|never]`
+- [x] Live progress bar on stderr for long queries (scan volume, records, elapsed), on by default, opt out with `--no-progress`
 - [x] Query metadata output: `--metadata` / `-M` with field selection
 - [x] Spill large results to a local file with a summary envelope: `--spill[=auto|always|never]`, `--spill-to`, `--spill-format`, `--spill-threshold`
 - [x] Local inspection of a spilled file (no Grail re-query): `dtctl inspect <file> --head/--tail/--page/--fields/--schema/--stats/--sample`

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -167,6 +167,7 @@ dtctl query "..." --max-result-records 5000
 dtctl query "..." --default-timeframe-start "2024-01-01T00:00:00Z"
 dtctl query "..." --timezone "Europe/Paris"
 dtctl query "..." --metadata                    # Include execution metadata
+dtctl query "..." --progress=always              # Live progress bar on stderr (auto/always/never)
 dtctl query "..." --live --interval 5s           # Live mode
 
 # Spill a large result to a file, return a summary (see dql-queries#spilling-large-results-to-a-file)

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -167,7 +167,7 @@ dtctl query "..." --max-result-records 5000
 dtctl query "..." --default-timeframe-start "2024-01-01T00:00:00Z"
 dtctl query "..." --timezone "Europe/Paris"
 dtctl query "..." --metadata                    # Include execution metadata
-dtctl query "..." --progress=always              # Live progress bar on stderr (auto/always/never)
+dtctl query "..." --no-progress                  # Disable the live progress bar (shown by default)
 dtctl query "..." --live --interval 5s           # Live mode
 
 # Spill a large result to a file, return a summary (see dql-queries#spilling-large-results-to-a-file)

--- a/docs/site/_docs/dql-queries.md
+++ b/docs/site/_docs/dql-queries.md
@@ -335,25 +335,24 @@ When the query finishes, the bar is replaced with a one-line summary:
 ✓ scanned 17.3 TB · 6.0B records in 42.1s
 ```
 
+The bar is shown by default for interactive terminals. Turn it off with
+`--no-progress`:
+
 ```bash
-# auto (default): show the bar only when stderr is an interactive terminal
+# default: progress bar shown when stderr is an interactive terminal
 dtctl query "fetch logs, from:-24h | summarize count()"
 
-# force it on (e.g. to emit plain per-line progress into a CI log)
-dtctl query "fetch logs | summarize count()" --progress=always
-
-# turn it off
-dtctl query "fetch logs | summarize count()" --progress=never
+# disable it
+dtctl query "fetch logs | summarize count()" --no-progress
 ```
 
 Notes:
 
 - The bar is drawn on **stderr only**, so it never corrupts piped or redirected
   results (`-o json > file`, `| jq`, etc.).
-- It is automatically suppressed for non-interactive output, under `--plain`,
-  and in [agent mode](ai-agent-mode). `NO_COLOR` keeps the bar but drops color.
-- `--progress=always` on a non-TTY (e.g. CI) prints plain, ANSI-free progress
-  lines instead of an animated bar.
+- It is automatically suppressed for non-interactive output (non-TTY stderr),
+  under `--plain`, and in [agent mode](ai-agent-mode). `NO_COLOR` keeps the bar
+  but drops color.
 - Fast queries that complete before the first poll show nothing.
 
 ### Caller Context
@@ -385,7 +384,7 @@ dtctl query "timeseries avg(dt.host.cpu.usage)" -o chart --fullscreen  # use ful
 | `--enable-preview` | Return preview results if available within the timeout |
 | `--fetch-timeout-seconds` | Time limit for fetching data (seconds) |
 | `--enforce-query-consumption-limit` | Enforce the tenant query consumption limit |
-| `--progress` | Live progress bar on stderr for long queries (`auto`/`always`/`never`) |
+| `--no-progress` | Disable the live progress bar shown on stderr for long queries |
 | `--max-result-records` | Maximum number of result records |
 | `--max-result-bytes` | Maximum result payload size in bytes |
 | `--default-scan-limit-gbytes` | Cap on how much data Grail scans (GB) |

--- a/docs/site/_docs/dql-queries.md
+++ b/docs/site/_docs/dql-queries.md
@@ -318,6 +318,44 @@ Available `--metadata` fields: `executionTimeMilliseconds`, `scannedRecords`,
 `canonicalQuery`, `timezone`, `locale`, `analysisTimeframe`, `contributions`,
 `metrics`.
 
+### Progress Indicator
+
+Long-running queries are executed asynchronously and polled until they finish.
+While polling, `dtctl` can draw a live progress bar on **stderr** showing the
+query's completion percentage, the volume of data scanned so far, the number of
+records scanned, and elapsed time:
+
+```
+⠹ scanning  57% ▕███████████▍░░░░░░░░▏  12.2 TB · 4.6B recs · 8.2s
+```
+
+When the query finishes, the bar is replaced with a one-line summary:
+
+```
+✓ scanned 17.3 TB · 6.0B records in 42.1s
+```
+
+```bash
+# auto (default): show the bar only when stderr is an interactive terminal
+dtctl query "fetch logs, from:-24h | summarize count()"
+
+# force it on (e.g. to emit plain per-line progress into a CI log)
+dtctl query "fetch logs | summarize count()" --progress=always
+
+# turn it off
+dtctl query "fetch logs | summarize count()" --progress=never
+```
+
+Notes:
+
+- The bar is drawn on **stderr only**, so it never corrupts piped or redirected
+  results (`-o json > file`, `| jq`, etc.).
+- It is automatically suppressed for non-interactive output, under `--plain`,
+  and in [agent mode](ai-agent-mode). `NO_COLOR` keeps the bar but drops color.
+- `--progress=always` on a non-TTY (e.g. CI) prints plain, ANSI-free progress
+  lines instead of an animated bar.
+- Fast queries that complete before the first poll show nothing.
+
 ### Caller Context
 
 ```bash
@@ -347,6 +385,7 @@ dtctl query "timeseries avg(dt.host.cpu.usage)" -o chart --fullscreen  # use ful
 | `--enable-preview` | Return preview results if available within the timeout |
 | `--fetch-timeout-seconds` | Time limit for fetching data (seconds) |
 | `--enforce-query-consumption-limit` | Enforce the tenant query consumption limit |
+| `--progress` | Live progress bar on stderr for long queries (`auto`/`always`/`never`) |
 | `--max-result-records` | Maximum number of result records |
 | `--max-result-bytes` | Maximum result payload size in bytes |
 | `--default-scan-limit-gbytes` | Cap on how much data Grail scans (GB) |

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -301,11 +301,15 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 	result, err := handler.ExecuteAndPollWithOptions(ctx, req, sdkquery.ExecuteAndPollOptions{
 		OnUnauthorized: onUnauthorized,
 		OnUpdate: func(u sdkquery.PollUpdate) {
-			previewRows := 0
-			if u.Preview != nil {
-				previewRows = len(u.Preview.Records)
+			state := output.ProgressState{
+				Progress:       u.Progress,
+				ScannedBytes:   u.ScannedBytes,
+				ScannedRecords: u.ScannedRecords,
 			}
-			reporter.Update(u.Progress, previewRows)
+			if u.Preview != nil {
+				state.PreviewRows = len(u.Preview.Records)
+			}
+			reporter.Update(state)
 		},
 	})
 	if err != nil {

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -129,6 +129,12 @@ type DQLExecuteOptions struct {
 	Locale   string // Query locale (e.g., "en_US")
 	Timezone string // Query timezone (e.g., "UTC", "Europe/Paris")
 
+	// ProgressMode controls the live progress indicator drawn on stderr while an
+	// asynchronous query is polled: "auto" (default; on for interactive TTYs),
+	// "always", or "never". It never affects stdout, so structured/piped output
+	// is unchanged. Empty is treated as "auto".
+	ProgressMode string
+
 	// Metadata options
 	MetadataFields []string // Metadata fields to include; nil/empty = disabled, ["all"] = all fields, specific names = filtered
 
@@ -282,7 +288,26 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 		}
 	}
 
-	result, err := handler.ExecuteAndPoll(ctx, req, onUnauthorized)
+	// Live progress on stderr. The reporter is a no-op unless stderr is an
+	// interactive TTY (or --progress=always), so piped/agent/structured output
+	// is untouched. Stop() erases the line on success, error, and cancellation.
+	progressMode := opts.ProgressMode
+	if progressMode == "" {
+		progressMode = output.ProgressAuto
+	}
+	reporter := output.NewProgressReporter(progressMode, opts.AgentMode)
+	defer reporter.Stop()
+
+	result, err := handler.ExecuteAndPollWithOptions(ctx, req, sdkquery.ExecuteAndPollOptions{
+		OnUnauthorized: onUnauthorized,
+		OnUpdate: func(u sdkquery.PollUpdate) {
+			previewRows := 0
+			if u.Preview != nil {
+				previewRows = len(u.Preview.Records)
+			}
+			reporter.Update(u.Progress, previewRows)
+		},
+	})
 	if err != nil {
 		// If context was cancelled, print cancellation message
 		if ctx.Err() != nil {

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -313,9 +313,10 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 		// Clear the bar before any further stderr output (cancellation notice,
 		// error hints). Stop is idempotent; the defer remains a safety net.
 		reporter.Stop()
-		// If context was cancelled, print cancellation message
+		// If context was cancelled, print cancellation message. Stop() above has
+		// already cleared any progress line, so no leading newline is needed.
 		if ctx.Err() != nil {
-			fmt.Fprintln(os.Stderr, "\nQuery cancelled.")
+			fmt.Fprintln(os.Stderr, "Query cancelled.")
 			return nil, nil
 		}
 		// Enhance known error types with CLI-specific hints

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -312,11 +312,10 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 			reporter.Update(state)
 		},
 	})
-	// Halt the animator and clear the line before any further stderr output
-	// (cancellation notice, error hints). Stop is idempotent; the defer remains
-	// as a safety net for panics.
-	reporter.Stop()
 	if err != nil {
+		// Clear the bar before any further stderr output (cancellation notice,
+		// error hints). Stop is idempotent; the defer remains a safety net.
+		reporter.Stop()
 		// If context was cancelled, print cancellation message
 		if ctx.Err() != nil {
 			fmt.Fprintln(os.Stderr, "\nQuery cancelled.")
@@ -329,6 +328,16 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 		}
 		return nil, err
 	}
+
+	// On success, replace the bar with a completion summary carrying the final
+	// scan totals from the result metadata (the terminal poll does not fire an
+	// OnUpdate, so the reporter's live state stops one poll short).
+	final := output.ProgressState{Progress: 100}
+	if m := result.GetMetadata(); m != nil {
+		final.ScannedBytes = m.ScannedBytes
+		final.ScannedRecords = m.ScannedRecords
+	}
+	reporter.Complete(final)
 
 	return result, nil
 }

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -312,10 +312,16 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 	if err != nil {
 		// Clear the bar before any further stderr output (cancellation notice,
 		// error hints). Stop is idempotent; the defer remains a safety net.
+		drawing := reporter.Drawing()
 		reporter.Stop()
-		// If context was cancelled, print cancellation message. Stop() above has
-		// already cleared any progress line, so no leading newline is needed.
+		// If context was cancelled, print cancellation message. When the reporter
+		// was drawing, Stop() above already cleared the line, so no leading
+		// newline is needed. When it was not (--no-progress, --plain, non-TTY),
+		// emit one to separate the message from a shell's "^C" echo.
 		if ctx.Err() != nil {
+			if !drawing {
+				fmt.Fprintln(os.Stderr)
+			}
 			fmt.Fprintln(os.Stderr, "Query cancelled.")
 			return nil, nil
 		}

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -129,11 +129,13 @@ type DQLExecuteOptions struct {
 	Locale   string // Query locale (e.g., "en_US")
 	Timezone string // Query timezone (e.g., "UTC", "Europe/Paris")
 
-	// NoProgress disables the live progress bar drawn on stderr while an
-	// asynchronous query is polled. By default (false) the bar is shown for
-	// interactive terminals only; it never affects stdout, so structured/piped
-	// output is unchanged regardless.
-	NoProgress bool
+	// ShowProgress opts in to the live progress bar drawn on stderr while an
+	// asynchronous query is polled. It is off by default so internal/library
+	// query callers (e.g. describe sub-queries, lookup metadata fetches) stay
+	// silent; only the user-facing `query` command sets it. Even when set, the
+	// bar is drawn only for interactive terminals and never affects stdout, so
+	// structured/piped output is unchanged regardless.
+	ShowProgress bool
 
 	// Metadata options
 	MetadataFields []string // Metadata fields to include; nil/empty = disabled, ["all"] = all fields, specific names = filtered
@@ -292,9 +294,13 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 	// interactive TTY, so piped/agent/structured output is untouched. Stop()
 	// erases the line on error and cancellation; Complete() replaces it with a
 	// summary on success.
-	reporter := output.NewProgressReporter(!opts.NoProgress, opts.AgentMode)
+	reporter := output.NewProgressReporter(opts.ShowProgress, opts.AgentMode)
 	defer reporter.Stop()
 
+	// Remember the last live scan totals so the completion summary can fall back
+	// to them if the terminal result metadata omits scannedBytes/Records. The
+	// closure runs synchronously in this goroutine, so these need no locking.
+	var lastScannedBytes, lastScannedRecords int64
 	result, err := handler.ExecuteAndPollWithOptions(ctx, req, sdkquery.ExecuteAndPollOptions{
 		OnUnauthorized: onUnauthorized,
 		OnUpdate: func(u sdkquery.PollUpdate) {
@@ -305,6 +311,12 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 			}
 			if u.Preview != nil {
 				state.PreviewRows = len(u.Preview.Records)
+			}
+			if u.ScannedBytes > 0 {
+				lastScannedBytes = u.ScannedBytes
+			}
+			if u.ScannedRecords > 0 {
+				lastScannedRecords = u.ScannedRecords
 			}
 			reporter.Update(state)
 		},
@@ -334,12 +346,17 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 	}
 
 	// On success, replace the bar with a completion summary carrying the final
-	// scan totals from the result metadata (the terminal poll does not fire an
-	// OnUpdate, so the reporter's live state stops one poll short).
-	final := output.ProgressState{Progress: 100}
+	// scan totals. Prefer the result metadata (authoritative), but fall back to
+	// the last live totals when the terminal envelope omits them, so a large scan
+	// the user watched climb is never reported as "done in Xs" with no volume.
+	final := output.ProgressState{Progress: 100, ScannedBytes: lastScannedBytes, ScannedRecords: lastScannedRecords}
 	if m := result.GetMetadata(); m != nil {
-		final.ScannedBytes = m.ScannedBytes
-		final.ScannedRecords = m.ScannedRecords
+		if m.ScannedBytes > 0 {
+			final.ScannedBytes = m.ScannedBytes
+		}
+		if m.ScannedRecords > 0 {
+			final.ScannedRecords = m.ScannedRecords
+		}
 	}
 	reporter.Complete(final)
 

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -312,6 +312,10 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 			reporter.Update(state)
 		},
 	})
+	// Halt the animator and clear the line before any further stderr output
+	// (cancellation notice, error hints). Stop is idempotent; the defer remains
+	// as a safety net for panics.
+	reporter.Stop()
 	if err != nil {
 		// If context was cancelled, print cancellation message
 		if ctx.Err() != nil {

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -129,11 +129,11 @@ type DQLExecuteOptions struct {
 	Locale   string // Query locale (e.g., "en_US")
 	Timezone string // Query timezone (e.g., "UTC", "Europe/Paris")
 
-	// ProgressMode controls the live progress indicator drawn on stderr while an
-	// asynchronous query is polled: "auto" (default; on for interactive TTYs),
-	// "always", or "never". It never affects stdout, so structured/piped output
-	// is unchanged. Empty is treated as "auto".
-	ProgressMode string
+	// NoProgress disables the live progress bar drawn on stderr while an
+	// asynchronous query is polled. By default (false) the bar is shown for
+	// interactive terminals only; it never affects stdout, so structured/piped
+	// output is unchanged regardless.
+	NoProgress bool
 
 	// Metadata options
 	MetadataFields []string // Metadata fields to include; nil/empty = disabled, ["all"] = all fields, specific names = filtered
@@ -289,13 +289,10 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 	}
 
 	// Live progress on stderr. The reporter is a no-op unless stderr is an
-	// interactive TTY (or --progress=always), so piped/agent/structured output
-	// is untouched. Stop() erases the line on success, error, and cancellation.
-	progressMode := opts.ProgressMode
-	if progressMode == "" {
-		progressMode = output.ProgressAuto
-	}
-	reporter := output.NewProgressReporter(progressMode, opts.AgentMode)
+	// interactive TTY, so piped/agent/structured output is untouched. Stop()
+	// erases the line on error and cancellation; Complete() replaces it with a
+	// summary on success.
+	reporter := output.NewProgressReporter(!opts.NoProgress, opts.AgentMode)
 	defer reporter.Stop()
 
 	result, err := handler.ExecuteAndPollWithOptions(ctx, req, sdkquery.ExecuteAndPollOptions{

--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -176,6 +176,15 @@ func (p *ProgressReporter) renderLocked() {
 	p.shown = true
 }
 
+// Drawing reports whether the reporter is actively drawing to the terminal
+// (enabled and stderr is a TTY). Callers use it to decide whether Stop() will
+// have cleared the line for them, or whether they must emit their own leading
+// newline to avoid gluing output to a partially printed line (e.g. a shell's
+// "^C" echo).
+func (p *ProgressReporter) Drawing() bool {
+	return p != nil && p.animate
+}
+
 // Stop halts the background animator and erases the progress line so the real
 // result renders on a clean row. Use it on error or cancellation; use Complete
 // on success to leave a summary. It is safe to call multiple times and when
@@ -320,7 +329,7 @@ func statsSuffix(s ProgressState, start time.Time) string {
 			parts = append(parts, humanizeMetric(s.ScannedRecords)+" recs")
 		}
 	} else if s.PreviewRows > 0 {
-		parts = append(parts, "preview: "+humanizeCount(s.PreviewRows)+" rows")
+		parts = append(parts, "preview: "+formatNumber(int64(s.PreviewRows))+" rows")
 	}
 	parts = append(parts, formatElapsed(time.Since(start)))
 	return "  " + strings.Join(parts, " · ")
@@ -358,30 +367,6 @@ func humanizeMetric(n int64) string {
 	default:
 		return fmt.Sprintf("%d", n)
 	}
-}
-
-// humanizeCount formats a non-negative integer with thousands separators, e.g.
-// 1234567 -> "1,234,567".
-func humanizeCount(n int) string {
-	s := fmt.Sprintf("%d", n)
-	if len(s) <= 3 {
-		return s
-	}
-	var b strings.Builder
-	pre := len(s) % 3
-	if pre > 0 {
-		b.WriteString(s[:pre])
-		if len(s) > pre {
-			b.WriteByte(',')
-		}
-	}
-	for i := pre; i < len(s); i += 3 {
-		b.WriteString(s[i : i+3])
-		if i+3 < len(s) {
-			b.WriteByte(',')
-		}
-	}
-	return b.String()
 }
 
 // visibleWidth returns the number of visible columns in s, skipping ANSI SGR

--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -112,8 +112,13 @@ func (p *ProgressReporter) Update(s ProgressState) {
 	}
 
 	p.mu.Lock()
+	// A late Update after Stop/Complete must not repaint the cleared line.
+	if p.stopped {
+		p.mu.Unlock()
+		return
+	}
 	p.latest = s
-	if !p.animating && !p.stopped && !p.manualTick {
+	if !p.animating && !p.manualTick {
 		p.animating = true
 		p.startTickerLocked()
 	}

--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -19,6 +20,10 @@ const (
 
 // progressBarWidth is the number of cells in the rendered bar.
 const progressBarWidth = 20
+
+// defaultTickInterval is how often the animated line is redrawn so the spinner
+// and elapsed timer advance smoothly between (much slower) query polls.
+const defaultTickInterval = 100 * time.Millisecond
 
 // progressSpinner holds the braille spinner frames advanced on each update.
 var progressSpinner = []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}
@@ -49,8 +54,10 @@ type ProgressState struct {
 // without disturbing piped or structured output. Color is emitted only when
 // ColorEnabled() is true, so NO_COLOR still yields a plain (monochrome) bar.
 //
-// A reporter is used from a single goroutine (the poll loop's OnUpdate callback
-// plus a deferred Stop), so it needs no synchronization.
+// In animated mode a background goroutine redraws the line on a fixed interval
+// (so the spinner and elapsed timer stay smooth between the far slower query
+// polls), while Update — called from the poll loop — only refreshes the shared
+// state. The mutex guards that state and serializes writes between the two.
 type ProgressReporter struct {
 	w io.Writer
 	// animate is true when stderr is an interactive TTY: the line is redrawn in
@@ -60,8 +67,21 @@ type ProgressReporter struct {
 	// plain, ANSI-free lines (one per update) so it survives in CI logs.
 	logLines bool
 	start    time.Time
-	spinIdx  int
-	lastVis  int // visible width of the last animated line, for padding/clearing
+	// tickInterval overrides the redraw cadence (tests only); 0 => default.
+	tickInterval time.Duration
+	// manualTick disables the background animator so tests can drive frames
+	// synchronously via Update; production always leaves it false.
+	manualTick bool
+
+	mu      sync.Mutex
+	latest  ProgressState
+	spinIdx int
+	lastVis int // visible width of the last animated line, for padding/clearing
+	started bool
+	stopped bool
+	ticker  *time.Ticker
+	done    chan struct{}
+	wg      sync.WaitGroup
 }
 
 // NewProgressReporter returns a reporter for the given mode. It draws an
@@ -97,35 +117,74 @@ func newProgressReporter(mode string, agentMode bool, w io.Writer) *ProgressRepo
 	return r
 }
 
-// Update redraws the progress line for the given state. It is a no-op when the
-// reporter is disabled.
+// Update refreshes the progress state. In animated mode it also starts the
+// background redraw loop on first call and repaints immediately so new poll
+// data (progress, scan totals) appears without waiting for the next tick. It is
+// a no-op when the reporter is disabled.
 func (p *ProgressReporter) Update(s ProgressState) {
 	if p == nil {
 		return
 	}
-	progress := s.Progress
-	if progress < 0 {
-		progress = 0
+	if s.Progress < 0 {
+		s.Progress = 0
 	}
-	if progress > 100 {
-		progress = 100
+	if s.Progress > 100 {
+		s.Progress = 100
 	}
 
 	if p.logLines {
-		fmt.Fprintf(p.w, "querying... %d%%%s\n", progress, plainStats(s))
+		fmt.Fprintf(p.w, "querying... %d%%%s\n", s.Progress, plainStats(s))
 		return
 	}
 	if !p.animate {
 		return
 	}
 
+	p.mu.Lock()
+	p.latest = s
+	if !p.started && !p.stopped && !p.manualTick {
+		p.started = true
+		p.startTickerLocked()
+	}
+	p.renderLocked()
+	p.mu.Unlock()
+}
+
+// startTickerLocked launches the background redraw goroutine. Caller holds mu.
+func (p *ProgressReporter) startTickerLocked() {
+	iv := p.tickInterval
+	if iv <= 0 {
+		iv = defaultTickInterval
+	}
+	p.ticker = time.NewTicker(iv)
+	p.done = make(chan struct{})
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		for {
+			select {
+			case <-p.done:
+				return
+			case <-p.ticker.C:
+				p.mu.Lock()
+				p.spinIdx++
+				p.renderLocked()
+				p.mu.Unlock()
+			}
+		}
+	}()
+}
+
+// renderLocked paints one frame from the current state. Caller holds mu.
+func (p *ProgressReporter) renderLocked() {
+	s := p.latest
 	verb := "querying"
 	if s.ScannedBytes > 0 {
 		verb = "scanning"
 	}
 	spin := colorize(Cyan, string(progressSpinner[p.spinIdx%len(progressSpinner)]))
-	pct := colorize(Bold, fmt.Sprintf("%3d%%", progress))
-	line := fmt.Sprintf("%s %s %s %s%s", spin, verb, pct, renderBar(progress), colorize(Dim, statsSuffix(s, p.start)))
+	pct := colorize(Bold, fmt.Sprintf("%3d%%", s.Progress))
+	line := fmt.Sprintf("%s %s %s %s%s", spin, verb, pct, renderBar(s.Progress), colorize(Dim, statsSuffix(s, p.start)))
 
 	// Return the cursor to column 0, write the new line, then pad with spaces to
 	// erase any tail left by a previously longer line. Padding is measured in
@@ -138,17 +197,39 @@ func (p *ProgressReporter) Update(s ProgressState) {
 	}
 	fmt.Fprintf(p.w, "\r%s%s", line, pad)
 	p.lastVis = vis
-	p.spinIdx++
 }
 
-// Stop erases the progress line (animated mode) so the real result renders on a
-// clean row. It is safe to call multiple times and when disabled.
+// Stop halts the background animator and erases the progress line so the real
+// result renders on a clean row. It is safe to call multiple times and when
+// disabled.
 func (p *ProgressReporter) Stop() {
-	if p == nil || !p.animate || p.lastVis == 0 {
+	if p == nil || !p.animate {
 		return
 	}
-	fmt.Fprintf(p.w, "\r%s\r", strings.Repeat(" ", p.lastVis))
-	p.lastVis = 0
+
+	p.mu.Lock()
+	if p.stopped {
+		p.mu.Unlock()
+		return
+	}
+	p.stopped = true
+	started, done, ticker := p.started, p.done, p.ticker
+	p.mu.Unlock()
+
+	// Wait for the animator to exit before clearing so no stray frame lands
+	// after the clear. Done outside the lock to avoid deadlocking the goroutine.
+	if started {
+		ticker.Stop()
+		close(done)
+		p.wg.Wait()
+	}
+
+	p.mu.Lock()
+	if p.lastVis > 0 {
+		fmt.Fprintf(p.w, "\r%s\r", strings.Repeat(" ", p.lastVis))
+		p.lastVis = 0
+	}
+	p.mu.Unlock()
 }
 
 // renderBar draws a fixed-width bar for a 0-100 percentage using block glyphs

--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -1,0 +1,159 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// ProgressMode controls whether a live progress indicator is drawn while a
+// long-running query is polled. It mirrors the auto|always|never convention
+// used elsewhere in the CLI.
+const (
+	ProgressAuto   = "auto"
+	ProgressAlways = "always"
+	ProgressNever  = "never"
+)
+
+// progressBarWidth is the number of cells in the rendered bar.
+const progressBarWidth = 20
+
+// progressSpinner holds the braille spinner frames advanced on each update.
+var progressSpinner = []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}
+
+// ProgressReporter renders an in-place progress line to stderr while a query
+// runs. When it is not enabled (non-TTY, --plain, agent mode, NO_COLOR, or
+// mode=never) every method is a no-op, so callers can wire it unconditionally
+// without disturbing piped or structured output.
+//
+// A reporter is used from a single goroutine (the poll loop's OnUpdate callback
+// plus a deferred Stop), so it needs no synchronization.
+type ProgressReporter struct {
+	w io.Writer
+	// animate is true when stderr is an interactive TTY: the line is redrawn in
+	// place with a carriage return and cleared on Stop.
+	animate bool
+	// logLines is true for mode=always on a non-TTY: progress is written as
+	// plain, ANSI-free lines (one per update) so it survives in CI logs.
+	logLines bool
+	spinIdx  int
+	lastLen  int
+}
+
+// NewProgressReporter returns a reporter for the given mode. It draws an
+// animated line only when stderr is a TTY and color is enabled (which already
+// folds in --plain and NO_COLOR); agent mode is always silent. mode=always
+// forces output even on a non-TTY, degrading to plain per-line logging.
+func NewProgressReporter(mode string, agentMode bool) *ProgressReporter {
+	return newProgressReporter(mode, agentMode, os.Stderr)
+}
+
+// newProgressReporter is the testable core of NewProgressReporter with an
+// injectable writer. isTerminalWriter reports whether w is an interactive TTY.
+func newProgressReporter(mode string, agentMode bool, w io.Writer) *ProgressReporter {
+	r := &ProgressReporter{w: w}
+	if agentMode || mode == ProgressNever {
+		return r
+	}
+
+	tty := isTerminalWriter(w) && ColorEnabled()
+	switch mode {
+	case ProgressAlways:
+		if tty {
+			r.animate = true
+		} else {
+			r.logLines = true
+		}
+	case ProgressAuto:
+		r.animate = tty
+	}
+	return r
+}
+
+// Update redraws the progress line with the given completion percentage and, if
+// previews are enabled, the number of rows seen so far. It is a no-op when the
+// reporter is disabled.
+func (p *ProgressReporter) Update(progress, previewRows int) {
+	if p == nil {
+		return
+	}
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 100 {
+		progress = 100
+	}
+
+	if p.logLines {
+		if previewRows > 0 {
+			fmt.Fprintf(p.w, "querying... %d%% (preview: %s rows)\n", progress, humanizeCount(previewRows))
+		} else {
+			fmt.Fprintf(p.w, "querying... %d%%\n", progress)
+		}
+		return
+	}
+	if !p.animate {
+		return
+	}
+
+	line := fmt.Sprintf("%c querying… %3d%% %s", progressSpinner[p.spinIdx%len(progressSpinner)], progress, renderBar(progress))
+	if previewRows > 0 {
+		line += fmt.Sprintf("  (preview: %s rows)", humanizeCount(previewRows))
+	}
+
+	// Return the cursor to column 0, write the new line, and pad with spaces to
+	// erase any tail left by a previously longer line. The next Update (or Stop)
+	// begins with its own carriage return, so leaving the cursor past the pad is
+	// fine. lastLen tracks the visible line width for Stop's clear.
+	pad := ""
+	if n := p.lastLen - len(line); n > 0 {
+		pad = strings.Repeat(" ", n)
+	}
+	fmt.Fprintf(p.w, "\r%s%s", line, pad)
+	p.lastLen = len(line)
+	p.spinIdx++
+}
+
+// Stop erases the progress line (animated mode) so the real result renders on a
+// clean row. It is safe to call multiple times and when disabled.
+func (p *ProgressReporter) Stop() {
+	if p == nil || !p.animate || p.lastLen == 0 {
+		return
+	}
+	fmt.Fprintf(p.w, "\r%s\r", strings.Repeat(" ", p.lastLen))
+	p.lastLen = 0
+}
+
+// renderBar draws a fixed-width bar for a 0-100 percentage using block glyphs.
+func renderBar(progress int) string {
+	filled := progress * progressBarWidth / 100
+	if filled > progressBarWidth {
+		filled = progressBarWidth
+	}
+	return "▕" + strings.Repeat("█", filled) + strings.Repeat("░", progressBarWidth-filled) + "▏"
+}
+
+// humanizeCount formats a non-negative integer with thousands separators, e.g.
+// 1234567 -> "1,234,567".
+func humanizeCount(n int) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	var b strings.Builder
+	pre := len(s) % 3
+	if pre > 0 {
+		b.WriteString(s[:pre])
+		if len(s) > pre {
+			b.WriteByte(',')
+		}
+	}
+	for i := pre; i < len(s); i += 3 {
+		b.WriteString(s[i : i+3])
+		if i+3 < len(s) {
+			b.WriteByte(',')
+		}
+	}
+	return b.String()
+}

--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 )
 
 // ProgressMode controls whether a live progress indicator is drawn while a
@@ -22,10 +23,31 @@ const progressBarWidth = 20
 // progressSpinner holds the braille spinner frames advanced on each update.
 var progressSpinner = []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}
 
+// partialBlocks maps an eighth (0-7) to the left-aligned partial block glyph
+// used to render sub-cell bar progress. Index 0 is empty (handled separately).
+var partialBlocks = []rune{' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉'}
+
+// ProgressState is a snapshot of a running query's progress passed to
+// ProgressReporter.Update. All fields are optional; zero values are omitted
+// from the rendered line.
+type ProgressState struct {
+	// Progress is the completion percentage (0-100).
+	Progress int
+	// ScannedBytes / ScannedRecords are the running scan totals reported by the
+	// backend. When non-zero they are shown in preference to the preview count,
+	// since they reflect the actual work (and cost) done so far.
+	ScannedBytes   int64
+	ScannedRecords int64
+	// PreviewRows is the number of rows in the latest preview snapshot, shown
+	// only when no scan totals are available (e.g. non-Grail-scan queries).
+	PreviewRows int
+}
+
 // ProgressReporter renders an in-place progress line to stderr while a query
-// runs. When it is not enabled (non-TTY, --plain, agent mode, NO_COLOR, or
+// runs. When it is not enabled (non-TTY stderr, --plain, agent mode, or
 // mode=never) every method is a no-op, so callers can wire it unconditionally
-// without disturbing piped or structured output.
+// without disturbing piped or structured output. Color is emitted only when
+// ColorEnabled() is true, so NO_COLOR still yields a plain (monochrome) bar.
 //
 // A reporter is used from a single goroutine (the poll loop's OnUpdate callback
 // plus a deferred Stop), so it needs no synchronization.
@@ -37,27 +59,31 @@ type ProgressReporter struct {
 	// logLines is true for mode=always on a non-TTY: progress is written as
 	// plain, ANSI-free lines (one per update) so it survives in CI logs.
 	logLines bool
+	start    time.Time
 	spinIdx  int
-	lastLen  int
+	lastVis  int // visible width of the last animated line, for padding/clearing
 }
 
 // NewProgressReporter returns a reporter for the given mode. It draws an
-// animated line only when stderr is a TTY and color is enabled (which already
-// folds in --plain and NO_COLOR); agent mode is always silent. mode=always
-// forces output even on a non-TTY, degrading to plain per-line logging.
+// animated line when stderr is a TTY and output is not --plain; agent mode is
+// always silent. mode=always forces output even on a non-TTY, degrading to
+// plain per-line logging.
 func NewProgressReporter(mode string, agentMode bool) *ProgressReporter {
 	return newProgressReporter(mode, agentMode, os.Stderr)
 }
 
 // newProgressReporter is the testable core of NewProgressReporter with an
-// injectable writer. isTerminalWriter reports whether w is an interactive TTY.
+// injectable writer.
 func newProgressReporter(mode string, agentMode bool, w io.Writer) *ProgressReporter {
-	r := &ProgressReporter{w: w}
+	r := &ProgressReporter{w: w, start: time.Now()}
 	if agentMode || mode == ProgressNever {
 		return r
 	}
 
-	tty := isTerminalWriter(w) && ColorEnabled()
+	// Progress is a stderr affordance, so gate on stderr being a TTY (not
+	// stdout) and on --plain — but not on NO_COLOR, which only suppresses color,
+	// not the bar itself.
+	tty := isTerminalWriter(w) && !plainModeEnabled
 	switch mode {
 	case ProgressAlways:
 		if tty {
@@ -71,13 +97,13 @@ func newProgressReporter(mode string, agentMode bool, w io.Writer) *ProgressRepo
 	return r
 }
 
-// Update redraws the progress line with the given completion percentage and, if
-// previews are enabled, the number of rows seen so far. It is a no-op when the
+// Update redraws the progress line for the given state. It is a no-op when the
 // reporter is disabled.
-func (p *ProgressReporter) Update(progress, previewRows int) {
+func (p *ProgressReporter) Update(s ProgressState) {
 	if p == nil {
 		return
 	}
+	progress := s.Progress
 	if progress < 0 {
 		progress = 0
 	}
@@ -86,52 +112,130 @@ func (p *ProgressReporter) Update(progress, previewRows int) {
 	}
 
 	if p.logLines {
-		if previewRows > 0 {
-			fmt.Fprintf(p.w, "querying... %d%% (preview: %s rows)\n", progress, humanizeCount(previewRows))
-		} else {
-			fmt.Fprintf(p.w, "querying... %d%%\n", progress)
-		}
+		fmt.Fprintf(p.w, "querying... %d%%%s\n", progress, plainStats(s))
 		return
 	}
 	if !p.animate {
 		return
 	}
 
-	line := fmt.Sprintf("%c querying… %3d%% %s", progressSpinner[p.spinIdx%len(progressSpinner)], progress, renderBar(progress))
-	if previewRows > 0 {
-		line += fmt.Sprintf("  (preview: %s rows)", humanizeCount(previewRows))
+	verb := "querying"
+	if s.ScannedBytes > 0 {
+		verb = "scanning"
 	}
+	spin := colorize(Cyan, string(progressSpinner[p.spinIdx%len(progressSpinner)]))
+	pct := colorize(Bold, fmt.Sprintf("%3d%%", progress))
+	line := fmt.Sprintf("%s %s %s %s%s", spin, verb, pct, renderBar(progress), colorize(Dim, statsSuffix(s, p.start)))
 
-	// Return the cursor to column 0, write the new line, and pad with spaces to
-	// erase any tail left by a previously longer line. The next Update (or Stop)
-	// begins with its own carriage return, so leaving the cursor past the pad is
-	// fine. lastLen tracks the visible line width for Stop's clear.
+	// Return the cursor to column 0, write the new line, then pad with spaces to
+	// erase any tail left by a previously longer line. Padding is measured in
+	// visible columns (ANSI escapes excluded) so a colored line never overflows
+	// the terminal width and wraps.
+	vis := visibleWidth(line)
 	pad := ""
-	if n := p.lastLen - len(line); n > 0 {
+	if n := p.lastVis - vis; n > 0 {
 		pad = strings.Repeat(" ", n)
 	}
 	fmt.Fprintf(p.w, "\r%s%s", line, pad)
-	p.lastLen = len(line)
+	p.lastVis = vis
 	p.spinIdx++
 }
 
 // Stop erases the progress line (animated mode) so the real result renders on a
 // clean row. It is safe to call multiple times and when disabled.
 func (p *ProgressReporter) Stop() {
-	if p == nil || !p.animate || p.lastLen == 0 {
+	if p == nil || !p.animate || p.lastVis == 0 {
 		return
 	}
-	fmt.Fprintf(p.w, "\r%s\r", strings.Repeat(" ", p.lastLen))
-	p.lastLen = 0
+	fmt.Fprintf(p.w, "\r%s\r", strings.Repeat(" ", p.lastVis))
+	p.lastVis = 0
 }
 
-// renderBar draws a fixed-width bar for a 0-100 percentage using block glyphs.
+// renderBar draws a fixed-width bar for a 0-100 percentage using block glyphs
+// with sub-cell resolution. The filled portion is colored; the remainder dim.
 func renderBar(progress int) string {
-	filled := progress * progressBarWidth / 100
-	if filled > progressBarWidth {
-		filled = progressBarWidth
+	exact := float64(progress) / 100 * float64(progressBarWidth)
+	full := int(exact)
+	if full > progressBarWidth {
+		full = progressBarWidth
 	}
-	return "▕" + strings.Repeat("█", filled) + strings.Repeat("░", progressBarWidth-filled) + "▏"
+	partial := ""
+	if full < progressBarWidth {
+		if e := int((exact - float64(full)) * 8); e > 0 {
+			partial = string(partialBlocks[e])
+		}
+	}
+	empty := progressBarWidth - full
+	if partial != "" {
+		empty--
+	}
+	filled := colorize(BrightCyan, strings.Repeat("█", full)+partial)
+	rest := colorize(Dim, strings.Repeat("░", empty))
+	return "▕" + filled + rest + "▏"
+}
+
+// statsSuffix renders the trailing stats segment for the animated line: scan
+// totals (preferred) or preview rows, plus elapsed time.
+func statsSuffix(s ProgressState, start time.Time) string {
+	var parts []string
+	if s.ScannedBytes > 0 {
+		parts = append(parts, formatBytes(s.ScannedBytes))
+		if s.ScannedRecords > 0 {
+			parts = append(parts, humanizeMetric(s.ScannedRecords)+" recs")
+		}
+	} else if s.PreviewRows > 0 {
+		parts = append(parts, "preview: "+humanizeCount(s.PreviewRows)+" rows")
+	}
+	parts = append(parts, formatElapsed(time.Since(start)))
+	return "  " + strings.Join(parts, " · ")
+}
+
+// plainStats renders the ANSI-free stats segment for the CI log-lines path.
+func plainStats(s ProgressState) string {
+	switch {
+	case s.ScannedBytes > 0:
+		if s.ScannedRecords > 0 {
+			return fmt.Sprintf(" (%s scanned, %s records)", formatBytes(s.ScannedBytes), humanizeMetric(s.ScannedRecords))
+		}
+		return fmt.Sprintf(" (%s scanned)", formatBytes(s.ScannedBytes))
+	case s.PreviewRows > 0:
+		return fmt.Sprintf(" (preview: %s rows)", humanizeCount(s.PreviewRows))
+	}
+	return ""
+}
+
+// colorize wraps text in a color code only when color is enabled.
+func colorize(code, text string) string {
+	if !ColorEnabled() {
+		return text
+	}
+	return code + text + Reset
+}
+
+// formatElapsed renders a duration compactly: "8.2s" under a minute, "1m03s"
+// above.
+func formatElapsed(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	m := int(d / time.Minute)
+	sec := int((d % time.Minute) / time.Second)
+	return fmt.Sprintf("%dm%02ds", m, sec)
+}
+
+// humanizeMetric formats a large count with a decimal SI-style suffix, e.g.
+// 5983657731 -> "6.0B", 2085739 -> "2.1M", 4200 -> "4.2K".
+func humanizeMetric(n int64) string {
+	switch {
+	case n >= 1_000_000_000:
+		return fmt.Sprintf("%.1fB", float64(n)/1_000_000_000)
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%.1fK", float64(n)/1_000)
+	default:
+		return fmt.Sprintf("%d", n)
+	}
 }
 
 // humanizeCount formats a non-negative integer with thousands separators, e.g.
@@ -156,4 +260,24 @@ func humanizeCount(n int) string {
 		}
 	}
 	return b.String()
+}
+
+// visibleWidth returns the number of visible columns in s, skipping ANSI SGR
+// escape sequences (\x1b[...m). Used so colored lines are padded and cleared by
+// their on-screen width rather than their byte length.
+func visibleWidth(s string) int {
+	w, inEsc := 0, false
+	for _, r := range s {
+		switch {
+		case inEsc:
+			if r == 'm' {
+				inEsc = false
+			}
+		case r == '\x1b':
+			inEsc = true
+		default:
+			w++
+		}
+	}
+	return w
 }

--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -253,6 +253,9 @@ func renderBar(progress int) string {
 	if full > progressBarWidth {
 		full = progressBarWidth
 	}
+	if full < 0 {
+		full = 0
+	}
 	partial := ""
 	if full < progressBarWidth {
 		if e := int((exact - float64(full)) * 8); e > 0 {

--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -73,15 +73,16 @@ type ProgressReporter struct {
 	// synchronously via Update; production always leaves it false.
 	manualTick bool
 
-	mu      sync.Mutex
-	latest  ProgressState
-	spinIdx int
-	lastVis int // visible width of the last animated line, for padding/clearing
-	started bool
-	stopped bool
-	ticker  *time.Ticker
-	done    chan struct{}
-	wg      sync.WaitGroup
+	mu        sync.Mutex
+	latest    ProgressState
+	spinIdx   int
+	lastVis   int  // visible width of the last animated line, for padding/clearing
+	shown     bool // at least one frame was drawn (gates the completion summary)
+	animating bool // the background ticker goroutine is running
+	stopped   bool
+	ticker    *time.Ticker
+	done      chan struct{}
+	wg        sync.WaitGroup
 }
 
 // NewProgressReporter returns a reporter for the given mode. It draws an
@@ -142,8 +143,8 @@ func (p *ProgressReporter) Update(s ProgressState) {
 
 	p.mu.Lock()
 	p.latest = s
-	if !p.started && !p.stopped && !p.manualTick {
-		p.started = true
+	if !p.animating && !p.stopped && !p.manualTick {
+		p.animating = true
 		p.startTickerLocked()
 	}
 	p.renderLocked()
@@ -197,33 +198,70 @@ func (p *ProgressReporter) renderLocked() {
 	}
 	fmt.Fprintf(p.w, "\r%s%s", line, pad)
 	p.lastVis = vis
+	p.shown = true
 }
 
 // Stop halts the background animator and erases the progress line so the real
-// result renders on a clean row. It is safe to call multiple times and when
+// result renders on a clean row. Use it on error or cancellation; use Complete
+// on success to leave a summary. It is safe to call multiple times and when
 // disabled.
 func (p *ProgressReporter) Stop() {
 	if p == nil || !p.animate {
 		return
 	}
-
-	p.mu.Lock()
-	if p.stopped {
-		p.mu.Unlock()
+	if _, first := p.stopAnimator(); !first {
 		return
 	}
+	p.clearLine()
+}
+
+// Complete halts the animator and, when a bar was actually shown, replaces it
+// with a one-line completion summary (a green check, the final scan totals, and
+// elapsed time). For a query too fast to have animated it just clears, adding
+// no noise. It is idempotent with Stop; whichever runs first wins.
+func (p *ProgressReporter) Complete(final ProgressState) {
+	if p == nil || !p.animate {
+		return
+	}
+	shown, first := p.stopAnimator()
+	if !first {
+		return
+	}
+	p.clearLine()
+	if !shown {
+		return
+	}
+	check := colorize(Bold+Green, "✓")
+	fmt.Fprintf(p.w, "%s %s\n", check, colorize(Dim, summaryText(final, p.start)))
+}
+
+// stopAnimator halts the background loop exactly once, waiting for the goroutine
+// to exit. It reports whether an animation had started and whether this was the
+// first stop (so callers don't double-clear or double-print). The wait happens
+// outside the lock to avoid deadlocking the goroutine.
+func (p *ProgressReporter) stopAnimator() (shown, firstStop bool) {
+	p.mu.Lock()
+	if p.stopped {
+		s := p.shown
+		p.mu.Unlock()
+		return s, false
+	}
 	p.stopped = true
-	started, done, ticker := p.started, p.done, p.ticker
+	shown = p.shown
+	animating := p.animating
+	done, ticker := p.done, p.ticker
 	p.mu.Unlock()
 
-	// Wait for the animator to exit before clearing so no stray frame lands
-	// after the clear. Done outside the lock to avoid deadlocking the goroutine.
-	if started {
+	if animating {
 		ticker.Stop()
 		close(done)
 		p.wg.Wait()
 	}
+	return shown, true
+}
 
+// clearLine erases the current animated line, if any.
+func (p *ProgressReporter) clearLine() {
 	p.mu.Lock()
 	if p.lastVis > 0 {
 		fmt.Fprintf(p.w, "\r%s\r", strings.Repeat(" ", p.lastVis))
@@ -250,9 +288,48 @@ func renderBar(progress int) string {
 	if partial != "" {
 		empty--
 	}
-	filled := colorize(BrightCyan, strings.Repeat("█", full)+partial)
-	rest := colorize(Dim, strings.Repeat("░", empty))
-	return "▕" + filled + rest + "▏"
+
+	var b strings.Builder
+	b.WriteString("▕")
+	// Render the moving frontier (the partial cell, or the last full cell when
+	// the bar lands exactly on a boundary) in bright cyan, with the body a
+	// calmer cyan — a subtle leading-edge glow rather than a flat block.
+	switch {
+	case partial != "":
+		if full > 0 {
+			b.WriteString(colorize(Cyan, strings.Repeat("█", full)))
+		}
+		b.WriteString(colorize(BrightCyan, partial))
+	case full > 0:
+		if full > 1 {
+			b.WriteString(colorize(Cyan, strings.Repeat("█", full-1)))
+		}
+		b.WriteString(colorize(BrightCyan, "█"))
+	}
+	b.WriteString(colorize(Dim, strings.Repeat("░", empty)))
+	b.WriteString("▏")
+	return b.String()
+}
+
+// summaryText renders the completion line body, e.g.
+// "scanned 17.3 TB · 6.0B records in 42.1s", or "done in 3.2s" for a query that
+// reported no scan totals.
+func summaryText(s ProgressState, start time.Time) string {
+	var b strings.Builder
+	if s.ScannedBytes > 0 {
+		b.WriteString("scanned ")
+		b.WriteString(formatBytes(s.ScannedBytes))
+		if s.ScannedRecords > 0 {
+			b.WriteString(" · ")
+			b.WriteString(humanizeMetric(s.ScannedRecords))
+			b.WriteString(" records")
+		}
+		b.WriteString(" in ")
+	} else {
+		b.WriteString("done in ")
+	}
+	b.WriteString(formatElapsed(time.Since(start)))
+	return b.String()
 }
 
 // statsSuffix renders the trailing stats segment for the animated line: scan

--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -9,15 +9,6 @@ import (
 	"time"
 )
 
-// ProgressMode controls whether a live progress indicator is drawn while a
-// long-running query is polled. It mirrors the auto|always|never convention
-// used elsewhere in the CLI.
-const (
-	ProgressAuto   = "auto"
-	ProgressAlways = "always"
-	ProgressNever  = "never"
-)
-
 // progressBarWidth is the number of cells in the rendered bar.
 const progressBarWidth = 20
 
@@ -49,24 +40,22 @@ type ProgressState struct {
 }
 
 // ProgressReporter renders an in-place progress line to stderr while a query
-// runs. When it is not enabled (non-TTY stderr, --plain, agent mode, or
-// mode=never) every method is a no-op, so callers can wire it unconditionally
-// without disturbing piped or structured output. Color is emitted only when
-// ColorEnabled() is true, so NO_COLOR still yields a plain (monochrome) bar.
+// runs. It is drawn only for an interactive terminal; when disabled (non-TTY
+// stderr, --plain, agent mode, or the user opted out) every method is a no-op,
+// so callers can wire it unconditionally without disturbing piped or structured
+// output. Color is emitted only when ColorEnabled() is true, so NO_COLOR still
+// yields a plain (monochrome) bar.
 //
-// In animated mode a background goroutine redraws the line on a fixed interval
-// (so the spinner and elapsed timer stay smooth between the far slower query
-// polls), while Update — called from the poll loop — only refreshes the shared
-// state. The mutex guards that state and serializes writes between the two.
+// A background goroutine redraws the line on a fixed interval (so the spinner
+// and elapsed timer stay smooth between the far slower query polls), while
+// Update — called from the poll loop — only refreshes the shared state. The
+// mutex guards that state and serializes writes between the two.
 type ProgressReporter struct {
 	w io.Writer
-	// animate is true when stderr is an interactive TTY: the line is redrawn in
-	// place with a carriage return and cleared on Stop.
+	// animate is true when the reporter is enabled and stderr is an interactive
+	// TTY: the line is redrawn in place with a carriage return and cleared on Stop.
 	animate bool
-	// logLines is true for mode=always on a non-TTY: progress is written as
-	// plain, ANSI-free lines (one per update) so it survives in CI logs.
-	logLines bool
-	start    time.Time
+	start   time.Time
 	// tickInterval overrides the redraw cadence (tests only); 0 => default.
 	tickInterval time.Duration
 	// manualTick disables the background animator so tests can drive frames
@@ -85,36 +74,21 @@ type ProgressReporter struct {
 	wg        sync.WaitGroup
 }
 
-// NewProgressReporter returns a reporter for the given mode. It draws an
-// animated line when stderr is a TTY and output is not --plain; agent mode is
-// always silent. mode=always forces output even on a non-TTY, degrading to
-// plain per-line logging.
-func NewProgressReporter(mode string, agentMode bool) *ProgressReporter {
-	return newProgressReporter(mode, agentMode, os.Stderr)
+// NewProgressReporter returns a reporter. When enabled is false (the user opted
+// out), or in agent mode, or under --plain, or when stderr is not an
+// interactive terminal, the reporter is a silent no-op. NO_COLOR is respected
+// for color only — the bar is still drawn, just without color.
+func NewProgressReporter(enabled, agentMode bool) *ProgressReporter {
+	return newProgressReporter(enabled, agentMode, os.Stderr)
 }
 
 // newProgressReporter is the testable core of NewProgressReporter with an
 // injectable writer.
-func newProgressReporter(mode string, agentMode bool, w io.Writer) *ProgressReporter {
+func newProgressReporter(enabled, agentMode bool, w io.Writer) *ProgressReporter {
 	r := &ProgressReporter{w: w, start: time.Now()}
-	if agentMode || mode == ProgressNever {
-		return r
-	}
-
-	// Progress is a stderr affordance, so gate on stderr being a TTY (not
-	// stdout) and on --plain — but not on NO_COLOR, which only suppresses color,
-	// not the bar itself.
-	tty := isTerminalWriter(w) && !plainModeEnabled
-	switch mode {
-	case ProgressAlways:
-		if tty {
-			r.animate = true
-		} else {
-			r.logLines = true
-		}
-	case ProgressAuto:
-		r.animate = tty
-	}
+	// Progress is a stderr affordance: gate on stderr being a TTY (not stdout)
+	// and on --plain/agent mode — but not on NO_COLOR, which only drops color.
+	r.animate = enabled && !agentMode && !plainModeEnabled && isTerminalWriter(w)
 	return r
 }
 
@@ -133,10 +107,6 @@ func (p *ProgressReporter) Update(s ProgressState) {
 		s.Progress = 100
 	}
 
-	if p.logLines {
-		fmt.Fprintf(p.w, "querying... %d%%%s\n", s.Progress, plainStats(s))
-		return
-	}
 	if !p.animate {
 		return
 	}
@@ -346,20 +316,6 @@ func statsSuffix(s ProgressState, start time.Time) string {
 	}
 	parts = append(parts, formatElapsed(time.Since(start)))
 	return "  " + strings.Join(parts, " · ")
-}
-
-// plainStats renders the ANSI-free stats segment for the CI log-lines path.
-func plainStats(s ProgressState) string {
-	switch {
-	case s.ScannedBytes > 0:
-		if s.ScannedRecords > 0 {
-			return fmt.Sprintf(" (%s scanned, %s records)", formatBytes(s.ScannedBytes), humanizeMetric(s.ScannedRecords))
-		}
-		return fmt.Sprintf(" (%s scanned)", formatBytes(s.ScannedBytes))
-	case s.PreviewRows > 0:
-		return fmt.Sprintf(" (preview: %s rows)", humanizeCount(s.PreviewRows))
-	}
-	return ""
 }
 
 // colorize wraps text in a color code only when color is enabled.

--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/term"
 )
 
 // progressBarWidth is the number of cells in the rendered bar.
@@ -61,6 +63,10 @@ type ProgressReporter struct {
 	// manualTick disables the background animator so tests can drive frames
 	// synchronously via Update; production always leaves it false.
 	manualTick bool
+	// termWidth overrides the detected terminal width (tests only); 0 => detect
+	// from the writer, and detection failing (non-*os.File writer) means no
+	// truncation.
+	termWidth int
 
 	mu        sync.Mutex
 	latest    ProgressState
@@ -158,9 +164,16 @@ func (p *ProgressReporter) renderLocked() {
 	if s.ScannedBytes > 0 {
 		verb = "scanning"
 	}
-	spin := colorize(Cyan, string(progressSpinner[p.spinIdx%len(progressSpinner)]))
-	pct := colorize(Bold, fmt.Sprintf("%3d%%", s.Progress))
-	line := fmt.Sprintf("%s %s %s %s%s", spin, verb, pct, renderBar(s.Progress), colorize(Dim, statsSuffix(s, p.start)))
+	spin := Colorize(Cyan, string(progressSpinner[p.spinIdx%len(progressSpinner)]))
+	pct := Colorize(Bold, fmt.Sprintf("%3d%%", s.Progress))
+	line := fmt.Sprintf("%s %s %s %s%s", spin, verb, pct, renderBar(s.Progress), Colorize(Dim, statsSuffix(s, p.start)))
+
+	// Clamp to the terminal width so a narrow terminal never wraps the line onto
+	// a second physical row (which a bare "\r" on the next frame cannot reach to
+	// erase, leaving stale rows behind). Truncation counts visible columns only.
+	if width := p.terminalWidth(); width > 0 {
+		line = truncateVisible(line, width)
+	}
 
 	// Return the cursor to column 0, write the new line, then pad with spaces to
 	// erase any tail left by a previously longer line. Padding is measured in
@@ -215,8 +228,8 @@ func (p *ProgressReporter) Complete(final ProgressState) {
 	if !shown {
 		return
 	}
-	check := colorize(Bold+Green, "✓")
-	fmt.Fprintf(p.w, "%s %s\n", check, colorize(Dim, summaryText(final, p.start)))
+	check := Colorize(Bold+Green, "✓")
+	fmt.Fprintf(p.w, "%s %s\n", check, Colorize(Dim, summaryText(final, p.start)))
 }
 
 // stopAnimator halts the background loop exactly once, waiting for the goroutine
@@ -284,16 +297,16 @@ func renderBar(progress int) string {
 	switch {
 	case partial != "":
 		if full > 0 {
-			b.WriteString(colorize(Cyan, strings.Repeat("█", full)))
+			b.WriteString(Colorize(Cyan, strings.Repeat("█", full)))
 		}
-		b.WriteString(colorize(BrightCyan, partial))
+		b.WriteString(Colorize(BrightCyan, partial))
 	case full > 0:
 		if full > 1 {
-			b.WriteString(colorize(Cyan, strings.Repeat("█", full-1)))
+			b.WriteString(Colorize(Cyan, strings.Repeat("█", full-1)))
 		}
-		b.WriteString(colorize(BrightCyan, "█"))
+		b.WriteString(Colorize(BrightCyan, "█"))
 	}
-	b.WriteString(colorize(Dim, strings.Repeat("░", empty)))
+	b.WriteString(Colorize(Dim, strings.Repeat("░", empty)))
 	b.WriteString("▏")
 	return b.String()
 }
@@ -335,17 +348,13 @@ func statsSuffix(s ProgressState, start time.Time) string {
 	return "  " + strings.Join(parts, " · ")
 }
 
-// colorize wraps text in a color code only when color is enabled.
-func colorize(code, text string) string {
-	if !ColorEnabled() {
-		return text
-	}
-	return code + text + Reset
-}
-
 // formatElapsed renders a duration compactly: "8.2s" under a minute, "1m03s"
 // above.
 func formatElapsed(d time.Duration) string {
+	// Round to the display resolution (tenths of a second) first so a value
+	// just under a minute (e.g. 59.97s) rolls over to "1m00s" instead of
+	// rounding to a nonsensical "60.0s".
+	d = d.Round(100 * time.Millisecond)
 	if d < time.Minute {
 		return fmt.Sprintf("%.1fs", d.Seconds())
 	}
@@ -355,18 +364,79 @@ func formatElapsed(d time.Duration) string {
 }
 
 // humanizeMetric formats a large count with a decimal SI-style suffix, e.g.
-// 5983657731 -> "6.0B", 2085739 -> "2.1M", 4200 -> "4.2K".
+// 5983657731 -> "6.0B", 2085739 -> "2.1M", 4200 -> "4.2K". Each threshold sits
+// just below its SI boundary so a value that would render as "1000.0<unit>"
+// (e.g. 999,950,000 -> "1000.0M") rolls up to the next unit ("1.0B") instead.
 func humanizeMetric(n int64) string {
+	f := float64(n)
 	switch {
-	case n >= 1_000_000_000:
-		return fmt.Sprintf("%.1fB", float64(n)/1_000_000_000)
-	case n >= 1_000_000:
-		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
-	case n >= 1_000:
-		return fmt.Sprintf("%.1fK", float64(n)/1_000)
+	case f >= 999_950_000:
+		return fmt.Sprintf("%.1fB", f/1_000_000_000)
+	case f >= 999_950:
+		return fmt.Sprintf("%.1fM", f/1_000_000)
+	case f >= 1_000:
+		return fmt.Sprintf("%.1fK", f/1_000)
 	default:
 		return fmt.Sprintf("%d", n)
 	}
+}
+
+// terminalWidth returns the writer's terminal width in columns, or 0 when it is
+// unknown (not an *os.File, or GetSize failed) — in which case the caller skips
+// truncation. A test override (termWidth) takes precedence.
+func (p *ProgressReporter) terminalWidth() int {
+	if p.termWidth > 0 {
+		return p.termWidth
+	}
+	f, ok := p.w.(*os.File)
+	if !ok {
+		return 0
+	}
+	w, _, err := term.GetSize(int(f.Fd()))
+	if err != nil {
+		return 0
+	}
+	return w
+}
+
+// truncateVisible returns s limited to at most max visible columns, passing ANSI
+// SGR escape sequences through uncounted so color codes are preserved. A reset is
+// appended when color is enabled so a cut inside a colored run does not bleed.
+func truncateVisible(s string, max int) string {
+	if max < 0 {
+		max = 0
+	}
+	if visibleWidth(s) <= max {
+		return s
+	}
+	var b strings.Builder
+	w, inEsc := 0, false
+	for _, r := range s {
+		switch {
+		case inEsc:
+			b.WriteRune(r)
+			if r == 'm' {
+				inEsc = false
+			}
+		case r == '\x1b':
+			inEsc = true
+			b.WriteRune(r)
+		default:
+			if w >= max {
+				// Visible budget spent; drop the rest (trailing glyphs/escapes).
+				if ColorEnabled() {
+					b.WriteString(Reset)
+				}
+				return b.String()
+			}
+			b.WriteRune(r)
+			w++
+		}
+	}
+	if ColorEnabled() {
+		b.WriteString(Reset)
+	}
+	return b.String()
 }
 
 // visibleWidth returns the number of visible columns in s, skipping ANSI SGR

--- a/pkg/output/progress_test.go
+++ b/pkg/output/progress_test.go
@@ -9,31 +9,24 @@ import (
 )
 
 func TestNewProgressReporter_Gating(t *testing.T) {
-	// A bytes.Buffer is never a TTY, so animate must stay false. mode=always on
-	// a non-TTY degrades to plain per-line logging; every other combination is
-	// fully silent.
+	// A bytes.Buffer is never a TTY, so animate must stay false in every case.
+	// (The TTY-enabled path is exercised by constructing the struct directly in
+	// the animation tests below.)
 	tests := []struct {
-		name         string
-		mode         string
-		agent        bool
-		wantAnimate  bool
-		wantLogLines bool
+		name    string
+		enabled bool
+		agent   bool
 	}{
-		{"auto non-tty", ProgressAuto, false, false, false},
-		{"always non-tty", ProgressAlways, false, false, true},
-		{"never non-tty", ProgressNever, false, false, false},
-		{"always agent mode", ProgressAlways, true, false, false},
-		{"auto agent mode", ProgressAuto, true, false, false},
-		{"never agent mode", ProgressNever, true, false, false},
+		{"enabled non-tty", true, false},
+		{"disabled non-tty", false, false},
+		{"enabled agent mode", true, true},
+		{"disabled agent mode", false, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := newProgressReporter(tt.mode, tt.agent, &bytes.Buffer{})
-			if r.animate != tt.wantAnimate {
-				t.Errorf("animate = %v, want %v", r.animate, tt.wantAnimate)
-			}
-			if r.logLines != tt.wantLogLines {
-				t.Errorf("logLines = %v, want %v", r.logLines, tt.wantLogLines)
+			r := newProgressReporter(tt.enabled, tt.agent, &bytes.Buffer{})
+			if r.animate {
+				t.Errorf("animate = true on a non-TTY writer, want false")
 			}
 		})
 	}
@@ -41,32 +34,11 @@ func TestNewProgressReporter_Gating(t *testing.T) {
 
 func TestProgressReporter_DisabledIsSilent(t *testing.T) {
 	var buf bytes.Buffer
-	r := newProgressReporter(ProgressAuto, false, &buf) // non-TTY auto => disabled
+	r := newProgressReporter(true, false, &buf) // enabled, but non-TTY => disabled
 	r.Update(ProgressState{Progress: 50, PreviewRows: 100})
 	r.Stop()
 	if buf.Len() != 0 {
 		t.Errorf("disabled reporter wrote %q, want nothing", buf.String())
-	}
-}
-
-func TestProgressReporter_LogLines(t *testing.T) {
-	var buf bytes.Buffer
-	r := newProgressReporter(ProgressAlways, false, &buf) // non-TTY always => logLines
-	r.Update(ProgressState{Progress: 20})
-	r.Update(ProgressState{Progress: 80, PreviewRows: 1234})
-	r.Update(ProgressState{Progress: 95, ScannedBytes: 13_359_294_822_752, ScannedRecords: 4_647_571_690})
-	r.Stop() // no-op for logLines
-
-	got := buf.String()
-	want := "querying... 20%\n" +
-		"querying... 80% (preview: 1,234 rows)\n" +
-		"querying... 95% (12.2 TB scanned, 4.6B records)\n"
-	if got != want {
-		t.Errorf("logLines output = %q, want %q", got, want)
-	}
-	// Plain log path must never emit ANSI escape sequences or carriage returns.
-	if strings.ContainsAny(got, "\r\x1b") {
-		t.Errorf("logLines output contains control chars: %q", got)
 	}
 }
 

--- a/pkg/output/progress_test.go
+++ b/pkg/output/progress_test.go
@@ -1,0 +1,135 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNewProgressReporter_Gating(t *testing.T) {
+	// A bytes.Buffer is never a TTY, so animate must stay false. mode=always on
+	// a non-TTY degrades to plain per-line logging; every other combination is
+	// fully silent.
+	tests := []struct {
+		name         string
+		mode         string
+		agent        bool
+		wantAnimate  bool
+		wantLogLines bool
+	}{
+		{"auto non-tty", ProgressAuto, false, false, false},
+		{"always non-tty", ProgressAlways, false, false, true},
+		{"never non-tty", ProgressNever, false, false, false},
+		{"always agent mode", ProgressAlways, true, false, false},
+		{"auto agent mode", ProgressAuto, true, false, false},
+		{"never agent mode", ProgressNever, true, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newProgressReporter(tt.mode, tt.agent, &bytes.Buffer{})
+			if r.animate != tt.wantAnimate {
+				t.Errorf("animate = %v, want %v", r.animate, tt.wantAnimate)
+			}
+			if r.logLines != tt.wantLogLines {
+				t.Errorf("logLines = %v, want %v", r.logLines, tt.wantLogLines)
+			}
+		})
+	}
+}
+
+func TestProgressReporter_DisabledIsSilent(t *testing.T) {
+	var buf bytes.Buffer
+	r := newProgressReporter(ProgressAuto, false, &buf) // non-TTY auto => disabled
+	r.Update(50, 100)
+	r.Stop()
+	if buf.Len() != 0 {
+		t.Errorf("disabled reporter wrote %q, want nothing", buf.String())
+	}
+}
+
+func TestProgressReporter_LogLines(t *testing.T) {
+	var buf bytes.Buffer
+	r := newProgressReporter(ProgressAlways, false, &buf) // non-TTY always => logLines
+	r.Update(20, 0)
+	r.Update(80, 1234)
+	r.Stop() // no-op for logLines
+
+	got := buf.String()
+	wantLines := []string{
+		"querying... 20%\n",
+		"querying... 80% (preview: 1,234 rows)\n",
+	}
+	want := strings.Join(wantLines, "")
+	if got != want {
+		t.Errorf("logLines output = %q, want %q", got, want)
+	}
+	// Plain log path must never emit ANSI escape sequences or carriage returns.
+	if strings.ContainsAny(got, "\r\x1b") {
+		t.Errorf("logLines output contains control chars: %q", got)
+	}
+}
+
+func TestProgressReporter_AnimateOverwritesAndClears(t *testing.T) {
+	var buf bytes.Buffer
+	// Force the animated path directly — a buffer is not a TTY.
+	r := &ProgressReporter{w: &buf, animate: true}
+
+	r.Update(45, 1204)
+	r.Update(90, 0) // shorter line (no preview suffix) must be fully padded over
+	r.Stop()
+
+	got := buf.String()
+	// Each Update begins by returning the cursor to column 0.
+	if !strings.HasPrefix(got, "\r") {
+		t.Errorf("animated output should start with a carriage return: %q", got)
+	}
+	if !strings.Contains(got, "45%") || !strings.Contains(got, "90%") {
+		t.Errorf("output missing progress values: %q", got)
+	}
+	if !strings.Contains(got, "(preview: 1,204 rows)") {
+		t.Errorf("output missing preview counter: %q", got)
+	}
+	// Stop clears the line and leaves the cursor at column 0.
+	if !strings.HasSuffix(got, "\r") {
+		t.Errorf("output should end cleared (trailing CR): %q", got)
+	}
+}
+
+func TestRenderBar(t *testing.T) {
+	tests := []struct {
+		progress   int
+		wantFilled int
+	}{
+		{0, 0},
+		{50, 10},
+		{100, 20},
+		{150, 20}, // clamped
+	}
+	for _, tt := range tests {
+		bar := renderBar(tt.progress)
+		if got := strings.Count(bar, "█"); got != tt.wantFilled {
+			t.Errorf("renderBar(%d) filled = %d, want %d (bar=%q)", tt.progress, got, tt.wantFilled, bar)
+		}
+		if total := strings.Count(bar, "█") + strings.Count(bar, "░"); total != progressBarWidth {
+			t.Errorf("renderBar(%d) total cells = %d, want %d", tt.progress, total, progressBarWidth)
+		}
+	}
+}
+
+func TestHumanizeCount(t *testing.T) {
+	tests := map[int]string{
+		0:       "0",
+		7:       "7",
+		42:      "42",
+		999:     "999",
+		1000:    "1,000",
+		1234:    "1,234",
+		12345:   "12,345",
+		1234567: "1,234,567",
+	}
+	for in, want := range tests {
+		if got := humanizeCount(in); got != want {
+			t.Errorf("humanizeCount(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/output/progress_test.go
+++ b/pkg/output/progress_test.go
@@ -3,6 +3,7 @@ package output
 import (
 	"bytes"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -71,8 +72,9 @@ func TestProgressReporter_LogLines(t *testing.T) {
 
 func TestProgressReporter_AnimateOverwritesAndClears(t *testing.T) {
 	var buf bytes.Buffer
-	// Force the animated path directly — a buffer is not a TTY.
-	r := &ProgressReporter{w: &buf, animate: true}
+	// Force the animated path directly — a buffer is not a TTY. manualTick keeps
+	// the background animator off so frames are driven synchronously by Update.
+	r := &ProgressReporter{w: &buf, animate: true, manualTick: true}
 
 	r.Update(ProgressState{Progress: 45, ScannedBytes: 13_359_294_822_752, ScannedRecords: 4_647_571_690})
 	r.Update(ProgressState{Progress: 90}) // shorter line must be fully padded over
@@ -106,7 +108,7 @@ func TestProgressReporter_AnimatePadsByVisibleWidth(t *testing.T) {
 	t.Cleanup(ResetColorCache)
 
 	var buf bytes.Buffer
-	r := &ProgressReporter{w: &buf, animate: true}
+	r := &ProgressReporter{w: &buf, animate: true, manualTick: true}
 	r.Update(ProgressState{Progress: 50, ScannedBytes: 1 << 40, ScannedRecords: 1_000_000})
 	if !ColorEnabled() {
 		t.Skip("color not enabled in this environment; visible-width path not exercised")
@@ -117,6 +119,59 @@ func TestProgressReporter_AnimatePadsByVisibleWidth(t *testing.T) {
 	if r.lastVis == 0 || r.lastVis >= len(buf.String()) {
 		t.Errorf("visible width %d should be >0 and less than byte length %d when colored", r.lastVis, len(buf.String()))
 	}
+}
+
+// syncBuf is a mutex-guarded buffer so the test can read output while the
+// background animator writes concurrently, without racing.
+type syncBuf struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+func TestProgressReporter_SpinnerAdvancesBetweenUpdates(t *testing.T) {
+	// The animator must keep the spinner moving on its own timer, without any
+	// further Update calls, and stop cleanly.
+	ResetColorCache()
+	t.Setenv("NO_COLOR", "1") // keep output ANSI-free so we count raw spinner runes
+	t.Cleanup(ResetColorCache)
+
+	buf := &syncBuf{}
+	r := &ProgressReporter{w: buf, animate: true, start: time.Now(), tickInterval: 10 * time.Millisecond}
+
+	r.Update(ProgressState{Progress: 30}) // starts the animator; no further updates
+	time.Sleep(80 * time.Millisecond)     // ~8 ticks
+	r.Stop()
+
+	// Count how many distinct spinner frames appeared — proves it advanced
+	// without additional Update calls.
+	out := buf.String()
+	distinct := 0
+	for _, g := range progressSpinner {
+		if strings.ContainsRune(out, g) {
+			distinct++
+		}
+	}
+	if distinct < 3 {
+		t.Errorf("spinner advanced through only %d distinct frames, want >=3 (output=%q)", distinct, out)
+	}
+	// After Stop the line is cleared and the animator has exited; a subsequent
+	// Stop must be a safe no-op.
+	if !strings.HasSuffix(out, "\r") {
+		t.Errorf("output should end cleared with a trailing CR: %q", out)
+	}
+	r.Stop() // must not panic (idempotent)
 }
 
 func TestRenderBar(t *testing.T) {

--- a/pkg/output/progress_test.go
+++ b/pkg/output/progress_test.go
@@ -174,6 +174,50 @@ func TestProgressReporter_SpinnerAdvancesBetweenUpdates(t *testing.T) {
 	r.Stop() // must not panic (idempotent)
 }
 
+func TestProgressReporter_CompletePrintsSummary(t *testing.T) {
+	var buf bytes.Buffer
+	// manualTick keeps the animator off; started must be forced so Complete
+	// treats this as a bar that was shown.
+	r := &ProgressReporter{w: &buf, animate: true, manualTick: true, start: time.Now().Add(-42100 * time.Millisecond)}
+	r.Update(ProgressState{Progress: 90, ScannedBytes: 1 << 40, ScannedRecords: 5_983_657_731})
+
+	r.Complete(ProgressState{Progress: 100, ScannedBytes: 19_051_610_460_057, ScannedRecords: 5_983_657_731})
+
+	got := buf.String()
+	if !strings.Contains(got, "✓") {
+		t.Errorf("summary should include a check mark: %q", got)
+	}
+	if !strings.Contains(got, "scanned 17.3 TB · 6.0B records in 42.1s") {
+		t.Errorf("summary body wrong: %q", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("summary should end with a newline: %q", got)
+	}
+}
+
+func TestProgressReporter_CompleteSilentWhenNoBar(t *testing.T) {
+	// A query too fast to have animated (never Update'd) must not print a
+	// summary — Complete just clears (a no-op here) and stays quiet.
+	var buf bytes.Buffer
+	r := &ProgressReporter{w: &buf, animate: true, manualTick: true, start: time.Now()}
+	r.Complete(ProgressState{Progress: 100, ScannedBytes: 1 << 40})
+	if buf.Len() != 0 {
+		t.Errorf("Complete without a prior bar should be silent, wrote %q", buf.String())
+	}
+}
+
+func TestProgressReporter_StopAfterCompleteIsNoop(t *testing.T) {
+	var buf bytes.Buffer
+	r := &ProgressReporter{w: &buf, animate: true, manualTick: true, start: time.Now()}
+	r.Update(ProgressState{Progress: 50})
+	r.Complete(ProgressState{Progress: 100})
+	n := buf.Len()
+	r.Stop() // must not clear or double-print after Complete already ran
+	if buf.Len() != n {
+		t.Errorf("Stop after Complete wrote extra bytes: %q", buf.String()[n:])
+	}
+}
+
 func TestRenderBar(t *testing.T) {
 	tests := []struct {
 		progress   int

--- a/pkg/output/progress_test.go
+++ b/pkg/output/progress_test.go
@@ -241,21 +241,3 @@ func TestFormatElapsed(t *testing.T) {
 		}
 	}
 }
-
-func TestHumanizeCount(t *testing.T) {
-	tests := map[int]string{
-		0:       "0",
-		7:       "7",
-		42:      "42",
-		999:     "999",
-		1000:    "1,000",
-		1234:    "1,234",
-		12345:   "12,345",
-		1234567: "1,234,567",
-	}
-	for in, want := range tests {
-		if got := humanizeCount(in); got != want {
-			t.Errorf("humanizeCount(%d) = %q, want %q", in, got, want)
-		}
-	}
-}

--- a/pkg/output/progress_test.go
+++ b/pkg/output/progress_test.go
@@ -219,6 +219,12 @@ func TestHumanizeMetric(t *testing.T) {
 		4200:       "4.2K",
 		2085739:    "2.1M",
 		5983657731: "6.0B",
+		// Boundary roll-up: values that would render as "1000.0<unit>" must roll
+		// up to the next unit instead.
+		999_949:     "999.9K",
+		999_950:     "1.0M",
+		999_949_999: "999.9M",
+		999_950_000: "1.0B",
 	}
 	for in, want := range tests {
 		if got := humanizeMetric(in); got != want {
@@ -234,10 +240,47 @@ func TestFormatElapsed(t *testing.T) {
 		59 * time.Second:        "59.0s",
 		63 * time.Second:        "1m03s",
 		125 * time.Second:       "2m05s",
+		// Boundary: a value that rounds to 60.0s must roll over to the minute
+		// form rather than print "60.0s".
+		59940 * time.Millisecond: "59.9s",
+		59950 * time.Millisecond: "1m00s",
+		59970 * time.Millisecond: "1m00s",
 	}
 	for in, want := range tests {
 		if got := formatElapsed(in); got != want {
 			t.Errorf("formatElapsed(%v) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestProgressReporter_ClampsToTerminalWidth(t *testing.T) {
+	// A narrow terminal must not receive a line wider than its width, or it
+	// wraps to a second physical row that a bare "\r" cannot erase.
+	t.Setenv("NO_COLOR", "1") // keep output ANSI-free so width == byte length
+	ResetColorCache()
+	t.Cleanup(ResetColorCache)
+
+	var buf bytes.Buffer
+	r := &ProgressReporter{w: &buf, animate: true, manualTick: true, start: time.Now(), termWidth: 20}
+	r.Update(ProgressState{Progress: 45, ScannedBytes: 13_359_294_822_752, ScannedRecords: 4_647_571_690})
+
+	got := strings.TrimPrefix(buf.String(), "\r")
+	if w := visibleWidth(got); w > 20 {
+		t.Errorf("line visible width = %d, want <= 20 (line=%q)", w, got)
+	}
+}
+
+func TestTruncateVisible(t *testing.T) {
+	if got := truncateVisible("hello world", 5); got != "hello" {
+		t.Errorf("truncateVisible plain = %q, want %q", got, "hello")
+	}
+	if got := truncateVisible("hi", 5); got != "hi" {
+		t.Errorf("truncateVisible shorter-than-max should be unchanged, got %q", got)
+	}
+	// ANSI escapes are passed through uncounted; only visible columns are capped.
+	colored := Cyan + "abcdef" + Reset
+	got := truncateVisible(colored, 3)
+	if visibleWidth(got) != 3 {
+		t.Errorf("truncateVisible colored visible width = %d, want 3 (got %q)", visibleWidth(got), got)
 	}
 }

--- a/pkg/output/progress_test.go
+++ b/pkg/output/progress_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewProgressReporter_Gating(t *testing.T) {
@@ -40,7 +41,7 @@ func TestNewProgressReporter_Gating(t *testing.T) {
 func TestProgressReporter_DisabledIsSilent(t *testing.T) {
 	var buf bytes.Buffer
 	r := newProgressReporter(ProgressAuto, false, &buf) // non-TTY auto => disabled
-	r.Update(50, 100)
+	r.Update(ProgressState{Progress: 50, PreviewRows: 100})
 	r.Stop()
 	if buf.Len() != 0 {
 		t.Errorf("disabled reporter wrote %q, want nothing", buf.String())
@@ -50,16 +51,15 @@ func TestProgressReporter_DisabledIsSilent(t *testing.T) {
 func TestProgressReporter_LogLines(t *testing.T) {
 	var buf bytes.Buffer
 	r := newProgressReporter(ProgressAlways, false, &buf) // non-TTY always => logLines
-	r.Update(20, 0)
-	r.Update(80, 1234)
+	r.Update(ProgressState{Progress: 20})
+	r.Update(ProgressState{Progress: 80, PreviewRows: 1234})
+	r.Update(ProgressState{Progress: 95, ScannedBytes: 13_359_294_822_752, ScannedRecords: 4_647_571_690})
 	r.Stop() // no-op for logLines
 
 	got := buf.String()
-	wantLines := []string{
-		"querying... 20%\n",
-		"querying... 80% (preview: 1,234 rows)\n",
-	}
-	want := strings.Join(wantLines, "")
+	want := "querying... 20%\n" +
+		"querying... 80% (preview: 1,234 rows)\n" +
+		"querying... 95% (12.2 TB scanned, 4.6B records)\n"
 	if got != want {
 		t.Errorf("logLines output = %q, want %q", got, want)
 	}
@@ -74,8 +74,8 @@ func TestProgressReporter_AnimateOverwritesAndClears(t *testing.T) {
 	// Force the animated path directly — a buffer is not a TTY.
 	r := &ProgressReporter{w: &buf, animate: true}
 
-	r.Update(45, 1204)
-	r.Update(90, 0) // shorter line (no preview suffix) must be fully padded over
+	r.Update(ProgressState{Progress: 45, ScannedBytes: 13_359_294_822_752, ScannedRecords: 4_647_571_690})
+	r.Update(ProgressState{Progress: 90}) // shorter line must be fully padded over
 	r.Stop()
 
 	got := buf.String()
@@ -86,12 +86,36 @@ func TestProgressReporter_AnimateOverwritesAndClears(t *testing.T) {
 	if !strings.Contains(got, "45%") || !strings.Contains(got, "90%") {
 		t.Errorf("output missing progress values: %q", got)
 	}
-	if !strings.Contains(got, "(preview: 1,204 rows)") {
-		t.Errorf("output missing preview counter: %q", got)
+	if !strings.Contains(got, "12.2 TB") || !strings.Contains(got, "4.6B recs") {
+		t.Errorf("output missing scan stats: %q", got)
+	}
+	if !strings.Contains(got, "scanning") {
+		t.Errorf("output should use the 'scanning' verb when bytes are present: %q", got)
 	}
 	// Stop clears the line and leaves the cursor at column 0.
 	if !strings.HasSuffix(got, "\r") {
 		t.Errorf("output should end cleared (trailing CR): %q", got)
+	}
+}
+
+func TestProgressReporter_AnimatePadsByVisibleWidth(t *testing.T) {
+	// With color enabled the line carries ANSI escapes; the clear on Stop must
+	// be sized by visible width, not byte length, or it would over-pad and wrap.
+	ResetColorCache()
+	t.Setenv("FORCE_COLOR", "1")
+	t.Cleanup(ResetColorCache)
+
+	var buf bytes.Buffer
+	r := &ProgressReporter{w: &buf, animate: true}
+	r.Update(ProgressState{Progress: 50, ScannedBytes: 1 << 40, ScannedRecords: 1_000_000})
+	if !ColorEnabled() {
+		t.Skip("color not enabled in this environment; visible-width path not exercised")
+	}
+	// The colored line contains ANSI escapes, so its byte length exceeds its
+	// on-screen width; lastVis must track the (smaller) visible width so Stop
+	// clears exactly the visible columns without wrapping.
+	if r.lastVis == 0 || r.lastVis >= len(buf.String()) {
+		t.Errorf("visible width %d should be >0 and less than byte length %d when colored", r.lastVis, len(buf.String()))
 	}
 }
 
@@ -112,6 +136,37 @@ func TestRenderBar(t *testing.T) {
 		}
 		if total := strings.Count(bar, "█") + strings.Count(bar, "░"); total != progressBarWidth {
 			t.Errorf("renderBar(%d) total cells = %d, want %d", tt.progress, total, progressBarWidth)
+		}
+	}
+}
+
+func TestHumanizeMetric(t *testing.T) {
+	tests := map[int64]string{
+		0:          "0",
+		999:        "999",
+		1000:       "1.0K",
+		4200:       "4.2K",
+		2085739:    "2.1M",
+		5983657731: "6.0B",
+	}
+	for in, want := range tests {
+		if got := humanizeMetric(in); got != want {
+			t.Errorf("humanizeMetric(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFormatElapsed(t *testing.T) {
+	tests := map[time.Duration]string{
+		500 * time.Millisecond:  "0.5s",
+		8200 * time.Millisecond: "8.2s",
+		59 * time.Second:        "59.0s",
+		63 * time.Second:        "1m03s",
+		125 * time.Second:       "2m05s",
+	}
+	for in, want := range tests {
+		if got := formatElapsed(in); got != want {
+			t.Errorf("formatElapsed(%v) = %q, want %q", in, got, want)
 		}
 	}
 }

--- a/pkg/resources/lookup/lookup.go
+++ b/pkg/resources/lookup/lookup.go
@@ -95,7 +95,8 @@ func (h *Handler) List() ([]Lookup, error) {
 	query := `fetch dt.system.files | filter startsWith(name, "/lookups/")`
 
 	executor := exec.NewDQLExecutor(h.client)
-	result, err := executor.ExecuteQuery(query)
+	// Internal metadata fetch, not a user-facing query: keep the progress bar off.
+	result, err := executor.ExecuteQueryWithOptions(query, exec.DQLExecuteOptions{NoProgress: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list lookup tables: %w", err)
 	}
@@ -159,7 +160,7 @@ func (h *Handler) Get(path string) (*Lookup, error) {
 
 	// First, get metadata from dt.system.files
 	metadataQuery := fmt.Sprintf(`fetch dt.system.files | filter name == "%s"`, path)
-	metadataResult, err := executor.ExecuteQuery(metadataQuery)
+	metadataResult, err := executor.ExecuteQueryWithOptions(metadataQuery, exec.DQLExecuteOptions{NoProgress: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get lookup table metadata %q: %w", path, err)
 	}

--- a/pkg/resources/lookup/lookup.go
+++ b/pkg/resources/lookup/lookup.go
@@ -95,8 +95,7 @@ func (h *Handler) List() ([]Lookup, error) {
 	query := `fetch dt.system.files | filter startsWith(name, "/lookups/")`
 
 	executor := exec.NewDQLExecutor(h.client)
-	// Internal metadata fetch, not a user-facing query: keep the progress bar off.
-	result, err := executor.ExecuteQueryWithOptions(query, exec.DQLExecuteOptions{NoProgress: true})
+	result, err := executor.ExecuteQuery(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list lookup tables: %w", err)
 	}
@@ -160,7 +159,7 @@ func (h *Handler) Get(path string) (*Lookup, error) {
 
 	// First, get metadata from dt.system.files
 	metadataQuery := fmt.Sprintf(`fetch dt.system.files | filter name == "%s"`, path)
-	metadataResult, err := executor.ExecuteQueryWithOptions(metadataQuery, exec.DQLExecuteOptions{NoProgress: true})
+	metadataResult, err := executor.ExecuteQuery(metadataQuery)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get lookup table metadata %q: %w", path, err)
 	}

--- a/sdk/api/query/query.go
+++ b/sdk/api/query/query.go
@@ -355,6 +355,12 @@ type PollUpdate struct {
 	// set EnablePreview and this poll carried preview records. Each preview is
 	// whole (not a delta to prior previews), so callers replace, never append.
 	Preview *Result
+	// ScannedBytes and ScannedRecords are the running scan totals reported by the
+	// backend for this poll. Grail populates and grows them on each poll of a
+	// mass-data query; they are 0 when the backend has not reported them (e.g. an
+	// early poll or a query type that does not scan Grail).
+	ScannedBytes   int64
+	ScannedRecords int64
 }
 
 // ExecuteAndPollOptions carries optional hooks for ExecuteAndPollWithOptions.
@@ -548,7 +554,12 @@ func emitUpdate(onUpdate func(PollUpdate), enablePreview bool, resp *Response) {
 	if enablePreview && resp.Result != nil && len(resp.Result.Records) > 0 {
 		preview = resp.Result
 	}
-	onUpdate(PollUpdate{Progress: resp.Progress, Preview: preview})
+	u := PollUpdate{Progress: resp.Progress, Preview: preview}
+	if m := resp.GetMetadata(); m != nil {
+		u.ScannedBytes = m.ScannedBytes
+		u.ScannedRecords = m.ScannedRecords
+	}
+	onUpdate(u)
 }
 
 func (h *Handler) applyHeaders(req *resty.Request) {

--- a/sdk/api/query/query.go
+++ b/sdk/api/query/query.go
@@ -344,6 +344,31 @@ func (h *Handler) Verify(ctx context.Context, req VerifyRequest) (*VerifyRespons
 	return &result, nil
 }
 
+// PollUpdate carries the state of a still-running query. It is delivered to the
+// OnUpdate callback of ExecuteAndPollWithOptions on the initial RUNNING response
+// and after each subsequent poll, letting callers render progress.
+type PollUpdate struct {
+	// Progress is the query's completion percentage (0-100) as reported by the
+	// backend. It may stay at 0 until the backend has a meaningful estimate.
+	Progress int
+	// Preview is a partial result snapshot. It is non-nil only when the request
+	// set EnablePreview and this poll carried preview records. Each preview is
+	// whole (not a delta to prior previews), so callers replace, never append.
+	Preview *Result
+}
+
+// ExecuteAndPollOptions carries optional hooks for ExecuteAndPollWithOptions.
+type ExecuteAndPollOptions struct {
+	// OnUnauthorized is invoked when a poll receives HTTP 401, allowing callers
+	// to refresh an expired token. It must return the new bearer token. If nil,
+	// 401 errors are returned directly.
+	OnUnauthorized func() (string, error)
+	// OnUpdate, if set, is called with the current progress/preview whenever the
+	// query is still RUNNING — once for the initial response and once per poll.
+	// It is never called for a query that completes synchronously.
+	OnUpdate func(PollUpdate)
+}
+
 // ExecuteAndPoll executes a DQL query and, if it returns asynchronously, polls
 // until completion or context cancellation. If the context is cancelled during
 // polling, a best-effort cancel is sent to the backend.
@@ -352,6 +377,14 @@ func (h *Handler) Verify(ctx context.Context, req VerifyRequest) (*VerifyRespons
 // allowing callers to refresh an expired token. It must return the new bearer
 // token. If nil, 401 errors are returned directly.
 func (h *Handler) ExecuteAndPoll(ctx context.Context, req ExecuteRequest, onUnauthorized func() (string, error)) (*Response, error) {
+	return h.ExecuteAndPollWithOptions(ctx, req, ExecuteAndPollOptions{OnUnauthorized: onUnauthorized})
+}
+
+// ExecuteAndPollWithOptions is ExecuteAndPoll with additional hooks (see
+// ExecuteAndPollOptions), notably an OnUpdate callback for surfacing progress
+// and preview results while the query is still running.
+func (h *Handler) ExecuteAndPollWithOptions(ctx context.Context, req ExecuteRequest, opts ExecuteAndPollOptions) (*Response, error) {
+	onUnauthorized := opts.OnUnauthorized
 	// Use an independent context for the initial execute so we always get the
 	// request token back even if the caller cancels mid-flight.
 	execCtx, execCancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -387,6 +420,9 @@ func (h *Handler) ExecuteAndPoll(ctx context.Context, req ExecuteRequest, onUnau
 	if result.RequestToken == "" {
 		return nil, fmt.Errorf("query is running but no request token provided")
 	}
+
+	// Surface the initial RUNNING state (progress may already be non-zero).
+	emitUpdate(opts.OnUpdate, req.EnablePreview, result)
 
 	// Poll loop.
 	pollCtx, pollCancel := context.WithTimeout(ctx, 5*time.Minute)
@@ -435,6 +471,7 @@ func (h *Handler) ExecuteAndPoll(ctx context.Context, req ExecuteRequest, onUnau
 		case "FAILED":
 			return pollResult, fmt.Errorf("query execution failed")
 		case "RUNNING":
+			emitUpdate(opts.OnUpdate, req.EnablePreview, pollResult)
 			continue
 		default:
 			return pollResult, nil
@@ -499,6 +536,20 @@ func (r *Response) GetMetrics() []MetricInfo {
 }
 
 // --- Internal helpers ---
+
+// emitUpdate invokes the OnUpdate callback (when set) with the progress and any
+// preview carried by a RUNNING response. A preview is attached only when the
+// request enabled previews and the response actually carried records.
+func emitUpdate(onUpdate func(PollUpdate), enablePreview bool, resp *Response) {
+	if onUpdate == nil {
+		return
+	}
+	var preview *Result
+	if enablePreview && resp.Result != nil && len(resp.Result.Records) > 0 {
+		preview = resp.Result
+	}
+	onUpdate(PollUpdate{Progress: resp.Progress, Preview: preview})
+}
 
 func (h *Handler) applyHeaders(req *resty.Request) {
 	for k, v := range h.headers {

--- a/sdk/api/query/query_test.go
+++ b/sdk/api/query/query_test.go
@@ -1107,3 +1107,105 @@ func TestExecuteAndPoll_NoRequestToken(t *testing.T) {
 		t.Errorf("error should mention missing token: %v", err)
 	}
 }
+
+// TestExecuteAndPollWithOptions_OnUpdate verifies that the OnUpdate callback is
+// invoked on the initial RUNNING response and on each subsequent RUNNING poll,
+// carrying the reported progress and (when previews are enabled) preview rows.
+func TestExecuteAndPollWithOptions_OnUpdate(t *testing.T) {
+	var pollCount atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/storage/query/v1/query:execute", func(w http.ResponseWriter, r *http.Request) {
+		// Initial async response: RUNNING at 10%, no preview yet.
+		resp := Response{State: "RUNNING", RequestToken: "tok-upd", Progress: 10}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/platform/storage/query/v1/query:poll", func(w http.ResponseWriter, r *http.Request) {
+		n := pollCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			// A RUNNING poll carrying a preview snapshot.
+			json.NewEncoder(w).Encode(Response{
+				State:        "RUNNING",
+				RequestToken: "tok-upd",
+				Progress:     60,
+				Result:       &Result{Records: []map[string]interface{}{{"a": 1}, {"a": 2}}},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(Response{
+			State:  "SUCCEEDED",
+			Result: &Result{Records: []map[string]interface{}{{"a": 1}, {"a": 2}, {"a": 3}}},
+		})
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+
+	var updates []PollUpdate
+	result, err := h.ExecuteAndPollWithOptions(context.Background(),
+		ExecuteRequest{Query: "fetch logs", EnablePreview: true},
+		ExecuteAndPollOptions{OnUpdate: func(u PollUpdate) { updates = append(updates, u) }},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteAndPollWithOptions() error: %v", err)
+	}
+	if result.State != "SUCCEEDED" {
+		t.Fatalf("State = %q, want SUCCEEDED", result.State)
+	}
+
+	// Expect: initial RUNNING (10%, no preview) + one RUNNING poll (60%, 2 rows).
+	// The terminal SUCCEEDED poll must NOT produce an update.
+	if len(updates) != 2 {
+		t.Fatalf("got %d updates, want 2: %+v", len(updates), updates)
+	}
+	if updates[0].Progress != 10 || updates[0].Preview != nil {
+		t.Errorf("first update = %+v, want progress 10 and no preview", updates[0])
+	}
+	if updates[1].Progress != 60 {
+		t.Errorf("second update progress = %d, want 60", updates[1].Progress)
+	}
+	if updates[1].Preview == nil || len(updates[1].Preview.Records) != 2 {
+		t.Errorf("second update should carry a 2-row preview, got %+v", updates[1].Preview)
+	}
+}
+
+// TestExecuteAndPollWithOptions_NoPreviewWhenDisabled verifies that previews are
+// never surfaced to OnUpdate when EnablePreview is false, even if the backend
+// happens to include a result on a RUNNING poll.
+func TestExecuteAndPollWithOptions_NoPreviewWhenDisabled(t *testing.T) {
+	var pollCount atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/storage/query/v1/query:execute", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(Response{State: "RUNNING", RequestToken: "tok-np", Progress: 5})
+	})
+	mux.HandleFunc("/platform/storage/query/v1/query:poll", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if pollCount.Add(1) == 1 {
+			json.NewEncoder(w).Encode(Response{
+				State: "RUNNING", RequestToken: "tok-np", Progress: 50,
+				Result: &Result{Records: []map[string]interface{}{{"a": 1}}},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(Response{State: "SUCCEEDED", Result: &Result{}})
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	var updates []PollUpdate
+	_, err := h.ExecuteAndPollWithOptions(context.Background(),
+		ExecuteRequest{Query: "fetch logs"}, // EnablePreview false
+		ExecuteAndPollOptions{OnUpdate: func(u PollUpdate) { updates = append(updates, u) }},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteAndPollWithOptions() error: %v", err)
+	}
+	for i, u := range updates {
+		if u.Preview != nil {
+			t.Errorf("update %d carried a preview despite EnablePreview=false: %+v", i, u.Preview)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a live progress indicator to `dtctl query` for long-running (asynchronous) queries. The DQL Query API executes long queries async and reports `progress` plus growing `scannedBytes`/`scannedRecords` on every poll — this surfaces that on **stderr** as an animated bar, then a one-line completion summary.

```
⠹ scanning  57% ▕███████████▍░░░░░░░░▏  12.2 TB · 4.6B recs · 8.2s
```
```
✓ scanned 17.3 TB · 6.0B records in 42.1s
```

Shown by default on interactive terminals; opt out with `--no-progress`.

## What it does

- **Live scan telemetry**: completion %, data volume scanned, records scanned, and elapsed time — updated each poll (real Grail scan totals, not estimates).
- **Smooth animation**: a background ~100ms ticker advances the spinner and elapsed timer independently of the (~5s) poll cadence, so it never freezes-and-jumps.
- **Completion summary**: on success the bar is replaced by a green-check summary with the final totals; only shown when a bar was actually drawn, so fast queries stay quiet.
- **Subtle visuals**: braille spinner, sub-cell (1/8-resolution) bar with a bright leading-edge glow, bold %, dim stats.

## Safety / gating

- Drawn on **stderr only** — stdout stays byte-clean, so `-o json > file`, `| jq`, Parquet, etc. are unaffected.
- Shown by default only when stderr is an interactive TTY. Suppressed under `--plain`, in agent mode, for non-interactive stderr, and in `--live` mode. `NO_COLOR` keeps the bar but drops color.
- `--no-progress` turns it off (matches the existing `--no-agent` convention).

## Implementation

- **SDK** (`sdk/api/query`): new `ExecuteAndPollWithOptions` with an `OnUpdate` callback carrying progress + scan totals + preview; `ExecuteAndPoll` kept as a shim. No new HTTP calls — the data was already on the wire.
- **Output** (`pkg/output/progress.go`): `ProgressReporter` with a mutex-guarded background animator; `Stop` (error/cancel) clears, `Complete` (success) prints the summary. Padding/clearing measured in visible width (ANSI-stripped) so colored lines never wrap.
- **Exec/CLI**: `--no-progress` plumbed through `pkg/exec` and `cmd/query.go`.

## Tests

- SDK: `OnUpdate` fires on each RUNNING poll with progress/scan-totals/preview, not on the terminal poll; previews gated on `--enable-preview`.
- Output: gating, silent-when-disabled, in-place overwrite + visible-width clear, real-ticker spinner advance, completion summary (+ silent-when-no-bar, Stop-after-Complete no-op), and the humanize/bar helpers.
- **`-race` clean** on `pkg/output` and `pkg/exec`; golden tests unaffected (stdout paths untouched).

## Docs

DQL queries guide (new Progress Indicator section), query parameter reference, quick start, command reference, and the implementation status matrix.
