### PR TITLE
feat(query): guide users to double quotes and fail wait fast on unrunnable queries

### DIFF
--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -60,10 +60,11 @@ Exit Codes:
 
 Examples:
   # Wait for a specific test span to arrive
-  dtctl wait query "fetch spans | filter test_id == 'test-123'" --for=count=1
+  # (DQL string values need double quotes; wrap the query in single quotes)
+  dtctl wait query 'fetch spans | filter test_id == "test-123"' --for=count=1
 
   # Wait for any error logs
-  dtctl wait query "fetch logs | filter status == 'ERROR'" --for=any --timeout 2m
+  dtctl wait query 'fetch logs | filter status == "ERROR"' --for=any --timeout 2m
 
   # Query with template variables
   dtctl wait query -f query.dql --set test_id=my-test --for=count-gte=1

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -337,10 +338,15 @@ func (e *DQLExecutor) ExecuteQueryWithContext(ctx context.Context, query string,
 			fmt.Fprintln(os.Stderr, "Query cancelled.")
 			return nil, nil
 		}
-		// Enhance known error types with CLI-specific hints
+		// Enhance known error types with CLI-specific hints.
 		var qErr *QueryError
-		if ok := isQueryError(err, &qErr); ok && qErr.ErrorType == "FILTER_SEGMENT_REQUIRES_VARIABLE" {
-			return nil, formatSegmentVariableError(qErr)
+		if isQueryError(err, &qErr) {
+			switch qErr.ErrorType {
+			case "FILTER_SEGMENT_REQUIRES_VARIABLE":
+				return nil, formatSegmentVariableError(qErr)
+			case "PARSE_ERROR_SINGLE_QUOTES":
+				return nil, formatSingleQuoteError(qErr)
+			}
 		}
 		return nil, err
 	}
@@ -392,6 +398,36 @@ func formatSegmentVariableError(qErr *QueryError) error {
 		"        values: [\"your-value-here\"]\n\n"+
 		"  dtctl query \"...\" --segments-file segments.yaml",
 		segmentID, variableName, segmentID, variableName, segmentID, variableName)
+}
+
+// formatSingleQuoteError produces a helpful error when a query uses single
+// quotes for a string literal. DQL only accepts double quotes; single quotes
+// are almost always the result of a shell-quoting collision — wrapping the
+// whole query in double quotes leaves no room for double-quoted string
+// literals, so users reach for single quotes instead. The wrapped *QueryError
+// is preserved in the chain so callers (agent envelope, wait fast-fail) can
+// still classify it. Advice is tailored per platform.
+func formatSingleQuoteError(qErr *QueryError) error {
+	return fmt.Errorf("%w\n\n%s", qErr, singleQuoteHint())
+}
+
+// singleQuoteHint returns platform-specific guidance for fixing a single-quoted
+// DQL string literal. On Windows it spells out the PowerShell and cmd.exe
+// forms, since that is where the double-quote collision bites hardest.
+func singleQuoteHint() string {
+	const base = "DQL string literals must use double quotes (\"...\"), not single quotes ('...')."
+	if runtime.GOOS == "windows" {
+		return base + "\n\n" +
+			"Your shell most likely stripped the double quotes. Quote the query so the inner \" survive:\n\n" +
+			"  PowerShell:  dtctl query 'fetch logs | filter status == \"ERROR\"'\n" +
+			"  cmd.exe:     dtctl query \"fetch logs | filter status == \\\"ERROR\\\"\"\n\n" +
+			"Or avoid shell quoting entirely by reading the query from a file or stdin:\n\n" +
+			"  dtctl query -f query.dql\n" +
+			"  dtctl query -f -   # then type/pipe the query on stdin"
+	}
+	return base + "\n\n" +
+		"Wrap the query in single quotes and use double quotes for values inside:\n\n" +
+		"  dtctl query 'fetch logs | filter status == \"ERROR\"'"
 }
 
 // VerifyQuery verifies a DQL query without executing it

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -341,6 +342,47 @@ func TestDQLExecutor_ExecuteQueryWithOptions_ErrorHandling(t *testing.T) {
 				t.Errorf("expected error to start with '%s', got '%s'", tt.expectedErrMsg, err.Error())
 			}
 		})
