### PR TITLE
fix(config): normalize environment URL scheme on context creation

### DIFF
--- a/sdk/session/config.go
+++ b/sdk/session/config.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/adrg/xdg"
 	"gopkg.in/yaml.v3"
+
+	"github.com/dynatrace-oss/dtctl/sdk/urls"
 )
 
 // Config represents the dtctl configuration
@@ -733,6 +735,8 @@ func (c *Config) SetContext(name, environment, tokenRef string) {
 
 // SetContextWithOptions creates or updates a context with optional fields
 func (c *Config) SetContextWithOptions(name, environment, tokenRef string, opts *ContextOptions) {
+	environment = urls.Normalize(environment)
+
 	for i, nc := range c.Contexts {
 		if nc.Name == name {
 			c.Contexts[i].Context.Environment = environment

--- a/sdk/session/config_test.go
+++ b/sdk/session/config_test.go
@@ -90,6 +90,23 @@ func TestConfig_SetContext(t *testing.T) {
 	}
 }
 
+func TestConfig_SetContext_NormalizesEnvironmentScheme(t *testing.T) {
+	cfg := NewConfig()
+
+	// A bare host without a scheme must be stored with https:// so that later
+	// queries don't fail with "unsupported protocol scheme".
+	cfg.SetContext("dev", "abc12345.apps.dynatrace.com", "dev-token")
+	if got := cfg.Contexts[0].Context.Environment; got != "https://abc12345.apps.dynatrace.com" {
+		t.Errorf("Environment = %v, want https://abc12345.apps.dynatrace.com", got)
+	}
+
+	// An explicit scheme is preserved as-is.
+	cfg.SetContext("local", "http://127.0.0.1:8080", "local-token")
+	if got := cfg.Contexts[1].Context.Environment; got != "http://127.0.0.1:8080" {
+		t.Errorf("Environment = %v, want http://127.0.0.1:8080", got)
+	}
+}
+
 func TestConfig_SetToken(t *testing.T) {
 	cfg := NewConfig()
 

--- a/sdk/urls/urls.go
+++ b/sdk/urls/urls.go
@@ -15,6 +15,23 @@ type Problem struct {
 	SuggestedURL string
 }
 
+// Normalize returns the environment URL with an "https://" scheme prepended when
+// no scheme is present. A URL that already carries an http:// or https:// scheme,
+// or is empty, is returned unchanged. Without a scheme Go's HTTP client rejects
+// requests with "unsupported protocol scheme", so a context stored from a bare
+// host (e.g. "abc12345.apps.dynatrace.com") would authenticate yet fail on every
+// query. Normalize does not correct the domain-level mistakes reported by Check.
+func Normalize(environmentURL string) string {
+	if environmentURL == "" {
+		return environmentURL
+	}
+	lower := strings.ToLower(environmentURL)
+	if !strings.HasPrefix(lower, "https://") && !strings.HasPrefix(lower, "http://") {
+		return "https://" + environmentURL
+	}
+	return environmentURL
+}
+
 // Check inspects a Dynatrace environment URL for common mistakes.
 // It returns a list of problems found (empty if the URL looks correct).
 func Check(environmentURL string) []Problem {

--- a/sdk/urls/urls_test.go
+++ b/sdk/urls/urls_test.go
@@ -112,6 +112,53 @@ func TestSuggestions(t *testing.T) {
 	}
 }
 
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "empty stays empty",
+			url:  "",
+			want: "",
+		},
+		{
+			name: "bare host gets https",
+			url:  "abc12345.apps.dynatrace.com",
+			want: "https://abc12345.apps.dynatrace.com",
+		},
+		{
+			name: "host with path gets https",
+			url:  "abc12345.apps.dynatrace.com/platform",
+			want: "https://abc12345.apps.dynatrace.com/platform",
+		},
+		{
+			name: "https untouched",
+			url:  "https://abc12345.apps.dynatrace.com",
+			want: "https://abc12345.apps.dynatrace.com",
+		},
+		{
+			name: "http untouched",
+			url:  "http://127.0.0.1:8080",
+			want: "http://127.0.0.1:8080",
+		},
+		{
+			name: "mixed-case scheme untouched",
+			url:  "HTTPS://abc12345.apps.dynatrace.com",
+			want: "HTTPS://abc12345.apps.dynatrace.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Normalize(tt.url); got != tt.want {
+				t.Errorf("Normalize(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && containsStr(s, substr)
 }


### PR DESCRIPTION
`dtctl auth login --environment <tenant>.apps.dynatrace.com` (no scheme) logged in fine, but every later query failed with `unsupported protocol scheme ""`

normalize the environment URL when a context is stored: a missing scheme defaults to `https://`, explicit `http://`/`https://` are left alone. this covers both `auth login` and `config set-context` since they share `SetContextWithOptions`

closes #292
