### PR TITLE
fix(query): surface Grail metadata in the agent envelope

### DIFF
--- a/pkg/exec/spill_exec.go
+++ b/pkg/exec/spill_exec.go
@@ -214,6 +214,7 @@ func (e *DQLExecutor) buildSpillResponse(query string, result *DQLQueryResponse,
 		EnvelopeVersion: output.EnvelopeVersion,
 		Result:          manifest,
 		Context:         ctx,
+		Metadata:        envelopeMetadata(result, opts),
 	}
 	return resp, true, nil
 }
@@ -236,13 +237,6 @@ func (e *DQLExecutor) inlineRecordsResponse(query string, result *DQLQueryRespon
 	}
 
 	res := &output.InlineRecords{Kind: output.KindRecords, Records: records}
-	// Agent mode defaults --metadata to "all"; preserve that provenance under the
-	// result payload (it previously rode alongside the bare records map).
-	if len(opts.MetadataFields) > 0 {
-		if meta := extractQueryMetadata(result); meta != nil {
-			res.Metadata = output.MetadataToMap(meta, opts.MetadataFields)
-		}
-	}
 
 	// Even an inline (small) result can be PARTIAL — a scan-limit stop can leave
 	// few rows. Surface the same notification advice so the agent isn't misled
@@ -266,7 +260,26 @@ func (e *DQLExecutor) inlineRecordsResponse(query string, result *DQLQueryRespon
 		EnvelopeVersion: output.EnvelopeVersion,
 		Result:          res,
 		Context:         ctx,
+		Metadata:        envelopeMetadata(result, opts),
 	}, true, nil
+}
+
+// envelopeMetadata returns the Grail/metrics query metadata for the agent
+// envelope's top-level `metadata` key, honoring --metadata field selection. It
+// returns nil when metadata was not requested (MetadataFields empty) or the
+// response carried none, so the key is omitted rather than emitted empty. Agent
+// mode defaults --metadata to "all", so an agent gets the metadata by default
+// without asking for it; the same placement is used for inline and spilled
+// results.
+func envelopeMetadata(result *DQLQueryResponse, opts DQLExecuteOptions) interface{} {
+	if len(opts.MetadataFields) == 0 {
+		return nil
+	}
+	meta := extractQueryMetadata(result)
+	if meta == nil {
+		return nil
+	}
+	return output.MetadataToMap(meta, opts.MetadataFields)
 }
 
 // resolveSpillTarget decides the format, destination path, and base dir for a

--- a/pkg/exec/spill_test.go
+++ b/pkg/exec/spill_test.go
@@ -760,3 +760,130 @@ func TestBuildSpillResponse_ParquetExplicitPath(t *testing.T) {
 		t.Errorf("parquet spill file missing or empty: err=%v", serr)
 	}
 }
