### PR TITLE
fix(auth): cache OAuth access token to cut ~0.5s off every command

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -98,6 +98,18 @@ func buildSessionStatus(contextName string, ctx *config.Context, tokenName strin
 	}
 
 	scopes := strings.Fields(stored.Scope)
+	if len(scopes) == 0 {
+		// Compact keyring storage may drop the scope string to fit size limits
+		// while keeping the (larger) access token cached. Prefer the scope
+		// companion entry, which preserves the full granted scope list; fall
+		// back to the access token's own scope claim (an audience-reduced
+		// subset) only if no companion exists.
+		if cached := tokenManager.CachedScopes(tokenName); len(cached) > 0 {
+			scopes = cached
+		} else if stored.AccessToken != "" {
+			scopes = auth.ExtractJWTScopes(stored.AccessToken)
+		}
+	}
 	if len(scopes) > 0 {
 		status.GrantedScopes = scopes
 	}

--- a/pkg/auth/session_shim.go
+++ b/pkg/auth/session_shim.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/dynatrace-oss/dtctl/pkg/config"
+	sdkauth "github.com/dynatrace-oss/dtctl/sdk/auth"
 	"github.com/dynatrace-oss/dtctl/sdk/session"
 )
 
@@ -56,6 +57,13 @@ func IsOAuthToken(tokenName string) bool   { return session.IsOAuthToken(tokenNa
 func IsTokenExpired(tokens *TokenSet) bool { return session.IsTokenExpired(tokens) }
 func DecodeRefreshTokenExpiry(refreshToken string) (time.Time, bool) {
 	return session.DecodeRefreshTokenExpiry(refreshToken)
+}
+
+// ExtractJWTScopes returns the granted scopes decoded from a JWT access token,
+// or nil when they cannot be determined. Used as a fallback for scope display
+// when the scope string was dropped from compact keyring storage.
+func ExtractJWTScopes(accessToken string) []string {
+	return sdkauth.ExtractJWTScopes(accessToken)
 }
 
 // GetScopesForSafetyLevel returns the OAuth scopes required for a given safety

--- a/sdk/auth/token.go
+++ b/sdk/auth/token.go
@@ -97,3 +97,60 @@ func ExtractJWTSubject(token string) (string, error) {
 
 	return claims.Sub, nil
 }
+
+// ExtractJWTScopes extracts the granted scopes from a JWT access token. It reads
+// the "scope" claim (a space-delimited string) or, failing that, the "scp"
+// claim (either a space-delimited string or an array of strings). It returns
+// nil when the token is not a decodable JWT, is a Dynatrace platform token
+// (dt0s16.*, not a JWT), or carries no recognizable scope claim. Callers use
+// this as a best-effort fallback for displaying scopes when the scope string
+// was dropped from compact keyring storage.
+func ExtractJWTScopes(token string) []string {
+	if token == "" || IsPlatformToken(token) {
+		return nil
+	}
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil
+	}
+
+	payload := parts[1]
+	if pad := len(payload) % 4; pad > 0 {
+		payload += strings.Repeat("=", 4-pad)
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(payload)
+	if err != nil {
+		return nil
+	}
+
+	var claims struct {
+		Scope string          `json:"scope"`
+		Scp   json.RawMessage `json:"scp"`
+	}
+	if err := json.Unmarshal(decoded, &claims); err != nil {
+		return nil
+	}
+
+	if scopes := strings.Fields(claims.Scope); len(scopes) > 0 {
+		return scopes
+	}
+
+	// "scp" may be encoded as a JSON array of strings or as a single
+	// space-delimited string, depending on the issuer.
+	if len(claims.Scp) > 0 {
+		var arr []string
+		if err := json.Unmarshal(claims.Scp, &arr); err == nil && len(arr) > 0 {
+			return arr
+		}
+		var str string
+		if err := json.Unmarshal(claims.Scp, &str); err == nil {
+			if scopes := strings.Fields(str); len(scopes) > 0 {
+				return scopes
+			}
+		}
+	}
+
+	return nil
+}

--- a/sdk/auth/token_test.go
+++ b/sdk/auth/token_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"testing"
 )
 
@@ -87,5 +88,66 @@ func TestExtractJWTSubject(t *testing.T) {
 	_, err = ExtractJWTSubject("not-a-jwt")
 	if err == nil {
 		t.Error("expected error for invalid JWT")
+	}
+}
+
+// makeJWT builds a minimal unsigned JWT (header.payload.signature) whose
+// payload is the JSON encoding of claims. Only the payload is decoded by
+// ExtractJWTScopes, so header and signature are placeholders.
+func makeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	return header + "." + body + ".sig"
+}
+
+func TestExtractJWTScopes(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  []string
+	}{
+		{
+			name:  "scope claim, space-delimited",
+			token: makeJWT(t, map[string]any{"scope": "storage:logs:read storage:events:read"}),
+			want:  []string{"storage:logs:read", "storage:events:read"},
+		},
+		{
+			name:  "scp claim as array",
+			token: makeJWT(t, map[string]any{"scp": []string{"openid", "offline_access"}}),
+			want:  []string{"openid", "offline_access"},
+		},
+		{
+			name:  "scp claim as string",
+			token: makeJWT(t, map[string]any{"scp": "openid offline_access"}),
+			want:  []string{"openid", "offline_access"},
+		},
+		{
+			name:  "scope preferred over scp",
+			token: makeJWT(t, map[string]any{"scope": "a b", "scp": []string{"c"}}),
+			want:  []string{"a", "b"},
+		},
+		{name: "no scope claim", token: makeJWT(t, map[string]any{"sub": "user-1"}), want: nil},
+		{name: "empty token", token: "", want: nil},
+		{name: "not a jwt", token: "not-a-jwt", want: nil},
+		{name: "platform token is not a jwt", token: "dt0s16.ABC.DEF", want: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractJWTScopes(tc.token)
+			if len(got) != len(tc.want) {
+				t.Fatalf("ExtractJWTScopes() = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("scope[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
 	}
 }

--- a/sdk/session/token_manager.go
+++ b/sdk/session/token_manager.go
@@ -21,6 +21,12 @@ const (
 
 	// TokenRefreshBuffer is how long before expiry we refresh tokens
 	TokenRefreshBuffer = 5 * time.Minute
+
+	// scopeCompanionSuffix names a keyring entry that holds only the granted
+	// scope string. It preserves the scope list — permission names, not a
+	// secret — when the primary token entry had to drop it to fit the keyring
+	// item size limit while keeping the (larger) access token cached.
+	scopeCompanionSuffix = ":scopes"
 )
 
 // TokenManager manages OAuth tokens including storage and refresh
@@ -287,7 +293,8 @@ func (tm *TokenManager) DeleteToken(tokenName string) error {
 
 	if tm.deps.keyringAvailable() {
 		err := tm.deps.deleteToken(tm.tokenStore, keyringName)
-		// Best-effort cleanup of any file-based fallback token.
+		// Best-effort cleanup of the scope companion and any file-based fallback token.
+		_ = tm.deps.deleteToken(tm.tokenStore, keyringName+scopeCompanionSuffix)
 		_ = tm.deps.fileDeleteToken(keyringName)
 		return err
 	}
@@ -316,8 +323,31 @@ func (tm *TokenManager) needsRefresh(tokens *TokenSet) bool {
 		return false
 	}
 
-	// Refresh if token expires within the buffer period
-	return time.Now().Add(TokenRefreshBuffer).After(tokens.ExpiresAt)
+	// Refresh if token expires within the buffer period.
+	return time.Now().Add(refreshBufferFor(tokens)).After(tokens.ExpiresAt)
+}
+
+// refreshBufferFor returns how long before expiry a token should be refreshed.
+//
+// The default buffer (TokenRefreshBuffer, 5 min) suits long-lived tokens, but
+// some Dynatrace SSO environments issue short-lived access tokens (~5 min).
+// When the token's lifetime is at or below the fixed buffer, every GetToken
+// call sees the token as "about to expire" and refreshes — an SSO round-trip
+// on every invocation that defeats the cached-token fast path. When the token
+// lifetime is known (ExpiresIn), cap the buffer at a fraction of it (with a
+// small floor) so a freshly cached token is reused for most of its life while
+// still being refreshed slightly ahead of expiry.
+func refreshBufferFor(tokens *TokenSet) time.Duration {
+	buffer := TokenRefreshBuffer
+	if tokens.ExpiresIn > 0 {
+		if capped := time.Duration(tokens.ExpiresIn) * time.Second / 5; capped < buffer {
+			buffer = capped
+		}
+		if buffer < 30*time.Second {
+			buffer = 30 * time.Second
+		}
+	}
+	return buffer
 }
 
 // loadToken loads a token from storage
@@ -368,55 +398,61 @@ func (tm *TokenManager) loadToken(tokenName string) (*StoredToken, error) {
 	return nil, fmt.Errorf("OAuth tokens require a storage backend (keyring or file); set %s=file to use file-based storage", EnvTokenStorage)
 }
 
-// saveToken saves a token to storage
+// saveToken saves a token to storage.
+//
+// The full token set (access + ID token JWTs + scope) can exceed a keyring
+// backend's per-item size limit — most notably the macOS Keychain, where the
+// full JSON routinely overflows. Rather than immediately dropping the access
+// token (which would defeat GetToken's fast path and force an SSO refresh on
+// every invocation), saveToken tries progressively smaller keyring encodings
+// via keyringEncodings, keeping the access token as long as it fits. Only when
+// even the access token alone is too large does it fall back to an
+// access-token-less form, and finally to file storage that can hold the full
+// token.
 func (tm *TokenManager) saveToken(tokenName string, stored *StoredToken) error {
 	keyringName := tm.getKeyringName(tokenName)
 
-	// Serialize token
-	data, err := json.Marshal(stored)
+	// Serialize the full token for the file-store fallback below.
+	fullData, err := json.Marshal(stored)
 	if err != nil {
 		return fmt.Errorf("failed to serialize token: %w", err)
 	}
 
 	// Save to keyring
 	if tm.deps.keyringAvailable() {
-		if err := tm.deps.setToken(tm.tokenStore, keyringName, string(data)); err != nil {
-			// Full token is too large for the keyring. Try medium-compact first: drop the
-			// access and ID token JWTs but keep scope and expiry so auth status / doctor
-			// can still show meaningful information.
-			medium := mediumCompactStoredTokenForKeyring(stored)
-			mediumData, marshalErr := json.Marshal(medium)
-			if marshalErr == nil {
-				if mediumErr := tm.deps.setToken(tm.tokenStore, keyringName, string(mediumData)); mediumErr == nil {
-					return nil
-				}
-			}
-			// Still too large — fall back to minimal compact (refresh token + name only).
-			compact := compactStoredTokenForKeyring(stored)
-			compactData, marshalErr := json.Marshal(compact)
+		var lastErr error
+		for _, enc := range keyringEncodings(stored) {
+			data, marshalErr := json.Marshal(enc)
 			if marshalErr != nil {
-				return fmt.Errorf("failed to save token to keyring: %w", err)
+				lastErr = marshalErr
+				continue
 			}
-			if compactErr := tm.deps.setToken(tm.tokenStore, keyringName, string(compactData)); compactErr != nil {
-				// Even the refresh token alone exceeds the keyring limit (e.g. macOS Keychain).
-				// Fall back to file storage as a last resort.
-				if isKeyringTooLargeErr(compactErr) {
-					if fileErr := tm.deps.fileSetToken(keyringName, string(data)); fileErr == nil {
-						// Remove any stale keyring entry so loadToken reads from file next time.
-						_ = tm.deps.deleteToken(tm.tokenStore, keyringName)
-						return nil
-					}
-				}
-				return fmt.Errorf("failed to save token to keyring: %w (compact fallback also failed: %v)", err, compactErr)
+			if setErr := tm.deps.setToken(tm.tokenStore, keyringName, string(data)); setErr == nil {
+				tm.syncScopeCompanion(keyringName, stored.Scope, enc.Scope)
+				return nil
+			} else {
+				lastErr = setErr
 			}
-			return nil
 		}
-		return nil
+		// Even the minimal (refresh-token-only) encoding could not be written.
+		// If that was a size limit, fall back to file storage, which can hold
+		// the full token (including the access token, so the fast path still
+		// works). Any other error (locked/corrupt keyring) is returned as-is.
+		if isKeyringTooLargeErr(lastErr) {
+			if fileErr := tm.deps.fileSetToken(keyringName, string(fullData)); fileErr == nil {
+				// Remove any stale keyring entry (and scope companion) so loadToken
+				// reads the full token — scope included — from the file next time.
+				_ = tm.deps.deleteToken(tm.tokenStore, keyringName)
+				_ = tm.deps.deleteToken(tm.tokenStore, keyringName+scopeCompanionSuffix)
+				return nil
+			}
+		}
+		return fmt.Errorf("failed to save token to keyring: %w", lastErr)
 	}
 
 	// Fall back to file-based storage
 	if tm.deps.fileStoreAvailable() {
-		if err := tm.deps.fileSetToken(keyringName, string(data)); err != nil {
+		if err := tm.deps.fileSetToken(keyringName, string(fullData)); err != nil {
 			return fmt.Errorf("failed to save token to file store: %w", err)
 		}
 		return nil
@@ -434,6 +470,56 @@ func isKeyringTooLargeErr(err error) bool {
 	}
 	msg := err.Error()
 	return strings.Contains(msg, "too big") || strings.Contains(msg, "exit status 161")
+}
+
+// keyringEncodings returns candidate serializations of stored for the keyring,
+// ordered from most complete to most compact. saveToken tries each in turn and
+// keeps the first that fits the backend's size limit.
+//
+// The ordering deliberately prefers retaining the access token (and its
+// expiry) over the id_token and the scope string, because a cached access
+// token lets GetToken's fast path skip the ~1s SSO refresh round-trip on every
+// invocation. The id_token is unused past login, and when the scope string is
+// dropped saveToken preserves it in a scope-companion entry (see
+// syncScopeCompanion), so dropping either from the primary entry is lossless.
+// Only when the access token itself does not fit do we fall back to the
+// access-token-less medium/minimal forms.
+func keyringEncodings(stored *StoredToken) []*StoredToken {
+	return []*StoredToken{
+		stored,                                     // full: access + id + scope + refresh
+		withoutIDTokenForKeyring(stored),           // drop id_token; keep access + scope
+		accessOnlyStoredTokenForKeyring(stored),    // drop id_token + scope; keep access (scope -> companion)
+		mediumCompactStoredTokenForKeyring(stored), // drop access + id; keep scope (no fast path)
+		compactStoredTokenForKeyring(stored),       // minimal: refresh token + name only
+	}
+}
+
+// withoutIDTokenForKeyring drops only the id_token JWT (unused by dtctl beyond
+// login), keeping the access token, scope, and expiry so both GetToken's fast
+// path and auth-status scope display keep working.
+func withoutIDTokenForKeyring(stored *StoredToken) *StoredToken {
+	if stored == nil {
+		return nil
+	}
+
+	compact := *stored
+	compact.IDToken = ""
+	return &compact
+}
+
+// accessOnlyStoredTokenForKeyring keeps the access token and its expiry (so the
+// fast path works) but drops the id_token JWT and the large scope string. The
+// dropped scope is preserved in the scope-companion entry so auth status still
+// shows the full granted scopes.
+func accessOnlyStoredTokenForKeyring(stored *StoredToken) *StoredToken {
+	if stored == nil {
+		return nil
+	}
+
+	compact := *stored
+	compact.IDToken = ""
+	compact.Scope = ""
+	return &compact
 }
 
 // mediumCompactStoredTokenForKeyring drops the large access/ID token JWTs but
@@ -464,6 +550,41 @@ func compactStoredTokenForKeyring(stored *StoredToken) *StoredToken {
 	compact.ExpiresIn = 0
 	compact.ExpiresAt = time.Time{}
 	return &compact
+}
+
+// syncScopeCompanion keeps the scope-companion keyring entry in sync with what
+// the primary token encoding actually stored. When the primary encoding had to
+// drop the scope string to fit the keyring size limit (origScope is non-empty
+// but the stored encoding's scope is empty), the scope is preserved in a
+// companion entry so auth status and doctor can still show the full granted
+// scopes without keeping the large scope string in the primary entry. In every
+// other case any stale companion is removed. The scope list is not a secret, so
+// this introduces no credential exposure. Best-effort: errors are ignored since
+// the companion is a display aid, not required for authentication.
+func (tm *TokenManager) syncScopeCompanion(keyringName, origScope, storedScope string) {
+	companion := keyringName + scopeCompanionSuffix
+	if origScope != "" && storedScope == "" {
+		_ = tm.deps.setToken(tm.tokenStore, companion, origScope)
+		return
+	}
+	_ = tm.deps.deleteToken(tm.tokenStore, companion)
+}
+
+// CachedScopes returns the granted scopes preserved in the scope-companion
+// keyring entry, or nil when there is none. It is used as a fallback for scope
+// display when the primary token entry dropped the scope string to fit size
+// limits. Only consulted for keyring storage; the file store keeps the full
+// token (scope included), so no companion is needed there.
+func (tm *TokenManager) CachedScopes(tokenName string) []string {
+	if !tm.deps.keyringAvailable() {
+		return nil
+	}
+	companion := tm.getKeyringName(tokenName) + scopeCompanionSuffix
+	v, err := tm.deps.getToken(tm.tokenStore, companion)
+	if err != nil || v == "" {
+		return nil
+	}
+	return strings.Fields(v)
 }
 
 // getKeyringName returns the keyring storage name for a token

--- a/sdk/session/token_manager_refresh_lock_test.go
+++ b/sdk/session/token_manager_refresh_lock_test.go
@@ -224,6 +224,14 @@ func TestTokenManager_RefreshToken_ConcurrentRotation(t *testing.T) {
 		store[name] = val
 		return nil
 	}
+	// saveToken clears the scope-companion entry after a successful write, so
+	// deleteToken must share the same lock as get/set.
+	tm.deps.deleteToken = func(_ *TokenStore, name string) error {
+		storeMu.Lock()
+		defer storeMu.Unlock()
+		delete(store, name)
+		return nil
+	}
 
 	// Rotation-faithful provider: each refresh token is single-use.
 	var providerMu sync.Mutex

--- a/sdk/session/token_manager_save_test.go
+++ b/sdk/session/token_manager_save_test.go
@@ -1,0 +1,375 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTMWithSizedKeyring returns a TokenManager backed by an in-memory keyring
+// that rejects any value longer than limitBytes with a macOS-style
+// "too big" error, plus an in-memory file store used as the last-resort
+// fallback. The returned maps expose what actually got persisted.
+func newTMWithSizedKeyring(t *testing.T, limitBytes int) (tm *TokenManager, keyring, files map[string]string) {
+	t.Helper()
+	keyring = make(map[string]string)
+	files = make(map[string]string)
+
+	oauthCfg := OAuthConfigForEnvironment(EnvironmentProd, DefaultSafetyLevel, nil)
+	var err error
+	tm, err = NewTokenManager(oauthCfg)
+	if err != nil {
+		t.Fatalf("NewTokenManager() error: %v", err)
+	}
+
+	tm.deps.keyringAvailable = func() bool { return true }
+	tm.deps.getToken = func(_ *TokenStore, name string) (string, error) {
+		v, ok := keyring[name]
+		if !ok {
+			return "", fmt.Errorf("token %q not found in keyring", name)
+		}
+		return v, nil
+	}
+	tm.deps.setToken = func(_ *TokenStore, name, val string) error {
+		if limitBytes >= 0 && len(val) > limitBytes {
+			return fmt.Errorf("data passed to Set was too big") // matches isKeyringTooLargeErr
+		}
+		keyring[name] = val
+		return nil
+	}
+	tm.deps.deleteToken = func(_ *TokenStore, name string) error {
+		delete(keyring, name)
+		return nil
+	}
+	tm.deps.fileStoreAvailable = func() bool { return false }
+	tm.deps.fileSetToken = func(name, val string) error {
+		files[name] = val
+		return nil
+	}
+	tm.deps.fileGetToken = func(name string) (string, error) {
+		v, ok := files[name]
+		if !ok {
+			return "", fmt.Errorf("token %q not found in file store", name)
+		}
+		return v, nil
+	}
+	tm.deps.fileDeleteToken = func(name string) error {
+		delete(files, name)
+		return nil
+	}
+	return tm, keyring, files
+}
+
+func sampleStoredToken() *StoredToken {
+	return &StoredToken{
+		Name: "my-token",
+		TokenSet: TokenSet{
+			AccessToken:  "ACCESS-" + strings.Repeat("a", 1000),
+			RefreshToken: "refresh-token",
+			IDToken:      "IDT-" + strings.Repeat("i", 1000),
+			TokenType:    "Bearer",
+			ExpiresIn:    3600,
+			Scope:        "openid " + strings.Repeat("scope ", 200),
+			ExpiresAt:    time.Now().Add(1 * time.Hour).UTC(),
+		},
+	}
+}
+
+func mustLen(t *testing.T, v any) int {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return len(b)
+}
+
+// TestSaveToken_PreservesAccessTokenUnderSizeLimit is the core regression test
+// for the "access token stripped on macOS" bug: when the full token set is too
+// large for the keyring but a smaller encoding that still contains the access
+// token fits, saveToken must persist that encoding — not fall straight to the
+// access-token-less form. Without the fix, GetToken's fast path never hits and
+// every invocation pays an SSO refresh.
+func TestSaveToken_PreservesAccessTokenUnderSizeLimit(t *testing.T) {
+	t.Parallel()
+	// Access token larger than the scope string, so every encoding that drops
+	// a field is strictly smaller than the one before it. This exercises the
+	// full tier ladder (full -> noID -> accessOnly -> medium -> minimal) in a
+	// single, deterministic ordering.
+	stored := sampleStoredToken()
+	stored.AccessToken = "ACCESS-" + strings.Repeat("a", 4000)
+
+	sizeFull := mustLen(t, stored)
+	sizeNoID := mustLen(t, withoutIDTokenForKeyring(stored))
+	sizeAccessOnly := mustLen(t, accessOnlyStoredTokenForKeyring(stored))
+	sizeMedium := mustLen(t, mediumCompactStoredTokenForKeyring(stored))
+	sizeMinimal := mustLen(t, compactStoredTokenForKeyring(stored))
+
+	// With access > id ~ scope, the ladder shrinks monotonically.
+	if !(sizeFull > sizeNoID && sizeNoID > sizeAccessOnly && sizeAccessOnly > sizeMedium && sizeMedium > sizeMinimal) {
+		t.Fatalf("expected monotonically shrinking encodings, got full=%d noID=%d accessOnly=%d medium=%d minimal=%d",
+			sizeFull, sizeNoID, sizeAccessOnly, sizeMedium, sizeMinimal)
+	}
+
+	tests := []struct {
+		name          string
+		limit         int
+		wantAccess    bool
+		wantScope     bool
+		wantID        bool
+		wantFileStore bool
+	}{
+		{name: "full fits", limit: sizeFull, wantAccess: true, wantScope: true, wantID: true},
+		{name: "drop id_token only", limit: sizeNoID, wantAccess: true, wantScope: true, wantID: false},
+		{name: "access-only (drop id+scope)", limit: sizeAccessOnly, wantAccess: true, wantScope: false, wantID: false},
+		{name: "medium (drop access, keep scope)", limit: sizeMedium, wantAccess: false, wantScope: true, wantID: false},
+		{name: "minimal (refresh only)", limit: sizeMinimal, wantAccess: false, wantScope: false, wantID: false},
+		{name: "smaller than minimal -> file store", limit: sizeMinimal - 1, wantFileStore: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tm, keyring, files := newTMWithSizedKeyring(t, tc.limit)
+			key := tm.getKeyringName("my-token")
+
+			if err := tm.saveToken("my-token", stored); err != nil {
+				t.Fatalf("saveToken() error = %v", err)
+			}
+
+			if tc.wantFileStore {
+				if _, ok := keyring[key]; ok {
+					t.Errorf("keyring entry should be absent when spilled to file store")
+				}
+				raw, ok := files[key]
+				if !ok {
+					t.Fatalf("expected token in file store, none found")
+				}
+				var got StoredToken
+				if err := json.Unmarshal([]byte(raw), &got); err != nil {
+					t.Fatalf("unmarshal file token: %v", err)
+				}
+				// File store holds the full token, including the access token.
+				if got.AccessToken != stored.AccessToken {
+					t.Errorf("file store access token = %q, want full access token", got.AccessToken)
+				}
+				return
+			}
+
+			raw, ok := keyring[key]
+			if !ok {
+				t.Fatalf("expected token in keyring, none found")
+			}
+			var got StoredToken
+			if err := json.Unmarshal([]byte(raw), &got); err != nil {
+				t.Fatalf("unmarshal keyring token: %v", err)
+			}
+
+			if hasAccess := got.AccessToken != ""; hasAccess != tc.wantAccess {
+				t.Errorf("access token present = %v, want %v", hasAccess, tc.wantAccess)
+			}
+			if hasScope := got.Scope != ""; hasScope != tc.wantScope {
+				t.Errorf("scope present = %v, want %v", hasScope, tc.wantScope)
+			}
+			if hasID := got.IDToken != ""; hasID != tc.wantID {
+				t.Errorf("id token present = %v, want %v", hasID, tc.wantID)
+			}
+			// The refresh token must survive in every keyring encoding.
+			if got.RefreshToken != stored.RefreshToken {
+				t.Errorf("refresh token = %q, want %q", got.RefreshToken, stored.RefreshToken)
+			}
+			// Any encoding that keeps the access token must keep its expiry so
+			// GetToken's fast path (AccessToken != "" && !needsRefresh) works.
+			if tc.wantAccess && got.ExpiresAt.IsZero() {
+				t.Errorf("expiry must be preserved alongside a cached access token")
+			}
+		})
+	}
+}
+
+// TestSaveToken_RoundTripsThroughGetTokenFastPath verifies that after saving a
+// token whose full form is too large for the keyring but whose access token
+// still fits, GetToken returns the cached access token without contacting the
+// OAuth endpoint.
+func TestSaveToken_RoundTripsThroughGetTokenFastPath(t *testing.T) {
+	t.Parallel()
+	stored := sampleStoredToken()
+	limit := mustLen(t, withoutIDTokenForKeyring(stored)) // full won't fit, no-id will
+
+	tm, _, _ := newTMWithSizedKeyring(t, limit)
+	var refreshCalled bool
+	tm.flow.httpDo = func(_ *http.Request) (*http.Response, error) {
+		refreshCalled = true
+		return nil, fmt.Errorf("OAuth endpoint must not be called on fast path")
+	}
+
+	if err := tm.saveToken("my-token", stored); err != nil {
+		t.Fatalf("saveToken() error = %v", err)
+	}
+
+	got, err := tm.GetToken("my-token")
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if got != stored.AccessToken {
+		t.Errorf("GetToken() = %q, want cached access token", got)
+	}
+	if refreshCalled {
+		t.Error("GetToken() triggered an OAuth refresh despite a cached, unexpired access token")
+	}
+}
+
+// TestSaveToken_ScopeCompanion verifies that the scope string is preserved in
+// a companion keyring entry exactly when the primary encoding had to drop it
+// (access token kept, scope dropped), and that CachedScopes reads it back. When
+// the primary encoding keeps the scope, no companion is written.
+func TestSaveToken_ScopeCompanion(t *testing.T) {
+	t.Parallel()
+	stored := sampleStoredToken()
+	stored.AccessToken = "ACCESS-" + strings.Repeat("a", 4000)
+	companionKey := func(tm *TokenManager) string { return tm.getKeyringName("my-token") + scopeCompanionSuffix }
+	wantScopes := strings.Fields(stored.Scope)
+
+	t.Run("scope dropped -> companion written and readable", func(t *testing.T) {
+		limit := mustLen(t, accessOnlyStoredTokenForKeyring(stored)) // keeps access, drops scope
+		tm, keyring, _ := newTMWithSizedKeyring(t, limit)
+		if err := tm.saveToken("my-token", stored); err != nil {
+			t.Fatalf("saveToken() error = %v", err)
+		}
+		if got := keyring[companionKey(tm)]; got != stored.Scope {
+			t.Errorf("companion scope = %q, want the full scope string", got)
+		}
+		got := tm.CachedScopes("my-token")
+		if len(got) != len(wantScopes) {
+			t.Fatalf("CachedScopes() = %d scopes, want %d", len(got), len(wantScopes))
+		}
+	})
+
+	t.Run("scope kept -> no companion", func(t *testing.T) {
+		limit := mustLen(t, withoutIDTokenForKeyring(stored)) // keeps access AND scope
+		tm, keyring, _ := newTMWithSizedKeyring(t, limit)
+		if err := tm.saveToken("my-token", stored); err != nil {
+			t.Fatalf("saveToken() error = %v", err)
+		}
+		if _, ok := keyring[companionKey(tm)]; ok {
+			t.Error("companion entry should not exist when scope is kept in the primary entry")
+		}
+		if got := tm.CachedScopes("my-token"); got != nil {
+			t.Errorf("CachedScopes() = %v, want nil", got)
+		}
+	})
+
+	t.Run("re-save with scope kept clears a stale companion", func(t *testing.T) {
+		tm, keyring, _ := newTMWithSizedKeyring(t, mustLen(t, accessOnlyStoredTokenForKeyring(stored)))
+		if err := tm.saveToken("my-token", stored); err != nil {
+			t.Fatalf("saveToken() error = %v", err)
+		}
+		if _, ok := keyring[companionKey(tm)]; !ok {
+			t.Fatal("expected companion to be written on first save")
+		}
+		// Raise the limit so the next save keeps the scope in the primary entry.
+		tm.deps.setToken = func(_ *TokenStore, name, val string) error {
+			keyring[name] = val
+			return nil
+		}
+		if err := tm.saveToken("my-token", stored); err != nil {
+			t.Fatalf("saveToken() error = %v", err)
+		}
+		if _, ok := keyring[companionKey(tm)]; ok {
+			t.Error("stale companion should have been removed when scope fits in the primary entry")
+		}
+	})
+
+	t.Run("DeleteToken removes the companion", func(t *testing.T) {
+		tm, keyring, _ := newTMWithSizedKeyring(t, mustLen(t, accessOnlyStoredTokenForKeyring(stored)))
+		if err := tm.saveToken("my-token", stored); err != nil {
+			t.Fatalf("saveToken() error = %v", err)
+		}
+		if _, ok := keyring[companionKey(tm)]; !ok {
+			t.Fatal("expected companion before delete")
+		}
+		if err := tm.DeleteToken("my-token"); err != nil {
+			t.Fatalf("DeleteToken() error = %v", err)
+		}
+		if _, ok := keyring[companionKey(tm)]; ok {
+			t.Error("companion entry should be removed by DeleteToken")
+		}
+	})
+}
+
+// TestNeedsRefresh_AdaptiveBufferForShortLivedTokens verifies that a token
+// whose lifetime is at or below the fixed 5-minute refresh buffer is still
+// reused for most of its life (rather than refreshed on every call), while
+// long-lived tokens keep the full 5-minute buffer.
+func TestNeedsRefresh_AdaptiveBufferForShortLivedTokens(t *testing.T) {
+	t.Parallel()
+	tm, _, _ := newTMWithSizedKeyring(t, 1<<20)
+
+	tests := []struct {
+		name        string
+		expiresIn   int
+		remaining   time.Duration
+		wantRefresh bool
+	}{
+		{name: "5m token, 4m left -> reuse", expiresIn: 300, remaining: 4 * time.Minute, wantRefresh: false},
+		{name: "5m token, 20s left -> refresh", expiresIn: 300, remaining: 20 * time.Second, wantRefresh: true},
+		{name: "1h token, 3m left -> refresh (full 5m buffer)", expiresIn: 3600, remaining: 3 * time.Minute, wantRefresh: true},
+		{name: "1h token, 10m left -> reuse", expiresIn: 3600, remaining: 10 * time.Minute, wantRefresh: false},
+		{name: "unknown lifetime, 3m left -> refresh (default buffer)", expiresIn: 0, remaining: 3 * time.Minute, wantRefresh: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tok := &TokenSet{
+				AccessToken: "a",
+				ExpiresIn:   tc.expiresIn,
+				ExpiresAt:   time.Now().Add(tc.remaining),
+			}
+			if got := tm.needsRefresh(tok); got != tc.wantRefresh {
+				t.Errorf("needsRefresh() = %v, want %v", got, tc.wantRefresh)
+			}
+		})
+	}
+}
+
+func TestKeyringEncodingHelpers(t *testing.T) {
+	t.Parallel()
+	stored := sampleStoredToken()
+
+	noID := withoutIDTokenForKeyring(stored)
+	if noID.AccessToken != stored.AccessToken || noID.Scope != stored.Scope || noID.RefreshToken != stored.RefreshToken {
+		t.Error("withoutIDTokenForKeyring must keep access, scope, and refresh tokens")
+	}
+	if noID.IDToken != "" {
+		t.Errorf("withoutIDTokenForKeyring IDToken = %q, want empty", noID.IDToken)
+	}
+	if noID.ExpiresAt.IsZero() {
+		t.Error("withoutIDTokenForKeyring must preserve ExpiresAt")
+	}
+
+	accessOnly := accessOnlyStoredTokenForKeyring(stored)
+	if accessOnly.AccessToken != stored.AccessToken || accessOnly.RefreshToken != stored.RefreshToken {
+		t.Error("accessOnlyStoredTokenForKeyring must keep access and refresh tokens")
+	}
+	if accessOnly.IDToken != "" || accessOnly.Scope != "" {
+		t.Errorf("accessOnlyStoredTokenForKeyring must drop id_token and scope, got id=%q scope=%q", accessOnly.IDToken, accessOnly.Scope)
+	}
+	if accessOnly.ExpiresAt.IsZero() {
+		t.Error("accessOnlyStoredTokenForKeyring must preserve ExpiresAt")
+	}
+
+	if withoutIDTokenForKeyring(nil) != nil || accessOnlyStoredTokenForKeyring(nil) != nil {
+		t.Error("nil input must return nil")
+	}
+
+	// keyringEncodings must be ordered largest-to-smallest and start with the
+	// unmodified full token.
+	encs := keyringEncodings(stored)
+	if len(encs) != 5 {
+		t.Fatalf("keyringEncodings returned %d encodings, want 5", len(encs))
+	}
+	if encs[0] != stored {
+		t.Error("first encoding must be the full, unmodified token")
+	}
+}


### PR DESCRIPTION
## Problem

Every `dtctl` invocation re-ran the SSO refresh-token exchange, adding **~0.5–1s of latency to every command**. A cross-process access-token cache already exists (`GetToken` fast path + refresh lock), but two issues combined to defeat it:

1. **macOS Keychain size limit.** The full token JSON (access + id token JWTs + the ~1.8 KB scope string) overflows the Keychain item limit, so `saveToken` fell straight to a compact encoding that **strips the access token**. The fast path (`AccessToken != "" && !needsRefresh`) could therefore never hit — `auth status` reported `accessTokenPresent: false` and every call refreshed.
2. **Refresh buffer ≥ token lifetime.** `TokenRefreshBuffer` (5 min) is at or above the lifetime of the short-lived access tokens some Dynatrace SSO environments issue (~5 min), so `needsRefresh` was *always* true — even once an access token was cached, it rotated on every call.

## Fix

- **Tiered keyring encoding.** `saveToken` now tries progressively smaller encodings and keeps the access token as long as it fits:
  `full → drop id_token → drop id_token+scope → access-less (old behavior) → minimal`. The last-resort file store still holds the full token.
- **Scope companion.** When the scope string must be dropped to make room for the access token, it is preserved in a small companion Keychain entry (permission names — not a secret), so `auth status` still shows the full granted scopes. Recovery order in `auth status`: primary entry → companion → the access token's own `scope` claim.
- **Adaptive refresh buffer.** `needsRefresh` caps the buffer at a fraction of the token lifetime (with a 30 s floor) when `ExpiresIn` is known, so short-lived tokens are reused for most of their life. Long-lived tokens keep the full 5 min buffer, and tokens with unknown lifetime are unchanged.

## Verification

Unit tests cover the encoding ladder, the scope-companion lifecycle (write / clear / delete), the adaptive buffer, and a fast-path round trip that asserts the OAuth endpoint is **not** contacted.

End-to-end against a dev tenant:

| | before | after |
|---|---|---|
| `auth status` accessTokenPresent | `false` | `true` |
| granted scopes shown | 72 | 72 (via companion) |
| access token across N queries | rotates every call | stable (fast path) |
| repeated `dtctl query` latency | ~1.4 s | ~0.9 s |

## Notes

- No credential moves to disk: the access token stays in the Keychain; only the non-secret scope list goes to the companion entry. The file-store fallback (for when even the refresh token alone won't fit) is unchanged.
- Existing `needsRefresh`/save-fallback tests are unaffected (they don't set `ExpiresIn`, so the 5 min buffer and prior fallback ordering are preserved).
