### PR TITLE
feat(account): add platform token management via Account Management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Token-based authentication and multi-environment configuration are covered in th
 | Notifications | get, describe, delete, watch |
 | Users & Groups | get, describe |
 | Live Debugger | breakpoints, workspace filters, snapshot decoding |
-| Platform Tokens | account token create, list, revoke (`dt0s16.*` via Account Management API) |
+| Platform Tokens | account create/list/delete token (`dt0s16.*` via Account Management API) |
 
 See the **[Command Reference](https://dynatrace-oss.github.io/dtctl/docs/command-reference/)** for the full list of verbs, flags, resource types, and aliases.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Token-based authentication and multi-environment configuration are covered in th
 | Notifications | get, describe, delete, watch |
 | Users & Groups | get, describe |
 | Live Debugger | breakpoints, workspace filters, snapshot decoding |
+| Platform Tokens | account token create, list, revoke (`dt0s16.*` via Account Management API) |
 
 See the **[Command Reference](https://dynatrace-oss.github.io/dtctl/docs/command-reference/)** for the full list of verbs, flags, resource types, and aliases.
 

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -1,0 +1,14 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var accountCmd = &cobra.Command{
+	Use:   "account",
+	Short: "Platform account administration",
+	Long:  "Commands for managing Dynatrace platform account resources.",
+	RunE:  requireSubcommand,
+}
+
+func init() {
+	rootCmd.AddCommand(accountCmd)
+}

--- a/cmd/account_login.go
+++ b/cmd/account_login.go
@@ -103,6 +103,17 @@ The account UUID is resolved from: --account-uuid flag > DTCTL_ACCOUNT_UUID > co
 			return fmt.Errorf("failed to store tokens: %w", err)
 		}
 
+		// Persist the UUID so follow-up commands find the keyring entry without
+		// requiring --account-uuid or DTCTL_ACCOUNT_UUID each time.
+		if ctx.AccountUUID == "" {
+			if nc, err := cfg.GetContext(cfg.CurrentContext); err == nil {
+				nc.Context.AccountUUID = accountUUID
+				if saveErr := cfg.Save(); saveErr != nil {
+					output.PrintWarning("Could not persist account-uuid to context: %v", saveErr)
+				}
+			}
+		}
+
 		output.PrintSuccess("Account token stored. Run 'dtctl account token list' to verify access.")
 		return nil
 	},

--- a/cmd/account_login.go
+++ b/cmd/account_login.go
@@ -114,7 +114,7 @@ The account UUID is resolved from: --account-uuid flag > DTCTL_ACCOUNT_UUID > co
 			}
 		}
 
-		output.PrintSuccess("Account token stored. Run 'dtctl account token list' to verify access.")
+		output.PrintSuccess("Account token stored. Run 'dtctl account list token' to verify access.")
 		return nil
 	},
 }

--- a/cmd/account_login.go
+++ b/cmd/account_login.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/auth"
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+var accountLoginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Authenticate for account-plane operations via browser-based OAuth",
+	Long: `Authenticate with the Dynatrace Account Management API using browser-based OAuth.
+
+Opens a browser window to complete login. On success, the account token is stored
+in the system keyring (or DTCTL_TOKEN_STORAGE=file fallback) so subsequent
+account commands work without DTCTL_ACCOUNT_TOKEN.
+
+The account UUID is resolved from: --account-uuid flag > DTCTL_ACCOUNT_UUID > context config.`,
+	Example: `  # Login (UUID from DTCTL_ACCOUNT_UUID or context account-uuid)
+  dtctl account login
+
+  # Login with explicit account UUID
+  dtctl account login --account-uuid xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		uuidFlag, _ := cmd.Flags().GetString("account-uuid")
+		timeoutStr, _ := cmd.Flags().GetString("timeout")
+
+		timeout, err := time.ParseDuration(timeoutStr)
+		if err != nil {
+			return fmt.Errorf("invalid timeout: %w", err)
+		}
+
+		cfg, err := LoadConfig()
+		if err != nil {
+			return err
+		}
+		ctx, err := cfg.CurrentContextObj()
+		if err != nil {
+			return err
+		}
+
+		// Resolve UUID: flag > env > config. Skip discovery — no token yet.
+		accountUUID := resolveUUIDNoDiscovery(ctx, uuidFlag)
+		if accountUUID == "" {
+			return fmt.Errorf("account UUID required: pass --account-uuid or set DTCTL_ACCOUNT_UUID")
+		}
+
+		env := auth.DetectEnvironment(ctx.Environment)
+		oauthConfig := auth.AccountOAuthConfig(env, ctx.SafetyLevel, accountUUID)
+
+		// Ensure token storage is available (mirrors auth login).
+		if keyringErr := authCheckKeyringFunc(); keyringErr != nil {
+			recovered := false
+			if strings.Contains(keyringErr.Error(), config.ErrMsgCollectionUnlock) {
+				output.PrintInfo("No keyring collection — creating one (you may be prompted for a password)...")
+				if initErr := authEnsureKeyringFunc(cmd.Context()); initErr == nil {
+					if authCheckKeyringFunc() == nil {
+						output.PrintSuccess("Keyring collection created")
+						recovered = true
+					}
+				}
+			}
+			if !recovered {
+				if !config.IsFileTokenStorage() {
+					return fmt.Errorf("token storage unavailable: %v\n\nSet DTCTL_TOKEN_STORAGE=file to use file-based fallback", keyringErr)
+				}
+				output.PrintWarning("Keyring unavailable; using file-based token storage (%s)", config.OAuthStorageBackend())
+			}
+		}
+
+		output.PrintInfo("Detected environment: %s", env)
+		output.PrintInfo("Account UUID: %s", accountUUID)
+		output.PrintInfo("Starting account OAuth flow (browser will open)...")
+
+		flow, err := auth.NewOAuthFlow(oauthConfig)
+		if err != nil {
+			return fmt.Errorf("failed to initialize OAuth: %w", err)
+		}
+
+		flowCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		tokens, err := flow.Start(flowCtx)
+		if err != nil {
+			return fmt.Errorf("authentication failed: %w", err)
+		}
+
+		output.PrintSuccess("Authentication successful!")
+
+		tokenManager, err := auth.NewTokenManager(oauthConfig)
+		if err != nil {
+			return fmt.Errorf("failed to create token manager: %w", err)
+		}
+
+		if err := tokenManager.SaveToken(accountTokenKeyName(accountUUID), tokens); err != nil {
+			return fmt.Errorf("failed to store tokens: %w", err)
+		}
+
+		output.PrintSuccess("Account token stored. Run 'dtctl account token list' to verify access.")
+		return nil
+	},
+}
+
+func init() {
+	accountCmd.AddCommand(accountLoginCmd)
+	accountLoginCmd.Flags().String("account-uuid", "", "account UUID (overrides DTCTL_ACCOUNT_UUID and context account-uuid)")
+	accountLoginCmd.Flags().String("timeout", "5m", "timeout for the OAuth browser flow")
+}

--- a/cmd/account_status.go
+++ b/cmd/account_status.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/auth"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+var accountStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show account authentication status",
+	Long: `Show the status of the account-plane authentication session.
+
+Displays the account UUID in use, whether a token is stored in the keyring
+from 'dtctl account login', when it expires, and whether DTCTL_ACCOUNT_TOKEN
+is overriding the stored token.`,
+	Example: `  dtctl account status`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := LoadConfig()
+		if err != nil {
+			return err
+		}
+		ctx, err := cfg.CurrentContextObj()
+		if err != nil {
+			return err
+		}
+
+		const w = 20
+
+		// Resolve UUID from env/config only (no discovery — no token yet).
+		accountUUID := ""
+		uuidSource := ""
+		if v := os.Getenv("DTCTL_ACCOUNT_UUID"); v != "" {
+			accountUUID = v
+			uuidSource = "DTCTL_ACCOUNT_UUID env var"
+		} else if ctx.AccountUUID != "" {
+			accountUUID = ctx.AccountUUID
+			uuidSource = "context config"
+		}
+
+		if accountUUID != "" {
+			output.DescribeKV("Account UUID:", w, "%s", accountUUID)
+			output.DescribeKV("UUID source:", w, "%s", uuidSource)
+		} else {
+			output.DescribeKV("Account UUID:", w, "%s", "(not set — run 'dtctl account login --account-uuid <uuid>')")
+		}
+
+		fmt.Fprintln(os.Stderr)
+
+		// Env var override warning.
+		if v := os.Getenv("DTCTL_ACCOUNT_TOKEN"); v != "" {
+			output.DescribeKV("Token source:", w, "%s", "DTCTL_ACCOUNT_TOKEN env var (overrides keyring)")
+			output.PrintWarning("DTCTL_ACCOUNT_TOKEN is set — it overrides any stored account token.")
+			output.PrintWarning("Unset it to use the token stored by 'dtctl account login'.")
+			fmt.Fprintln(os.Stderr)
+		}
+
+		// Keyring token status.
+		if accountUUID == "" {
+			output.DescribeKV("Keyring token:", w, "%s", "(unknown — account UUID not set)")
+			return nil
+		}
+
+		env := auth.DetectEnvironment(ctx.Environment)
+		oauthCfg := auth.AccountOAuthConfig(env, ctx.SafetyLevel, accountUUID)
+		tm, err := auth.NewTokenManager(oauthCfg)
+		if err != nil {
+			return fmt.Errorf("token manager: %w", err)
+		}
+
+		stored, err := tm.GetTokenInfo(accountTokenKeyName(accountUUID))
+		if err != nil || stored == nil {
+			output.DescribeKV("Keyring token:", w, "%s", "not found — run 'dtctl account login'")
+			return nil
+		}
+
+		output.DescribeKV("Keyring token:", w, "%s", "present")
+		output.DescribeKV("Storage:", w, "%s", "keyring")
+
+		if stored.AccessToken != "" {
+			if stored.ExpiresAt.IsZero() {
+				output.DescribeKV("Access token:", w, "%s", "present (expiry unknown)")
+			} else {
+				remaining := time.Until(stored.ExpiresAt).Round(time.Second)
+				if remaining > 0 {
+					output.DescribeKV("Access token:", w, "valid for %s (expires %s)", remaining, stored.ExpiresAt.Format(time.RFC3339))
+				} else {
+					output.DescribeKV("Access token:", w, "expired at %s", stored.ExpiresAt.Format(time.RFC3339))
+				}
+			}
+		} else {
+			output.DescribeKV("Access token:", w, "%s", "not cached locally (will refresh on next call)")
+		}
+
+		if stored.RefreshToken != "" {
+			if exp, ok := auth.DecodeRefreshTokenExpiry(stored.RefreshToken); ok {
+				remaining := time.Until(exp).Round(time.Second)
+				if remaining > 0 {
+					output.DescribeKV("Refresh token:", w, "valid for %s (expires %s)", remaining, exp.Format(time.RFC3339))
+				} else {
+					output.DescribeKV("Refresh token:", w, "expired — run 'dtctl account login' again")
+				}
+			} else {
+				output.DescribeKV("Refresh token:", w, "%s", "present")
+			}
+		} else {
+			output.DescribeKV("Refresh token:", w, "%s", "not present")
+		}
+
+		if stored.Scope != "" {
+			output.DescribeKV("Scopes:", w, "%s", strings.Join(strings.Fields(stored.Scope), ", "))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	accountCmd.AddCommand(accountStatusCmd)
+}

--- a/cmd/account_token.go
+++ b/cmd/account_token.go
@@ -25,18 +25,24 @@ var accountTokenCreateCmd = &cobra.Command{
 	Short: "Create a platform token",
 	Long: `Create a new Dynatrace platform token.
 
+The --user-uuid flag is optional; if omitted, the current user's UUID is
+resolved automatically from the account token's JWT subject claim.
+
 Examples:
   # Create a token with 90-day expiry (default)
-  dtctl account token create --name ci-pipeline --scope account-idm-read --user-uuid <uuid>
+  dtctl account token create --name ci-pipeline --scope account-idm-read
 
   # Create a token expiring in 30 days
-  dtctl account token create --name ci-pipeline --scope account-idm-read --user-uuid <uuid> --expires 30d
+  dtctl account token create --name ci-pipeline --scope account-idm-read --expires 30d
 
   # Create with explicit expiration date (RFC3339)
-  dtctl account token create --name ci-pipeline --scope account-idm-read --user-uuid <uuid> --expires-at 2026-10-01T00:00:00Z
+  dtctl account token create --name ci-pipeline --scope account-idm-read --expires-at 2026-10-01T00:00:00Z
+
+  # Create for a specific user
+  dtctl account token create --name ci-pipeline --scope account-idm-read --user-uuid <uuid>
 
   # Dry run to preview
-  dtctl account token create --name ci-pipeline --scope account-idm-read --user-uuid <uuid> --dry-run
+  dtctl account token create --name ci-pipeline --scope account-idm-read --dry-run
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
@@ -52,9 +58,6 @@ Examples:
 		}
 		if len(scopes) == 0 {
 			return fmt.Errorf("--scope is required")
-		}
-		if userUUID == "" {
-			return fmt.Errorf("--user-uuid is required")
 		}
 		if expiresAt != "" && cmd.Flags().Changed("expires") {
 			return fmt.Errorf("--expires and --expires-at are mutually exclusive")
@@ -83,6 +86,18 @@ Examples:
 			tags = []string{}
 		}
 
+		accClient, accountUUID, err := SetupAccountWithSafety(safety.OperationCreate)
+		if err != nil {
+			return err
+		}
+
+		if userUUID == "" {
+			userUUID, err = resolveCurrentAccountUserUUID(accountUUID)
+			if err != nil {
+				return fmt.Errorf("could not auto-resolve user UUID from account token: %w\nHint: provide --user-uuid explicitly", err)
+			}
+		}
+
 		req := platformtoken.PlatformTokenCreate{
 			Name:           name,
 			UserUUID:       userUUID,
@@ -99,11 +114,6 @@ Examples:
 			output.PrintInfo("UserUUID: %s", req.UserUUID)
 			output.PrintInfo("Expires:  %s", req.ExpirationDate)
 			return nil
-		}
-
-		accClient, accountUUID, err := SetupAccountWithSafety(safety.OperationCreate)
-		if err != nil {
-			return err
 		}
 
 		handler := platformtoken.NewHandler(accClient, accountUUID)
@@ -209,7 +219,7 @@ func init() {
 	accountTokenCreateCmd.Flags().StringArray("scope", nil, "token scope; may be specified multiple times (required)")
 	accountTokenCreateCmd.Flags().String("expires", "90d", "token lifetime (e.g. 30d, 720h)")
 	accountTokenCreateCmd.Flags().String("expires-at", "", "exact expiration date in RFC3339 format (mutually exclusive with --expires)")
-	accountTokenCreateCmd.Flags().String("user-uuid", "", "user UUID the token belongs to (required)")
+	accountTokenCreateCmd.Flags().String("user-uuid", "", "user UUID the token belongs to (default: current user)")
 	accountTokenCreateCmd.Flags().StringArray("resource", nil, "token resource; may be specified multiple times")
 	accountTokenCreateCmd.Flags().StringArray("tag", nil, "token tag; may be specified multiple times")
 }

