### PR TITLE
feat(settings): add --validate-only flag to create, edit, and delete settings commands

### DIFF
--- a/cmd/create_settings.go
+++ b/cmd/create_settings.go
@@ -29,6 +29,9 @@ Examples:
 
   # Dry run to preview
   dtctl create settings -f settings.yaml --schema builtin:openpipeline.logs.pipelines --scope environment --dry-run
+
+  # Validate against the API without creating
+  dtctl create settings -f settings.yaml --schema builtin:openpipeline.logs.pipelines --scope environment --validate-only
 `,
 	Aliases: []string{"setting"},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -36,6 +39,7 @@ Examples:
 		schemaID, _ := cmd.Flags().GetString("schema")
 		scope, _ := cmd.Flags().GetString("scope")
 		setFlags, _ := cmd.Flags().GetStringArray("set")
+		validateOnly, _ := cmd.Flags().GetBool("validate-only")
 
 		if file == "" {
 			return fmt.Errorf("--file is required")
@@ -89,6 +93,25 @@ Examples:
 			return nil
 		}
 
+		req := settings.SettingsObjectCreate{
+			SchemaID: schemaID,
+			Scope:    scope,
+			Value:    value,
+		}
+
+		if validateOnly {
+			_, c, err := SetupClient()
+			if err != nil {
+				return err
+			}
+			handler := settings.NewHandler(c)
+			if err := handler.ValidateCreate(req); err != nil {
+				return fmt.Errorf("validation failed: %w", err)
+			}
+			output.PrintSuccess("Validation passed")
+			return nil
+		}
+
 		_, c, err := SetupWithSafety(safety.OperationCreate)
 		if err != nil {
 			return err
@@ -96,11 +119,7 @@ Examples:
 
 		handler := settings.NewHandler(c)
 
-		result, err := handler.Create(settings.SettingsObjectCreate{
-			SchemaID: schemaID,
-			Scope:    scope,
-			Value:    value,
-		})
+		result, err := handler.Create(req)
 		if err != nil {
 			return fmt.Errorf("failed to create settings object: %w", err)
 		}
@@ -116,6 +135,7 @@ func init() {
 	createSettingsCmd.Flags().String("schema", "", "schema ID (required)")
 	createSettingsCmd.Flags().String("scope", "", "scope for the settings object (required)")
 	createSettingsCmd.Flags().StringArray("set", []string{}, "set template variable (key=value)")
+	createSettingsCmd.Flags().Bool("validate-only", false, "validate the settings object against the API without creating it")
 	_ = createSettingsCmd.MarkFlagRequired("file")
 	_ = createSettingsCmd.MarkFlagRequired("schema")
 	_ = createSettingsCmd.MarkFlagRequired("scope")

--- a/cmd/create_settings_test.go
+++ b/cmd/create_settings_test.go
@@ -37,8 +37,7 @@ func TestCreateSettingsValidateOnly_Success(t *testing.T) {
 	cfgFile = configPath
 	plainMode = true
 
-	// Note: avoid ResetCommandFlags here — it calls Set("[]") on the StringArray --set flag,
-	// which adds the literal string "[]" as a value and breaks template parsing.
+	testutil.ResetCommandFlags(createSettingsCmd)
 	_ = createSettingsCmd.Flags().Set("file", settingsFile)
 	_ = createSettingsCmd.Flags().Set("schema", "builtin:alerting.profile")
 	_ = createSettingsCmd.Flags().Set("scope", "environment")
@@ -72,7 +71,7 @@ func TestCreateSettingsValidateOnly_ValidationFailed(t *testing.T) {
 	cfgFile = configPath
 	plainMode = true
 
-	// Note: avoid ResetCommandFlags here — see TestCreateSettingsValidateOnly_Success.
+	testutil.ResetCommandFlags(createSettingsCmd)
 	_ = createSettingsCmd.Flags().Set("file", settingsFile)
 	_ = createSettingsCmd.Flags().Set("schema", "builtin:alerting.profile")
 	_ = createSettingsCmd.Flags().Set("scope", "environment")

--- a/cmd/create_settings_test.go
+++ b/cmd/create_settings_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
+)
+
+func TestCreateSettingsValidateOnly_Success(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/classic/environment-api/v2/settings/objects": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			if r.URL.Query().Get("validateOnly") != "true" {
+				t.Errorf("expected validateOnly=true, got %q", r.URL.Query().Get("validateOnly"))
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	settingsFile := testutil.CreateTempFile(t, `{"key": "value"}`, "settings-*.json")
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+	}()
+	cfgFile = configPath
+	plainMode = true
+
+	// Note: avoid ResetCommandFlags here — it calls Set("[]") on the StringArray --set flag,
+	// which adds the literal string "[]" as a value and breaks template parsing.
+	_ = createSettingsCmd.Flags().Set("file", settingsFile)
+	_ = createSettingsCmd.Flags().Set("schema", "builtin:alerting.profile")
+	_ = createSettingsCmd.Flags().Set("scope", "environment")
+	_ = createSettingsCmd.Flags().Set("validate-only", "true")
+
+	if err := createSettingsCmd.RunE(createSettingsCmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+}
+
+func TestCreateSettingsValidateOnly_ValidationFailed(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/classic/environment-api/v2/settings/objects": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error": {"code": 400, "message": "invalid value"}}`))
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	settingsFile := testutil.CreateTempFile(t, `{"key": "value"}`, "settings-*.json")
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+	}()
+	cfgFile = configPath
+	plainMode = true
+
+	// Note: avoid ResetCommandFlags here — see TestCreateSettingsValidateOnly_Success.
+	_ = createSettingsCmd.Flags().Set("file", settingsFile)
+	_ = createSettingsCmd.Flags().Set("schema", "builtin:alerting.profile")
+	_ = createSettingsCmd.Flags().Set("scope", "environment")
+	_ = createSettingsCmd.Flags().Set("validate-only", "true")
+
+	err := createSettingsCmd.RunE(createSettingsCmd, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "validation failed") {
+		t.Errorf("expected error containing 'validation failed', got %q", err.Error())
+	}
+}