+	}
+}
+
+func TestDQLExecutor_ExecuteQueryWithOptions_SingleQuoteHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"single quotes are not allowed","details":{"errorType":"PARSE_ERROR_SINGLE_QUOTES"}}}`))
+	}))
+	defer server.Close()
+
+	c, err := client.NewForTesting(server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = NewDQLExecutor(c).ExecuteQueryWithOptions(`fetch logs | filter status == 'ERROR'`, DQLExecuteOptions{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// The enriched message must guide the user toward double quotes.
+	msg := err.Error()
+	if !strings.Contains(msg, `double quotes`) {
+		t.Errorf("expected hint about double quotes, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, `status == "ERROR"`) {
+		t.Errorf("expected a corrected example in the hint, got:\n%s", msg)
+	}
+
+	// The underlying *QueryError must remain in the chain so callers (agent
+	// envelope, wait fast-fail) can still classify it.
+	var qErr *QueryError
+	if !errors.As(err, &qErr) {
+		t.Fatalf("expected *QueryError to remain in the error chain, got %T", err)
+	}
+	if qErr.ErrorType != "PARSE_ERROR_SINGLE_QUOTES" {
+		t.Errorf("ErrorType = %q, want PARSE_ERROR_SINGLE_QUOTES", qErr.ErrorType)
+	}
+	if qErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want 400", qErr.StatusCode)
 	}
 }
 

--- a/pkg/wait/query_waiter.go
+++ b/pkg/wait/query_waiter.go
@@ -2,8 +2,10 @@ package wait
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"time"
 
@@ -143,6 +145,22 @@ func (w *QueryWaiter) Wait(ctx context.Context) (*Result, error) {
 				}, ctx.Err()
 			}
 
+			// Permanent query errors (e.g. a malformed DQL query) can never
+			// succeed, so retrying with backoff is pointless — fail fast.
+			if isPermanentQueryError(err) {
+				elapsed := time.Since(startTime)
+				if !w.config.Quiet {
+					fmt.Fprintf(w.config.ProgressOut, "\nQuery error (not retryable): %v\n", err)
+					fmt.Fprintf(w.config.ProgressOut, "Elapsed: %s\n", elapsed.Round(100*time.Millisecond))
+				}
+				return &Result{
+					Success:       false,
+					Attempts:      attempt + 1,
+					Elapsed:       elapsed,
+					FailureReason: "query error",
+				}, nil
+			}
+
 			// Transient error - log and retry
 			if w.config.Verbose {
 				fmt.Fprintf(w.config.ProgressOut, "  Query error: %v (will retry)\n", err)
@@ -229,6 +247,25 @@ func (w *QueryWaiter) Wait(ctx context.Context) (*Result, error) {
 
 		attempt++
 	}
+}
+
+// isPermanentQueryError reports whether a query execution error is permanent —
+// i.e. re-running the identical query cannot succeed. A structured DQL error
+// with a 4xx status means the query or request itself is rejected (parse
+// errors, unknown fields, invalid arguments), so retrying is futile. HTTP 408
+// (request timeout) and 429 (too many requests) are the transient exceptions
+// and remain retryable. Non-QueryError failures (network blips, 5xx) are
+// treated as transient.
+func isPermanentQueryError(err error) bool {
+	var qErr *exec.QueryError
+	if !errors.As(err, &qErr) {
+		return false
+	}
+	switch qErr.StatusCode {
+	case http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return false
+	}
+	return qErr.StatusCode >= 400 && qErr.StatusCode < 500
 }
 
 // PrintResults prints the query results if output format is specified

--- a/pkg/wait/query_waiter_test.go
+++ b/pkg/wait/query_waiter_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
@@ -143,6 +144,49 @@ func TestWait_MaxAttemptsExceeded(t *testing.T) {
 	}
 	if callCount != 2 {
 		t.Errorf("expected 2 calls, got %d", callCount)
+	}
+}
+
+// --- Wait: permanent query error fails fast ---
+
+func TestWait_PermanentQueryError_FailsFast(t *testing.T) {
+	callCount := 0
+	executor, cleanup := newWaiterTestExecutor(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		// A malformed DQL query — the backend rejects it with a 4xx parse error.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":{"message":"single quotes are not allowed","details":{"errorType":"PARSE_ERROR_SINGLE_QUOTES"}}}`)
+	})
+	defer cleanup()
+
+	buf := &bytes.Buffer{}
+	config := WaitConfig{
+		Query:       "fetch logs | filter status == 'ERROR'",
+		Condition:   Condition{Type: ConditionTypeAny, Operator: OpGreater, Value: 0},
+		MaxAttempts: 5,
+		Quiet:       false,
+		ProgressOut: buf,
+		Backoff:     BackoffConfig{MinInterval: 0, MaxInterval: 0},
+	}
+	waiter := NewQueryWaiter(executor, config)
+
+	result, err := waiter.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v (expected nil; controlled failure via result)", err)
+	}
+	if result == nil || result.Success {
+		t.Fatalf("expected non-success result, got %+v", result)
+	}
+	if result.FailureReason != "query error" {
+		t.Errorf("FailureReason = %q, want %q", result.FailureReason, "query error")
+	}
+	// Must not retry a query that can never parse.
+	if callCount != 1 {
+		t.Errorf("expected exactly 1 attempt (no retries), got %d", callCount)
+	}
+	if !strings.Contains(buf.String(), "not retryable") {
+		t.Errorf("expected progress output to explain the query is not retryable, got:\n%s", buf.String())
 	}
 }
 