--- a/cmd/account_token.go
+++ b/cmd/account_token.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/platformtoken"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
+)
+
+var accountTokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Manage platform tokens",
+	Long:  "Commands for creating, listing, and revoking Dynatrace platform tokens.",
+	RunE:  requireSubcommand,
+}
+
+var accountTokenCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a platform token",
+	Long: `Create a new Dynatrace platform token.
+
+Examples:
+  # Create a token with 90-day expiry (default)
+  dtctl account token create --name ci-pipeline --scope account-idm-read --user-uuid <uuid>
+
+  # Create a token expiring in 30 days
+  dtctl account token create --name ci-pipeline --scope account-idm-read --user-uuid <uuid> --expires 30d
+
+  # Create with explicit expiration date (RFC3339)
+  dtctl account token create --name ci-pipeline --scope account-idm-read --user-uuid <uuid> --expires-at 2026-10-01T00:00:00Z
+
+  # Dry run to preview
+  dtctl account token create --name ci-pipeline --scope account-idm-read --user-uuid <uuid> --dry-run
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name, _ := cmd.Flags().GetString("name")
+		scopes, _ := cmd.Flags().GetStringArray("scope")
+		expires, _ := cmd.Flags().GetString("expires")
+		expiresAt, _ := cmd.Flags().GetString("expires-at")
+		userUUID, _ := cmd.Flags().GetString("user-uuid")
+		resources, _ := cmd.Flags().GetStringArray("resource")
+		tags, _ := cmd.Flags().GetStringArray("tag")
+
+		if name == "" {
+			return fmt.Errorf("--name is required")
+		}
+		if len(scopes) == 0 {
+			return fmt.Errorf("--scope is required")
+		}
+		if userUUID == "" {
+			return fmt.Errorf("--user-uuid is required")
+		}
+		if expiresAt != "" && cmd.Flags().Changed("expires") {
+			return fmt.Errorf("--expires and --expires-at are mutually exclusive")
+		}
+
+		var expirationDate string
+		if expiresAt != "" {
+			t, err := time.Parse(time.RFC3339, expiresAt)
+			if err != nil {
+				return fmt.Errorf("invalid --expires-at value %q: must be RFC3339 (e.g. 2026-10-01T00:00:00Z): %w", expiresAt, err)
+			}
+			expirationDate = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		} else {
+			t, err := parseExpiresDuration(expires)
+			if err != nil {
+				return err
+			}
+			expirationDate = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+
+		// Ensure empty slices (not nil) so API receives [] not null.
+		if resources == nil {
+			resources = []string{}
+		}
+		if tags == nil {
+			tags = []string{}
+		}
+
+		req := platformtoken.PlatformTokenCreate{
+			Name:           name,
+			UserUUID:       userUUID,
+			Scope:          scopes,
+			Resource:       resources,
+			Tags:           tags,
+			ExpirationDate: expirationDate,
+		}
+
+		if dryRun {
+			output.PrintInfo("Dry run: would create platform token")
+			output.PrintInfo("Name:     %s", req.Name)
+			output.PrintInfo("Scope:    %s", strings.Join(req.Scope, ", "))
+			output.PrintInfo("UserUUID: %s", req.UserUUID)
+			output.PrintInfo("Expires:  %s", req.ExpirationDate)
+			return nil
+		}
+
+		accClient, accountUUID, err := SetupAccountWithSafety(safety.OperationCreate)
+		if err != nil {
+			return err
+		}
+
+		handler := platformtoken.NewHandler(accClient, accountUUID)
+		res, err := handler.Create(req)
+		if err != nil {
+			return err
+		}
+
+		output.PrintSuccess("Platform token %q created (expires: %s)", res.Name, res.ExpirationDate)
+		output.PrintWarning("Token secret shown once — store it now:")
+		fmt.Println(res.Token)
+		return nil
+	},
+}
+
+var accountTokenListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List platform tokens",
+	Long: `List all platform tokens for the account.
+
+Examples:
+  # List all tokens
+  dtctl account token list
+
+  # Output as JSON
+  dtctl account token list -o json
+`,
+	Aliases: []string{"ls", "get"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		accClient, accountUUID, err := SetupAccount()
+		if err != nil {
+			return err
+		}
+
+		handler := platformtoken.NewHandler(accClient, accountUUID)
+		tokens, err := handler.List()
+		if err != nil {
+			return err
+		}
+
+		return NewPrinter().PrintList(tokens)
+	},
+}
+
+var accountTokenRevokeCmd = &cobra.Command{
+	Use:     "revoke <tokenId>",
+	Aliases: []string{"delete"},
+	Short:   "Revoke a platform token",
+	Long: `Revoke (delete) a platform token by its ID.
+
+Examples:
+  # Revoke a token
+  dtctl account token revoke <tokenId>
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tokenID := args[0]
+
+		if dryRun {
+			output.PrintInfo("Dry run: would revoke platform token %q", tokenID)
+			return nil
+		}
+
+		accClient, accountUUID, err := SetupAccountWithSafety(safety.OperationDelete)
+		if err != nil {
+			return err
+		}
+
+		handler := platformtoken.NewHandler(accClient, accountUUID)
+		if err := handler.Revoke(tokenID); err != nil {
+			return err
+		}
+
+		output.PrintSuccess("Platform token %q revoked", tokenID)
+		return nil
+	},
+}
+
+// parseExpiresDuration parses strings like "90d" or "720h" into a future time.
+func parseExpiresDuration(s string) (time.Time, error) {
+	if strings.HasSuffix(s, "d") {
+		days, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid duration %q: expected Nd (e.g. 90d)", s)
+		}
+		return time.Now().UTC().Add(time.Duration(days) * 24 * time.Hour), nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	return time.Now().UTC().Add(d), nil
+}
+
+func init() {
+	accountCmd.AddCommand(accountTokenCmd)
+	accountTokenCmd.AddCommand(accountTokenCreateCmd)
+	accountTokenCmd.AddCommand(accountTokenListCmd)
+	accountTokenCmd.AddCommand(accountTokenRevokeCmd)
+
+	// Create flags
+	accountTokenCreateCmd.Flags().String("name", "", "token name (required)")
+	accountTokenCreateCmd.Flags().StringArray("scope", nil, "token scope; may be specified multiple times (required)")
+	accountTokenCreateCmd.Flags().String("expires", "90d", "token lifetime (e.g. 30d, 720h)")
+	accountTokenCreateCmd.Flags().String("expires-at", "", "exact expiration date in RFC3339 format (mutually exclusive with --expires)")
+	accountTokenCreateCmd.Flags().String("user-uuid", "", "user UUID the token belongs to (required)")
+	accountTokenCreateCmd.Flags().StringArray("resource", nil, "token resource; may be specified multiple times")
+	accountTokenCreateCmd.Flags().StringArray("tag", nil, "token tag; may be specified multiple times")
+}

--- a/cmd/account_token.go
+++ b/cmd/account_token.go
@@ -13,15 +13,49 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 )
 
-var accountTokenCmd = &cobra.Command{
-	Use:   "token",
-	Short: "Manage platform tokens",
-	Long:  "Commands for creating, listing, and revoking Dynatrace platform tokens.",
+var accountListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List account resources",
 	RunE:  requireSubcommand,
 }
 
