### PR TITLE
fix(extension): fix upload Content-Type (415) and add activate command

### DIFF
--- a/cmd/activate.go
+++ b/cmd/activate.go
@@ -1,0 +1,21 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+// activateCmd is the parent command for activation operations.
+var activateCmd = &cobra.Command{
+	Use:   "activate",
+	Short: "Activate a resource version",
+	Long: `Activate a specific version of a Dynatrace resource.
+
+Available resources:
+  extension (ext)     Activate an Extensions 2.0 extension version`,
+	Example: `  # Activate extension version 1.0.2
+  dtctl activate extension custom:my-extension --version 1.0.2`,
+	RunE: requireSubcommand,
+}
+
+func init() {
+	rootCmd.AddCommand(activateCmd)
+	activateCmd.AddCommand(activateExtensionCmd)
+}

--- a/cmd/activate_extension.go
+++ b/cmd/activate_extension.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/extension"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
+)
+
+// activateExtensionCmd activates a specific version of an extension environment-wide.
+var activateExtensionCmd = &cobra.Command{
+	Use:     "extension <extension-name>",
+	Aliases: []string{"ext"},
+	Short:   "Activate an Extensions 2.0 extension version",
+	Long: `Activate a specific version of an Extensions 2.0 extension environment-wide.
+
+Sends POST /platform/extensions/v2/extensions/{name} with body {"version": "<version>"}.
+The server returns 202 Accepted and deploys bundled assets (e.g. OpenPipeline configs)
+asynchronously. The version must already be uploaded.
+
+Use 'dtctl create extension -f <zip>' to upload a new version first, then activate
+it with this command.
+
+Examples:
+  # Activate version 1.0.2 of a custom extension
+  dtctl activate extension custom:my-extension --version 1.0.2
+
+  # Activate a specific version of a built-in extension
+  dtctl activate extension com.dynatrace.extension.host-monitoring --version 1.2.3
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		extensionName := args[0]
+		version, _ := cmd.Flags().GetString("version")
+
+		if version == "" {
+			return fmt.Errorf("--version is required")
+		}
+
+		if dryRun {
+			fmt.Printf("Dry run: would activate extension %q version %s\n", extensionName, version)
+			return nil
+		}
+
+		_, c, err := SetupWithSafety(safety.OperationUpdate)
+		if err != nil {
+			return err
+		}
+
+		handler := extension.NewHandler(c)
+		result, err := handler.SetEnvironmentConfig(extensionName, version)
+		if err != nil {
+			return err
+		}
+
+		output.PrintSuccess("Extension activated (202 Accepted — bundled assets deploy asynchronously)")
+		output.PrintInfo("  Name:    %s", result.ExtensionName)
+		output.PrintInfo("  Version: %s", result.ExtensionVersion)
+		return nil
+	},
+}
+
+func init() {
+	activateExtensionCmd.Flags().String("version", "", "version to activate (required)")
+}

--- a/cmd/activate_extension.go
+++ b/cmd/activate_extension.go
@@ -56,7 +56,7 @@ Examples:
 			return err
 		}
 
-		output.PrintSuccess("Extension activated (202 Accepted — bundled assets deploy asynchronously)")
+		output.PrintSuccess("Extension activated (bundled assets deploy asynchronously)")
 		output.PrintInfo("  Name:    %s", result.ExtensionName)
 		output.PrintInfo("  Version: %s", result.ExtensionVersion)
 		return nil

--- a/cmd/create_extensions.go
+++ b/cmd/create_extensions.go
@@ -83,7 +83,7 @@ func runUploadExtension(file string) error {
 	}
 
 	handler := extension.NewHandler(c)
-	result, err := handler.Upload(filepath.Base(file), zipData)
+	result, _, err := handler.Upload(filepath.Base(file), zipData)
 	if err != nil {
 		return err
 	}

--- a/cmd/create_extensions.go
+++ b/cmd/create_extensions.go
@@ -83,7 +83,7 @@ func runUploadExtension(file string) error {
 	}
 
 	handler := extension.NewHandler(c)
-	result, _, err := handler.Upload(filepath.Base(file), zipData)
+	result, err := handler.Upload(filepath.Base(file), zipData)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/listing.go
+++ b/pkg/commands/listing.go
@@ -94,8 +94,9 @@ var MutatingVerbs = map[string]string{
 	"unshare": "OperationUpdate",
 	"update":  "OperationUpdate",
 	"exec":    "OperationCreate", // semantically mutating (runs workflows, functions)
-	"enable":  "OperationUpdate", // PUTs updated monitoring/credential config to the tenant
-	"disable": "OperationUpdate", // PUTs updated monitoring config with enabled=false
+	"enable":   "OperationUpdate", // PUTs updated monitoring/credential config to the tenant
+	"disable":  "OperationUpdate", // PUTs updated monitoring config with enabled=false
+	"activate": "OperationUpdate", // POSTs version activation for extensions and similar resources
 }
 
 // ResourceAliases are the standard resource aliases built into dtctl.

--- a/pkg/resources/extension/extension.go
+++ b/pkg/resources/extension/extension.go
@@ -186,6 +186,7 @@ type (
 	ExtensionEnvironmentConfig    = sdkext.ExtensionEnvironmentConfig
 	ExtensionStatus               = sdkext.ExtensionStatus
 	ActiveGateEntry               = sdkext.ActiveGateEntry
+	ActivationResponse            = sdkext.ActivationResponse
 )
 
 // Handler handles Extensions 2.0 resources.
@@ -266,12 +267,14 @@ func (h *Handler) UpdateMonitoringConfiguration(extensionName, configID string, 
 }
 
 // Upload uploads a custom extension zip file to the Dynatrace environment.
-func (h *Handler) Upload(fileName string, zipData []byte) (*ExtensionVersion, error) {
-	v, err := h.sdk.Upload(context.Background(), fileName, zipData)
+// It returns the parsed extension version (may have empty fields for non-standard
+// responses), the raw response body bytes, and any error.
+func (h *Handler) Upload(fileName string, zipData []byte) (*ExtensionVersion, []byte, error) {
+	v, raw, err := h.sdk.Upload(context.Background(), fileName, zipData)
 	if err != nil {
-		return nil, err
+		return nil, raw, err
 	}
-	return fromSDKExtensionVersion(v), nil
+	return fromSDKExtensionVersion(v), raw, nil
 }
 
 // InstallFromHub installs a Dynatrace Hub extension into the environment.
@@ -297,6 +300,11 @@ func (h *Handler) GetMonitoringConfigurationSchema(extensionName, version string
 // Download downloads the extension zip package for a specific version.
 func (h *Handler) Download(extensionName, version string) ([]byte, error) {
 	return h.sdk.Download(context.Background(), extensionName, version)
+}
+
+// SetEnvironmentConfig activates a specific version of an extension environment-wide.
+func (h *Handler) SetEnvironmentConfig(extensionName, version string) (*ActivationResponse, error) {
+	return h.sdk.SetEnvironmentConfig(context.Background(), extensionName, version)
 }
 
 // GetActiveGateGroups retrieves the active gate groups available for a specific extension version.

--- a/pkg/resources/extension/extension.go
+++ b/pkg/resources/extension/extension.go
@@ -267,14 +267,12 @@ func (h *Handler) UpdateMonitoringConfiguration(extensionName, configID string, 
 }
 
 // Upload uploads a custom extension zip file to the Dynatrace environment.
-// It returns the parsed extension version (may have empty fields for non-standard
-// responses), the raw response body bytes, and any error.
-func (h *Handler) Upload(fileName string, zipData []byte) (*ExtensionVersion, []byte, error) {
-	v, raw, err := h.sdk.Upload(context.Background(), fileName, zipData)
+func (h *Handler) Upload(fileName string, zipData []byte) (*ExtensionVersion, error) {
+	v, err := h.sdk.Upload(context.Background(), fileName, zipData)
 	if err != nil {
-		return nil, raw, err
+		return nil, err
 	}
-	return fromSDKExtensionVersion(v), raw, nil
+	return fromSDKExtensionVersion(v), nil
 }
 
 // InstallFromHub installs a Dynatrace Hub extension into the environment.

--- a/pkg/resources/extension/extension_test.go
+++ b/pkg/resources/extension/extension_test.go
@@ -1131,7 +1131,7 @@ func TestUpload(t *testing.T) {
 			}
 
 			handler := NewHandler(c)
-			result, _, err := handler.Upload(tt.fileName, tt.zipData)
+			result, err := handler.Upload(tt.fileName, tt.zipData)
 
 			if tt.expectError {
 				if err == nil {

--- a/pkg/resources/extension/extension_test.go
+++ b/pkg/resources/extension/extension_test.go
@@ -1111,8 +1111,8 @@ func TestUpload(t *testing.T) {
 					return
 				}
 				ct := r.Header.Get("Content-Type")
-				if !strings.HasPrefix(ct, "multipart/form-data") {
-					t.Errorf("expected multipart/form-data content type, got %s", ct)
+				if ct != "application/octet-stream" {
+					t.Errorf("expected application/octet-stream content type, got %s", ct)
 					w.WriteHeader(http.StatusBadRequest)
 					return
 				}
@@ -1131,7 +1131,7 @@ func TestUpload(t *testing.T) {
 			}
 
 			handler := NewHandler(c)
-			result, err := handler.Upload(tt.fileName, tt.zipData)
+			result, _, err := handler.Upload(tt.fileName, tt.zipData)
 
 			if tt.expectError {
 				if err == nil {
@@ -1484,6 +1484,111 @@ func TestGetActiveGateGroups(t *testing.T) {
 				if result.Items[0].AvailableActiveGates != tt.response.Items[0].AvailableActiveGates {
 					t.Errorf("expected AvailableActiveGates %d, got %d", tt.response.Items[0].AvailableActiveGates, result.Items[0].AvailableActiveGates)
 				}
+			}
+		})
+	}
+}
+
+func TestSetEnvironmentConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		extensionName string
+		version       string
+		statusCode    int
+		response      ActivationResponse
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "successful activation",
+			extensionName: "custom:my-extension",
+			version:       "1.0.2",
+			statusCode:    202,
+			response: ActivationResponse{
+				ExtensionName:    "custom:my-extension",
+				ExtensionVersion: "1.0.2",
+			},
+		},
+		{
+			name:          "extension not found",
+			extensionName: "custom:missing-extension",
+			version:       "1.0.0",
+			statusCode:    404,
+			expectError:   true,
+			errorContains: "not found",
+		},
+		{
+			name:          "access denied",
+			extensionName: "custom:forbidden-extension",
+			version:       "1.0.0",
+			statusCode:    403,
+			expectError:   true,
+			errorContains: "access denied",
+		},
+		{
+			name:          "version already active",
+			extensionName: "custom:my-extension",
+			version:       "1.0.2",
+			statusCode:    409,
+			expectError:   true,
+			errorContains: "already active",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expectedPath := "/platform/extensions/v2/extensions/" + url.PathEscape(tt.extensionName)
+				if r.URL.Path != expectedPath {
+					t.Errorf("unexpected path: %s (expected %s)", r.URL.Path, expectedPath)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if r.Method != http.MethodPost {
+					t.Errorf("unexpected method: %s (expected POST)", r.Method)
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				var body map[string]string
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+				}
+				if body["version"] != tt.version {
+					t.Errorf("unexpected version in body: %q (expected %q)", body["version"], tt.version)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				if tt.statusCode == 202 {
+					json.NewEncoder(w).Encode(tt.response)
+				}
+			}))
+			defer server.Close()
+
+			c, err := client.New(server.URL, "test-token")
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+
+			handler := NewHandler(c)
+			result, err := handler.SetEnvironmentConfig(tt.extensionName, tt.version)
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.ExtensionName != tt.response.ExtensionName {
+				t.Errorf("expected ExtensionName %q, got %q", tt.response.ExtensionName, result.ExtensionName)
+			}
+			if result.ExtensionVersion != tt.response.ExtensionVersion {
+				t.Errorf("expected ExtensionVersion %q, got %q", tt.response.ExtensionVersion, result.ExtensionVersion)
 			}
 		})
 	}

--- a/sdk/api/extension/extension.go
+++ b/sdk/api/extension/extension.go
@@ -526,35 +526,35 @@ func (h *Handler) UpdateMonitoringConfiguration(ctx context.Context, extensionNa
 // The fileName parameter is retained for API compatibility but is not used in the request;
 // the bundle is sent as a raw application/octet-stream body as required by the DT Platform
 // Extensions v2 API (multipart/form-data results in HTTP 415 Unsupported Media Type).
-func (h *Handler) Upload(ctx context.Context, fileName string, zipData []byte) (*ExtensionVersion, []byte, error) {
+func (h *Handler) Upload(ctx context.Context, fileName string, zipData []byte) (*ExtensionVersion, error) {
 	resp, err := h.client.HTTP().R().SetContext(ctx).
 		SetHeader("Content-Type", "application/octet-stream").
 		SetBody(zipData).
 		Post("/platform/extensions/v2/extensions")
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to upload extension: %w", err)
+		return nil, fmt.Errorf("failed to upload extension: %w", err)
 	}
 	if err := httpclient.CheckResponse(resp); err != nil {
 		var apiErr *httpclient.APIError
 		if errors.As(err, &apiErr) {
 			switch apiErr.StatusCode {
 			case http.StatusBadRequest:
-				return nil, nil, fmt.Errorf("invalid extension package: %w", err)
+				return nil, fmt.Errorf("invalid extension package: %w", err)
 			case http.StatusForbidden:
-				return nil, nil, fmt.Errorf("access denied: insufficient permissions to upload extensions")
+				return nil, fmt.Errorf("access denied: insufficient permissions to upload extensions")
 			case http.StatusConflict:
-				return nil, nil, fmt.Errorf("extension version already exists: %w", err)
+				return nil, fmt.Errorf("extension version already exists: %w", err)
 			}
 		}
-		return nil, nil, fmt.Errorf("failed to upload extension: %w", err)
+		return nil, fmt.Errorf("failed to upload extension: %w", err)
 	}
 
 	rawBody := resp.Body()
 	var result ExtensionVersion
 	if err := json.Unmarshal(rawBody, &result); err != nil {
-		return nil, rawBody, fmt.Errorf("upload extension: parse response: %w", err)
+		return nil, fmt.Errorf("upload extension: parse response: %w (body: %.512s)", err, rawBody)
 	}
-	return &result, rawBody, nil
+	return &result, nil
 }
 
 // InstallFromHub installs a Dynatrace Hub extension into the environment using the

--- a/sdk/api/extension/extension.go
+++ b/sdk/api/extension/extension.go
@@ -1,12 +1,10 @@
 package extension
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
@@ -525,53 +523,38 @@ func (h *Handler) UpdateMonitoringConfiguration(ctx context.Context, extensionNa
 
 // Upload uploads a custom extension zip file to the Dynatrace environment.
 // The zipData should contain the raw bytes of the extension zip package.
-// The optional fileName is used as the multipart filename; if empty, "extension.zip" is used.
-func (h *Handler) Upload(ctx context.Context, fileName string, zipData []byte) (*ExtensionVersion, error) {
-	if fileName == "" {
-		fileName = "extension.zip"
-	}
-
-	var body bytes.Buffer
-	writer := multipart.NewWriter(&body)
-
-	part, err := writer.CreateFormFile("file", fileName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create multipart field: %w", err)
-	}
-	if _, err := part.Write(zipData); err != nil {
-		return nil, fmt.Errorf("failed to write extension data: %w", err)
-	}
-	if err := writer.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
-	}
-
+// The fileName parameter is retained for API compatibility but is not used in the request;
+// the bundle is sent as a raw application/octet-stream body as required by the DT Platform
+// Extensions v2 API (multipart/form-data results in HTTP 415 Unsupported Media Type).
+func (h *Handler) Upload(ctx context.Context, fileName string, zipData []byte) (*ExtensionVersion, []byte, error) {
 	resp, err := h.client.HTTP().R().SetContext(ctx).
-		SetHeader("Content-Type", writer.FormDataContentType()).
-		SetBody(body.Bytes()).
+		SetHeader("Content-Type", "application/octet-stream").
+		SetBody(zipData).
 		Post("/platform/extensions/v2/extensions")
 	if err != nil {
-		return nil, fmt.Errorf("failed to upload extension: %w", err)
+		return nil, nil, fmt.Errorf("failed to upload extension: %w", err)
 	}
 	if err := httpclient.CheckResponse(resp); err != nil {
 		var apiErr *httpclient.APIError
 		if errors.As(err, &apiErr) {
 			switch apiErr.StatusCode {
 			case http.StatusBadRequest:
-				return nil, fmt.Errorf("invalid extension package: %w", err)
+				return nil, nil, fmt.Errorf("invalid extension package: %w", err)
 			case http.StatusForbidden:
-				return nil, fmt.Errorf("access denied: insufficient permissions to upload extensions")
+				return nil, nil, fmt.Errorf("access denied: insufficient permissions to upload extensions")
 			case http.StatusConflict:
-				return nil, fmt.Errorf("extension version already exists: %w", err)
+				return nil, nil, fmt.Errorf("extension version already exists: %w", err)
 			}
 		}
-		return nil, fmt.Errorf("failed to upload extension: %w", err)
+		return nil, nil, fmt.Errorf("failed to upload extension: %w", err)
 	}
 
+	rawBody := resp.Body()
 	var result ExtensionVersion
-	if err := json.Unmarshal(resp.Body(), &result); err != nil {
-		return nil, fmt.Errorf("upload extension: parse response: %w", err)
+	if err := json.Unmarshal(rawBody, &result); err != nil {
+		return nil, rawBody, fmt.Errorf("upload extension: parse response: %w", err)
 	}
-	return &result, nil
+	return &result, rawBody, nil
 }
 
 // InstallFromHub installs a Dynatrace Hub extension into the environment using the
@@ -684,6 +667,50 @@ func (h *Handler) GetMonitoringConfigurationSchema(ctx context.Context, extensio
 		return nil, fmt.Errorf("failed to get monitoring configuration schema: %w", err)
 	}
 	return json.RawMessage(resp.Body()), nil
+}
+
+// ActivationResponse is the response body from activating an extension version.
+type ActivationResponse struct {
+	ExtensionName    string `json:"extensionName"`
+	ExtensionVersion string `json:"extensionVersion"`
+}
+
+// SetEnvironmentConfig activates a specific version of a custom extension.
+// The DT Platform Extensions v2 API activates a custom extension via
+// POST /platform/extensions/v2/extensions/{name} with body {"version":"x.y.z"}.
+// The server returns 202 Accepted while the bundled assets (e.g. OpenPipeline
+// configs) are deployed asynchronously.
+func (h *Handler) SetEnvironmentConfig(ctx context.Context, extensionName, version string) (*ActivationResponse, error) {
+	body := map[string]string{"version": version}
+	resp, err := h.client.HTTP().R().SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		Post(fmt.Sprintf("/platform/extensions/v2/extensions/%s", url.PathEscape(extensionName)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to activate extension: %w", err)
+	}
+	if err := httpclient.CheckResponse(resp); err != nil {
+		var apiErr *httpclient.APIError
+		if errors.As(err, &apiErr) {
+			switch apiErr.StatusCode {
+			case http.StatusNotFound:
+				return nil, fmt.Errorf("extension %q not found", extensionName)
+			case http.StatusForbidden:
+				return nil, fmt.Errorf("access denied to extension %q", extensionName)
+			case http.StatusBadRequest:
+				return nil, fmt.Errorf("invalid request activating extension %q version %q: %w", extensionName, version, err)
+			case http.StatusConflict:
+				return nil, fmt.Errorf("extension %q version %q is already active", extensionName, version)
+			}
+		}
+		return nil, fmt.Errorf("failed to activate extension: %w", err)
+	}
+
+	var result ActivationResponse
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, fmt.Errorf("activate extension: parse response: %w", err)
+	}
+	return &result, nil
 }
 
 // GetActiveGateGroups retrieves the active gate groups available for a specific extension version.


### PR DESCRIPTION
## Summary

### Bug fix: `dtctl create extension -f <zip>` always returns HTTP 415

**What was wrong:** The upload used `multipart/form-data` (via `multipart.NewWriter`), but the DT Platform Extensions v2 API (`POST /platform/extensions/v2/extensions`) requires `Content-Type: application/octet-stream`. Every upload attempt failed with `415 Unsupported Media Type`.

**Fix:** `sdk/api/extension/extension.go` — `Upload()` now sends the raw ZIP bytes with `Content-Type: application/octet-stream` directly. The multipart encoding is removed entirely.

**How to reproduce (before fix):** `dtctl create extension -f any-extension.zip` → API returns HTTP 415.

---

### New feature: `dtctl activate extension`

After uploading a custom extension you must separately activate the desired version to deploy its bundled assets (OpenPipeline configs, dashboards, etc.).

**API endpoint used:**
```
POST /platform/extensions/v2/extensions/{extensionName}
Content-Type: application/json
Body: {"version": "x.y.z"}
→ 202 Accepted: {"extensionName": "...", "extensionVersion": "..."}
```

Note: this is the same route as `InstallFromHub` but with a JSON body instead of a `?version=` query parameter. The server deploys bundled assets asynchronously after accepting the request.

**Example usage:**
```
# Upload first, then activate
dtctl create extension -f custom:my-extension-1.0.2.zip
dtctl activate extension custom:my-extension --version 1.0.2

# Short alias
dtctl activate ext custom:my-extension --version 1.0.2
```

---

## Changes

- `sdk/api/extension/extension.go`: `Upload()` sends `application/octet-stream`; new `SetEnvironmentConfig()` + `ActivationResponse` type
- `pkg/resources/extension/extension.go`: wrapper methods updated; `ActivationResponse` re-exported
- `pkg/commands/listing.go`: `activate` added to `MutatingVerbs` (required by `TestMutatingVerbsMatchSafetyCheckerUsage`)
- `cmd/activate.go`: parent `activate` command
- `cmd/activate_extension.go`: `activate extension <name> --version <ver>` subcommand
- `pkg/resources/extension/extension_test.go`: `TestSetEnvironmentConfig` covering success (202), 404, 403, 409; existing `TestUpload` updated for new Content-Type

## Test plan

- [ ] `go test ./...` passes (all packages green)
- [ ] `dtctl create extension -f <any>.zip` uploads successfully (no more 415)
- [ ] `dtctl activate extension <name> --version <ver>` activates and prints name + version
- [ ] `dtctl activate extension <name> --version <ver> --dry-run` prints dry-run message without calling the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)