--- a/skills/dtctl/references/DQL-reference.md
+++ b/skills/dtctl/references/DQL-reference.md
@@ -28,6 +28,32 @@ smartscapeNodes SERVICE
 fieldsAdd ts = formatTimestamp(timestamp, format:"yyyy-MM-dd HH:mm:ss")
 ```
 
+## String Quoting (read this first)
+
+DQL string literals **must use double quotes** (`"ERROR"`), never single quotes.
+`filter status == 'ERROR'` fails with `PARSE_ERROR_SINGLE_QUOTES`, and an
+**unquoted** bareword like `filter status == ERROR` is parsed as a *field
+reference* (compares `status` to a field named `ERROR`) — so it silently
+returns **zero rows with no error**. Both are common mistakes; neither is a bug.
+
+```dql
+filter status == "ERROR"          -- correct
+filter status == 'ERROR'          -- WRONG: PARSE_ERROR_SINGLE_QUOTES
+filter status == ERROR            -- WRONG: matches nothing (ERROR = field ref)
+```
+
+Because the value needs double quotes, wrap the **whole query** so your shell
+preserves them:
+
+| Shell | Command |
+|-------|---------|
+| bash/zsh, PowerShell | `dtctl query 'fetch logs \| filter status == "ERROR"'` (single-quote the query) |
+| cmd.exe | `dtctl query "fetch logs \| filter status == \"ERROR\""` (escape inner quotes) |
+| any (quote-free) | `dtctl query -f query.dql` or pipe/stdin with `dtctl query -f -` |
+
+When generating a `dtctl query` command for a user, **prefer the single-quoted
+wrapper** (or `-f`) so the double-quoted DQL values survive intact.
+
 ## Data Sources
 
 ```dql

--- a/skills/dtctl/references/troubleshooting.md
+++ b/skills/dtctl/references/troubleshooting.md
@@ -37,6 +37,32 @@ dtctl auth status --plain
 
 ## Common Issues
 
