### PR TITLE
fix(extension): fix upload Content-Type — multipart/form-data → application/octet-stream

### DIFF
--- a/pkg/resources/extension/extension_test.go
+++ b/pkg/resources/extension/extension_test.go
@@ -1111,8 +1111,8 @@ func TestUpload(t *testing.T) {
 					return
 				}
 				ct := r.Header.Get("Content-Type")
-				if !strings.HasPrefix(ct, "multipart/form-data") {
-					t.Errorf("expected multipart/form-data content type, got %s", ct)
+				if ct != "application/octet-stream" {
+					t.Errorf("expected application/octet-stream content type, got %s", ct)
 					w.WriteHeader(http.StatusBadRequest)
 					return
 				}

--- a/sdk/api/extension/extension.go
+++ b/sdk/api/extension/extension.go
@@ -1,12 +1,10 @@
 package extension
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
@@ -525,29 +523,13 @@ func (h *Handler) UpdateMonitoringConfiguration(ctx context.Context, extensionNa
 
 // Upload uploads a custom extension zip file to the Dynatrace environment.
 // The zipData should contain the raw bytes of the extension zip package.
-// The optional fileName is used as the multipart filename; if empty, "extension.zip" is used.
+// The fileName parameter is retained for API compatibility but is not used in the
+// request; the bundle is sent as a raw application/octet-stream body as required
+// by the DT Platform Extensions v2 API (multipart/form-data results in HTTP 415).
 func (h *Handler) Upload(ctx context.Context, fileName string, zipData []byte) (*ExtensionVersion, error) {
-	if fileName == "" {
-		fileName = "extension.zip"
-	}
-
-	var body bytes.Buffer
-	writer := multipart.NewWriter(&body)
-
-	part, err := writer.CreateFormFile("file", fileName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create multipart field: %w", err)
-	}
-	if _, err := part.Write(zipData); err != nil {
-		return nil, fmt.Errorf("failed to write extension data: %w", err)
-	}
-	if err := writer.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
-	}
-
 	resp, err := h.client.HTTP().R().SetContext(ctx).
-		SetHeader("Content-Type", writer.FormDataContentType()).
-		SetBody(body.Bytes()).
+		SetHeader("Content-Type", "application/octet-stream").
+		SetBody(zipData).
 		Post("/platform/extensions/v2/extensions")
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload extension: %w", err)
@@ -567,9 +549,10 @@ func (h *Handler) Upload(ctx context.Context, fileName string, zipData []byte) (
 		return nil, fmt.Errorf("failed to upload extension: %w", err)
 	}
 
+	rawBody := resp.Body()
 	var result ExtensionVersion
-	if err := json.Unmarshal(resp.Body(), &result); err != nil {
-		return nil, fmt.Errorf("upload extension: parse response: %w", err)
+	if err := json.Unmarshal(rawBody, &result); err != nil {
+		return nil, fmt.Errorf("upload extension: parse response: %w (body: %.512s)", err, rawBody)
 	}
 	return &result, nil
 }


### PR DESCRIPTION
## Problem

`dtctl create extension -f <zip>` always failed with **HTTP 415 Unsupported Media Type**.

The upload implementation used `multipart/form-data` (via `multipart.NewWriter`), but the DT Platform Extensions v2 API requires `Content-Type: application/octet-stream`:

```
POST /platform/extensions/v2/extensions
Content-Type: application/octet-stream
<raw zip bytes>
```

## Fix

- `sdk/api/extension/extension.go`: remove multipart encoding; send raw ZIP bytes directly with `Content-Type: application/octet-stream`
- Drop now-unused `bytes` and `mime/multipart` imports
- Embed raw response body in parse-failure error message for easier debugging
- `pkg/resources/extension/extension_test.go`: update `TestUpload` to assert `application/octet-stream` Content-Type (was checking for `multipart/form-data`)

## How to reproduce (before fix)

```sh
dtctl create extension -f any-extension.zip
# → Error: API error (415): Unsupported Media Type
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)