### PR TITLE
fix(get): get app should show correct last modification time

### DIFF
--- a/cmd/describe_apps.go
+++ b/cmd/describe_apps.go
@@ -53,11 +53,11 @@ Examples:
 			}
 
 			if app.ModificationInfo != nil {
-				if app.ModificationInfo.CreatedTime != "" {
-					output.DescribeKV("Created:", w, "%s (by %s)", app.ModificationInfo.CreatedTime, app.ModificationInfo.CreatedBy)
+				if app.ModificationInfo.CreatedAt != "" {
+					output.DescribeKV("Created:", w, "%s (by %s)", app.ModificationInfo.CreatedAt, app.ModificationInfo.CreatedBy)
 				}
-				if app.ModificationInfo.LastModifiedTime != "" {
-					output.DescribeKV("Modified:", w, "%s (by %s)", app.ModificationInfo.LastModifiedTime, app.ModificationInfo.LastModifiedBy)
+				if app.ModificationInfo.LastModifiedAt != "" {
+					output.DescribeKV("Modified:", w, "%s (by %s)", app.ModificationInfo.LastModifiedAt, app.ModificationInfo.LastModifiedBy)
 				}
 			}
 

--- a/pkg/output/golden_test.go
+++ b/pkg/output/golden_test.go
@@ -1332,10 +1332,10 @@ func describeAppFixture() appengine.App {
 			SubResourceTypes: []string{"function", "action"},
 		},
 		ModificationInfo: &appengine.ModificationInfo{
-			CreatedBy:        "user-a@example.invalid",
-			CreatedTime:      "2025-01-10T08:00:00Z",
-			LastModifiedBy:   "user-b@example.invalid",
-			LastModifiedTime: "2025-03-15T10:30:00Z",
+			CreatedBy:      "user-a@example.invalid",
+			CreatedAt:      "2025-01-10T08:00:00Z",
+			LastModifiedBy: "user-b@example.invalid",
+			LastModifiedAt: "2025-03-15T10:30:00Z",
 		},
 	}
 }

--- a/pkg/output/testdata/golden/describe/app-json.golden
+++ b/pkg/output/testdata/golden/describe/app-json.golden
@@ -12,8 +12,8 @@
   },
   "modificationInfo": {
     "createdBy": "user-a@example.invalid",
-    "createdTime": "2025-01-10T08:00:00Z",
+    "createdAt": "2025-01-10T08:00:00Z",
     "lastModifiedBy": "user-b@example.invalid",
-    "lastModifiedTime": "2025-03-15T10:30:00Z"
+    "lastModifiedAt": "2025-03-15T10:30:00Z"
   }
 }

--- a/pkg/output/testdata/golden/describe/app-toon.golden
+++ b/pkg/output/testdata/golden/describe/app-toon.golden
@@ -1,10 +1,10 @@
 description: A custom monitoring application
 id: my.custom-app
 modificationInfo:
+  createdAt: "2025-01-10T08:00:00Z"
   createdBy: user-a@example.invalid
-  createdTime: "2025-01-10T08:00:00Z"
+  lastModifiedAt: "2025-03-15T10:30:00Z"
   lastModifiedBy: user-b@example.invalid
-  lastModifiedTime: "2025-03-15T10:30:00Z"
 name: Custom App
 resourceStatus:
   status: OK

--- a/pkg/output/testdata/golden/describe/app-yaml.golden
+++ b/pkg/output/testdata/golden/describe/app-yaml.golden
@@ -13,6 +13,6 @@ signatureinfo: null
 manifest: {}
 modificationinfo:
   createdby: user-a@example.invalid
-  createdtime: "2025-01-10T08:00:00Z"
+  createdat: "2025-01-10T08:00:00Z"
   lastmodifiedby: user-b@example.invalid
-  lastmodifiedtime: "2025-03-15T10:30:00Z"
+  lastmodifiedat: "2025-03-15T10:30:00Z"

--- a/pkg/resources/appengine/appengine_test.go
+++ b/pkg/resources/appengine/appengine_test.go
@@ -138,6 +138,52 @@ func TestHandler_GetApp(t *testing.T) {
 	}
 }
 
+func TestHandler_GetApp_ModificationInfo(t *testing.T) {
+	// Use a raw JSON body (not a marshaled App) so the test actually exercises
+	// the JSON tags on ModificationInfo — the registry returns createdAt/lastModifiedAt.
+	const body = `{
+		"id": "dynatrace.automations",
+		"name": "Workflows",
+		"version": "1.3253.0",
+		"modificationInfo": {
+			"createdBy": "system",
+			"createdAt": "2023-02-23T10:55:12.553Z",
+			"lastModifiedBy": "system",
+			"lastModifiedAt": "2026-07-03T09:11:53.765Z"
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	app, err := NewHandler(c).GetApp("dynatrace.automations")
+	if err != nil {
+		t.Fatalf("GetApp() error = %v", err)
+	}
+
+	if app.ModificationInfo == nil {
+		t.Fatal("GetApp() ModificationInfo = nil, want populated")
+	}
+	if got, want := app.ModificationInfo.CreatedAt, "2023-02-23T10:55:12.553Z"; got != want {
+		t.Errorf("CreatedAt = %q, want %q", got, want)
+	}
+	if got, want := app.ModificationInfo.LastModifiedAt, "2026-07-03T09:11:53.765Z"; got != want {
+		t.Errorf("LastModifiedAt = %q, want %q", got, want)
+	}
+	if got, want := app.ModificationInfo.LastModifiedBy, "system"; got != want {
+		t.Errorf("LastModifiedBy = %q, want %q", got, want)
+	}
+}
+
 func TestContains(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/sdk/api/appengine/appengine.go
+++ b/sdk/api/appengine/appengine.go
@@ -46,10 +46,10 @@ type SignatureInfo struct {
 
 // ModificationInfo contains modification timestamps
 type ModificationInfo struct {
-	CreatedBy        string `json:"createdBy,omitempty"`
-	CreatedTime      string `json:"createdTime,omitempty"`
-	LastModifiedBy   string `json:"lastModifiedBy,omitempty"`
-	LastModifiedTime string `json:"lastModifiedTime,omitempty"`
+	CreatedBy      string `json:"createdBy,omitempty"`
+	CreatedAt      string `json:"createdAt,omitempty"`
+	LastModifiedBy string `json:"lastModifiedBy,omitempty"`
+	LastModifiedAt string `json:"lastModifiedAt,omitempty"`
 }
 
 // AppList represents a list of apps


### PR DESCRIPTION


## Description

<!-- What does this PR do? -->

App engine returns field `lastModifiedAt` and `createdAt` in `modificationInfo`. 
We currently use incorrect field names `lastModifiedTime` `createdTime`, hence this PR corrects those: `lastModifiedAt`, `createdAt`

## Related Issues

Closes #338

## Testing

<!-- How did you test this? -->

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Manual test command locally