--- a/cmd/delete_settings_test.go
+++ b/cmd/delete_settings_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
+)
+
+func TestDeleteSettingsValidateOnly_Success(t *testing.T) {
+	const objectID = "test-obj-delete-validate"
+
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/classic/environment-api/v2/settings/objects/" + objectID: func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"objectId":"` + objectID + `","schemaVersion":"1.0","summary":"Test"}`))
+			case http.MethodDelete:
+				if r.URL.Query().Get("validateOnly") != "true" {
+					t.Errorf("expected validateOnly=true, got %q", r.URL.Query().Get("validateOnly"))
+				}
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				t.Errorf("unexpected method %s", r.Method)
+			}
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+	}()
+	cfgFile = configPath
+	plainMode = true
+
+	testutil.ResetCommandFlags(deleteSettingsCmd)
+	_ = deleteSettingsCmd.Flags().Set("validate-only", "true")
+
+	if err := deleteSettingsCmd.RunE(deleteSettingsCmd, []string{objectID}); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+}
+
+func TestDeleteSettingsValidateOnly_ValidationFailed(t *testing.T) {
+	const objectID = "test-obj-delete-validate-fail"
+
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/classic/environment-api/v2/settings/objects/" + objectID: func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"objectId":"` + objectID + `","schemaVersion":"1.0"}`))
+			case http.MethodDelete:
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error": {"code": 400, "message": "deletion not allowed"}}`))
+			}
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+	}()
+	cfgFile = configPath
+	plainMode = true
+
+	testutil.ResetCommandFlags(deleteSettingsCmd)
+	_ = deleteSettingsCmd.Flags().Set("validate-only", "true")
+
+	err := deleteSettingsCmd.RunE(deleteSettingsCmd, []string{objectID})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "validation failed") {
+		t.Errorf("expected error containing 'validation failed', got %q", err.Error())
+	}
+}

--- a/cmd/edit_settings.go
+++ b/cmd/edit_settings.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/settings"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
@@ -35,12 +37,23 @@ Examples:
 
   # Edit a settings object in JSON
   dtctl edit setting vu9U3hXa3q0AAAABABRidWlsdGluOnJ1bS53ZWIubmFtZQ... --format=json
