### PR TITLE
feat(config): honor DTCTL_CONFIG as a trusted explicit config

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -29,10 +29,20 @@ func loadRawConfig() (*config.Config, error) {
 	return config.LoadWithoutExpansion()
 }
 
-// saveConfig saves configuration respecting the --config flag and local config presence
+// saveConfig saves configuration respecting the --config flag, DTCTL_CONFIG, and
+// local config presence. The path selection MUST mirror the read precedence used
+// by loadConfigRaw/loadRawConfig (and config.Load) so that config-management
+// commands round-trip the same file they loaded — otherwise a mutation read from
+// DTCTL_CONFIG would be written to a different file (global or a local
+// .dtctl.yaml), silently clobbering it.
 func saveConfig(cfg *config.Config) error {
 	if cfgFile != "" {
 		return cfg.SaveTo(cfgFile)
+	}
+	// An explicit config named in the environment is trusted like --config and
+	// short-circuits local discovery, so writes must target it too.
+	if envPath := os.Getenv(config.EnvConfig); envPath != "" {
+		return cfg.SaveTo(envPath)
 	}
 	// If a local config exists, save to it
 	if local := config.FindLocalConfig(); local != "" {

--- a/cmd/config_custom_test.go
+++ b/cmd/config_custom_test.go
@@ -91,6 +91,98 @@ func TestConfigFlagRespected(t *testing.T) {
 	}
 }
 
+// TestEnvConfigSaveRoundTrips verifies that when DTCTL_CONFIG names an explicit
+// config, a config-mutating command writes back to that same file rather than
+// the global config or an auto-discovered local .dtctl.yaml. This guards the
+// load/save symmetry: loadConfigRaw reads DTCTL_CONFIG, so saveConfig must
+// target it too, otherwise the mutation would silently clobber a different file.
+func TestEnvConfigSaveRoundTrips(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// A global config location that must stay untouched.
+	defaultConfigDir := filepath.Join(tmpDir, "default")
+	if err := os.MkdirAll(defaultConfigDir, 0700); err != nil {
+		t.Fatalf("failed to create default config dir: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", defaultConfigDir)
+	xdg.Reload()
+	defer xdg.Reload()
+
+	// The explicit, trusted config named via DTCTL_CONFIG.
+	envConfigPath := filepath.Join(tmpDir, "workspace", "ws-config.yaml")
+	if err := os.MkdirAll(filepath.Dir(envConfigPath), 0700); err != nil {
+		t.Fatalf("failed to create workspace dir: %v", err)
+	}
+	seed := `apiVersion: v1
+kind: Config
+current-context: seed-ctx
+contexts:
+  - name: seed-ctx
+    context:
+      environment: https://seed.example.com
+      token-ref: seed-token
+`
+	if err := os.WriteFile(envConfigPath, []byte(seed), 0600); err != nil {
+		t.Fatalf("failed to write env config: %v", err)
+	}
+
+	// Ensure the --config flag is not in play; only DTCTL_CONFIG.
+	originalCfgFile := cfgFile
+	defer func() { cfgFile = originalCfgFile }()
+	cfgFile = ""
+
+	// Run from an empty dir so no local .dtctl.yaml can be auto-discovered.
+	emptyDir := filepath.Join(tmpDir, "empty")
+	if err := os.MkdirAll(emptyDir, 0700); err != nil {
+		t.Fatalf("failed to create empty dir: %v", err)
+	}
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWd) }()
+	if err := os.Chdir(emptyDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
+
+	t.Setenv(config.EnvConfig, envConfigPath)
+	viper.Reset()
+	defer viper.Reset()
+
+	// Mutate the config via set-context.
+	cmd := configSetContextCmd
+	if err := cmd.Flags().Set("environment", "https://updated.example.com"); err != nil {
+		t.Fatalf("failed to set environment flag: %v", err)
+	}
+	if err := cmd.Flags().Set("token-ref", "new-token"); err != nil {
+		t.Fatalf("failed to set token-ref flag: %v", err)
+	}
+	if err := cmd.Flags().Set("safety-level", "readonly"); err != nil {
+		t.Fatalf("failed to set safety-level flag: %v", err)
+	}
+	if err := cmd.RunE(cmd, []string{"new-ctx"}); err != nil {
+		t.Fatalf("set-context failed: %v", err)
+	}
+
+	// The mutation must have landed in the DTCTL_CONFIG file, preserving the seed.
+	cfg, err := config.LoadFrom(envConfigPath)
+	if err != nil {
+		t.Fatalf("failed to reload env config: %v", err)
+	}
+	if _, err := cfg.GetContext("new-ctx"); err != nil {
+		t.Error("new-ctx missing from DTCTL_CONFIG file; save did not target it")
+	}
+	if _, err := cfg.GetContext("seed-ctx"); err != nil {
+		t.Error("seed-ctx missing; save clobbered the existing DTCTL_CONFIG content instead of round-tripping")
+	}
+
+	// The global config must never have been created.
+	globalPath := filepath.Join(defaultConfigDir, "dtctl", "config")
+	if _, err := os.Stat(globalPath); err == nil {
+		t.Errorf("global config was written at %s; save ignored DTCTL_CONFIG", globalPath)
+	}
+}
+
 // TestConfigCommandsRespectCustomPath tests that all config commands respect the --config flag
 func TestConfigCommandsRespectCustomPath(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -911,6 +911,10 @@ func initConfig() {
 
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
+	} else if envPath := os.Getenv(config.EnvConfig); envPath != "" {
+		// DTCTL_CONFIG is an explicit, trusted config that bypasses discovery —
+		// mirror config.Load's precedence so diagnostics name the right file.
+		viper.SetConfigFile(envPath)
 	} else {
 		// Check for local config first (.dtctl.yaml in current or parent directories)
 		localConfig := config.FindLocalConfig()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,7 +107,7 @@ func execute() int {
 		if cfg.IgnoredExecKeys() {
 			fmt.Fprintf(os.Stderr,
 				"warning: ignoring aliases and hooks from local config %q "+
-					"(code-execution keys are only honored from the global config)\n",
+					"(honored only from the global config, --config, or DTCTL_CONFIG)\n",
 				cfg.LocalConfigPath())
 		}
 

--- a/docs/site/_docs/configuration.md
+++ b/docs/site/_docs/configuration.md
@@ -131,8 +131,9 @@ Commit the file to version control without secrets -- each developer or CI syste
 ### Config Search Order
 
 1. `--config` flag (explicit path)
-2. `.dtctl.yaml` in the current directory or any parent (walks up to root)
-3. Global config (`~/.config/dtctl/config`)
+2. `DTCTL_CONFIG` environment variable (explicit path)
+3. `.dtctl.yaml` in the current directory or any parent (walks up to root)
+4. Global config (`~/.config/dtctl/config`)
 
 > **Security: local configs cannot run commands.** Because a `.dtctl.yaml` is
 > auto-discovered by walking up from your current directory, it is treated as
@@ -141,10 +142,30 @@ Commit the file to version control without secrets -- each developer or CI syste
 > apply hooks** found in an auto-discovered local `.dtctl.yaml`, printing a
 > warning to stderr when it does. These code-execution keys are honored **only**
 > from the global config (`~/.config/dtctl/config`) or a config you point at
-> explicitly with `--config`. A local config may still define contexts, tokens,
-> and other preferences. As an additional safeguard, an alias can never shadow a
-> built-in command (e.g. `get`, `apply`, `version`) regardless of where it is
-> defined.
+> explicitly with `--config` or `DTCTL_CONFIG`. A local config may still define
+> contexts, tokens, and other preferences. As an additional safeguard, an alias
+> can never shadow a built-in command (e.g. `get`, `apply`, `version`)
+> regardless of where it is defined.
+
+#### Trusting a prepared workspace with `DTCTL_CONFIG`
+
+When you control the config file — for example an automation harness that
+generates a clean working directory with its own `.dtctl.yaml`, skills, and
+hooks — export `DTCTL_CONFIG` so dtctl treats that file as an explicit, trusted
+config, exactly like `--config`:
+
+```bash
+export DTCTL_CONFIG="$PWD/.dtctl.yaml"
+```
+
+This honors the file's aliases and apply hooks without touching the invocation
+(an agent can keep running `dtctl apply` unchanged), and it **skips
+auto-discovery entirely** — a stray `.dtctl.yaml` elsewhere on disk can never
+shadow the file you named. Because it points at one specific file rather than
+blanket-trusting whatever is discovered, it does not reopen the
+untrusted-working-directory threat model above. Point it only at a config you
+trust, and prefer scoping it to the session (e.g. exported by the harness or a
+per-repo setup script) rather than your global shell profile.
 
 ## Safety Levels
 
@@ -211,8 +232,9 @@ contexts:
 Per-context hooks take precedence over global hooks. The special value `"none"` disables the global hook for a specific context.
 
 > **Security: hooks are ignored in local configs.** Apply hooks are honored only
-> from the global config (`~/.config/dtctl/config`) or an explicit `--config`
-> file. Hooks defined in an auto-discovered local `.dtctl.yaml` (whether in
+> from the global config (`~/.config/dtctl/config`) or a config named explicitly
+> with `--config` or `DTCTL_CONFIG`. Hooks defined in an auto-discovered local
+> `.dtctl.yaml` (whether in
 > `preferences` or a context) are **ignored**, since a local config from an
 > untrusted working directory must not be able to run commands. dtctl prints a
 > warning to stderr when it ignores them. (The hook values remain in the file
@@ -371,7 +393,8 @@ This guard is also enforced at **resolution** time: even an alias written
 directly into a config file (bypassing `alias set`) can never override a
 built-in — dtctl ignores it and runs the real command, warning on stderr.
 
-Aliases are honored only from the global config or an explicit `--config` file.
+Aliases are honored only from the global config or a config named explicitly
+with `--config` or `DTCTL_CONFIG`.
 Aliases in an auto-discovered local `.dtctl.yaml` are **ignored** for security
 (see [Config Search Order](#config-search-order)), so `alias export` / `import`
 should target the global config, not a per-project file.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -216,9 +216,21 @@ func findLocalConfigFrom(startDir string) string {
 	}
 }
 
+// EnvConfig names an explicit config file, equivalent to passing --config.
+// When set, dtctl loads exactly that file and treats it as trusted (its
+// aliases and apply hooks are honored), skipping auto-discovery entirely. This
+// is the supported way to run in a prepared, trusted workspace — e.g. kb-run
+// creates a clean directory with a .dtctl.yaml and exports this variable, so an
+// agent invoking `dtctl apply` runs the intended hooks without a --config flag.
+// Because it names a specific operator-chosen file (not a directory to search),
+// it does not reopen the untrusted-working-directory vector that IsLocal()
+// guards against: a stray .dtctl.yaml elsewhere on disk can never be picked up.
+const EnvConfig = "DTCTL_CONFIG"
+
 // Load loads the configuration with the following precedence:
-//  1. Local config (.dtctl.yaml in current directory or parent directories)
-//  2. Global config (XDG_CONFIG_HOME/dtctl/config)
+//  1. Explicit config from the DTCTL_CONFIG environment variable (trusted)
+//  2. Local config (.dtctl.yaml in current directory or parent directories)
+//  3. Global config (XDG_CONFIG_HOME/dtctl/config)
 //
 // If a local config is found, it is used exclusively (not merged with global).
 //
@@ -226,12 +238,20 @@ func findLocalConfigFrom(startDir string) string {
 // classic "untrusted working directory / checked-out repo / shared dir"
 // scenario). Code-execution keys — shell aliases and apply hooks — defined in
 // such a config are never honored: alias resolution and hook execution check
-// IsLocal() and skip them. These keys are honored only from the global config
-// or an explicit --config file (loaded via LoadFrom), which carry stronger
-// ownership expectations. The keys are still loaded into the struct (and never
-// mutated here) so that config-management commands round-trip the file without
-// silently destroying a user's own aliases or hooks.
+// IsLocal() and skip them. These keys are honored only from the global config,
+// an explicit --config file, or a config named by DTCTL_CONFIG (all loaded via
+// LoadFrom without markLocal), which carry stronger ownership expectations. The
+// keys are still loaded into the struct (and never mutated here) so that
+// config-management commands round-trip the file without silently destroying a
+// user's own aliases or hooks.
 func Load() (*Config, error) {
+	// An explicit config named in the environment is trusted, exactly like
+	// --config, and short-circuits auto-discovery so a closer untrusted
+	// .dtctl.yaml can never shadow it. It is intentionally not marked local.
+	if envPath := os.Getenv(EnvConfig); envPath != "" {
+		return LoadFrom(envPath)
+	}
+
 	// Check for local config first
 	localConfig := FindLocalConfig()
 	if localConfig != "" {
@@ -306,6 +326,11 @@ func LoadFromWithoutExpansion(path string) (*Config, error) {
 // LoadWithoutExpansion loads the configuration without expanding environment variables,
 // using the same search order as Load (local config, then global config).
 func LoadWithoutExpansion() (*Config, error) {
+	// Honor DTCTL_CONFIG with the same precedence as Load: an explicit,
+	// trusted config that bypasses auto-discovery. See EnvConfig.
+	if envPath := os.Getenv(EnvConfig); envPath != "" {
+		return LoadFromWithoutExpansion(envPath)
+	}
 	if local := FindLocalConfig(); local != "" {
 		cfg, err := LoadFromWithoutExpansion(local)
 		if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1058,6 +1058,152 @@ preferences:
 	}
 }
 
+// TestLoad_EnvConfigIsTrusted verifies that a config named by DTCTL_CONFIG is
+// treated as an explicit, trusted config (like --config): its aliases and apply
+// hooks are honored and it is not flagged as local. This is the kb-run /
+// prepared-workspace use case where an agent runs `dtctl apply` without a flag.
+func TestLoad_EnvConfigIsTrusted(t *testing.T) {
+	// NOT parallel: os.Chdir + os.Setenv are process-global.
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "workspace-config.yaml")
+	content := `apiVersion: v1
+kind: Config
+current-context: ws-ctx
+contexts:
+  - name: ws-ctx
+    context:
+      environment: https://ws.dt.com
+      token-ref: ws-token
+preferences:
+  hooks:
+    pre-apply: "bash validate.sh"
+    post-apply: "echo done"
+aliases:
+  wf: "get workflows"
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	// Run from an empty dir so no local .dtctl.yaml can be auto-discovered.
+	emptyDir := t.TempDir()
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWd) }()
+	if err := os.Chdir(emptyDir); err != nil {
+		t.Fatalf("Failed to change directory: %v", err)
+	}
+
+	t.Setenv(EnvConfig, path)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.IsLocal() {
+		t.Error("IsLocal() = true, want false for DTCTL_CONFIG-named config")
+	}
+	if cfg.IgnoredExecKeys() {
+		t.Error("IgnoredExecKeys() = true, want false for trusted env config")
+	}
+	if cfg.GetPreApplyHook() != "bash validate.sh" {
+		t.Errorf("GetPreApplyHook() = %q, want honored", cfg.GetPreApplyHook())
+	}
+	if cfg.GetPostApplyHook() != "echo done" {
+		t.Errorf("GetPostApplyHook() = %q, want honored", cfg.GetPostApplyHook())
+	}
+	if _, ok := cfg.GetAlias("wf"); !ok {
+		t.Error("GetAlias(wf) missing; env config must honor aliases")
+	}
+}
+
+// TestLoad_EnvConfigShadowsLocalDiscovery verifies that when DTCTL_CONFIG is
+// set, auto-discovery is skipped entirely: a closer (untrusted) .dtctl.yaml in
+// the working directory can never shadow or downgrade the explicitly named
+// config. This is the core security property distinguishing DTCTL_CONFIG from a
+// blanket "trust discovered configs" switch.
+func TestLoad_EnvConfigShadowsLocalDiscovery(t *testing.T) {
+	// NOT parallel: os.Chdir + os.Setenv are process-global.
+	trustedDir := t.TempDir()
+	trustedPath := filepath.Join(trustedDir, "trusted.yaml")
+	trusted := `apiVersion: v1
+kind: Config
+current-context: trusted-ctx
+contexts:
+  - name: trusted-ctx
+    context:
+      environment: https://trusted.dt.com
+      token-ref: t
+preferences:
+  hooks:
+    pre-apply: "echo trusted-hook"
+`
+	if err := os.WriteFile(trustedPath, []byte(trusted), 0600); err != nil {
+		t.Fatalf("Failed to write trusted config: %v", err)
+	}
+
+	// A hostile local config sitting in the working directory.
+	workDir := t.TempDir()
+	localPath := filepath.Join(workDir, LocalConfigName)
+	local := `apiVersion: v1
+kind: Config
+current-context: evil-ctx
+contexts:
+  - name: evil-ctx
+    context:
+      environment: https://evil.dt.com
+      token-ref: t
+preferences:
+  hooks:
+    pre-apply: "bash -c 'id > /tmp/pwned'"
+`
+	if err := os.WriteFile(localPath, []byte(local), 0600); err != nil {
+		t.Fatalf("Failed to write local config: %v", err)
+	}
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWd) }()
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("Failed to change directory: %v", err)
+	}
+
+	t.Setenv(EnvConfig, trustedPath)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.IsLocal() {
+		t.Error("IsLocal() = true, want false: DTCTL_CONFIG must bypass discovery")
+	}
+	if cfg.CurrentContext != "trusted-ctx" {
+		t.Errorf("CurrentContext = %q, want trusted-ctx (local config must not be loaded)", cfg.CurrentContext)
+	}
+	if got := cfg.GetPreApplyHook(); got != "echo trusted-hook" {
+		t.Errorf("GetPreApplyHook() = %q, want the trusted hook (never the local one)", got)
+	}
+}
+
+// TestLoad_EnvConfigMissingFileErrors verifies that DTCTL_CONFIG pointing at a
+// nonexistent file fails closed rather than silently falling back to
+// (untrusted) auto-discovery, which would be a surprising security downgrade.
+func TestLoad_EnvConfigMissingFileErrors(t *testing.T) {
+	// NOT parallel: os.Setenv is process-global.
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	t.Setenv(EnvConfig, missing)
+
+	if _, err := Load(); err == nil {
+		t.Error("Load() error = nil, want error for missing DTCTL_CONFIG file")
+	}
+}
+
 func TestConfig_DeleteContext(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Summary

Adds a `DTCTL_CONFIG` environment variable that names a config file and is treated exactly like `--config`: dtctl loads that file, honors its aliases and apply hooks, and **skips auto-discovery entirely**.

This restores the hooks/aliases functionality that #268 (correctly) disabled for auto-discovered local `.dtctl.yaml` files, but only for configs the operator explicitly trusts.

## Motivation ([AI-36](https://dt-rnd.atlassian.net/browse/AI-36) follow-up)

#268 treats an auto-discovered `.dtctl.yaml` (walk-up from cwd) as untrusted and ignores its aliases/apply hooks — the untrusted-working-directory RCE threat model.

That broke prepared-workspace tooling (kb-run, `ai-dashboard-generation`) that generates a **clean, trusted** directory with its own `.dtctl.yaml`, skills, and hooks, then starts an agent in it. The agent runs `dtctl apply` via a skill, so `--config` isn't a workable fix (the skill can't assume a relative path). Exporting an env var once for the session is the natural fit:

```bash
export DTCTL_CONFIG="$PWD/.dtctl.yaml"
```

## Why not a blanket "honor hooks from any discovered config" flag

A boolean that re-trusts *discovery* reopens exactly the hole #268 closed — while set, `cd`-ing into any repo with a planted `.dtctl.yaml` is RCE, and such env vars tend to migrate into shell profiles. `DTCTL_CONFIG` instead names **one specific file**, reusing the already-audited `explicit == trusted` boundary. A stray `.dtctl.yaml` elsewhere on disk can never shadow it.

## Behavior

- Precedence: `--config` flag > `DTCTL_CONFIG` > walk-up discovery > global config
- The named config is loaded via `LoadFrom` (not marked local) → aliases + hooks honored
- Auto-discovery is bypassed when `DTCTL_CONFIG` is set → no closer config can shadow it
- A missing `DTCTL_CONFIG` path **fails closed** (error) rather than silently downgrading to untrusted discovery

## Changes

- `pkg/config`: `EnvConfig = "DTCTL_CONFIG"`; honored in `Load()` and `LoadWithoutExpansion()`
- `cmd/root`: ignored-exec-keys warning now names `--config` and `DTCTL_CONFIG` as the escape hatches
- `docs/site/_docs/configuration.md`: search order, trust model, and a "Trusting a prepared workspace" section
- tests: trusted+hooks-honored, shadows-local-discovery (the security property), missing-file-fails-closed

## Verification

- `go build ./...`, `go vet ./pkg/config`, `gofmt` — clean
- `go test ./pkg/config ./cmd` — pass
- Binary smoke test: local discovery → warning + keys ignored; same file via `DTCTL_CONFIG` → trusted, no warning; missing path → clean `config_error`