-var accountTokenCreateCmd = &cobra.Command{
+var accountListTokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "List platform tokens",
+	Long: `List all platform tokens for the account.
+
+Examples:
+  # List all tokens
+  dtctl account list token
+
+  # Output as JSON
+  dtctl account list token -o json
+`,
+	Aliases: []string{"tokens"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		accClient, accountUUID, err := SetupAccount()
+		if err != nil {
+			return err
+		}
+
+		handler := platformtoken.NewHandler(accClient, accountUUID)
+		tokens, err := handler.List()
+		if err != nil {
+			return err
+		}
+
+		return NewPrinter().PrintList(tokens)
+	},
+}
+
+var accountCreateCmd = &cobra.Command{
 	Use:   "create",
+	Short: "Create account resources",
+	RunE:  requireSubcommand,
+}
+
+var accountCreateTokenCmd = &cobra.Command{
+	Use:   "token",
 	Short: "Create a platform token",
 	Long: `Create a new Dynatrace platform token.
 
@@ -30,27 +64,28 @@ resolved automatically from the account token's JWT subject claim.
 
 Examples:
   # Create a token with 90-day expiry (default)
-  dtctl account token create --name ci-pipeline --scope account-idm-read
+  dtctl account create token --name ci-pipeline --scope account-idm-read
 
   # Create a token with multiple scopes (repeat or comma-separate)
-  dtctl account token create --name ci-pipeline --scope account-idm-read,storage:buckets:read
-  dtctl account token create --name ci-pipeline --scope account-idm-read --scope storage:buckets:read
+  dtctl account create token --name ci-pipeline --scope account-idm-read,storage:buckets:read
+  dtctl account create token --name ci-pipeline --scope account-idm-read --scope storage:buckets:read
 
   # Create a token expiring in 30 days
-  dtctl account token create --name ci-pipeline --scope account-idm-read --expires 30d
+  dtctl account create token --name ci-pipeline --scope account-idm-read --expires 30d
 
   # Create with explicit expiration date (RFC3339)
-  dtctl account token create --name ci-pipeline --scope account-idm-read --expires-at 2026-10-01T00:00:00Z
+  dtctl account create token --name ci-pipeline --scope account-idm-read --expires-at 2026-10-01T00:00:00Z
 
   # Create for a specific user
-  dtctl account token create --name ci-pipeline --scope account-idm-read --user-uuid <uuid>
+  dtctl account create token --name ci-pipeline --scope account-idm-read --user-uuid <uuid>
 
   # Dry run to preview
-  dtctl account token create --name ci-pipeline --scope account-idm-read --dry-run
+  dtctl account create token --name ci-pipeline --scope account-idm-read --dry-run
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
-		scopes, _ := cmd.Flags().GetStringSlice("scope")
+		rawScopes, _ := cmd.Flags().GetStringArray("scope")
+		scopes := normalizeScopes(rawScopes)
 		expires, _ := cmd.Flags().GetString("expires")
 		expiresAt, _ := cmd.Flags().GetString("expires-at")
 		userUUID, _ := cmd.Flags().GetString("user-uuid")
@@ -129,51 +164,28 @@ Examples:
 	},
 }
 
-var accountTokenListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List platform tokens",
-	Long: `List all platform tokens for the account.
-
-Examples:
-  # List all tokens
-  dtctl account token list
-
-  # Output as JSON
-  dtctl account token list -o json
-`,
-	Aliases: []string{"ls", "get"},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		accClient, accountUUID, err := SetupAccount()
-		if err != nil {
-			return err
-		}
-
-		handler := platformtoken.NewHandler(accClient, accountUUID)
-		tokens, err := handler.List()
-		if err != nil {
-			return err
-		}
-
-		return NewPrinter().PrintList(tokens)
-	},
+var accountDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete account resources",
+	RunE:  requireSubcommand,
 }
 
-var accountTokenRevokeCmd = &cobra.Command{
-	Use:     "revoke <tokenId>",
-	Aliases: []string{"delete"},
-	Short:   "Revoke a platform token",
-	Long: `Revoke (delete) a platform token by its ID.
+var accountDeleteTokenCmd = &cobra.Command{
+	Use:     "token <tokenId>",
+	Aliases: []string{"revoke"},
+	Short:   "Delete (revoke) a platform token",
+	Long: `Delete (revoke) a platform token by its ID.
 
 Examples:
-  # Revoke a token
-  dtctl account token revoke <tokenId>
+  # Delete a token
+  dtctl account delete token <tokenId>
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		tokenID := args[0]
 
 		if dryRun {
-			output.PrintInfo("Dry run: would revoke platform token %q", tokenID)
+			output.PrintInfo("Dry run: would delete platform token %q", tokenID)
 			return nil
 		}
 
@@ -187,9 +199,21 @@ Examples:
 			return err
 		}
 
-		output.PrintSuccess("Platform token %q revoked", tokenID)
+		output.PrintSuccess("Platform token %q deleted", tokenID)
 		return nil
 	},
+}
+
+// normalizeScopes splits and trims scope values so both "a, b" and "a b" work.
+func normalizeScopes(scopes []string) []string {
+	var result []string
+	for _, s := range scopes {
+		s = strings.ReplaceAll(s, ",", " ")
+		for _, part := range strings.Fields(s) {
+			result = append(result, part)
+		}
+	}
+	return result
 }
 
 // parseExpiresDuration parses strings like "90d" or "720h" into a future time.
@@ -209,17 +233,21 @@ func parseExpiresDuration(s string) (time.Time, error) {
 }
 
 func init() {
-	accountCmd.AddCommand(accountTokenCmd)
-	accountTokenCmd.AddCommand(accountTokenCreateCmd)
-	accountTokenCmd.AddCommand(accountTokenListCmd)
-	accountTokenCmd.AddCommand(accountTokenRevokeCmd)
+	accountCmd.AddCommand(accountListCmd)
+	accountListCmd.AddCommand(accountListTokenCmd)
+
+	accountCmd.AddCommand(accountCreateCmd)
+	accountCreateCmd.AddCommand(accountCreateTokenCmd)
+
+	accountCmd.AddCommand(accountDeleteCmd)
+	accountDeleteCmd.AddCommand(accountDeleteTokenCmd)
 
 	// Create flags
-	accountTokenCreateCmd.Flags().String("name", "", "token name (required)")
-	accountTokenCreateCmd.Flags().StringSlice("scope", nil, "token scope; repeat or comma-separate for multiple (required)")
-	accountTokenCreateCmd.Flags().String("expires", "90d", "token lifetime (e.g. 30d, 720h)")
-	accountTokenCreateCmd.Flags().String("expires-at", "", "exact expiration date in RFC3339 format (mutually exclusive with --expires)")
-	accountTokenCreateCmd.Flags().String("user-uuid", "", "user UUID the token belongs to (default: current user)")
-	accountTokenCreateCmd.Flags().StringArray("resource", nil, "environment URL(s) the token is scoped to (default: current environment)")
-	accountTokenCreateCmd.Flags().StringArray("tag", nil, "token tag; may be specified multiple times")
+	accountCreateTokenCmd.Flags().String("name", "", "token name (required)")
+	accountCreateTokenCmd.Flags().StringArray("scope", nil, "token scope; repeat or comma/space/newline-separate for multiple (required)")
+	accountCreateTokenCmd.Flags().String("expires", "90d", "token lifetime (e.g. 30d, 720h)")
+	accountCreateTokenCmd.Flags().String("expires-at", "", "exact expiration date in RFC3339 format (mutually exclusive with --expires)")
+	accountCreateTokenCmd.Flags().String("user-uuid", "", "user UUID the token belongs to (default: current user)")
+	accountCreateTokenCmd.Flags().StringArray("resource", nil, "environment URL(s) the token is scoped to (default: current environment)")
+	accountCreateTokenCmd.Flags().StringArray("tag", nil, "token tag; may be specified multiple times")
 }

--- a/cmd/account_token.go
+++ b/cmd/account_token.go
@@ -90,6 +90,18 @@ Examples:
 			}
 		}
 
+		if len(resources) == 0 {
+			cfg, err := LoadConfig()
+			if err != nil {
+				return fmt.Errorf("resolving default resource: %w", err)
+			}
+			ctx, err := cfg.CurrentContextObj()
+			if err != nil {
+				return fmt.Errorf("resolving default resource: %w", err)
+			}
+			resources = []string{ctx.Environment}
+		}
+
 		req := platformtoken.PlatformTokenCreate{
 			Name:           name,
 			UserUUID:       userUUID,
@@ -212,6 +224,6 @@ func init() {
 	accountTokenCreateCmd.Flags().String("expires", "90d", "token lifetime (e.g. 30d, 720h)")
 	accountTokenCreateCmd.Flags().String("expires-at", "", "exact expiration date in RFC3339 format (mutually exclusive with --expires)")
 	accountTokenCreateCmd.Flags().String("user-uuid", "", "user UUID the token belongs to (default: current user)")
-	accountTokenCreateCmd.Flags().StringArray("resource", nil, "token resource; may be specified multiple times")
+	accountTokenCreateCmd.Flags().StringArray("resource", nil, "environment URL(s) the token is scoped to (default: current environment)")
 	accountTokenCreateCmd.Flags().StringArray("tag", nil, "token tag; may be specified multiple times")
 }

--- a/cmd/account_token.go
+++ b/cmd/account_token.go
@@ -91,15 +91,7 @@ Examples:
 		}
 
 		if len(resources) == 0 {
-			cfg, err := LoadConfig()
-			if err != nil {
-				return fmt.Errorf("resolving default resource: %w", err)
-			}
-			ctx, err := cfg.CurrentContextObj()
-			if err != nil {
-				return fmt.Errorf("resolving default resource: %w", err)
-			}
-			resources = []string{ctx.Environment}
+			resources = []string{"urn:dtaccount:" + accountUUID}
 		}
 
 		req := platformtoken.PlatformTokenCreate{

--- a/cmd/account_token.go
+++ b/cmd/account_token.go
@@ -32,7 +32,8 @@ Examples:
   # Create a token with 90-day expiry (default)
   dtctl account token create --name ci-pipeline --scope account-idm-read
 
-  # Create a token with multiple scopes (repeat --scope for each)
+  # Create a token with multiple scopes (repeat or comma-separate)
+  dtctl account token create --name ci-pipeline --scope account-idm-read,storage:buckets:read
   dtctl account token create --name ci-pipeline --scope account-idm-read --scope storage:buckets:read
 
   # Create a token expiring in 30 days
@@ -49,7 +50,7 @@ Examples:
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
-		scopes, _ := cmd.Flags().GetStringArray("scope")
+		scopes, _ := cmd.Flags().GetStringSlice("scope")
 		expires, _ := cmd.Flags().GetString("expires")
 		expiresAt, _ := cmd.Flags().GetString("expires-at")
 		userUUID, _ := cmd.Flags().GetString("user-uuid")
@@ -121,7 +122,7 @@ Examples:
 			return err
 		}
 
-		output.PrintSuccess("Platform token %q created (expires: %s)", res.Name, res.ExpirationDate)
+		output.PrintSuccess("Platform token %q created (expires: %s)", res.Name, expirationDate)
 		output.PrintWarning("Token secret shown once — store it now:")
 		fmt.Println(res.Token)
 		return nil
@@ -215,7 +216,7 @@ func init() {
 
 	// Create flags
 	accountTokenCreateCmd.Flags().String("name", "", "token name (required)")
-	accountTokenCreateCmd.Flags().StringArray("scope", nil, "token scope; may be specified multiple times (required)")
+	accountTokenCreateCmd.Flags().StringSlice("scope", nil, "token scope; repeat or comma-separate for multiple (required)")
 	accountTokenCreateCmd.Flags().String("expires", "90d", "token lifetime (e.g. 30d, 720h)")
 	accountTokenCreateCmd.Flags().String("expires-at", "", "exact expiration date in RFC3339 format (mutually exclusive with --expires)")
 	accountTokenCreateCmd.Flags().String("user-uuid", "", "user UUID the token belongs to (default: current user)")

--- a/cmd/account_token.go
+++ b/cmd/account_token.go
@@ -32,6 +32,9 @@ Examples:
   # Create a token with 90-day expiry (default)
   dtctl account token create --name ci-pipeline --scope account-idm-read
 
+  # Create a token with multiple scopes (repeat --scope for each)
+  dtctl account token create --name ci-pipeline --scope account-idm-read --scope storage:buckets:read
+
   # Create a token expiring in 30 days
   dtctl account token create --name ci-pipeline --scope account-idm-read --expires 30d
 

--- a/cmd/account_token.go
+++ b/cmd/account_token.go
@@ -78,14 +78,6 @@ Examples:
 			expirationDate = t.UTC().Format("2006-01-02T15:04:05.000Z")
 		}
 
-		// Ensure empty slices (not nil) so API receives [] not null.
-		if resources == nil {
-			resources = []string{}
-		}
-		if tags == nil {
-			tags = []string{}
-		}
-
 		accClient, accountUUID, err := SetupAccountWithSafety(safety.OperationCreate)
 		if err != nil {
 			return err

--- a/cmd/account_token.go
+++ b/cmd/account_token.go
@@ -209,9 +209,7 @@ func normalizeScopes(scopes []string) []string {
 	var result []string
 	for _, s := range scopes {
 		s = strings.ReplaceAll(s, ",", " ")
-		for _, part := range strings.Fields(s) {
-			result = append(result, part)
-		}
+		result = append(result, strings.Fields(s)...)
 	}
 	return result
 }

--- a/cmd/account_token_test.go
+++ b/cmd/account_token_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeScopes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "comma-separated with spaces",
+			input: []string{"scope1, scope2, scope3"},
+			want:  []string{"scope1", "scope2", "scope3"},
+		},
+		{
+			name:  "space-separated",
+			input: []string{"scope1 scope2 scope3"},
+			want:  []string{"scope1", "scope2", "scope3"},
+		},
+		{
+			name:  "comma-separated no spaces",
+			input: []string{"scope1,scope2,scope3"},
+			want:  []string{"scope1", "scope2", "scope3"},
+		},
+		{
+			name:  "multiple flag values",
+			input: []string{"scope1", "scope2", "scope3"},
+			want:  []string{"scope1", "scope2", "scope3"},
+		},
+		{
+			name:  "mixed comma and space",
+			input: []string{"scope1, scope2", "scope3 scope4"},
+			want:  []string{"scope1", "scope2", "scope3", "scope4"},
+		},
+		{
+			name:  "newline-separated",
+			input: []string{"scope1\nscope2\nscope3"},
+			want:  []string{"scope1", "scope2", "scope3"},
+		},
+		{
+			name:  "mixed whitespace",
+			input: []string{"scope1\t scope2\n scope3"},
+			want:  []string{"scope1", "scope2", "scope3"},
+		},
+		{
+			name:  "single scope",
+			input: []string{"scope1"},
+			want:  []string{"scope1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeScopes(tt.input)
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("normalizeScopes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/dynatrace-oss/dtctl/pkg/aidetect"
 	"github.com/dynatrace-oss/dtctl/pkg/apply"
+	"github.com/dynatrace-oss/dtctl/pkg/auth"
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
@@ -28,6 +29,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/suggest"
 	"github.com/dynatrace-oss/dtctl/pkg/tracing"
 	sdkquery "github.com/dynatrace-oss/dtctl/sdk/api/query"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
 )
 
 var (
@@ -956,6 +958,144 @@ func NewClientFromConfig(cfg *config.Config) (*client.Client, error) {
 		client.InjectTraceContext(c, tracingRootCtx)
 	}
 	return c, nil
+}
+
+// resolveAccountUUID resolves the account UUID using:
+// 1. DTCTL_ACCOUNT_UUID env var
+// 2. Context account-uuid config field
+// 3. Auto-discovery via access-info
+// Returns an error if none of the sources yields a UUID.
+func resolveAccountUUID(cfg *config.Config, envToken string) (string, error) {
+	if v := os.Getenv("DTCTL_ACCOUNT_UUID"); v != "" {
+		return v, nil
+	}
+	ctx, err := cfg.CurrentContextObj()
+	if err != nil {
+		return "", err
+	}
+	if ctx.AccountUUID != "" {
+		return ctx.AccountUUID, nil
+	}
+	// Auto-discovery
+	env := auth.DetectEnvironment(ctx.Environment)
+	iamBase := client.IAMBaseURLForEnvironment(env)
+	uuid, _, err := client.DiscoverAccountUUID(iamBase, envToken, extractEnvironmentID(ctx.Environment))
+	if err != nil {
+		return "", fmt.Errorf("could not resolve account UUID (set DTCTL_ACCOUNT_UUID or account-uuid in context): %w", err)
+	}
+	return uuid, nil
+}
+
+// extractEnvironmentID extracts the environment ID from a Dynatrace environment URL.
+// e.g. "https://abc12345.apps.dynatrace.com" → "abc12345"
+func extractEnvironmentID(envURL string) string {
+	// strip scheme
+	s := strings.TrimPrefix(envURL, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	// take first segment
+	if i := strings.Index(s, "."); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// accountTokenKeyName returns the keyring token name for a given account UUID.
+func accountTokenKeyName(uuid string) string {
+	return "account-" + uuid
+}
+
+// resolveUUIDNoDiscovery returns the account UUID from flagValue > DTCTL_ACCOUNT_UUID > ctx.AccountUUID.
+// It never calls the API, so it is safe to call before a token is available.
+func resolveUUIDNoDiscovery(ctx *config.Context, flagValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if v := os.Getenv("DTCTL_ACCOUNT_UUID"); v != "" {
+		return v
+	}
+	return ctx.AccountUUID
+}
+
+// resolveAccountToken resolves the account token using:
+// 1. DTCTL_ACCOUNT_TOKEN env var
+// 2. Keyring (if accountUUID is known) — stored by `dtctl account login`
+// 3. Error with hint to run `dtctl account login`
+func resolveAccountToken(cfg *config.Config, accountUUID string) (string, error) {
+	if v := os.Getenv("DTCTL_ACCOUNT_TOKEN"); v != "" {
+		return v, nil
+	}
+	if accountUUID != "" {
+		if ctx, err := cfg.CurrentContextObj(); err == nil {
+			env := auth.DetectEnvironment(ctx.Environment)
+			oauthCfg := auth.AccountOAuthConfig(env, ctx.SafetyLevel, accountUUID)
+			if tm, err := auth.NewTokenManager(oauthCfg); err == nil {
+				if token, err := tm.GetToken(accountTokenKeyName(accountUUID)); err == nil && token != "" {
+					return token, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("account token required: set DTCTL_ACCOUNT_TOKEN or run 'dtctl account login'")
+}
+
+// SetupAccount resolves account credentials and builds an account-plane httpclient.
+// Use for read-only account commands (no safety check).
+func SetupAccount() (*httpclient.Client, string, error) {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	return setupAccountClient(cfg)
+}
+
+// SetupAccountWithSafety resolves account credentials, runs a safety check,
+// and builds an account-plane httpclient. Use for mutating account commands.
+func SetupAccountWithSafety(op safety.Operation) (*httpclient.Client, string, error) {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	checker, err := NewSafetyChecker(cfg)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := checker.CheckError(op, safety.OwnershipUnknown); err != nil {
+		return nil, "", err
+	}
+	return setupAccountClient(cfg)
+}
+
+func setupAccountClient(cfg *config.Config) (*httpclient.Client, string, error) {
+	ctx, err := cfg.CurrentContextObj()
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Sniff UUID from env/config without a token — needed for keyring lookup.
+	partialUUID := resolveUUIDNoDiscovery(ctx, "")
+
+	accountToken, err := resolveAccountToken(cfg, partialUUID)
+	if err != nil {
+		return nil, "", err
+	}
+
+	env := auth.DetectEnvironment(ctx.Environment)
+	accountUUID, err := resolveAccountUUID(cfg, accountToken)
+	if err != nil {
+		return nil, "", err
+	}
+
+	baseURL := client.AccountBaseURLForEnvironment(env)
+	c, err := httpclient.New(baseURL, httpclient.WithToken(accountToken))
+	if err != nil {
+		return nil, "", err
+	}
+	level := verbosity
+	if debugMode {
+		level = 2
+	}
+	c.EnableVerboseLogging(level, os.Stderr)
+	return c, accountUUID, nil
 }
 
 // flagsTakingValues is the set of persistent long flags that consume the next

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/suggest"
 	"github.com/dynatrace-oss/dtctl/pkg/tracing"
 	sdkquery "github.com/dynatrace-oss/dtctl/sdk/api/query"
+	sdkauth "github.com/dynatrace-oss/dtctl/sdk/auth"
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
 )
 
@@ -1036,6 +1037,20 @@ func resolveAccountToken(cfg *config.Config, accountUUID string) (string, error)
 		}
 	}
 	return "", fmt.Errorf("account token required: set DTCTL_ACCOUNT_TOKEN or run 'dtctl account login'")
+}
+
+// resolveCurrentAccountUserUUID extracts the current user's UUID from the account
+// token's JWT sub claim. Used to auto-populate --user-uuid on token creation.
+func resolveCurrentAccountUserUUID(accountUUID string) (string, error) {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return "", err
+	}
+	token, err := resolveAccountToken(cfg, accountUUID)
+	if err != nil {
+		return "", err
+	}
+	return sdkauth.ExtractJWTSubject(token)
 }
 
 // SetupAccount resolves account credentials and builds an account-plane httpclient.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1080,7 +1080,11 @@ func setupAccountClient(cfg *config.Config) (*httpclient.Client, string, error) 
 	}
 
 	env := auth.DetectEnvironment(ctx.Environment)
-	accountUUID, err := resolveAccountUUID(cfg, accountToken)
+
+	// Use the environment token for discovery — the IAM access-info endpoint
+	// rejects account-plane tokens.
+	envToken, _ := client.GetTokenWithOAuthSupport(cfg, ctx.TokenRef)
+	accountUUID, err := resolveAccountUUID(cfg, envToken)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1093,6 +1097,11 @@ func setupAccountClient(cfg *config.Config) (*httpclient.Client, string, error) 
 	level := verbosity
 	if debugMode {
 		level = 2
+	}
+	// Cap at 1 — level 2 dumps response bodies, which would expose the
+	// one-time token secret returned by `account token create`.
+	if level > 1 {
+		level = 1
 	}
 	c.EnableVerboseLogging(level, os.Stderr)
 	return c, accountUUID, nil

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -89,7 +89,7 @@ This document tracks the current implementation status of dtctl. For future plan
 
 | Resource | list | create | revoke |
 |----------|------|--------|--------|
-| account token | ✅ | ✅ | ✅ |
+| token (account) | ✅ | ✅ | ✅ |
 
 #### Cloud Connections
 

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -85,6 +85,12 @@ This document tracks the current implementation status of dtctl. For future plan
 | anomaly-detector | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | classic-pipelines-translation | ✅ | - | - | - | - | - |
 
+#### Account Management
+
+| Resource | list | create | revoke |
+|----------|------|--------|--------|
+| account token | ✅ | ✅ | ✅ |
+
 #### Cloud Connections
 
 | Resource | get | describe | create | delete | apply |

--- a/pkg/auth/account_scopes.go
+++ b/pkg/auth/account_scopes.go
@@ -1,6 +1,9 @@
 package auth
 
-import "github.com/dynatrace-oss/dtctl/pkg/config"
+import (
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/sdk/session"
+)
 
 // accountScopesForSafetyLevel returns account OAuth scopes for the given safety level.
 // platform-token:tokens:manage covers list/revoke; platform-token:tokens:write is required for create.
@@ -11,4 +14,12 @@ func accountScopesForSafetyLevel(level config.SafetyLevel) []string {
 	default:
 		return []string{"account-idm-read", "account-idm-write", "platform-token:tokens:manage", "platform-token:tokens:write"}
 	}
+}
+
+// AccountOAuthConfig returns an OAuth config for account-plane operations.
+// The resource is set to "urn:dtaccount:{uuid}" per Dynatrace account OAuth spec.
+func AccountOAuthConfig(env Environment, safetyLevel config.SafetyLevel, accountUUID string) *OAuthConfig {
+	cfg := session.OAuthConfigForEnvironment(env, safetyLevel, accountScopesForSafetyLevel(safetyLevel))
+	cfg.EnvironmentURL = "urn:dtaccount:" + accountUUID
+	return cfg
 }

--- a/pkg/auth/account_scopes.go
+++ b/pkg/auth/account_scopes.go
@@ -1,0 +1,14 @@
+package auth
+
+import "github.com/dynatrace-oss/dtctl/pkg/config"
+
+// accountScopesForSafetyLevel returns account OAuth scopes for the given safety level.
+// platform-token:tokens:manage covers list/revoke; platform-token:tokens:write is required for create.
+func accountScopesForSafetyLevel(level config.SafetyLevel) []string {
+	switch level {
+	case config.SafetyLevelReadOnly:
+		return []string{"account-idm-read", "platform-token:tokens:manage"}
+	default:
+		return []string{"account-idm-read", "account-idm-write", "platform-token:tokens:manage", "platform-token:tokens:write"}
+	}
+}

--- a/pkg/auth/account_scopes_test.go
+++ b/pkg/auth/account_scopes_test.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+)
+
+func TestAccountScopesForSafetyLevel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		level      config.SafetyLevel
+		wantScopes []string
+	}{
+		{
+			level:      config.SafetyLevelReadOnly,
+			wantScopes: []string{"account-idm-read", "platform-token:tokens:manage"},
+		},
+		{
+			level:      config.SafetyLevelReadWriteAll,
+			wantScopes: []string{"account-idm-read", "account-idm-write", "platform-token:tokens:manage", "platform-token:tokens:write"},
+		},
+		{
+			level:      config.SafetyLevelDangerouslyUnrestricted,
+			wantScopes: []string{"account-idm-read", "account-idm-write", "platform-token:tokens:manage", "platform-token:tokens:write"},
+		},
+	}
+	for _, tt := range tests {
+		got := accountScopesForSafetyLevel(tt.level)
+		if len(got) != len(tt.wantScopes) {
+			t.Errorf("accountScopesForSafetyLevel(%q) = %v, want %v", tt.level, got, tt.wantScopes)
+			continue
+		}
+		for i, s := range got {
+			if s != tt.wantScopes[i] {
+				t.Errorf("accountScopesForSafetyLevel(%q)[%d] = %q, want %q", tt.level, i, s, tt.wantScopes[i])
+			}
+		}
+	}
+}
+
+func TestAccountOAuthConfig(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		env             Environment
+		safetyLevel     config.SafetyLevel
+		accountUUID     string
+		wantEnvURL      string
+		wantScopesCount int
+	}{
+		{
+			name:            "prod read-only",
+			env:             EnvironmentProd,
+			safetyLevel:     config.SafetyLevelReadOnly,
+			accountUUID:     "aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb",
+			wantEnvURL:      "urn:dtaccount:aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb",
+			wantScopesCount: 2,
+		},
+		{
+			name:            "dev readwrite-all",
+			env:             EnvironmentDev,
+			safetyLevel:     config.SafetyLevelReadWriteAll,
+			accountUUID:     "11111111-2222-3333-4444-555555555555",
+			wantEnvURL:      "urn:dtaccount:11111111-2222-3333-4444-555555555555",
+			wantScopesCount: 4,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := AccountOAuthConfig(tt.env, tt.safetyLevel, tt.accountUUID)
+			if cfg.EnvironmentURL != tt.wantEnvURL {
+				t.Errorf("EnvironmentURL = %q, want %q", cfg.EnvironmentURL, tt.wantEnvURL)
+			}
+			if len(cfg.Scopes) != tt.wantScopesCount {
+				t.Errorf("Scopes = %v, want %d scopes", cfg.Scopes, tt.wantScopesCount)
+			}
+		})
+	}
+}

--- a/pkg/auth/resource_scopes.go
+++ b/pkg/auth/resource_scopes.go
@@ -162,7 +162,7 @@ var localResources = map[string]bool{
 	// auth (local token storage / introspection)
 	"login": true, "logout": true, "refresh": true, "status": true, "whoami": true,
 	// alias management
-	"export": true, "import": true, "list": true,
+	"export": true, "import": true, "list": true, "create": true,
 	// skills (local install)
 	"install": true, "uninstall": true,
 }

--- a/pkg/client/account.go
+++ b/pkg/client/account.go
@@ -1,0 +1,27 @@
+package client
+
+import "github.com/dynatrace-oss/dtctl/pkg/auth"
+
+// AccountBaseURLForEnvironment maps a tier to the account API base URL.
+func AccountBaseURLForEnvironment(env auth.Environment) string {
+	switch env {
+	case auth.EnvironmentDev:
+		return "https://api-dev.internal.dynatracelabs.com"
+	case auth.EnvironmentHard:
+		return "https://api-hardening.internal.dynatracelabs.com"
+	default: // prod
+		return "https://api.dynatrace.com"
+	}
+}
+
+// IAMBaseURLForEnvironment maps a tier to the IAM service URL (for access-info).
+func IAMBaseURLForEnvironment(env auth.Environment) string {
+	switch env {
+	case auth.EnvironmentDev:
+		return "https://iam-dev.dynatracelabs.com"
+	case auth.EnvironmentHard:
+		return "https://iam-hardening.dynatracelabs.com"
+	default: // prod
+		return "https://iam.dynatrace.com"
+	}
+}

--- a/pkg/client/account_discovery.go
+++ b/pkg/client/account_discovery.go
@@ -12,9 +12,9 @@ type AccessInfoResponse struct {
 }
 
 type AccessInfoAccount struct {
-	UUID              string                 `json:"uuid"`
-	Name              string                 `json:"name"`
-	AccountServiceURL string                 `json:"accountServiceUrl,omitempty"`
+	UUID              string                  `json:"uuid"`
+	Name              string                  `json:"name"`
+	AccountServiceURL string                  `json:"accountServiceUrl,omitempty"`
 	Environments      []AccessInfoEnvironment `json:"environments,omitempty"`
 }
 

--- a/pkg/client/account_discovery.go
+++ b/pkg/client/account_discovery.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type AccessInfoResponse struct {
+	Accounts []AccessInfoAccount `json:"accounts"`
+}
+
+type AccessInfoAccount struct {
+	UUID              string                 `json:"uuid"`
+	Name              string                 `json:"name"`
+	AccountServiceURL string                 `json:"accountServiceUrl,omitempty"`
+	Environments      []AccessInfoEnvironment `json:"environments,omitempty"`
+}
+
+type AccessInfoEnvironment struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	ServiceURL string `json:"serviceUrl,omitempty"`
+}
+
+// DiscoverAccountUUID calls the IAM access-info endpoint to find the account UUID
+// that contains the given environment ID. Uses the environment token (needs `openid` scope).
+// Returns (uuid, accountName, error).
+func DiscoverAccountUUID(iamBaseURL, envToken, environmentID string) (string, string, error) {
+	req, err := http.NewRequest("GET", iamBaseURL+"/iam/v1/access-info", nil)
+	if err != nil {
+		return "", "", fmt.Errorf("build access-info request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+envToken)
+	req.Header.Set("Accept", "application/json")
+
+	c := &http.Client{Timeout: 10 * time.Second}
+	resp, err := c.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("access-info request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("access-info returned %d", resp.StatusCode)
+	}
+
+	var info AccessInfoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return "", "", fmt.Errorf("decode access-info: %w", err)
+	}
+
+	for _, acct := range info.Accounts {
+		for _, env := range acct.Environments {
+			if env.ID == environmentID {
+				return acct.UUID, acct.Name, nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("no account found for environment %q", environmentID)
+}

--- a/pkg/client/account_discovery_test.go
+++ b/pkg/client/account_discovery_test.go
@@ -1,0 +1,109 @@
+package client_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+)
+
+func TestDiscoverAccountUUID(t *testing.T) {
+	t.Parallel()
+
+	canned := client.AccessInfoResponse{
+		Accounts: []client.AccessInfoAccount{
+			{
+				UUID: "11111111-2222-3333-4444-555555555555",
+				Name: "Acme Corp",
+				Environments: []client.AccessInfoEnvironment{
+					{ID: "abc12345", Name: "Production"},
+					{ID: "abc99999", Name: "Staging"},
+				},
+			},
+			{
+				UUID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+				Name: "Other Corp",
+				Environments: []client.AccessInfoEnvironment{
+					{ID: "xyz11111", Name: "Dev"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		envID       string
+		wantUUID    string
+		wantName    string
+		wantErrFrag string
+	}{
+		{
+			name:     "found in first account",
+			envID:    "abc12345",
+			wantUUID: "11111111-2222-3333-4444-555555555555",
+			wantName: "Acme Corp",
+		},
+		{
+			name:     "found in second account",
+			envID:    "xyz11111",
+			wantUUID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			wantName: "Other Corp",
+		},
+		{
+			name:        "not found",
+			envID:       "unknown000",
+			wantErrFrag: `no account found for environment "unknown000"`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/iam/v1/access-info" {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(canned)
+			}))
+			defer srv.Close()
+
+			uuid, name, err := client.DiscoverAccountUUID(srv.URL, "test-token", tt.envID)
+			if tt.wantErrFrag != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrFrag)
+				}
+				if err.Error() != tt.wantErrFrag {
+					t.Fatalf("error = %q, want %q", err.Error(), tt.wantErrFrag)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if uuid != tt.wantUUID {
+				t.Errorf("uuid = %q, want %q", uuid, tt.wantUUID)
+			}
+			if name != tt.wantName {
+				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestDiscoverAccountUUID_ServerError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, _, err := client.DiscoverAccountUUID(srv.URL, "bad-token", "abc12345")
+	if err == nil {
+		t.Fatal("expected error for 401, got nil")
+	}
+}

--- a/pkg/client/account_test.go
+++ b/pkg/client/account_test.go
@@ -1,0 +1,44 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/auth"
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+)
+
+func TestAccountBaseURLForEnvironment(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		env  auth.Environment
+		want string
+	}{
+		{auth.EnvironmentProd, "https://api.dynatrace.com"},
+		{auth.EnvironmentDev, "https://api-dev.internal.dynatracelabs.com"},
+		{auth.EnvironmentHard, "https://api-hardening.internal.dynatracelabs.com"},
+	}
+	for _, tt := range tests {
+		got := client.AccountBaseURLForEnvironment(tt.env)
+		if got != tt.want {
+			t.Errorf("AccountBaseURLForEnvironment(%q) = %q, want %q", tt.env, got, tt.want)
+		}
+	}
+}
+
+func TestIAMBaseURLForEnvironment(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		env  auth.Environment
+		want string
+	}{
+		{auth.EnvironmentProd, "https://iam.dynatrace.com"},
+		{auth.EnvironmentDev, "https://iam-dev.dynatracelabs.com"},
+		{auth.EnvironmentHard, "https://iam-hardening.dynatracelabs.com"},
+	}
+	for _, tt := range tests {
+		got := client.IAMBaseURLForEnvironment(tt.env)
+		if got != tt.want {
+			t.Errorf("IAMBaseURLForEnvironment(%q) = %q, want %q", tt.env, got, tt.want)
+		}
+	}
+}

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -2306,20 +2306,26 @@ func TestDQLExecutor_CancelQuery_EmptyToken(t *testing.T) {
 // before any poll request is sent.  ExecuteQueryWithContext must call query:cancel with
 // the correct token and return (nil, nil).
 func TestDQLExecutor_CancelAfterExecute(t *testing.T) {
-	executeReturned := make(chan struct{})
 	cancelCalled := false
 	cancelToken := ""
+
+	// Declare ctx/cancel before the server so the handler closure can call cancel().
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/platform/storage/query/v1/query:execute":
+			// Cancel ctx before writing the response body. The executor's HTTP call
+			// uses an independent context (execCtx), so it still receives the response.
+			// When ExecuteAndPollWithOptions checks ctx.Err() after Execute returns,
+			// the cancellation is guaranteed to be visible via the happens-before chain:
+			// cancel() → write body → (network) → read body → ctx.Err().
+			cancel()
 			resp := DQLQueryResponse{State: "RUNNING", RequestToken: "tok-after-execute"}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 			_ = json.NewEncoder(w).Encode(resp)
-			// Signal that the execute response has been written; the test will now
-			// cancel the context before any poll request can be issued.
-			close(executeReturned)
 
 		case "/platform/storage/query/v1/query:cancel":
 			cancelCalled = true
@@ -2338,16 +2344,6 @@ func TestDQLExecutor_CancelAfterExecute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Cancel the context as soon as the execute response is delivered, so that
-	// the ctx.Err() check immediately after the POST fires before any poll.
-	go func() {
-		<-executeReturned
-		cancel()
-	}()
 
 	executor := NewDQLExecutor(c)
 	result, err := executor.ExecuteQueryWithContext(ctx, "fetch logs", DQLExecuteOptions{})

--- a/pkg/output/golden_test.go
+++ b/pkg/output/golden_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/resources/gcpmonitoringconfig"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/hub"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/iam"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/platformtoken"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/segment"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/settings"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/slo"
@@ -2650,4 +2651,63 @@ func TestGolden_DescribeExtensionAssets(t *testing.T) {
 			assertGolden(t, "describe/extension-assets-"+name, buf.String())
 		})
 	}
+}
+
+func platformTokenFixtures() []platformtoken.PlatformToken {
+	return []platformtoken.PlatformToken{
+		{
+			Name:           "ci-pipeline",
+			TokenID:        "a1b2c3d4-e5f6-4a7b-8c9d-000000000001",
+			Status:         "ACTIVE",
+			ExpirationDate: "2026-10-01T00:00:00.000Z",
+			Scope:          "storage:events:read account-idm-read",
+		},
+		{
+			Name:           "dev-automation",
+			TokenID:        "b2c3d4e5-f6a7-4b8c-9d0e-000000000002",
+			Status:         "ACTIVE",
+			ExpirationDate: "2026-12-31T00:00:00.000Z",
+			Scope:          "account-idm-write",
+		},
+		{
+			Name:           "legacy-token",
+			TokenID:        "c3d4e5f6-a7b8-4c9d-0e1f-000000000003",
+			Status:         "REVOKED",
+			ExpirationDate: "2025-01-01T00:00:00.000Z",
+			Scope:          "storage:logs:read",
+		},
+	}
+}
+
+func TestGolden_GetPlatformTokens(t *testing.T) {
+	tokens := platformTokenFixtures()
+
+	formats := map[string]string{
+		"table": "table",
+		"wide":  "wide",
+		"json":  "json",
+		"yaml":  "yaml",
+		"csv":   "csv",
+		"toon":  "toon",
+	}
+
+	for name, format := range formats {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printer := NewPrinterWithWriter(format, &buf)
+			if err := printer.PrintList(tokens); err != nil {
+				t.Fatalf("PrintList failed: %v", err)
+			}
+			assertGolden(t, "get/platform-tokens-"+name, buf.String())
+		})
+	}
+}
+
+func TestGolden_GetPlatformTokens_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	printer := NewPrinterWithWriter("table", &buf)
+	if err := printer.PrintList([]platformtoken.PlatformToken{}); err != nil {
+		t.Fatalf("PrintList failed: %v", err)
+	}
+	assertGolden(t, "empty/platform-tokens", buf.String())
 }

--- a/pkg/output/testdata/golden/empty/platform-tokens.golden
+++ b/pkg/output/testdata/golden/empty/platform-tokens.golden
@@ -1,0 +1,1 @@
+No resources found.

--- a/pkg/output/testdata/golden/get/platform-tokens-csv.golden
+++ b/pkg/output/testdata/golden/get/platform-tokens-csv.golden
@@ -1,0 +1,4 @@
+NAME,TOKEN-ID,STATUS,EXPIRES,SCOPE
+ci-pipeline,a1b2c3d4-e5f6-4a7b-8c9d-000000000001,ACTIVE,2026-10-01T00:00:00.000Z,storage:events:read account-idm-read
+dev-automation,b2c3d4e5-f6a7-4b8c-9d0e-000000000002,ACTIVE,2026-12-31T00:00:00.000Z,account-idm-write
+legacy-token,c3d4e5f6-a7b8-4c9d-0e1f-000000000003,REVOKED,2025-01-01T00:00:00.000Z,storage:logs:read

--- a/pkg/output/testdata/golden/get/platform-tokens-json.golden
+++ b/pkg/output/testdata/golden/get/platform-tokens-json.golden
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "ci-pipeline",
+    "tokenId": "a1b2c3d4-e5f6-4a7b-8c9d-000000000001",
+    "status": "ACTIVE",
+    "expirationDate": "2026-10-01T00:00:00.000Z",
+    "scope": "storage:events:read account-idm-read"
+  },
+  {
+    "name": "dev-automation",
+    "tokenId": "b2c3d4e5-f6a7-4b8c-9d0e-000000000002",
+    "status": "ACTIVE",
+    "expirationDate": "2026-12-31T00:00:00.000Z",
+    "scope": "account-idm-write"
+  },
+  {
+    "name": "legacy-token",
+    "tokenId": "c3d4e5f6-a7b8-4c9d-0e1f-000000000003",
+    "status": "REVOKED",
+    "expirationDate": "2025-01-01T00:00:00.000Z",
+    "scope": "storage:logs:read"
+  }
+]

--- a/pkg/output/testdata/golden/get/platform-tokens-table.golden
+++ b/pkg/output/testdata/golden/get/platform-tokens-table.golden
@@ -1,0 +1,4 @@
+NAME             TOKEN-ID                               STATUS    EXPIRES                    
+ci-pipeline      a1b2c3d4-e5f6-4a7b-8c9d-000000000001   ACTIVE    2026-10-01T00:00:00.000Z   
+dev-automation   b2c3d4e5-f6a7-4b8c-9d0e-000000000002   ACTIVE    2026-12-31T00:00:00.000Z   
+legacy-token     c3d4e5f6-a7b8-4c9d-0e1f-000000000003   REVOKED   2025-01-01T00:00:00.000Z   

--- a/pkg/output/testdata/golden/get/platform-tokens-toon.golden
+++ b/pkg/output/testdata/golden/get/platform-tokens-toon.golden
@@ -1,0 +1,4 @@
+[#3]{expirationDate,name,scope,status,tokenId}:
+  "2026-10-01T00:00:00.000Z",ci-pipeline,"storage:events:read account-idm-read",ACTIVE,a1b2c3d4-e5f6-4a7b-8c9d-000000000001
+  "2026-12-31T00:00:00.000Z",dev-automation,account-idm-write,ACTIVE,b2c3d4e5-f6a7-4b8c-9d0e-000000000002
+  "2025-01-01T00:00:00.000Z",legacy-token,"storage:logs:read",REVOKED,c3d4e5f6-a7b8-4c9d-0e1f-000000000003

--- a/pkg/output/testdata/golden/get/platform-tokens-wide.golden
+++ b/pkg/output/testdata/golden/get/platform-tokens-wide.golden
@@ -1,0 +1,4 @@
+NAME             TOKEN-ID                               STATUS    EXPIRES                    SCOPE                                  
+ci-pipeline      a1b2c3d4-e5f6-4a7b-8c9d-000000000001   ACTIVE    2026-10-01T00:00:00.000Z   storage:events:read account-idm-read   
+dev-automation   b2c3d4e5-f6a7-4b8c-9d0e-000000000002   ACTIVE    2026-12-31T00:00:00.000Z   account-idm-write                      
+legacy-token     c3d4e5f6-a7b8-4c9d-0e1f-000000000003   REVOKED   2025-01-01T00:00:00.000Z   storage:logs:read                      

--- a/pkg/output/testdata/golden/get/platform-tokens-yaml.golden
+++ b/pkg/output/testdata/golden/get/platform-tokens-yaml.golden
@@ -1,0 +1,18 @@
+- name: ci-pipeline
+  tokenid: a1b2c3d4-e5f6-4a7b-8c9d-000000000001
+  status: ACTIVE
+  expirationdate: "2026-10-01T00:00:00.000Z"
+  scope: storage:events:read account-idm-read
+  token: ""
+- name: dev-automation
+  tokenid: b2c3d4e5-f6a7-4b8c-9d0e-000000000002
+  status: ACTIVE
+  expirationdate: "2026-12-31T00:00:00.000Z"
+  scope: account-idm-write
+  token: ""
+- name: legacy-token
+  tokenid: c3d4e5f6-a7b8-4c9d-0e1f-000000000003
+  status: REVOKED
+  expirationdate: "2025-01-01T00:00:00.000Z"
+  scope: storage:logs:read
+  token: ""

--- a/pkg/resources/platformtoken/platformtoken.go
+++ b/pkg/resources/platformtoken/platformtoken.go
@@ -44,13 +44,13 @@ func fromSDK(s *sdkpt.PlatformToken) PlatformToken {
 
 // List returns all platform tokens.
 func (h *Handler) List() ([]PlatformToken, error) {
-	res, err := h.sdk.List(context.Background())
+	sdkTokens, err := h.sdk.List(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	tokens := make([]PlatformToken, len(res.PlatformTokens))
-	for i := range res.PlatformTokens {
-		tokens[i] = fromSDK(&res.PlatformTokens[i])
+	tokens := make([]PlatformToken, len(sdkTokens))
+	for i := range sdkTokens {
+		tokens[i] = fromSDK(&sdkTokens[i])
 	}
 	return tokens, nil
 }

--- a/pkg/resources/platformtoken/platformtoken.go
+++ b/pkg/resources/platformtoken/platformtoken.go
@@ -3,6 +3,7 @@ package platformtoken
 import (
 	"context"
 	"strings"
+	"time"
 
 	sdkpt "github.com/dynatrace-oss/dtctl/sdk/api/platformtoken"
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
@@ -32,10 +33,18 @@ func NewHandler(accountClient *httpclient.Client, accountUUID string) *Handler {
 }
 
 func fromSDK(s *sdkpt.PlatformToken) PlatformToken {
+	status := s.Status
+	if s.ExpirationDate != "" && status == "ACTIVE" {
+		if exp, err := time.Parse(time.RFC3339Nano, s.ExpirationDate); err == nil {
+			if time.Now().UTC().After(exp) {
+				status = "EXPIRED"
+			}
+		}
+	}
 	return PlatformToken{
 		Name:           s.Name,
 		TokenID:        s.TokenID,
-		Status:         s.Status,
+		Status:         status,
 		ExpirationDate: s.ExpirationDate,
 		Scope:          strings.Join(s.Scope, " "),
 		Token:          s.Token,

--- a/pkg/resources/platformtoken/platformtoken.go
+++ b/pkg/resources/platformtoken/platformtoken.go
@@ -1,0 +1,71 @@
+package platformtoken
+
+import (
+	"context"
+	"strings"
+
+	sdkpt "github.com/dynatrace-oss/dtctl/sdk/api/platformtoken"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+// Re-export SDK create type for use in cmd layer.
+type PlatformTokenCreate = sdkpt.PlatformTokenCreate
+
+// PlatformToken is the CLI output struct with table tags.
+type PlatformToken struct {
+	Name           string `json:"name"            table:"NAME"`
+	TokenID        string `json:"tokenId"         table:"TOKEN-ID"`
+	Status         string `json:"status"          table:"STATUS"`
+	ExpirationDate string `json:"expirationDate"  table:"EXPIRES"`
+	Scope          string `json:"scope"           table:"SCOPE,wide"`
+	Token          string `json:"token,omitempty" table:"-"` // never shown in table
+}
+
+// Handler wraps the SDK handler with CLI-specific output conversion.
+type Handler struct {
+	sdk *sdkpt.Handler
+}
+
+// NewHandler creates a CLI platform token handler.
+func NewHandler(accountClient *httpclient.Client, accountUUID string) *Handler {
+	return &Handler{sdk: sdkpt.NewHandler(accountClient, accountUUID)}
+}
+
+func fromSDK(s *sdkpt.PlatformToken) PlatformToken {
+	return PlatformToken{
+		Name:           s.Name,
+		TokenID:        s.TokenID,
+		Status:         s.Status,
+		ExpirationDate: s.ExpirationDate,
+		Scope:          strings.Join(s.Scope, " "),
+		Token:          s.Token,
+	}
+}
+
+// List returns all platform tokens.
+func (h *Handler) List() ([]PlatformToken, error) {
+	res, err := h.sdk.List(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	tokens := make([]PlatformToken, len(res.PlatformTokens))
+	for i := range res.PlatformTokens {
+		tokens[i] = fromSDK(&res.PlatformTokens[i])
+	}
+	return tokens, nil
+}
+
+// Create creates a new platform token.
+func (h *Handler) Create(req PlatformTokenCreate) (*PlatformToken, error) {
+	res, err := h.sdk.Create(context.Background(), req)
+	if err != nil {
+		return nil, err
+	}
+	t := fromSDK(res)
+	return &t, nil
+}
+
+// Revoke revokes (deletes) a platform token by ID.
+func (h *Handler) Revoke(tokenID string) error {
+	return h.sdk.Revoke(context.Background(), tokenID)
+}

--- a/pkg/resources/platformtoken/platformtoken_test.go
+++ b/pkg/resources/platformtoken/platformtoken_test.go
@@ -75,7 +75,8 @@ func TestList(t *testing.T) {
 	mux.HandleFunc(tokenBasePath(uuid), func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(sdkpt.PlatformTokenListResponse{
-			PlatformTokens: []sdkpt.PlatformToken{
+			Total: 2,
+			Results: []sdkpt.PlatformToken{
 				{Name: "alpha", TokenID: "tok-a", Status: "ACTIVE", Scope: []string{"account-idm-read"}},
 				{Name: "beta", TokenID: "tok-b", Status: "REVOKED", Scope: []string{"storage:events:read"}},
 			},

--- a/pkg/resources/platformtoken/platformtoken_test.go
+++ b/pkg/resources/platformtoken/platformtoken_test.go
@@ -1,0 +1,149 @@
+package platformtoken
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	sdkpt "github.com/dynatrace-oss/dtctl/sdk/api/platformtoken"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *httpclient.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c, err := httpclient.New(srv.URL, httpclient.WithToken("dt0c01.test"))
+	if err != nil {
+		t.Fatalf("httpclient.New: %v", err)
+	}
+	return c
+}
+
+func tokenBasePath(accountUUID string) string {
+	return fmt.Sprintf("/iam/v1/accounts/%s/platform-tokens", accountUUID)
+}
+
+func TestFromSDK(t *testing.T) {
+	sdk := sdkpt.PlatformToken{
+		Name:           "ci-token",
+		TokenID:        "tok-001",
+		Status:         "ACTIVE",
+		ExpirationDate: "2026-10-01T00:00:00.000Z",
+		Scope:          []string{"storage:events:read", "account-idm-read"},
+		Token:          "dt0s16.secret",
+	}
+	got := fromSDK(&sdk)
+	if got.Name != "ci-token" {
+		t.Errorf("Name = %q, want %q", got.Name, "ci-token")
+	}
+	if got.TokenID != "tok-001" {
+		t.Errorf("TokenID = %q, want %q", got.TokenID, "tok-001")
+	}
+	if got.Status != "ACTIVE" {
+		t.Errorf("Status = %q, want %q", got.Status, "ACTIVE")
+	}
+	if got.ExpirationDate != "2026-10-01T00:00:00.000Z" {
+		t.Errorf("ExpirationDate = %q, want %q", got.ExpirationDate, "2026-10-01T00:00:00.000Z")
+	}
+	if got.Scope != "storage:events:read account-idm-read" {
+		t.Errorf("Scope = %q, want joined string", got.Scope)
+	}
+	if got.Token != "dt0s16.secret" {
+		t.Errorf("Token = %q, want secret", got.Token)
+	}
+}
+
+func TestToken_TableTag_HidesSecret(t *testing.T) {
+	// Token must have table:"-" — verify by checking struct tag
+	ft, ok := reflect.TypeOf(PlatformToken{}).FieldByName("Token")
+	if !ok {
+		t.Fatal("PlatformToken.Token field not found")
+	}
+	tag := ft.Tag.Get("table")
+	if tag != "-" {
+		t.Errorf("PlatformToken.Token table tag = %q, want \"-\"", tag)
+	}
+}
+
+func TestList(t *testing.T) {
+	const uuid = "list-uuid"
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenBasePath(uuid), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(sdkpt.PlatformTokenListResponse{
+			PlatformTokens: []sdkpt.PlatformToken{
+				{Name: "alpha", TokenID: "tok-a", Status: "ACTIVE", Scope: []string{"account-idm-read"}},
+				{Name: "beta", TokenID: "tok-b", Status: "REVOKED", Scope: []string{"storage:events:read"}},
+			},
+		})
+	})
+
+	h := NewHandler(newTestClient(t, mux), uuid)
+	tokens, err := h.List()
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(tokens) != 2 {
+		t.Fatalf("got %d tokens, want 2", len(tokens))
+	}
+	if tokens[0].TokenID != "tok-a" {
+		t.Errorf("tokens[0].TokenID = %q, want %q", tokens[0].TokenID, "tok-a")
+	}
+	if tokens[1].Scope != "storage:events:read" {
+		t.Errorf("tokens[1].Scope = %q, want joined scope", tokens[1].Scope)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	const uuid = "create-uuid"
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenBasePath(uuid), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(sdkpt.PlatformToken{
+			Name:    "ci-token",
+			TokenID: "tok-new",
+			Token:   "dt0s16.thetoken",
+			Status:  "ACTIVE",
+			Scope:   []string{"account-idm-write"},
+		})
+	})
+
+	h := NewHandler(newTestClient(t, mux), uuid)
+	result, err := h.Create(PlatformTokenCreate{
+		Name:           "ci-token",
+		UserUUID:       "user-001",
+		Scope:          []string{"account-idm-write"},
+		Resource:       []string{},
+		Tags:           []string{},
+		ExpirationDate: "2026-10-01T00:00:00.000Z",
+	})
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+	if result.Token != "dt0s16.thetoken" {
+		t.Errorf("Token = %q, want secret", result.Token)
+	}
+}
+
+func TestRevoke(t *testing.T) {
+	const uuid = "revoke-uuid"
+	const tokenID = "tok-to-delete"
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenBasePath(uuid)+"/"+tokenID, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	h := NewHandler(newTestClient(t, mux), uuid)
+	if err := h.Revoke(tokenID); err != nil {
+		t.Fatalf("Revoke() error: %v", err)
+	}
+}

--- a/pkg/resources/platformtoken/platformtoken_test.go
+++ b/pkg/resources/platformtoken/platformtoken_test.go
@@ -57,6 +57,32 @@ func TestFromSDK(t *testing.T) {
 	}
 }
 
+func TestFromSDK_ExpiredToken(t *testing.T) {
+	sdk := sdkpt.PlatformToken{
+		Name:           "old-token",
+		TokenID:        "tok-old",
+		Status:         "ACTIVE",
+		ExpirationDate: "2020-01-01T00:00:00.000Z",
+	}
+	got := fromSDK(&sdk)
+	if got.Status != "EXPIRED" {
+		t.Errorf("Status = %q, want %q for past expiration", got.Status, "EXPIRED")
+	}
+}
+
+func TestFromSDK_RevokedNotOverridden(t *testing.T) {
+	sdk := sdkpt.PlatformToken{
+		Name:           "revoked-token",
+		TokenID:        "tok-rev",
+		Status:         "REVOKED",
+		ExpirationDate: "2020-01-01T00:00:00.000Z",
+	}
+	got := fromSDK(&sdk)
+	if got.Status != "REVOKED" {
+		t.Errorf("Status = %q, want %q (REVOKED should not be overridden)", got.Status, "REVOKED")
+	}
+}
+
 func TestToken_TableTag_HidesSecret(t *testing.T) {
 	// Token must have table:"-" — verify by checking struct tag
 	ft, ok := reflect.TypeOf(PlatformToken{}).FieldByName("Token")

--- a/sdk/api/platformtoken/platformtoken.go
+++ b/sdk/api/platformtoken/platformtoken.go
@@ -1,0 +1,114 @@
+package platformtoken
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+// Handler handles platform token resources via the Account Management API.
+type Handler struct {
+	client      *httpclient.Client
+	accountUUID string
+}
+
+// NewHandler creates a new platform token handler.
+func NewHandler(c *httpclient.Client, accountUUID string) *Handler {
+	return &Handler{client: c, accountUUID: accountUUID}
+}
+
+// PlatformToken represents a Dynatrace platform token.
+type PlatformToken struct {
+	Name           string   `json:"name"`
+	TokenID        string   `json:"tokenId"`
+	Token          string   `json:"token,omitempty"` // secret, returned only on create
+	AccountUUID    string   `json:"accountUuid,omitempty"`
+	Scope          []string `json:"scope"`
+	Resource       []string `json:"resource,omitempty"`
+	Status         string   `json:"status,omitempty"`
+	ExpirationDate string   `json:"expirationDate,omitempty"`
+	CreatedAt      string   `json:"createdAt,omitempty"`
+	Owner          string   `json:"owner,omitempty"`
+}
+
+// PlatformTokenListResponse wraps the list API response.
+type PlatformTokenListResponse struct {
+	PlatformTokens []PlatformToken `json:"platformTokens"`
+	NextPageKey    string          `json:"nextPageKey,omitempty"`
+}
+
+// PlatformTokenCreate is the request body for creating a platform token.
+type PlatformTokenCreate struct {
+	Name           string   `json:"name"`
+	UserUUID       string   `json:"userUuid"`
+	Scope          []string `json:"scope"`
+	Resource       []string `json:"resource"`
+	Tags           []string `json:"tags"`
+	ExpirationDate string   `json:"expirationDate"`
+}
+
+func (h *Handler) basePath() string {
+	return fmt.Sprintf("/iam/v1/accounts/%s/platform-tokens", h.accountUUID)
+}
+
+// List returns all platform tokens for the account.
+func (h *Handler) List(ctx context.Context) (*PlatformTokenListResponse, error) {
+	var all []PlatformToken
+	var nextPageKey string
+	for {
+		req := h.client.HTTP().R().SetContext(ctx)
+		if nextPageKey != "" {
+			req.SetQueryParam("page-key", nextPageKey)
+		}
+		resp, err := req.Get(h.basePath())
+		if err != nil {
+			return nil, fmt.Errorf("list platform tokens: %w", err)
+		}
+		if err := httpclient.CheckResponse(resp); err != nil {
+			return nil, fmt.Errorf("list platform tokens: %w", err)
+		}
+		var page PlatformTokenListResponse
+		if err := json.Unmarshal(resp.Body(), &page); err != nil {
+			return nil, fmt.Errorf("list platform tokens: parse response: %w", err)
+		}
+		all = append(all, page.PlatformTokens...)
+		if page.NextPageKey == "" {
+			break
+		}
+		nextPageKey = page.NextPageKey
+	}
+	return &PlatformTokenListResponse{PlatformTokens: all}, nil
+}
+
+// Create creates a new platform token.
+func (h *Handler) Create(ctx context.Context, req PlatformTokenCreate) (*PlatformToken, error) {
+	resp, err := h.client.HTTP().R().SetContext(ctx).
+		SetBody(req).
+		Post(h.basePath())
+	if err != nil {
+		return nil, fmt.Errorf("create platform token: %w", err)
+	}
+	if err := httpclient.CheckResponse(resp); err != nil {
+		return nil, fmt.Errorf("create platform token: %w", err)
+	}
+	var result PlatformToken
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, fmt.Errorf("create platform token: parse response: %w", err)
+	}
+	return &result, nil
+}
+
+// Revoke deletes (revokes) a platform token by ID.
+func (h *Handler) Revoke(ctx context.Context, tokenID string) error {
+	resp, err := h.client.HTTP().R().SetContext(ctx).
+		Delete(fmt.Sprintf("%s/%s", h.basePath(), tokenID))
+	if err != nil {
+		return fmt.Errorf("revoke platform token: %w", err)
+	}
+	if err := httpclient.CheckResponse(resp); err != nil {
+		return fmt.Errorf("revoke platform token %q: %w", tokenID, err)
+	}
+	return nil
+}

--- a/sdk/api/platformtoken/platformtoken.go
+++ b/sdk/api/platformtoken/platformtoken.go
@@ -47,8 +47,8 @@ type PlatformTokenCreate struct {
 	Name           string   `json:"name"`
 	UserUUID       string   `json:"userUuid"`
 	Scope          []string `json:"scope"`
-	Resource       []string `json:"resource"`
-	Tags           []string `json:"tags"`
+	Resource       []string `json:"resource,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
 	ExpirationDate string   `json:"expirationDate"`
 }
 

--- a/sdk/api/platformtoken/platformtoken.go
+++ b/sdk/api/platformtoken/platformtoken.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
 )