+
+  # Validate the edited value against the API without saving
+  dtctl edit setting vu9U3hXa3q0AAAABABRidWlsdGluOnJ1bS53ZWIubmFtZQ... --validate-only
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		identifier := args[0]
+		validateOnly, _ := cmd.Flags().GetBool("validate-only")
 
-		cfg, c, err := SetupWithSafety(safety.OperationUpdate)
+		var cfg *config.Config
+		var c *client.Client
+		var err error
+		if validateOnly {
+			cfg, c, err = SetupClient()
+		} else {
+			cfg, c, err = SetupWithSafety(safety.OperationUpdate)
+		}
 		if err != nil {
 			return err
 		}
@@ -140,6 +153,14 @@ Examples:
 			return fmt.Errorf("failed to parse edited JSON: %w", err)
 		}
 
+		if validateOnly {
+			if err := handler.ValidateUpdate(identifier, value); err != nil {
+				return fmt.Errorf("validation failed: %w", err)
+			}
+			output.PrintSuccess("Validation passed")
+			return nil
+		}
+
 		// Update the settings object
 		result, err := handler.Update(identifier, value)
 		if err != nil {
@@ -153,4 +174,5 @@ Examples:
 
 func init() {
 	editSettingCmd.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
+	editSettingCmd.Flags().Bool("validate-only", false, "validate the edited value against the API without saving")
 }

--- a/cmd/edit_settings.go
+++ b/cmd/edit_settings.go
@@ -39,6 +39,7 @@ Examples:
   dtctl edit setting vu9U3hXa3q0AAAABABRidWlsdGluOnJ1bS53ZWIubmFtZQ... --format=json
 
   # Validate the edited value against the API without saving
+  # (the editor still opens; changes are validated but not persisted)
   dtctl edit setting vu9U3hXa3q0AAAABABRidWlsdGluOnJ1bS53ZWIubmFtZQ... --validate-only
 `,
 	Args: cobra.ExactArgs(1),

--- a/cmd/edit_settings_test.go
+++ b/cmd/edit_settings_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
+)
+
+// makeEditorScript creates a temporary shell script that overwrites its first
+// argument with the given JSON content. Used to simulate an editor in tests.
+func makeEditorScript(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "editor-*.sh")
+	if err != nil {
+		t.Fatalf("failed to create editor script: %v", err)
+	}
+	_, _ = f.WriteString("#!/bin/sh\nprintf '" + content + "' > \"$1\"\n")
+	_ = f.Close()
+	_ = os.Chmod(f.Name(), 0755)
+	t.Cleanup(func() { os.Remove(f.Name()) })
+	return f.Name()
+}
+
+func TestEditSettingsValidateOnly_Success(t *testing.T) {
+	const objectID = "test-edit-validate-obj"
+
+	t.Setenv("EDITOR", makeEditorScript(t, `{"enabled":false}`))
+
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/classic/environment-api/v2/settings/objects/" + objectID: func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"objectId":"` + objectID + `","schemaVersion":"1.0","value":{"enabled":true}}`))
+			case http.MethodPut:
+				if r.URL.Query().Get("validateOnly") != "true" {
+					t.Errorf("expected validateOnly=true, got %q", r.URL.Query().Get("validateOnly"))
+				}
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Errorf("unexpected method %s", r.Method)
+			}
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+	}()
+	cfgFile = configPath
+	plainMode = true
+
+	testutil.ResetCommandFlags(editSettingCmd)
+	_ = editSettingCmd.Flags().Set("validate-only", "true")
+	_ = editSettingCmd.Flags().Set("format", "json")
+
+	if err := editSettingCmd.RunE(editSettingCmd, []string{objectID}); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+}
+
+func TestEditSettingsValidateOnly_ValidationFailed(t *testing.T) {
+	const objectID = "test-edit-validate-fail-obj"
+
+	t.Setenv("EDITOR", makeEditorScript(t, `{"enabled":false}`))
+
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		"/platform/classic/environment-api/v2/settings/objects/" + objectID: func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"objectId":"` + objectID + `","schemaVersion":"1.0","value":{"enabled":true}}`))
+			case http.MethodPut:
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":{"code":400,"message":"invalid value"}}`))
+			}
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+	}()
+	cfgFile = configPath
+	plainMode = true
+
+	testutil.ResetCommandFlags(editSettingCmd)
+	_ = editSettingCmd.Flags().Set("validate-only", "true")
+	_ = editSettingCmd.Flags().Set("format", "json")
+
+	err := editSettingCmd.RunE(editSettingCmd, []string{objectID})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "validation failed") {
+		t.Errorf("expected error containing 'validation failed', got %q", err.Error())
+	}
+}