+
+// resultWithScanStats returns a small result carrying Grail execution metadata
+// (queryId, execution time, scanned records/bytes) so the envelope-building
+// paths can be checked for the top-level `metadata` block (#362).
+func resultWithScanStats() (*DQLQueryResponse, []map[string]interface{}) {
+	resp, records := sampleResult(false)
+	resp.Metadata.Grail.QueryID = "q-123"
+	resp.Metadata.Grail.ExecutionTimeMilliseconds = 219
+	resp.Metadata.Grail.ScannedRecords = 4200
+	resp.Metadata.Grail.ScannedBytes = 987654
+	return resp, records
+}
+
+func metadataMap(t *testing.T, resp output.Response) map[string]interface{} {
+	t.Helper()
+	if resp.Metadata == nil {
+		t.Fatalf("envelope has no top-level metadata")
+	}
+	// The metadata must live at the envelope's top level, not inside the result
+	// payload: an agent reads d["metadata"], mirroring `-o json --metadata`.
+	js, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(js, &parsed); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	m, ok := parsed["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("top-level metadata is %T, want object:\n%s", parsed["metadata"], js)
+	}
+	return m
+}
+
+func TestBuildSpillResponse_InlineMetadataTopLevel(t *testing.T) {
+	e := &DQLExecutor{}
+	result, records := resultWithScanStats()
+	opts := DQLExecuteOptions{
+		AgentMode:      true,
+		MetadataFields: []string{"all"},
+		Spill:          SpillOptions{Mode: SpillAuto, Threshold: 1 << 20, Dir: t.TempDir(), Format: "json"},
+	}
+	resp, handled, err := e.buildSpillResponse("fetch logs", result, records, "json", opts)
+	if err != nil || !handled {
+		t.Fatalf("buildSpillResponse: handled=%v err=%v", handled, err)
+	}
+	if resp.Context.Decided != "inline" {
+		t.Fatalf("decided = %q, want inline", resp.Context.Decided)
+	}
+	m := metadataMap(t, resp)
+	if m["executionTimeMilliseconds"] != float64(219) {
+		t.Errorf("executionTimeMilliseconds = %v, want 219", m["executionTimeMilliseconds"])
+	}
+	if m["scannedBytes"] != float64(987654) {
+		t.Errorf("scannedBytes = %v, want 987654", m["scannedBytes"])
+	}
+	if m["queryId"] != "q-123" {
+		t.Errorf("queryId = %v, want q-123", m["queryId"])
+	}
+	// The result payload must not also carry the metadata (no duplication).
+	ir := resp.Result.(*output.InlineRecords)
+	rjs, _ := json.Marshal(ir)
+	if strings.Contains(string(rjs), "executionTimeMilliseconds") {
+		t.Errorf("metadata leaked into result payload:\n%s", rjs)
+	}
+}
+
+func TestBuildSpillResponse_SpilledMetadataTopLevel(t *testing.T) {
+	e := &DQLExecutor{}
+	result, records := resultWithScanStats()
+	opts := DQLExecuteOptions{
+		AgentMode:      true,
+		MetadataFields: []string{"all"},
+		Spill:          SpillOptions{Mode: SpillAlways, Threshold: 1 << 20, Dir: t.TempDir(), Format: "json"},
+	}
+	resp, spilled, err := e.buildSpillResponse("fetch logs", result, records, "json", opts)
+	if err != nil || !spilled {
+		t.Fatalf("expected spilled: spilled=%v err=%v", spilled, err)
+	}
+	m := metadataMap(t, resp)
+	if m["scannedRecords"] != float64(4200) {
+		t.Errorf("scannedRecords = %v, want 4200", m["scannedRecords"])
+	}
+}
+
+func TestBuildSpillResponse_FieldSelectionHonored(t *testing.T) {
+	e := &DQLExecutor{}
+	result, records := resultWithScanStats()
+	opts := DQLExecuteOptions{
+		AgentMode:      true,
+		MetadataFields: []string{"executionTimeMilliseconds"},
+		Spill:          SpillOptions{Mode: SpillAuto, Threshold: 1 << 20, Dir: t.TempDir(), Format: "json"},
+	}
+	resp, _, err := e.buildSpillResponse("fetch logs", result, records, "json", opts)
+	if err != nil {
+		t.Fatalf("buildSpillResponse: %v", err)
+	}
+	m := metadataMap(t, resp)
+	if _, ok := m["executionTimeMilliseconds"]; !ok {
+		t.Errorf("selected field executionTimeMilliseconds missing: %v", m)
+	}
+	if _, ok := m["scannedBytes"]; ok {
+		t.Errorf("field selection not honored: scannedBytes should be absent: %v", m)
+	}
+}
+
+func TestBuildSpillResponse_NoMetadataWhenNotRequested(t *testing.T) {
+	e := &DQLExecutor{}
+	result, records := resultWithScanStats()
+	opts := DQLExecuteOptions{
+		AgentMode: true,
+		// MetadataFields empty: agent did not request metadata.
+		Spill: SpillOptions{Mode: SpillAuto, Threshold: 1 << 20, Dir: t.TempDir(), Format: "json"},
+	}
+	resp, _, err := e.buildSpillResponse("fetch logs", result, records, "json", opts)
+	if err != nil {
+		t.Fatalf("buildSpillResponse: %v", err)
+	}
+	if resp.Metadata != nil {
+		t.Errorf("metadata should be omitted when not requested, got %v", resp.Metadata)
+	}
+	js, _ := json.Marshal(resp)
+	if strings.Contains(string(js), `"metadata"`) {
+		t.Errorf("metadata key should be absent:\n%s", js)
+	}
+}

--- a/pkg/output/agent.go
+++ b/pkg/output/agent.go
@@ -46,6 +46,12 @@ type Response struct {
 	Result          interface{}      `json:"result"`
 	Error           *ErrorDetail     `json:"error,omitempty"`
 	Context         *ResponseContext `json:"context,omitempty"`
+	// Metadata carries the Grail query metadata (execution time, scanned
+	// records/bytes, sampled, queryId, ...) alongside the result, mirroring the
+	// non-agent `-o json --metadata` shape. Populated on the query envelope when
+	// --metadata is requested and the response carried metadata; omitted
+	// otherwise so other envelopes stay byte-for-byte unchanged.
+	Metadata interface{} `json:"metadata,omitempty"`
 }
 
 // ResponseContext provides operational metadata alongside the result.

--- a/pkg/output/manifest.go
+++ b/pkg/output/manifest.go
@@ -56,10 +56,12 @@ type SampleStats struct {
 // still behind the same self-describing discriminator so an agent branches on
 // result.kind uniformly across inline and spilled results (D2/D31). Emitted only
 // in agent mode on the spill-aware path; the non-spill output path is unchanged.
+// Query metadata rides on the envelope's top-level `metadata` key (Response.Metadata),
+// not inside the result payload, so it is placed identically for inline and
+// spilled results.
 type InlineRecords struct {
-	Kind     string                   `json:"kind"`
-	Records  []map[string]interface{} `json:"records"`
-	Metadata interface{}              `json:"metadata,omitempty"`
+	Kind    string                   `json:"kind"`
+	Records []map[string]interface{} `json:"records"`
 }
 
 // ResultFileManifest is the result payload for the KindResultFile /


### PR DESCRIPTION
in agent mode `-M`/`--metadata` was accepted but never reached the envelope: for an inline result the metadata sat inside `result.metadata`, for a spilled result it was dropped entirely, so an agent reading the top-level envelope couldn't see query cost/performance

put the metadata on the envelope's top-level `metadata` key for both inline and spilled results, matching the non-agent `-o json --metadata` shape and honoring field selection. the key is omitted when metadata wasn't requested

closes #362