@@ -33,10 +34,12 @@ type PlatformToken struct {
 	Owner          string   `json:"owner,omitempty"`
 }
 
-// PlatformTokenListResponse wraps the list API response.
+// PlatformTokenListResponse wraps the list API page response.
 type PlatformTokenListResponse struct {
-	PlatformTokens []PlatformToken `json:"platformTokens"`
-	NextPageKey    string          `json:"nextPageKey,omitempty"`
+	Total      int             `json:"total"`
+	PageSize   int             `json:"pageSize"`
+	PageNumber int             `json:"pageNumber"`
+	Results    []PlatformToken `json:"results"`
 }
 
 // PlatformTokenCreate is the request body for creating a platform token.
@@ -53,15 +56,15 @@ func (h *Handler) basePath() string {
 	return fmt.Sprintf("/iam/v1/accounts/%s/platform-tokens", h.accountUUID)
 }
 
+const listPageSize = 100
+
 // List returns all platform tokens for the account.
-func (h *Handler) List(ctx context.Context) (*PlatformTokenListResponse, error) {
+func (h *Handler) List(ctx context.Context) ([]PlatformToken, error) {
 	var all []PlatformToken
-	var nextPageKey string
-	for {
-		req := h.client.HTTP().R().SetContext(ctx)
-		if nextPageKey != "" {
-			req.SetQueryParam("page-key", nextPageKey)
-		}
+	for pageNum := 0; ; pageNum++ {
+		req := h.client.HTTP().R().SetContext(ctx).
+			SetQueryParam("pageSize", strconv.Itoa(listPageSize)).
+			SetQueryParam("pageNumber", strconv.Itoa(pageNum))
 		resp, err := req.Get(h.basePath())
 		if err != nil {
 			return nil, fmt.Errorf("list platform tokens: %w", err)
@@ -73,13 +76,12 @@ func (h *Handler) List(ctx context.Context) (*PlatformTokenListResponse, error) 
 		if err := json.Unmarshal(resp.Body(), &page); err != nil {
 			return nil, fmt.Errorf("list platform tokens: parse response: %w", err)
 		}
-		all = append(all, page.PlatformTokens...)
-		if page.NextPageKey == "" {
+		all = append(all, page.Results...)
+		if len(page.Results) == 0 || len(all) >= page.Total {
 			break
 		}
-		nextPageKey = page.NextPageKey
 	}
-	return &PlatformTokenListResponse{PlatformTokens: all}, nil
+	return all, nil
 }
 
 // Create creates a new platform token.

--- a/sdk/api/platformtoken/platformtoken_test.go
+++ b/sdk/api/platformtoken/platformtoken_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
@@ -29,16 +30,6 @@ func tokenBasePath() string {
 	return fmt.Sprintf("/iam/v1/accounts/%s/platform-tokens", testAccountUUID)
 }
 
-// paginationGuard rejects page-size combined with page-key (API constraint).
-func paginationGuard(w http.ResponseWriter, r *http.Request) bool {
-	if r.URL.Query().Get("page-size") != "" && r.URL.Query().Get("page-key") != "" {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprint(w, `{"error":{"code":400,"message":"Constraints violated."}}`)
-		return true
-	}
-	return false
-}
-
 func TestList(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(tokenBasePath(), func(w http.ResponseWriter, r *http.Request) {
@@ -46,11 +37,9 @@ func TestList(t *testing.T) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		if paginationGuard(w, r) {
-			return
-		}
 		resp := PlatformTokenListResponse{
-			PlatformTokens: []PlatformToken{
+			Total:   2,
+			Results: []PlatformToken{
 				{Name: "ci-token", TokenID: "tok-001", Status: "ACTIVE", Scope: []string{"storage:events:read"}},
 				{Name: "dev-token", TokenID: "tok-002", Status: "ACTIVE", Scope: []string{"account-idm-read"}},
 			},
@@ -64,11 +53,11 @@ func TestList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List() error: %v", err)
 	}
-	if len(result.PlatformTokens) != 2 {
-		t.Errorf("got %d tokens, want 2", len(result.PlatformTokens))
+	if len(result) != 2 {
+		t.Errorf("got %d tokens, want 2", len(result))
 	}
-	if result.PlatformTokens[0].TokenID != "tok-001" {
-		t.Errorf("TokenID = %q, want %q", result.PlatformTokens[0].TokenID, "tok-001")
+	if result[0].TokenID != "tok-001" {
+		t.Errorf("TokenID = %q, want %q", result[0].TokenID, "tok-001")
 	}
 }
 
@@ -80,25 +69,22 @@ func TestList_Paginated(t *testing.T) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		if paginationGuard(w, r) {
-			return
-		}
 		call++
 		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Query().Get("page-key") == "" {
-			// First page
+		pageNum, _ := strconv.Atoi(r.URL.Query().Get("pageNumber"))
+		if pageNum == 0 {
 			json.NewEncoder(w).Encode(PlatformTokenListResponse{
-				PlatformTokens: []PlatformToken{
-					{Name: "token-a", TokenID: "tok-a", Status: "ACTIVE"},
-				},
-				NextPageKey: "page2key",
+				Total:      2,
+				PageSize:   1,
+				PageNumber: 0,
+				Results:    []PlatformToken{{Name: "token-a", TokenID: "tok-a", Status: "ACTIVE"}},
 			})
 		} else {
-			// Second page
 			json.NewEncoder(w).Encode(PlatformTokenListResponse{
-				PlatformTokens: []PlatformToken{
-					{Name: "token-b", TokenID: "tok-b", Status: "ACTIVE"},
-				},
+				Total:      2,
+				PageSize:   1,
+				PageNumber: 1,
+				Results:    []PlatformToken{{Name: "token-b", TokenID: "tok-b", Status: "ACTIVE"}},
 			})
 		}
 	})
@@ -108,17 +94,17 @@ func TestList_Paginated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List() error: %v", err)
 	}
-	if len(result.PlatformTokens) != 2 {
-		t.Errorf("got %d tokens after pagination, want 2", len(result.PlatformTokens))
+	if len(result) != 2 {
+		t.Errorf("got %d tokens after pagination, want 2", len(result))
 	}
 	if call != 2 {
 		t.Errorf("expected 2 HTTP calls, got %d", call)
 	}
-	if result.PlatformTokens[0].TokenID != "tok-a" {
-		t.Errorf("first token = %q, want %q", result.PlatformTokens[0].TokenID, "tok-a")
+	if result[0].TokenID != "tok-a" {
+		t.Errorf("first token = %q, want %q", result[0].TokenID, "tok-a")
 	}
-	if result.PlatformTokens[1].TokenID != "tok-b" {
-		t.Errorf("second token = %q, want %q", result.PlatformTokens[1].TokenID, "tok-b")
+	if result[1].TokenID != "tok-b" {
+		t.Errorf("second token = %q, want %q", result[1].TokenID, "tok-b")
 	}
 }
 

--- a/sdk/api/platformtoken/platformtoken_test.go
+++ b/sdk/api/platformtoken/platformtoken_test.go
@@ -1,0 +1,248 @@
+package platformtoken
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+const testAccountUUID = "test-uuid"
+
+func newTestClient(t *testing.T, handler http.Handler) *httpclient.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c, err := httpclient.New(srv.URL, httpclient.WithToken("dt0c01.test"))
+	if err != nil {
+		t.Fatalf("httpclient.New: %v", err)
+	}
+	return c
+}
+
+func tokenBasePath() string {
+	return fmt.Sprintf("/iam/v1/accounts/%s/platform-tokens", testAccountUUID)
+}
+
+// paginationGuard rejects page-size combined with page-key (API constraint).
+func paginationGuard(w http.ResponseWriter, r *http.Request) bool {
+	if r.URL.Query().Get("page-size") != "" && r.URL.Query().Get("page-key") != "" {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":{"code":400,"message":"Constraints violated."}}`)
+		return true
+	}
+	return false
+}
+
+func TestList(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenBasePath(), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if paginationGuard(w, r) {
+			return
+		}
+		resp := PlatformTokenListResponse{
+			PlatformTokens: []PlatformToken{
+				{Name: "ci-token", TokenID: "tok-001", Status: "ACTIVE", Scope: []string{"storage:events:read"}},
+				{Name: "dev-token", TokenID: "tok-002", Status: "ACTIVE", Scope: []string{"account-idm-read"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	h := NewHandler(newTestClient(t, mux), testAccountUUID)
+	result, err := h.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(result.PlatformTokens) != 2 {
+		t.Errorf("got %d tokens, want 2", len(result.PlatformTokens))
+	}
+	if result.PlatformTokens[0].TokenID != "tok-001" {
+		t.Errorf("TokenID = %q, want %q", result.PlatformTokens[0].TokenID, "tok-001")
+	}
+}
+
+func TestList_Paginated(t *testing.T) {
+	call := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenBasePath(), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if paginationGuard(w, r) {
+			return
+		}
+		call++
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page-key") == "" {
+			// First page
+			json.NewEncoder(w).Encode(PlatformTokenListResponse{
+				PlatformTokens: []PlatformToken{
+					{Name: "token-a", TokenID: "tok-a", Status: "ACTIVE"},
+				},
+				NextPageKey: "page2key",
+			})
+		} else {
+			// Second page
+			json.NewEncoder(w).Encode(PlatformTokenListResponse{
+				PlatformTokens: []PlatformToken{
+					{Name: "token-b", TokenID: "tok-b", Status: "ACTIVE"},
+				},
+			})
+		}
+	})
+
+	h := NewHandler(newTestClient(t, mux), testAccountUUID)
+	result, err := h.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(result.PlatformTokens) != 2 {
+		t.Errorf("got %d tokens after pagination, want 2", len(result.PlatformTokens))
+	}
+	if call != 2 {
+		t.Errorf("expected 2 HTTP calls, got %d", call)
+	}
+	if result.PlatformTokens[0].TokenID != "tok-a" {
+		t.Errorf("first token = %q, want %q", result.PlatformTokens[0].TokenID, "tok-a")
+	}
+	if result.PlatformTokens[1].TokenID != "tok-b" {
+		t.Errorf("second token = %q, want %q", result.PlatformTokens[1].TokenID, "tok-b")
+	}
+}
+
+func TestCreate(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenBasePath(), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req PlatformTokenCreate
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.Name == "" {
+			http.Error(w, `{"error":{"message":"name is required"}}`, http.StatusBadRequest)
+			return
+		}
+		if len(req.Scope) == 0 {
+			http.Error(w, `{"error":{"message":"scope is required"}}`, http.StatusBadRequest)
+			return
+		}
+		if req.UserUUID == "" {
+			http.Error(w, `{"error":{"message":"userUuid is required"}}`, http.StatusBadRequest)
+			return
+		}
+		resp := PlatformToken{
+			Name:           req.Name,
+			TokenID:        "tok-new-001",
+			Token:          "dt0s16.secrettoken.example",
+			AccountUUID:    testAccountUUID,
+			Scope:          req.Scope,
+			Status:         "ACTIVE",
+			ExpirationDate: req.ExpirationDate,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	h := NewHandler(newTestClient(t, mux), testAccountUUID)
+	result, err := h.Create(context.Background(), PlatformTokenCreate{
+		Name:           "ci-token",
+		UserUUID:       "user-uuid-001",
+		Scope:          []string{"storage:events:read"},
+		Resource:       []string{},
+		Tags:           []string{},
+		ExpirationDate: "2026-10-01T00:00:00.000Z",
+	})
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+	if result.TokenID != "tok-new-001" {
+		t.Errorf("TokenID = %q, want %q", result.TokenID, "tok-new-001")
+	}
+	if result.Token != "dt0s16.secrettoken.example" {
+		t.Errorf("Token = %q, want secret token", result.Token)
+	}
+}
+
+func TestRevoke(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenBasePath()+"/tok-001", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	h := NewHandler(newTestClient(t, mux), testAccountUUID)
+	if err := h.Revoke(context.Background(), "tok-001"); err != nil {
+		t.Fatalf("Revoke() error: %v", err)
+	}
+}
+
+func TestList_Unauthorized(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenBasePath(), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error":{"message":"unauthorized"}}`)
+	})
+
+	h := NewHandler(newTestClient(t, mux), testAccountUUID)
+	_, err := h.List(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	if !errors.Is(err, httpclient.ErrUnauthorized) {
+		t.Errorf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+func TestList_Forbidden(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenBasePath(), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"error":{"message":"forbidden"}}`)
+	})
+
+	h := NewHandler(newTestClient(t, mux), testAccountUUID)
+	_, err := h.List(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+	if !errors.Is(err, httpclient.ErrForbidden) {
+		t.Errorf("expected ErrForbidden, got %v", err)
+	}
+}
+
+func TestRevoke_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenBasePath()+"/missing-id", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":{"message":"token not found"}}`)
+	})
+
+	h := NewHandler(newTestClient(t, mux), testAccountUUID)
+	err := h.Revoke(context.Background(), "missing-id")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !errors.Is(err, httpclient.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/sdk/api/platformtoken/platformtoken_test.go
+++ b/sdk/api/platformtoken/platformtoken_test.go
@@ -38,7 +38,7 @@ func TestList(t *testing.T) {
 			return
 		}
 		resp := PlatformTokenListResponse{
-			Total:   2,
+			Total: 2,
 			Results: []PlatformToken{
 				{Name: "ci-token", TokenID: "tok-001", Status: "ACTIVE", Scope: []string{"storage:events:read"}},
 				{Name: "dev-token", TokenID: "tok-002", Status: "ACTIVE", Scope: []string{"account-idm-read"}},

--- a/sdk/session/config.go
+++ b/sdk/session/config.go
@@ -110,6 +110,7 @@ type Context struct {
 	TokenRef    string      `yaml:"token-ref" table:"TOKEN-REF"`
 	SafetyLevel SafetyLevel `yaml:"safety-level,omitempty" table:"SAFETY-LEVEL"`
 	Description string      `yaml:"description,omitempty" table:"DESCRIPTION,wide"`
+	AccountUUID string      `yaml:"account-uuid,omitempty" table:"ACCOUNT-UUID,wide"`
 	// Profile binds a command profile to this context, restricting the visible
 	// command surface when the context is active (unless overridden by
 	// DTCTL_PROFILE). Empty means the full command tree. See profile.go.

--- a/sdk/session/config_test.go
+++ b/sdk/session/config_test.go
@@ -2319,6 +2319,41 @@ func TestConfig_PruneEmptyEnvironments(t *testing.T) {
 	}
 }
 
+func TestContext_AccountUUIDRoundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	cfg := NewConfig()
+	cfg.CurrentContext = "prod"
+	cfg.Contexts = []NamedContext{
+		{
+			Name: "prod",
+			Context: Context{
+				Environment: "https://abc12345.apps.dynatrace.com",
+				TokenRef:    "prod-token",
+				AccountUUID: "aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb",
+			},
+		},
+	}
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if len(loaded.Contexts) != 1 {
+		t.Fatalf("want 1 context, got %d", len(loaded.Contexts))
+	}
+	got := loaded.Contexts[0].Context.AccountUUID
+	want := cfg.Contexts[0].Context.AccountUUID
+	if got != want {
+		t.Errorf("AccountUUID = %q, want %q", got, want)
+	}
+}
+
 func contextNames(contexts []NamedContext) []string {
 	names := make([]string, len(contexts))
 	for i, nc := range contexts {

--- a/sdk/session/oauth_flow.go
+++ b/sdk/session/oauth_flow.go
@@ -151,6 +151,15 @@ func OAuthConfigFromEnvironmentURL(environmentURL string, safetyLevel SafetyLeve
 	return cfg
 }
 
+// AccountOAuthConfig returns an OAuth config for account-plane operations.
+// The resource is set to "urn:dtaccount:{uuid}" per Dynatrace account OAuth spec.
+func AccountOAuthConfig(env Environment, safetyLevel config.SafetyLevel, accountUUID string) *OAuthConfig {
+	cfg := OAuthConfigForEnvironment(env, safetyLevel)
+	cfg.Scopes = accountScopesForSafetyLevel(safetyLevel)
+	cfg.EnvironmentURL = "urn:dtaccount:" + accountUUID
+	return cfg
+}
+
 type TokenSet struct {
 	AccessToken  string    `json:"access_token"`
 	RefreshToken string    `json:"refresh_token"`

--- a/sdk/session/oauth_flow.go
+++ b/sdk/session/oauth_flow.go
@@ -151,15 +151,6 @@ func OAuthConfigFromEnvironmentURL(environmentURL string, safetyLevel SafetyLeve
 	return cfg
 }
 
-// AccountOAuthConfig returns an OAuth config for account-plane operations.
-// The resource is set to "urn:dtaccount:{uuid}" per Dynatrace account OAuth spec.
-func AccountOAuthConfig(env Environment, safetyLevel config.SafetyLevel, accountUUID string) *OAuthConfig {
-	cfg := OAuthConfigForEnvironment(env, safetyLevel)
-	cfg.Scopes = accountScopesForSafetyLevel(safetyLevel)
-	cfg.EnvironmentURL = "urn:dtaccount:" + accountUUID
-	return cfg
-}
-
 type TokenSet struct {
 	AccessToken  string    `json:"access_token"`
 	RefreshToken string    `json:"refresh_token"`

--- a/test/e2e/account_token_test.go
+++ b/test/e2e/account_token_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+// +build integration
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/resources/platformtoken"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+// setupAccountTokenTest checks required env vars and returns an httpclient.Client
+// pointed at the account management API, plus the account UUID.
+func setupAccountTokenTest(t *testing.T) (*httpclient.Client, string) {
+	t.Helper()
+
+	token := os.Getenv("DTCTL_ACCOUNT_TOKEN")
+	if token == "" {
+		t.Skip("Skipping account token test: DTCTL_ACCOUNT_TOKEN not set")
+	}
+
+	accountUUID := os.Getenv("DTCTL_ACCOUNT_UUID")
+	if accountUUID == "" {
+		t.Skip("Skipping account token test: DTCTL_ACCOUNT_UUID not set")
+	}
+
+	baseURL := os.Getenv("DTCTL_ACCOUNT_BASE_URL")
+	if baseURL == "" {
+		baseURL = "https://api.dynatrace.com"
+	}
+
+	c, err := httpclient.New(baseURL, httpclient.WithToken(token))
+	if err != nil {
+		t.Fatalf("failed to create account client: %v", err)
+	}
+
+	return c, accountUUID
+}
+
+func TestAccountTokenLifecycle(t *testing.T) {
+	c, accountUUID := setupAccountTokenTest(t)
+
+	userUUID := os.Getenv("DTCTL_ACCOUNT_USER_UUID")
+	if userUUID == "" {
+		t.Skip("Skipping account token lifecycle test: DTCTL_ACCOUNT_USER_UUID not set")
+	}
+
+	handler := platformtoken.NewHandler(c, accountUUID)
+
+	// Step 1: List tokens (read-only, always safe)
+	t.Log("Step 1: Listing platform tokens...")
+	tokens, err := handler.List()
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	t.Logf("Found %d existing platform tokens", len(tokens))
+
+	// Step 2: Create a token
+	t.Log("Step 2: Creating platform token...")
+	created, err := handler.Create(platformtoken.PlatformTokenCreate{
+		Name:           fmt.Sprintf("dtctl-e2e-test-token"),
+		UserUUID:       userUUID,
+		Scope:          []string{"account-idm-read"},
+		Resource:       []string{},
+		Tags:           []string{},
+		ExpirationDate: "2026-12-31T00:00:00.000Z",
+	})
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+	if created.TokenID == "" {
+		t.Fatal("created token has no TokenID")
+	}
+	if created.Token == "" {
+		t.Fatal("created token secret missing from response")
+	}
+	t.Logf("Created token: %s (ID: %s)", created.Name, created.TokenID)
+
+	// Step 3: Revoke the token
+	t.Log("Step 3: Revoking platform token...")
+	if err := handler.Revoke(created.TokenID); err != nil {
+		t.Fatalf("Revoke() error: %v", err)
+	}
+	t.Logf("Revoked token: %s", created.TokenID)
+}
+
+func TestAccountTokenList_ReadOnly(t *testing.T) {
+	c, accountUUID := setupAccountTokenTest(t)
+	handler := platformtoken.NewHandler(c, accountUUID)
+
+	tokens, err := handler.List()
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	t.Logf("Listed %d platform tokens", len(tokens))
+}

--- a/test/e2e/account_token_test.go
+++ b/test/e2e/account_token_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/platformtoken"
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
@@ -61,7 +62,7 @@ func TestAccountTokenLifecycle(t *testing.T) {
 	// Step 2: Create a token
 	t.Log("Step 2: Creating platform token...")
 	created, err := handler.Create(platformtoken.PlatformTokenCreate{
-		Name:           fmt.Sprintf("dtctl-e2e-test-token"),
+		Name:           fmt.Sprintf("dtctl-e2e-test-token-%d", time.Now().UnixMilli()),
 		UserUUID:       userUUID,
 		Scope:          []string{"account-idm-read"},
 		Resource:       []string{},

--- a/test/e2e/account_token_test.go
+++ b/test/e2e/account_token_test.go
@@ -9,23 +9,58 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dynatrace-oss/dtctl/pkg/auth"
+	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/platformtoken"
+	sdkauth "github.com/dynatrace-oss/dtctl/sdk/auth"
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
 )
 
-// setupAccountTokenTest checks required env vars and returns an httpclient.Client
-// pointed at the account management API, plus the account UUID.
-func setupAccountTokenTest(t *testing.T) (*httpclient.Client, string) {
+// setupAccountTokenTest resolves account credentials in priority order:
+//  1. DTCTL_ACCOUNT_TOKEN + DTCTL_ACCOUNT_UUID env vars (CI / explicit override)
+//  2. Local dtctl config + keyring (after `dtctl account login`)
+func setupAccountTokenTest(t *testing.T) (*httpclient.Client, string, string) {
 	t.Helper()
 
 	token := os.Getenv("DTCTL_ACCOUNT_TOKEN")
-	if token == "" {
-		t.Skip("Skipping account token test: DTCTL_ACCOUNT_TOKEN not set")
+	accountUUID := os.Getenv("DTCTL_ACCOUNT_UUID")
+
+	if token == "" || accountUUID == "" {
+		// Fall back to the local config + keyring so developers who have run
+		// `dtctl account login` don't need to set any env vars.
+		cfg, err := config.Load()
+		if err != nil {
+			t.Skip("Skipping account token test: DTCTL_ACCOUNT_TOKEN/UUID not set and config not loadable:", err)
+		}
+		ctx, err := cfg.CurrentContextObj()
+		if err != nil {
+			t.Skip("Skipping account token test: DTCTL_ACCOUNT_TOKEN/UUID not set and no current context:", err)
+		}
+
+		if accountUUID == "" {
+			accountUUID = ctx.AccountUUID
+		}
+		if accountUUID == "" {
+			t.Skip("Skipping account token test: set DTCTL_ACCOUNT_UUID or account-uuid in your dtctl context")
+		}
+
+		if token == "" {
+			env := auth.DetectEnvironment(ctx.Environment)
+			oauthCfg := auth.AccountOAuthConfig(env, ctx.SafetyLevel, accountUUID)
+			tm, err := auth.NewTokenManager(oauthCfg)
+			if err != nil {
+				t.Skip("Skipping account token test: could not open keyring:", err)
+			}
+			token, err = tm.GetToken("account-" + accountUUID)
+			if err != nil || token == "" {
+				t.Skip("Skipping account token test: no account token in keyring — run 'dtctl account login'")
+			}
+		}
 	}
 
-	accountUUID := os.Getenv("DTCTL_ACCOUNT_UUID")
-	if accountUUID == "" {
-		t.Skip("Skipping account token test: DTCTL_ACCOUNT_UUID not set")
+	userUUID, err := sdkauth.ExtractJWTSubject(token)
+	if err != nil {
+		t.Fatalf("could not extract user UUID from account token: %v", err)
 	}
 
 	baseURL := os.Getenv("DTCTL_ACCOUNT_BASE_URL")
@@ -38,63 +73,131 @@ func setupAccountTokenTest(t *testing.T) (*httpclient.Client, string) {
 		t.Fatalf("failed to create account client: %v", err)
 	}
 
-	return c, accountUUID
+	return c, accountUUID, userUUID
 }
 
-func TestAccountTokenLifecycle(t *testing.T) {
-	c, accountUUID := setupAccountTokenTest(t)
-
-	userUUID := os.Getenv("DTCTL_ACCOUNT_USER_UUID")
-	if userUUID == "" {
-		t.Skip("Skipping account token lifecycle test: DTCTL_ACCOUNT_USER_UUID not set")
-	}
-
-	handler := platformtoken.NewHandler(c, accountUUID)
-
-	// Step 1: List tokens (read-only, always safe)
-	t.Log("Step 1: Listing platform tokens...")
-	tokens, err := handler.List()
-	if err != nil {
-		t.Fatalf("List() error: %v", err)
-	}
-	t.Logf("Found %d existing platform tokens", len(tokens))
-
-	// Step 2: Create a token
-	t.Log("Step 2: Creating platform token...")
-	created, err := handler.Create(platformtoken.PlatformTokenCreate{
-		Name:           fmt.Sprintf("dtctl-e2e-test-token-%d", time.Now().UnixMilli()),
+// createTestToken creates a token and registers cleanup. Returns the created token.
+func createTestToken(t *testing.T, handler *platformtoken.Handler, name, userUUID, accountUUID string, scopes []string) *platformtoken.PlatformToken {
+	t.Helper()
+	expiration := time.Now().UTC().Add(24 * time.Hour).Format("2006-01-02T15:04:05.000Z")
+	tok, err := handler.Create(platformtoken.PlatformTokenCreate{
+		Name:           name,
 		UserUUID:       userUUID,
-		Scope:          []string{"account-idm-read"},
-		Resource:       []string{},
-		Tags:           []string{},
-		ExpirationDate: "2026-12-31T00:00:00.000Z",
+		Scope:          scopes,
+		Resource:       []string{"urn:dtaccount:" + accountUUID},
+		ExpirationDate: expiration,
 	})
 	if err != nil {
-		t.Fatalf("Create() error: %v", err)
+		t.Fatalf("Create(%q): %v", name, err)
 	}
-	if created.TokenID == "" {
-		t.Fatal("created token has no TokenID")
+	if tok.TokenID == "" {
+		t.Fatalf("Create(%q): empty TokenID", name)
 	}
-	if created.Token == "" {
-		t.Fatal("created token secret missing from response")
+	if tok.Token == "" {
+		t.Fatalf("Create(%q): missing token secret in response", name)
 	}
-	t.Logf("Created token: %s (ID: %s)", created.Name, created.TokenID)
-
-	// Step 3: Revoke the token
-	t.Log("Step 3: Revoking platform token...")
-	if err := handler.Revoke(created.TokenID); err != nil {
-		t.Fatalf("Revoke() error: %v", err)
-	}
-	t.Logf("Revoked token: %s", created.TokenID)
+	t.Logf("created token %q (ID: %s)", name, tok.TokenID)
+	t.Cleanup(func() {
+		_ = handler.Revoke(tok.TokenID)
+	})
+	return tok
 }
 
+func findInList(tokens []platformtoken.PlatformToken, tokenID string) *platformtoken.PlatformToken {
+	for i := range tokens {
+		if tokens[i].TokenID == tokenID {
+			return &tokens[i]
+		}
+	}
+	return nil
+}
+
+// TestAccountTokenList_ReadOnly verifies that listing tokens works without write access.
 func TestAccountTokenList_ReadOnly(t *testing.T) {
-	c, accountUUID := setupAccountTokenTest(t)
+	c, accountUUID, _ := setupAccountTokenTest(t)
 	handler := platformtoken.NewHandler(c, accountUUID)
 
 	tokens, err := handler.List()
 	if err != nil {
 		t.Fatalf("List() error: %v", err)
 	}
-	t.Logf("Listed %d platform tokens", len(tokens))
+	t.Logf("listed %d platform tokens", len(tokens))
+}
+
+// TestAccountTokenLifecycle covers the full create → list → revoke → verify cycle
+// for tokens with single and multiple scopes.
+func TestAccountTokenLifecycle(t *testing.T) {
+	c, accountUUID, userUUID := setupAccountTokenTest(t)
+	handler := platformtoken.NewHandler(c, accountUUID)
+
+	ts := fmt.Sprintf("%d", time.Now().UnixMilli())
+
+	// Create three tokens:
+	//   token1 — single scope
+	//   token2, token3 — multiple scopes
+	token1 := createTestToken(t, handler, "dtctl-e2e-tok1-"+ts, userUUID, accountUUID, []string{"storage:buckets:read"})
+	token2 := createTestToken(t, handler, "dtctl-e2e-tok2-"+ts, userUUID, accountUUID, []string{"storage:buckets:read", "storage:logs:read"})
+	token3 := createTestToken(t, handler, "dtctl-e2e-tok3-"+ts, userUUID, accountUUID, []string{"storage:buckets:read", "storage:logs:read"})
+
+	t.Run("verify_in_list", func(t *testing.T) {
+		tokens, err := handler.List()
+		if err != nil {
+			t.Fatalf("List() error: %v", err)
+		}
+		for _, tok := range []*platformtoken.PlatformToken{token1, token2, token3} {
+			entry := findInList(tokens, tok.TokenID)
+			if entry == nil {
+				t.Errorf("token %q (ID: %s) not found in list after creation", tok.Name, tok.TokenID)
+				continue
+			}
+			if entry.Status == "REVOKED" {
+				t.Errorf("token %q shows REVOKED immediately after creation", tok.TokenID)
+			}
+		}
+	})
+
+	t.Run("revoke", func(t *testing.T) {
+		for _, tok := range []*platformtoken.PlatformToken{token1, token2, token3} {
+			if err := handler.Revoke(tok.TokenID); err != nil {
+				t.Errorf("Revoke(%q): %v", tok.TokenID, err)
+			} else {
+				t.Logf("revoked %s", tok.TokenID)
+			}
+		}
+	})
+
+	t.Run("verify_after_revoke", func(t *testing.T) {
+		tokens, err := handler.List()
+		if err != nil {
+			t.Fatalf("List() error: %v", err)
+		}
+		for _, tok := range []*platformtoken.PlatformToken{token1, token2, token3} {
+			entry := findInList(tokens, tok.TokenID)
+			if entry == nil {
+				continue // absent from list is fine
+			}
+			if entry.Status != "REVOKED" {
+				t.Errorf("token %q still has status %q after revoke", tok.TokenID, entry.Status)
+			}
+		}
+	})
+}
+
+// TestAccountTokenDoubleRevoke verifies that revoking an already-revoked token returns an error.
+func TestAccountTokenDoubleRevoke(t *testing.T) {
+	c, accountUUID, userUUID := setupAccountTokenTest(t)
+	handler := platformtoken.NewHandler(c, accountUUID)
+
+	ts := fmt.Sprintf("%d", time.Now().UnixMilli())
+	tok := createTestToken(t, handler, "dtctl-e2e-dbl-revoke-"+ts, userUUID, accountUUID, []string{"storage:buckets:read"})
+
+	if err := handler.Revoke(tok.TokenID); err != nil {
+		t.Fatalf("first Revoke() error: %v", err)
+	}
+
+	if err := handler.Revoke(tok.TokenID); err == nil {
+		t.Error("second Revoke() should have returned an error for an already-revoked token")
+	} else {
+		t.Logf("second Revoke() correctly returned error: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

- Adds `dtctl account login` — browser-based PKCE OAuth for the account plane
- Adds `dtctl account status` — shows stored token state, expiry, and scopes
- Adds platform token CRUD via the [Account Management API](https://api.dynatrace.com/spec/?urls.primaryName=Account+Management+API#/Platform+tokens/platformTokens) — commands follow the standard `dtctl <verb> <resource>` pattern
- Safety levels are enforced for account-plane operations: `readonly` blocks all mutating commands via the safety checker **and** limits the OAuth scopes requested at login (`platform-token:tokens:write` is not granted, so token creation is rejected at the API level too)
- `--user-uuid` is optional: defaults to the current user extracted from the account JWT subject claim
- Expired tokens show `STATUS=EXPIRED` in list output (client-side derivation — the API always returns `ACTIVE`)
- Account UUID is persisted to context config on login so follow-up commands don't require `--account-uuid` again

## New commands

```
dtctl account login [--account-uuid <uuid>]     # stores account token in keyring
dtctl account status                             # show token state/expiry/scopes
dtctl account list token [-o json|yaml|table]
dtctl account create token --name <n> --scope <s1>,<s2> [--expires 30d]
dtctl account delete token <tokenId>
```

## Safety levels

Safety level enforcement follows the same pattern as environment-plane commands, applied at two layers:

| Safety level | Safety checker | OAuth scopes |
|---|---|---|
| `readonly` | blocks `create`/`delete` | `account-idm-read`, `platform-token:tokens:manage` |
| `readwrite-mine` / `readwrite-all` | allows create/delete | + `account-idm-write`, `platform-token:tokens:write` |

`platform-token:tokens:manage` covers list and delete; `platform-token:tokens:write` is required for create.

## Required OAuth scopes on the Heimdall client

The following scopes must be present on `dt0s12.dtctl-*`:

| Scope | Purpose |
|---|---|
| `account-idm-read` | list operations |
| `account-idm-write` | mutating operations |
| `platform-token:tokens:manage` | list + delete platform tokens |
| `platform-token:tokens:write` | create platform tokens |

## How to test

### E2E tests (recommended)

After running `dtctl account login --account-uuid <uuid>` once, the tests pick up credentials from the keyring automatically — no env vars needed:

```sh
go test -v -tags integration -run TestAccountToken ./test/e2e/
```

For CI or without a local login, pass credentials explicitly:

```sh
DTCTL_ACCOUNT_TOKEN=<oauth-token> DTCTL_ACCOUNT_UUID=<uuid> \
  go test -v -tags integration -run TestAccountToken ./test/e2e/
```

Covered by the tests:
- List tokens (read-only)
- Create tokens with single and multiple scopes
- Verify created tokens appear in list
- Delete (revoke) tokens and verify they are gone/REVOKED
- Double-delete returns an error

### Manual smoke test

#### 1. Build

```sh
go build -o ~/bin/dtctl .
```

#### 2. Log in to the account plane

```sh
~/bin/dtctl account login --account-uuid <your-account-uuid>
# browser opens → complete login → token stored in keyring
```

#### 3. Verify token state

```sh
~/bin/dtctl account status
# should show: token valid, scopes include platform-token:tokens:manage and platform-token:tokens:write
```

#### 4. List existing platform tokens

```sh
~/bin/dtctl account list token
~/bin/dtctl account list token -o json
# expired tokens show STATUS=EXPIRED
```

#### 5. Create a token (user UUID and resource auto-resolved)

```sh
# single scope
~/bin/dtctl account create token --name test-ci-token-1 --scope storage:buckets:read --expires 1d

# multiple scopes — comma-separated or repeated flag, both work
~/bin/dtctl account create token --name test-ci-token-2 --scope storage:buckets:read,storage:logs:read --expires 1d
~/bin/dtctl account create token --name test-ci-token-3 --scope storage:buckets:read --scope storage:logs:read --expires 1d

# output: token secret printed once — note it down
```

#### 6. Verify it appears in the list

```sh
~/bin/dtctl account list token
```

#### 7. Delete (revoke) it

```sh
~/bin/dtctl account delete token <tokenId-from-step-5>
~/bin/dtctl account list token  # should be gone or show REVOKED status
```

#### 8. Dry-run (no API calls, no credentials needed)

```sh
~/bin/dtctl account create token --name x --scope y --dry-run
~/bin/dtctl account delete token tok-123 --dry-run
```

#### 9. Readonly safety check

```sh
# switch to a readonly context and attempt create — should be blocked
~/bin/dtctl account create token --name x --scope y
# expected: safety check error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)