--- a/cmd/edit_settings_test.go
+++ b/cmd/edit_settings_test.go
@@ -3,21 +3,51 @@ package cmd
 import (
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/dynatrace-oss/dtctl/cmd/testutil"
 )
 
-// makeEditorScript creates a temporary shell script that overwrites its first
-// argument with the given JSON content. Used to simulate an editor in tests.
+// makeEditorScript creates a temporary script that overwrites its first
+// argument with the given content. Uses a .bat file on Windows (invoked via
+// "cmd /c"), a .sh file everywhere else. The content is written to a
+// separate temp file to avoid shell-escaping issues.
 func makeEditorScript(t *testing.T, content string) string {
 	t.Helper()
+
+	// Write content to a source file; the script just copies it over.
+	src, err := os.CreateTemp("", "editor-src-*")
+	if err != nil {
+		t.Fatalf("failed to create content file: %v", err)
+	}
+	if _, err := src.WriteString(content); err != nil {
+		t.Fatalf("failed to write content: %v", err)
+	}
+	_ = src.Close()
+	srcPath := src.Name()
+	t.Cleanup(func() { os.Remove(srcPath) })
+
+	if runtime.GOOS == "windows" {
+		f, err := os.CreateTemp("", "editor-*.bat")
+		if err != nil {
+			t.Fatalf("failed to create editor script: %v", err)
+		}
+		_, _ = f.WriteString("@echo off\ncopy /Y \"" + srcPath + "\" \"%~1\"\n")
+		_ = f.Close()
+		batPath := f.Name()
+		t.Cleanup(func() { os.Remove(batPath) })
+		// edit_settings.go splits EDITOR on spaces; "cmd /c path" expands to
+		// exec.Command("cmd", "/c", batPath, tmpfile).
+		return "cmd /c " + batPath
+	}
+
 	f, err := os.CreateTemp("", "editor-*.sh")
 	if err != nil {
 		t.Fatalf("failed to create editor script: %v", err)
 	}
-	_, _ = f.WriteString("#!/bin/sh\nprintf '" + content + "' > \"$1\"\n")
+	_, _ = f.WriteString("#!/bin/sh\ncp '" + srcPath + "' \"$1\"\n")
 	_ = f.Close()
 	_ = os.Chmod(f.Name(), 0755)
 	t.Cleanup(func() { os.Remove(f.Name()) })

--- a/cmd/get_settings.go
+++ b/cmd/get_settings.go
@@ -121,11 +121,28 @@ Examples:
 
   # Delete without confirmation
   dtctl delete settings <object-id> -y
+
+  # Validate deletion against the API without deleting
+  dtctl delete settings <object-id> --validate-only
 `,
 	Aliases: []string{"setting"},
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		objectID := args[0]
+		validateOnly, _ := cmd.Flags().GetBool("validate-only")
+
+		if validateOnly {
+			_, c, err := SetupClient()
+			if err != nil {
+				return err
+			}
+			handler := settings.NewHandler(c)
+			if err := handler.ValidateDelete(objectID); err != nil {
+				return fmt.Errorf("validation failed: %w", err)
+			}
+			output.PrintSuccess("Validation passed")
+			return nil
+		}
 
 		_, c, err := SetupWithSafety(safety.OperationDelete)
 		if err != nil {
@@ -168,4 +185,5 @@ func init() {
 
 	// Delete settings flags
 	deleteSettingsCmd.Flags().BoolVarP(&forceDelete, "yes", "y", false, "Skip confirmation prompt")
+	deleteSettingsCmd.Flags().Bool("validate-only", false, "validate the deletion against the API without deleting")
 }

--- a/cmd/testutil/helpers.go
+++ b/cmd/testutil/helpers.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -78,6 +79,17 @@ func CreateTempFile(t *testing.T, content string, pattern string) string {
 func ResetCommandFlags(cmd *cobra.Command) {
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		flag.Changed = false
-		_ = flag.Value.Set(flag.DefValue)
+		if sv, ok := flag.Value.(pflag.SliceValue); ok {
+			// SliceValue.Set appends rather than replaces; use Replace to restore the
+			// declared default. StringArray stores DefValue as JSON; other slice types
+			// fall back to nil (empty) if the format doesn't parse.
+			var defaults []string
+			if flag.DefValue != "[]" {
+				_ = json.Unmarshal([]byte(flag.DefValue), &defaults)
+			}
+			_ = sv.Replace(defaults)
+		} else {
+			_ = flag.Value.Set(flag.DefValue)
+		}
 	})
 }

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2098,6 +2098,12 @@ dtctl create settings -f pipeline.yaml \
   --schema builtin:openpipeline.logs.pipelines \
   --scope environment \
   --dry-run
+
+# Validate against the API without creating
+dtctl create settings -f pipeline.yaml \
+  --schema builtin:openpipeline.logs.pipelines \
+  --scope environment \
+  --validate-only
 ```
 
 **Example pipeline file** (`log-pipeline.yaml`):
@@ -2144,6 +2150,9 @@ dtctl update settings aaaaaaaa-bbbb-cccc-dddd-000000000001 \
 dtctl update settings aaaaaaaa-bbbb-cccc-dddd-000000000001 \
   -f pipeline.yaml \
   --dry-run
+
+# Validate against the API without saving
+dtctl edit setting aaaaaaaa-bbbb-cccc-dddd-000000000001 --validate-only
 ```
 
 **Note:** Updates use optimistic locking automatically - the current version is fetched before updating to prevent conflicts.
@@ -2158,6 +2167,9 @@ dtctl delete settings aaaaaaaa-bbbb-cccc-dddd-000000000001
 
 # Delete without confirmation
 dtctl delete settings aaaaaaaa-bbbb-cccc-dddd-000000000001 -y
+
+# Validate deletion against the API without deleting
+dtctl delete settings aaaaaaaa-bbbb-cccc-dddd-000000000001 --validate-only
 ```
 
 ### OpenPipeline Configuration Workflow

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2150,12 +2150,24 @@ dtctl update settings aaaaaaaa-bbbb-cccc-dddd-000000000001 \
 dtctl update settings aaaaaaaa-bbbb-cccc-dddd-000000000001 \
   -f pipeline.yaml \
   --dry-run
-
-# Validate against the API without saving
-dtctl edit setting aaaaaaaa-bbbb-cccc-dddd-000000000001 --validate-only
 ```
 
 **Note:** Updates use optimistic locking automatically - the current version is fetched before updating to prevent conflicts.
+
+### Edit Settings Objects
+
+Open a settings object in your editor and save changes interactively:
+
+```bash
+# Edit a settings object (opens in $EDITOR, defaults to vim)
+dtctl edit setting aaaaaaaa-bbbb-cccc-dddd-000000000001
+
+# Edit in JSON format
+dtctl edit setting aaaaaaaa-bbbb-cccc-dddd-000000000001 --format=json
+
+# Validate the edited value against the API without saving
+dtctl edit setting aaaaaaaa-bbbb-cccc-dddd-000000000001 --validate-only
+```
 
 ### Delete Settings Objects
 

--- a/pkg/resources/settings/handler_test.go
+++ b/pkg/resources/settings/handler_test.go
@@ -567,6 +567,64 @@ func TestValidateCreate_ValidationFailed(t *testing.T) {
 	}
 }
 
+// --- ValidateDelete ---
+
+func TestValidateDelete_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/obj-to-validate-delete", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(SettingsObject{ObjectID: "obj-to-validate-delete", SchemaVersion: "1"})
+		} else if r.Method == http.MethodDelete {
+			if r.URL.Query().Get("validateOnly") != "true" {
+				t.Error("expected validateOnly=true query param")
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+	h, cleanup := newTestHandler(t, mux)
+	defer cleanup()
+
+	err := h.ValidateDelete("obj-to-validate-delete")
+	if err != nil {
+		t.Fatalf("ValidateDelete() error = %v", err)
+	}
+}
+
+func TestValidateDelete_ValidationFailed(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/obj-validate-fail", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(SettingsObject{ObjectID: "obj-validate-fail", SchemaVersion: "1"})
+		} else if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, "deletion not allowed")
+		}
+	})
+	h, cleanup := newTestHandler(t, mux)
+	defer cleanup()
+
+	err := h.ValidateDelete("obj-validate-fail")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestValidateDelete_GetFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/not-found-obj", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	h, cleanup := newTestHandler(t, mux)
+	defer cleanup()
+
+	err := h.ValidateDelete("not-found-obj")
+	if err == nil {
+		t.Fatal("expected error from Get, got nil")
+	}
+}
+
 // --- GetRaw ---
 
 func TestGetRaw_Success(t *testing.T) {

--- a/pkg/resources/settings/settings.go
+++ b/pkg/resources/settings/settings.go
@@ -209,6 +209,16 @@ func (h *Handler) Update(objectID string, value map[string]any) (*SettingsObject
 	return h.Get(obj.ObjectID)
 }
 
+// ValidateDelete validates a settings object deletion without applying it.
+// Auto-fetches the current schemaVersion for the If-Match header.
+func (h *Handler) ValidateDelete(objectID string) error {
+	obj, err := h.sdk.Get(context.Background(), objectID)
+	if err != nil {
+		return err
+	}
+	return h.sdk.ValidateDelete(context.Background(), obj.ObjectID, obj.SchemaVersion)
+}
+
 // Delete deletes a settings object.
 // Auto-fetches the current schemaVersion for the If-Match header.
 func (h *Handler) Delete(objectID string) error {

--- a/pkg/resources/settings/settings.go
+++ b/pkg/resources/settings/settings.go
@@ -216,7 +216,7 @@ func (h *Handler) ValidateDelete(objectID string) error {
 	if err != nil {
 		return err
 	}
-	return h.sdk.ValidateDelete(context.Background(), obj.ObjectID, obj.SchemaVersion)
+	return h.sdk.ValidateDelete(context.Background(), objectID, obj.SchemaVersion)
 }
 
 // Delete deletes a settings object.

--- a/sdk/api/settings/settings.go
+++ b/sdk/api/settings/settings.go
@@ -302,6 +302,23 @@ func (h *Handler) Update(ctx context.Context, objectID, schemaVersion string, va
 	return nil
 }
 
+// ValidateDelete validates a settings object deletion without applying it.
+// The schemaVersion is used for the If-Match header (obtain it from Get).
+func (h *Handler) ValidateDelete(ctx context.Context, objectID, schemaVersion string) error {
+	resp, err := h.client.HTTP().R().SetContext(ctx).
+		SetHeader("If-Match", schemaVersion).
+		SetQueryParam("validateOnly", "true").
+		Delete(fmt.Sprintf("/platform/classic/environment-api/v2/settings/objects/%s", objectID))
+	if err != nil {
+		return fmt.Errorf("validate settings object %q deletion: %w", objectID, err)
+	}
+	if err := httpclient.CheckResponse(resp); err != nil {
+		return fmt.Errorf("validate settings object %q deletion: %w", objectID, err)
+	}
+
+	return nil
+}
+
 // Delete deletes a settings object.
 // The schemaVersion is used for the If-Match header (obtain it from Get).
 func (h *Handler) Delete(ctx context.Context, objectID, schemaVersion string) error {


### PR DESCRIPTION
## Description

Exposes the Settings API `validateOnly` query parameter through the CLI for all three mutating settings commands:

- `dtctl create settings --validate-only` — POSTs with `?validateOnly=true`; skips the safety check (non-mutating)
- `dtctl edit setting --validate-only` — opens the editor as usual, then PUTs with `?validateOnly=true` instead of saving
- `dtctl delete settings --validate-only` — DELETEs with `?validateOnly=true`; skips the safety check and confirmation prompt

## Related Issues

-

## Testing

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)