+### PARSE_ERROR_SINGLE_QUOTES / query filter returns nothing
+DQL string literals require **double** quotes. Two frequent traps:
+
+- `filter status == 'ERROR'` → `PARSE_ERROR_SINGLE_QUOTES` (single quotes are invalid).
+- `filter status == ERROR` (unquoted) → silently returns **zero rows**; the
+  bareword is read as a field reference, not the string `"ERROR"`.
+
+Use double quotes for the value and pick a shell wrapper that preserves them:
+
+```bash
+# bash/zsh + PowerShell: single-quote the whole query
+dtctl query 'fetch logs | filter status == "ERROR"'
+```
+```cmd
+:: cmd.exe: escape the inner double quotes
+dtctl query "fetch logs | filter status == \"ERROR\""
+```
+```powershell
+# PowerShell here-string (no escaping headaches)
+dtctl query -f - -o json @'
+fetch logs | filter status == "ERROR"
+'@
+```
+
+Quote-free everywhere: put the DQL in a file and run `dtctl query -f query.dql`.
+
 ### 401/403 Authentication Errors
 ```bash
 # Re-store credentials


### PR DESCRIPTION
## Motivation

A user hit `PARSE_ERROR_SINGLE_QUOTES` on `dtctl query "... status == 'ERROR'"` and couldn't recover — even an AI assistant gave a confidently wrong answer ("it's an enum, drop the quotes", which silently returns zero rows). The root cause is a shell-quoting collision: DQL string literals require **double** quotes, but wrapping the whole query in `"..."` for the shell leaves no room for them, so users reach for single quotes. `dtctl wait query` made it worse by retrying the unrunnable query with backoff until timeout.

None of this is a DQL bug — but the errors were unhelpful. This PR makes the failure modes self-explanatory.

## Changes

**`feat(query)` — explain the double-quote rule on single-quote errors.**
On `PARSE_ERROR_SINGLE_QUOTES`, the executor now attaches platform-aware guidance, mirroring the existing `FILTER_SEGMENT_REQUIRES_VARIABLE` enrichment. On Windows it spells out both the PowerShell and `cmd.exe` forms plus the `-f` file/stdin escape hatch; elsewhere it shows the single-quote wrapper. The underlying `*QueryError` is wrapped with `%w`, so the agent envelope and `wait` classification still see the structured error.

```
query failed (PARSE_ERROR_SINGLE_QUOTES): ...

DQL string literals must use double quotes ("..."), not single quotes ('...').

Wrap the query in single quotes and use double quotes for values inside:

  dtctl query 'fetch logs | filter status == "ERROR"'
```

**`feat(wait)` — fail fast on permanent query errors.**
A malformed query can never succeed, so `wait` now classifies structured 4xx DQL errors (except 408/429, which stay retryable) as permanent and stops immediately with a clear message and exit code 3, instead of retrying to timeout. Also fixes the built-in `wait` examples, which used single quotes inside the DQL and would themselves have failed to parse.

**`docs(dtctl-skill)` — document DQL string quoting and shell escaping.**
Adds a "String Quoting" section to the DQL reference (covering both the single-quote error and the silent zero-rows trap from an unquoted bareword) and a troubleshooting entry with per-shell command wrappers, so agents stop generating single-quoted DQL values.

## Verification

Reproduced the user's exact commands against a live tenant with the built binary:

- `dtctl query "... status == 'ERROR'"` → exit 1, now prints the quoting hint.
- `dtctl wait query "... status == 'ERROR'" --for=any --timeout 2m` → fails fast in ~400ms with exit 3 (was: retried until the 2m timeout).
- `dtctl query 'fetch logs | filter status == "ERROR"'` (correct form) → still returns rows.

New unit tests: `TestDQLExecutor_ExecuteQueryWithOptions_SingleQuoteHint` (enrichment + `errors.As` still finds `*QueryError`) and `TestWait_PermanentQueryError_FailsFast` (exactly one attempt, `FailureReason == "query error"`). `go test ./pkg/exec/... ./pkg/wait/... ./cmd/... ./pkg/output/...` all pass.

## Notes

Shell detection is intentionally kept simple: the `PARSE_ERROR_SINGLE_QUOTES` trigger is already a near-certain signal of a shell-quoting collision, so no parent-process sniffing is needed to decide whether to show the hint — `runtime.GOOS` only tailors the example (Windows shows PowerShell + cmd.exe forms). This avoids brittle PID-walking to distinguish `powershell.exe` / `pwsh.exe` / `cmd.exe`.
