### PR TITLE
Parse and show correct GraphQL Facade error for breakpoint commands

### DIFF
--- a/cmd/update_breakpoints.go
+++ b/cmd/update_breakpoints.go
@@ -31,6 +31,21 @@ Filters are workspace-scoped, so updating them with --filters also re-scopes
 every existing breakpoint in the workspace. When active breakpoints would be
 affected you are asked to confirm; pass --yes (-y) to skip the prompt.
 
+Condition expressions (--condition):
+  Conditions limit data collection to moments when the expression is true.
+  Supported operators: ==, !=, >, >=, <, <=, in, &&, ||, (), []
+  Use && for AND, || for OR, and parentheses to control precedence.
+  Array and map elements can be indexed with []: arr[4]!=4, dict['a']!=4
+  Use .size() to check collection length: arr.size() >= 32
+
+  Examples:
+    "value>othervalue"
+    "a==1 && b!='bbb'"
+    "(a<=1 || b=='bbb') && (x<y)"
+    "'bbb' in a"
+
+  Docs: https://docs.dynatrace.com/docs/shortlink/do-breakpoints#breakpoint-conditions
+
 Note: Live Debugger support is experimental. The underlying APIs and query
 behavior may change in future releases.
 
@@ -560,7 +575,7 @@ func getOptionalBoolFlag(cmd *cobra.Command, flagName string, trailingArgs []str
 
 func init() {
 	updateCmd.AddCommand(updateBreakpointCmd)
-	updateBreakpointCmd.Flags().String("condition", "", "Condition expression for the breakpoint")
+	updateBreakpointCmd.Flags().String("condition", "", `Condition expression (e.g. "a==1 && b!='bbb'", "'val' in arr", "x>0 && y<=10")`)
 	updateBreakpointCmd.Flags().String("enabled", "", "Enable or disable the breakpoint")
 	updateBreakpointCmd.Flags().String("filters", "", "workspace filters to apply (comma-separated key:value pairs)")
 	updateBreakpointCmd.Flags().BoolP("yes", "y", false, "skip the confirmation prompt when changing workspace filters affects existing breakpoints")

--- a/sdk/api/livedebugger/livedebugger.go
+++ b/sdk/api/livedebugger/livedebugger.go
@@ -465,10 +465,28 @@ func (h *Handler) executeGraphQL(ctx context.Context, query string, variables ma
 	}
 
 	if errorsValue, ok := response["errors"]; ok {
-		return response, fmt.Errorf("live debugger graphql returned errors: %v", errorsValue)
+		return response, fmt.Errorf("live debugger graphql returned errors: %s", extractGraphQLErrorMessages(errorsValue))
 	}
 
 	return response, nil
+}
+
+func extractGraphQLErrorMessages(errorsValue interface{}) string {
+	errs, ok := errorsValue.([]interface{})
+	if !ok {
+		return fmt.Sprintf("%v", errorsValue)
+	}
+	msgs := make([]string, 0, len(errs))
+	for _, e := range errs {
+		if m, ok := e.(map[string]interface{}); ok {
+			if msg, ok := m["message"].(string); ok {
+				msgs = append(msgs, msg)
+				continue
+			}
+		}
+		msgs = append(msgs, fmt.Sprintf("%v", e))
+	}
+	return strings.Join(msgs, "; ")
 }
 
 func buildGraphQLURL(environmentURL string) (string, error) {


### PR DESCRIPTION
Summary
- Fix unreadable [map[message:...]] error output when a breakpoint condition expression is invalid — GraphQL error objects are now parsed and their message fields extracted and joined into a human-readable string
- Add condition expression documentation to dtctl update breakpoint --help, including supported operators, examples, and a link to the Dynatrace docs

Details

When the Live Debugger GraphQL API returned an application-level error (e.g. for an invalid condition expression), the error was formatted with %v directly on the raw []interface{} value, producing output like:

Error: live debugger graphql returned errors: [map[message:Internal Error; dt.correlation_id: GENERATED-307ba5c5-...]]

Now it reads:

Error: live debugger graphql returned errors: Internal Error

This applies to all GraphQL operations (create, edit, delete, enable/disable breakpoints) since they all go through executeGraphQL.

Testing

-  Run dtctl update breakpoint <id> --condition "invalid$$expr" and verify the error message is readable
-  Run dtctl create breakpoint <file:line> --condition "invalid$$expr" and verify the same
-  Run dtctl update breakpoint --help and verify the condition expression section is present with operators, examples, and the docs link
- go test ./... passes