### PR TITLE
feat(query): agent-mode fix, NOT_STARTED polling, and DQL recovery guidance

### DIFF
--- a/cmd/get_extensions.go
+++ b/cmd/get_extensions.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/extension"
@@ -71,7 +73,14 @@ Examples:
   # Output as JSON
   dtctl get extension-configs com.dynatrace.extension.host-monitoring -o json
 `,
-	Args: cobra.ExactArgs(1),
+	// Not ExactArgs: evals showed agents calling this bare 8×/batch and getting
+	// the unhelpful "accepts 1 arg(s), received 0".
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("extension-configs requires the extension name — list installed extensions first: dtctl get extensions")
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		extensionName := args[0]
 		configID, _ := cmd.Flags().GetString("config-id")

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -178,6 +178,26 @@ Examples:
 
 		queryFile, _ := cmd.Flags().GetString("file")
 		setFlags, _ := cmd.Flags().GetStringArray("set")
+		dqlFlag, _ := cmd.Flags().GetString("dql")
+		if dqlFlag != "" && len(args) == 0 {
+			args = []string{dqlFlag}
+		}
+		// Agents write `dtctl query dql <text>` / `query execute <text>`
+		// (hallucinated subcommands) and shell-split queries into several
+		// positional args. Until now args[0] was sent alone — the literal
+		// string "dql", or a truncated query — producing an opaque
+		// UNKNOWN_COMMAND or silently wrong results. Strip the marker token
+		// and rejoin the fragments instead (no DQL statement starts with
+		// these words).
+		if len(args) > 1 {
+			switch args[0] {
+			case "dql", "execute", "exec", "run":
+				args = args[1:]
+			}
+		}
+		if len(args) > 1 {
+			args = []string{strings.Join(args, " ")}
+		}
 
 		var query string
 
@@ -719,6 +739,7 @@ func init() {
 	// Flags for main query command
 	queryCmd.Flags().StringP("file", "f", "", "read query from file")
 	queryCmd.Flags().StringArray("set", []string{}, "set template variable (key=value)")
+	queryCmd.Flags().String("dql", "", "DQL text (alias for the positional argument)")
 
 	// Live mode flags
 	queryCmd.Flags().Bool("live", false, "enable live mode with periodic updates")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -934,9 +934,14 @@ func initConfig() {
 	// Auto-detect AI agent environment and enable agent mode
 	if !agentMode && !noAgent {
 		if info := aidetect.Detect(); info.Detected {
-			// Only auto-enable if user hasn't explicitly chosen a non-JSON output format
+			// Only auto-enable if user hasn't explicitly chosen a non-JSON
+			// output format. An explicit `-o json` is compatible — the agent
+			// envelope IS json. Agents append `-o json` to nearly every call
+			// out of habit, and treating that as an opt-out silently disarmed
+			// every envelope affordance (suggestions, warnings, advice) for
+			// exactly the audience they were built for.
 			outputFlag := rootCmd.PersistentFlags().Lookup("output")
-			if outputFlag == nil || !outputFlag.Changed {
+			if outputFlag == nil || !outputFlag.Changed || outputFormat == "json" {
 				agentMode = true
 			}
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -449,12 +449,13 @@ func levenshtein(a, b string) int {
 func dqlErrorAdvice(e *sdkquery.QueryError) []string {
 	text := e.Error()
 	var s []string
-	if strings.Contains(text, "smartscapeNode") || strings.Contains(text, "smartscapeEdge") ||
-		strings.Contains(text, "smartscape.nodes") || strings.Contains(text, "smartscape.edges") {
+	switch {
+	case strings.Contains(text, "smartscapeNode") || strings.Contains(text, "smartscapeEdge") ||
+		strings.Contains(text, "smartscape.nodes") || strings.Contains(text, "smartscape.edges"):
 		s = append(s, `smartscape is queried via the COMMANDS smartscapeNodes/smartscapeEdges, not fetch — start the query with them: dtctl query 'smartscapeNodes "HOST" | limit 10'`)
-	} else if e.ErrorType == "UNKNOWN_DATA_OBJECT" && strings.Contains(text, "dt.entity.") {
+	case e.ErrorType == "UNKNOWN_DATA_OBJECT" && strings.Contains(text, "dt.entity."):
 		s = append(s, `for a current-state entity census use: dtctl query 'smartscapeNodes "<TYPE>" | summarize count()' — dt.entity.* tables are event-lookback views and exist only for some types`)
-	} else if e.ErrorType == "UNKNOWN_DATA_OBJECT" {
+	case e.ErrorType == "UNKNOWN_DATA_OBJECT":
 		if m := unknownObjectRe.FindStringSubmatch(text); len(m) == 2 {
 			if near := nearestStreams(m[1]); len(near) > 0 {
 				s = append(s, fmt.Sprintf("no data object named %q — closest real streams: %s. The full catalog: dtctl query 'fetch dt.system.data_objects | fields name'", m[1], strings.Join(near, ", ")))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/suggest"
 	"github.com/dynatrace-oss/dtctl/pkg/tracing"
+	sdkquery "github.com/dynatrace-oss/dtctl/sdk/api/query"
 )
 
 var (
@@ -270,17 +272,62 @@ func collectSubcommands(cmd *cobra.Command) []string {
 	return commands
 }
 
+var (
+	unknownFlagRe = regexp.MustCompile(`unknown (?:shorthand )?flag: ['-]*(\w+)['-]*`)
+	unknownCmdRe  = regexp.MustCompile(`unknown command "(\w+)"`)
+)
+
 // enhanceFlagError adds suggestions to flag errors
 func enhanceFlagError(cmd *cobra.Command, err error) error {
 	errStr := err.Error()
 
 	// Handle unknown flag errors
 	if strings.Contains(errStr, "unknown flag") || strings.Contains(errStr, "unknown shorthand flag") {
+		if m := unknownFlagRe.FindStringSubmatch(errStr); len(m) == 2 {
+			if fe := adviseFlag(cmd, m[1]); fe != nil {
+				return fe
+			}
+		}
 		flags := collectFlags(cmd)
 		return suggest.ParseFlagError(errStr, flags)
 	}
 
 	return err
+}
+
+// adviseFlag handles flags agents carry over from other CLIs, where the
+// closest-name suggestion misleads (evals saw --limit → "did you mean --live?").
+func adviseFlag(cmd *cobra.Command, flag string) *suggest.FlagError {
+	switch {
+	case flag == "format":
+		return &suggest.FlagError{Flag: flag,
+			Message:    "unknown flag --format",
+			Suggestion: &suggest.Suggestion{Value: "output"}}
+	case cmd.Name() == "query" && flag == "limit":
+		return &suggest.FlagError{Flag: flag,
+			Message: "unknown flag --limit — DQL limits rows inside the query text: append `| limit N`"}
+	case cmd.Name() == "query" && flag == "query":
+		return &suggest.FlagError{Flag: flag,
+			Message: "unknown flag --query — pass the DQL text as the positional argument: dtctl query 'fetch ...'"}
+	}
+	return nil
+}
+
+// verbSynonyms maps verbs agents guess from other CLIs to the dtctl verb that
+// does the job; the edit-distance fallback suggests nonsense for these
+// (evals saw `list` → "did you mean alias?").
+var verbSynonyms = map[string]struct{ verb, hint string }{
+	"list":   {"get", "resources are listed with `dtctl get <resource>`; data is queried with `dtctl query '<DQL>'` (catalog: dtctl commands)"},
+	"ls":     {"get", "resources are listed with `dtctl get <resource>` (catalog: dtctl commands)"},
+	"show":   {"describe", "use `dtctl get <resource>` for lists, `dtctl describe <resource> <name>` for one item's detail"},
+	"search": {"query", "search data with DQL: dtctl query 'fetch logs | filter contains(content, \"...\")'"},
+	"remove": {"delete", "use `dtctl delete <resource> <id>`"},
+	"rm":     {"delete", "use `dtctl delete <resource> <id>`"},
+	// DQL commands agents promote to dtctl commands (evals: `dtctl smartscapeNodes ...`).
+	"smartscapeNodes": {"query", `smartscapeNodes is a DQL command — run it through query: dtctl query 'smartscapeNodes "HOST" | limit 10'`},
+	"smartscapeEdges": {"query", `smartscapeEdges is a DQL command — run it through query: dtctl query 'smartscapeEdges "runs_on" | limit 10'`},
+	"fetch":           {"query", "fetch is DQL — run it through query: dtctl query 'fetch logs | limit 10'"},
+	"timeseries":      {"query", "timeseries is DQL — run it through query: dtctl query 'timeseries avg(dt.host.cpu.usage), from:now()-1h'"},
 }
 
 // enhanceCommandError adds suggestions to unknown command errors
@@ -289,6 +336,16 @@ func enhanceCommandError(cmd *cobra.Command, err error) error {
 
 	// Handle unknown command errors
 	if strings.Contains(errStr, "unknown command") {
+		if m := unknownCmdRe.FindStringSubmatch(errStr); len(m) == 2 {
+			if syn, ok := verbSynonyms[m[1]]; ok {
+				return &suggest.CommandError{
+					Command:    m[1],
+					Message:    fmt.Sprintf("unknown command %q", m[1]),
+					Suggestion: &suggest.Suggestion{Value: syn.verb},
+					UsageHint:  syn.hint,
+				}
+			}
+		}
 		commands := collectSubcommands(cmd)
 		return suggest.ParseCommandError(errStr, commands)
 	}
@@ -305,6 +362,115 @@ func setupErrorHandlers(cmd *cobra.Command) {
 	for _, sub := range cmd.Commands() {
 		setupErrorHandlers(sub)
 	}
+}
+
+// coreStreams are Grail data objects agents most often need. Used to answer
+// UNKNOWN_DATA_OBJECT guesses with real names instead of leaving the agent
+// to enumerate variants (evals: usersession→user_sessions→rum_events→…, ten
+// failed guesses, then "0 RUM events" reported as the answer).
+var coreStreams = []string{
+	"logs", "spans", "events", "bizevents",
+	"user.events", "user.sessions",
+	"security.events",
+	"dt.davis.events", "dt.davis.problems",
+	"metric.series",
+	"dt.system.buckets", "dt.system.data_objects", "dt.system.events",
+}
+
+// streamKeywords routes an unknown data-object name to the streams agents
+// were actually looking for, by topic. Checked before edit distance because
+// the guesses are usually semantic (rum_events), not typos.
+var streamKeywords = []struct {
+	keys    []string
+	streams []string
+}{
+	{[]string{"session", "rum", "useraction", "user_action", "user.action"}, []string{"user.sessions", "user.events"}},
+	{[]string{"user"}, []string{"user.events", "user.sessions"}},
+	{[]string{"metric"}, []string{"metric.series"}},
+	{[]string{"vuln", "security", "compliance", "detection"}, []string{"security.events"}},
+	{[]string{"problem"}, []string{"dt.davis.problems"}},
+	{[]string{"davis"}, []string{"dt.davis.events", "dt.davis.problems"}},
+	{[]string{"trace", "span"}, []string{"spans"}},
+	{[]string{"log"}, []string{"logs"}},
+	{[]string{"bizevent", "business"}, []string{"bizevents"}},
+	{[]string{"bucket"}, []string{"dt.system.buckets"}},
+}
+
+// unknownObjectRe pulls the offending name out of the API's
+// "<name> isn't a valid data object." detail.
+var unknownObjectRe = regexp.MustCompile(`(\S+) isn't a valid data object`)
+
+// nearestStreams suggests real stream names for an unknown data-object guess:
+// keyword routing first, edit distance over coreStreams as fallback.
+func nearestStreams(name string) []string {
+	n := strings.ToLower(strings.Trim(name, `"'`))
+	for _, kw := range streamKeywords {
+		for _, k := range kw.keys {
+			if strings.Contains(n, k) {
+				return kw.streams
+			}
+		}
+	}
+	norm := func(s string) string {
+		return strings.NewReplacer(".", "", "_", "", "-", "").Replace(strings.ToLower(s))
+	}
+	var best []string
+	for _, s := range coreStreams {
+		if d := levenshtein(norm(n), norm(s)); d <= 3 {
+			best = append(best, s)
+		}
+	}
+	return best
+}
+
+// levenshtein is a plain edit distance; inputs here are short stream names.
+func levenshtein(a, b string) int {
+	prev := make([]int, len(b)+1)
+	cur := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		cur[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			cur[j] = min(min(cur[j-1]+1, prev[j]+1), prev[j-1]+cost)
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(b)]
+}
+
+// dqlErrorAdvice maps recurring DQL mistake classes (observed in agent evals)
+// to recovery suggestions carried in the error envelope.
+func dqlErrorAdvice(e *sdkquery.QueryError) []string {
+	text := e.Error()
+	var s []string
+	if strings.Contains(text, "smartscapeNode") || strings.Contains(text, "smartscapeEdge") ||
+		strings.Contains(text, "smartscape.nodes") || strings.Contains(text, "smartscape.edges") {
+		s = append(s, `smartscape is queried via the COMMANDS smartscapeNodes/smartscapeEdges, not fetch — start the query with them: dtctl query 'smartscapeNodes "HOST" | limit 10'`)
+	} else if e.ErrorType == "UNKNOWN_DATA_OBJECT" && strings.Contains(text, "dt.entity.") {
+		s = append(s, `for a current-state entity census use: dtctl query 'smartscapeNodes "<TYPE>" | summarize count()' — dt.entity.* tables are event-lookback views and exist only for some types`)
+	} else if e.ErrorType == "UNKNOWN_DATA_OBJECT" {
+		if m := unknownObjectRe.FindStringSubmatch(text); len(m) == 2 {
+			if near := nearestStreams(m[1]); len(near) > 0 {
+				s = append(s, fmt.Sprintf("no data object named %q — closest real streams: %s. The full catalog: dtctl query 'fetch dt.system.data_objects | fields name'", m[1], strings.Join(near, ", ")))
+			} else {
+				s = append(s, fmt.Sprintf("no data object named %q — common streams: %s. The full catalog: dtctl query 'fetch dt.system.data_objects | fields name'", m[1], strings.Join(coreStreams, ", ")))
+			}
+		}
+	}
+	if e.ErrorType == "FIELD_DOES_NOT_EXIST" &&
+		(strings.Contains(text, "toRelationships") || strings.Contains(text, "fromRelationships")) {
+		s = append(s, `toRelationships/fromRelationships are classic Environment-API fields, not DQL — topology hops use smartscapeEdges: dtctl query 'smartscapeEdges "runs_on" | filter in(source_id, {toSmartscapeId("SERVICE-…")}) | fields target_id'`)
+	}
+	if e.ErrorType == "INVALID_TIMEFRAME" {
+		s = append(s, "timeframe values accept ISO-8601 timestamps or now()-relative expressions — parentheses required: now()-6h, not now-6h — e.g. from:now()-6h, to:now() or --default-timeframe-start 'now()-6h'")
+	}
+	return s
 }
 
 // errorToDetail converts any error into a structured ErrorDetail for agent/plain mode output.
@@ -391,6 +557,23 @@ func errorToDetail(err error) *output.ErrorDetail {
 		}
 	}
 
+	// query.QueryError — a typed DQL API error. The envelope code becomes the
+	// API's error type (e.g. unknown_data_object) and recurring mistake
+	// classes get a targeted recovery suggestion.
+	var queryErr *sdkquery.QueryError
+	if errors.As(err, &queryErr) {
+		code := strings.ToLower(queryErr.ErrorType)
+		if code == "" {
+			code = output.ClassifyHTTPError(queryErr.StatusCode)
+		}
+		return &output.ErrorDetail{
+			Code:        code,
+			Message:     queryErr.Error(),
+			StatusCode:  queryErr.StatusCode,
+			Suggestions: dqlErrorAdvice(queryErr),
+		}
+	}
+
 	// suggest.CommandError — unknown command with "did you mean?" suggestions
 	var cmdErr *suggest.CommandError
 	if errors.As(err, &cmdErr) {
@@ -402,6 +585,9 @@ func errorToDetail(err error) *output.ErrorDetail {
 			detail.Suggestions = []string{
 				fmt.Sprintf("did you mean %q?", cmdErr.Suggestion.Value),
 			}
+		}
+		if cmdErr.UsageHint != "" {
+			detail.Suggestions = append(detail.Suggestions, cmdErr.UsageHint)
 		}
 		return detail
 	}
@@ -586,6 +772,13 @@ func requireSubcommand(cmd *cobra.Command, args []string) error {
 		}
 		return fmt.Errorf("requires a resource type\n\nAvailable resources:\n  %s\n\nUsage:\n  %s <resource> [id] [flags]",
 			strings.Join(resources, "\n  "), cmd.CommandPath())
+	}
+
+	// Schema introspection is DQL-side, not a resource — agents try
+	// `describe field` / `describe dataobject` when hunting for a schema.
+	switch args[0] {
+	case "field", "fields", "dataobject", "data-object", "dataobjects", "schema":
+		return fmt.Errorf("unknown resource type %q — the data schema is queried, not described: dtctl query 'fetch dt.system.data_objects | fields name' lists tables; a table's fields show up in its records", args[0])
 	}
 
 	// Check if the first arg looks like an unknown subcommand
@@ -939,7 +1132,7 @@ func initConfig() {
 			// envelope IS json. Agents append `-o json` to nearly every call
 			// out of habit, and treating that as an opt-out silently disarmed
 			// every envelope affordance (suggestions, warnings, advice) for
-			// exactly the audience they were built for.
+			// exactly the audience they were built for (matrix-11 forensics).
 			outputFlag := rootCmd.PersistentFlags().Lookup("output")
 			if outputFlag == nil || !outputFlag.Changed || outputFormat == "json" {
 				agentMode = true

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -493,6 +493,46 @@ func TestInitConfig(t *testing.T) {
 	}
 }
 
+// TestAgentModeAutoDetectWithExplicitJSON locks the matrix-11 finding: agents
+// append `-o json` to nearly every call, and treating any explicit -o as an
+// agent-mode opt-out silently disarmed every envelope affordance for exactly
+// the audience it was built for. Explicit json must keep agent mode on; an
+// explicit non-JSON format must still opt out.
+func TestAgentModeAutoDetectWithExplicitJSON(t *testing.T) {
+	origAgent, origNoAgent, origOutput := agentMode, noAgent, outputFormat
+	outputFlag := rootCmd.PersistentFlags().Lookup("output")
+	origChanged := outputFlag.Changed
+	defer func() {
+		agentMode, noAgent, outputFormat = origAgent, origNoAgent, origOutput
+		outputFlag.Changed = origChanged
+		os.Unsetenv("AI_AGENT")
+	}()
+	os.Setenv("AI_AGENT", "1")
+
+	cases := []struct {
+		name    string
+		format  string
+		changed bool
+		want    bool
+	}{
+		{"no explicit output", "table", false, true},
+		{"explicit -o json", "json", true, true},
+		{"explicit -o yaml", "yaml", true, false},
+		{"explicit -o table", "table", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agentMode, noAgent = false, false
+			outputFormat = tc.format
+			outputFlag.Changed = tc.changed
+			initConfig()
+			if agentMode != tc.want {
+				t.Errorf("agentMode = %v, want %v", agentMode, tc.want)
+			}
+		})
+	}
+}
+
 // TestEnhanceFlagError tests flag error enhancement with suggestions
 func TestEnhanceFlagError(t *testing.T) {
 	tests := []struct {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/suggest"
+	sdkquery "github.com/dynatrace-oss/dtctl/sdk/api/query"
 )
 
 // TestBuildSpanName verifies that buildSpanName correctly extracts the verb and
@@ -577,6 +579,137 @@ func TestEnhanceFlagError(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestVerbSynonyms locks the mapping from verbs agents guess (list, show, …)
+// to real dtctl verbs, replacing the useless edit-distance fallback
+// ("list" → "alias") observed in evals.
+func TestVerbSynonyms(t *testing.T) {
+	err := enhanceCommandError(rootCmd, fmt.Errorf(`unknown command "list" for "dtctl"`))
+	var cmdErr *suggest.CommandError
+	if !errors.As(err, &cmdErr) {
+		t.Fatalf("expected CommandError, got %T: %v", err, err)
+	}
+	if cmdErr.Suggestion == nil || cmdErr.Suggestion.Value != "get" {
+		t.Errorf("list should suggest get, got %+v", cmdErr.Suggestion)
+	}
+	if !strings.Contains(cmdErr.UsageHint, "dtctl get <resource>") {
+		t.Errorf("usage hint missing: %q", cmdErr.UsageHint)
+	}
+	// The hint must reach the agent envelope.
+	detail := errorToDetail(err)
+	if len(detail.Suggestions) != 2 || !strings.Contains(detail.Suggestions[1], "dtctl get <resource>") {
+		t.Errorf("envelope suggestions = %v", detail.Suggestions)
+	}
+	// Non-synonym verbs still go through edit-distance matching.
+	err = enhanceCommandError(rootCmd, fmt.Errorf(`unknown command "quer" for "dtctl"`))
+	if !errors.As(err, &cmdErr) || cmdErr.Suggestion == nil || cmdErr.Suggestion.Value != "query" {
+		t.Errorf("quer should still suggest query, got %v", err)
+	}
+}
+
+// TestAdviseFlag locks the special-cased flag guidance for flags agents carry
+// over from other CLIs (--format, and --limit/--query on the query command).
+func TestAdviseFlag(t *testing.T) {
+	queryLike := &cobra.Command{Use: "query"}
+	getLike := &cobra.Command{Use: "get"}
+	cases := []struct {
+		cmd         *cobra.Command
+		flag        string
+		wantNil     bool
+		wantMessage string
+		wantSuggest string
+	}{
+		{getLike, "format", false, "unknown flag --format", "output"},
+		{queryLike, "limit", false, "append `| limit N`", ""},
+		{queryLike, "query", false, "positional argument", ""},
+		{getLike, "limit", true, "", ""},
+		{queryLike, "outpt", true, "", ""},
+	}
+	for _, tc := range cases {
+		fe := adviseFlag(tc.cmd, tc.flag)
+		if tc.wantNil {
+			if fe != nil {
+				t.Errorf("adviseFlag(%s, --%s) = %v, want nil", tc.cmd.Name(), tc.flag, fe)
+			}
+			continue
+		}
+		if fe == nil {
+			t.Fatalf("adviseFlag(%s, --%s) = nil", tc.cmd.Name(), tc.flag)
+		}
+		if !strings.Contains(fe.Message, tc.wantMessage) {
+			t.Errorf("message %q missing %q", fe.Message, tc.wantMessage)
+		}
+		if tc.wantSuggest != "" && (fe.Suggestion == nil || fe.Suggestion.Value != tc.wantSuggest) {
+			t.Errorf("suggestion = %+v, want %s", fe.Suggestion, tc.wantSuggest)
+		}
+	}
+}
+
+// TestDqlErrorAdviceTimeframe locks the INVALID_TIMEFRAME recovery hint
+// (evals: --default-timeframe-start now-6h, missing the parentheses).
+func TestDqlErrorAdviceTimeframe(t *testing.T) {
+	s := dqlErrorAdvice(&sdkquery.QueryError{ErrorType: "INVALID_TIMEFRAME", Message: "INVALID_TIMEFRAME"})
+	if len(s) != 1 || !strings.Contains(s[0], "now()-6h") {
+		t.Errorf("advice = %v", s)
+	}
+}
+
+// TestDqlErrorAdviceStreamNearMiss locks the UNKNOWN_DATA_OBJECT near-miss
+// suggestions (evals: agents guessed usersession/usersessions/rum_events/
+// dt.rum.sessions across ten calls without finding user.events, then
+// reported "0 RUM events" as the measured answer).
+func TestDqlErrorAdviceStreamNearMiss(t *testing.T) {
+	cases := []struct {
+		guess string
+		want  string
+	}{
+		{"usersessions", "user.sessions"},
+		{"rum_events", "user.sessions"},
+		{"dt.rum.sessions", "user.sessions"},
+		{"user_actions", "user.sessions"},
+		{"dt.metrics", "metric.series"},
+		{"vulnerabilities", "security.events"},
+		{"traces", "spans"},
+		{"bizevent", "bizevents"},
+	}
+	for _, tc := range cases {
+		e := &sdkquery.QueryError{ErrorType: "UNKNOWN_DATA_OBJECT",
+			Message: "UNKNOWN_DATA_OBJECT", Detail: tc.guess + " isn't a valid data object."}
+		s := dqlErrorAdvice(e)
+		if len(s) == 0 || !strings.Contains(s[0], tc.want) {
+			t.Errorf("advice for %q = %v, want mention of %q", tc.guess, s, tc.want)
+		}
+		if !strings.Contains(s[0], "dt.system.data_objects") {
+			t.Errorf("advice for %q lacks the catalog pointer: %v", tc.guess, s)
+		}
+	}
+	// dt.entity.* guesses keep their dedicated census advice, not near-miss.
+	e := &sdkquery.QueryError{ErrorType: "UNKNOWN_DATA_OBJECT",
+		Message: "UNKNOWN_DATA_OBJECT", Detail: "dt.entity.database isn't a valid data object."}
+	if s := dqlErrorAdvice(e); len(s) == 0 || !strings.Contains(s[0], "smartscapeNodes") {
+		t.Errorf("dt.entity advice = %v", s)
+	}
+}
+
+// TestDqlErrorAdviceClassicRelationships locks the redirect for the classic
+// Environment-API relationship idiom (evals: repeated `fieldsAdd
+// toRelationships` FIELD_DOES_NOT_EXIST failures, 28-call topology flail).
+func TestDqlErrorAdviceClassicRelationships(t *testing.T) {
+	for _, f := range []string{"toRelationships", "fromRelationships"} {
+		e := &sdkquery.QueryError{ErrorType: "FIELD_DOES_NOT_EXIST",
+			Message: "FIELD_DOES_NOT_EXIST", Detail: "The field " + f + " doesn't exist."}
+		s := dqlErrorAdvice(e)
+		if len(s) == 0 || !strings.Contains(s[0], "smartscapeEdges") {
+			t.Errorf("advice for %s = %v", f, s)
+		}
+	}
+	// Other unknown fields stay silent — no generic field advice exists.
+	e := &sdkquery.QueryError{ErrorType: "FIELD_DOES_NOT_EXIST",
+		Message: "FIELD_DOES_NOT_EXIST", Detail: "The field foo doesn't exist."}
+	if s := dqlErrorAdvice(e); len(s) != 0 {
+		t.Errorf("unexpected advice for unrelated field: %v", s)
 	}
 }
 

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -564,6 +566,108 @@ func notificationAdvice(notifications []QueryNotification) (warnings, suggestion
 		suggestions = append(suggestions, agentAdviceForNotification(n.NotificationType, n.Message)...)
 	}
 	return warnings, suggestions
+}
+
+// heavyScanWarnBytes is the scanned-data level above which the agent envelope
+// warns. An agent that cannot see the bill will happily re-run an 85 GB scan
+// it already paid for; the warning makes the cost visible and steers toward
+// reusing the result it just received.
+const heavyScanWarnBytes = 10 * 1000 * 1000 * 1000
+
+// heavyScanAdvice emits an envelope warning + suggestion when a query scanned
+// a large amount of data, so the cost is visible in-band.
+func heavyScanAdvice(result *DQLQueryResponse) (warnings, suggestions []string) {
+	meta := extractQueryMetadata(result)
+	if meta == nil || meta.ScannedBytes < heavyScanWarnBytes {
+		return nil, nil
+	}
+	warnings = append(warnings, fmt.Sprintf(
+		"this query scanned %.1f GB — re-running it costs the same again", float64(meta.ScannedBytes)/1e9))
+	suggestions = append(suggestions,
+		"# heavy scan: reuse this result (dtctl inspect on a spilled file) instead of re-querying; narrow the timeframe or bucket to reduce cost")
+	return warnings, suggestions
+}
+
+// timestampFilterRe spots a filter stage constraining the timestamp field —
+// the idiom agents reach for when they mean "query an older window".
+var timestampFilterRe = regexp.MustCompile(`(?i)\|\s*filter\b[^|]*\btimestamp\b`)
+
+// windowAdvice explains the silent-default-window trap on empty results.
+// Fires only on an empty result (no rows, or the single all-zero row a
+// `summarize count()` yields) from a query with no explicit window anywhere:
+//   - with a `filter timestamp` stage: the filter cannot widen the scanned
+//     window, so filtering for data older than the default returns nothing —
+//     silently (the t23 trap).
+//   - without one: the emptiness may still be the window, not the data —
+//     discovery fetches (metric.series) only show series that had datapoints
+//     inside the window, and agents reported "0 OOM pods" off exactly that
+//     (the t9 trap). Phrased as a possibility, since zero may be the answer.
+func windowAdvice(query string, records []map[string]interface{}, opts DQLExecuteOptions) []string {
+	if opts.DefaultTimeframeStart != "" || opts.DefaultTimeframeEnd != "" {
+		return nil
+	}
+	if len(records) > 1 || (len(records) == 1 && !allAggregatesZero(records[0])) {
+		return nil
+	}
+	if strings.Contains(query, "from:") || strings.Contains(query, "to:") || strings.Contains(query, "timeframe:") {
+		return nil
+	}
+	if timestampFilterRe.MatchString(query) {
+		return []string{"# empty result with a `filter timestamp ...` stage: timestamp filters do NOT widen the scanned window (default: the last 2h) — set the window in the fetch instead, e.g. `fetch logs, from:now()-24h, to:now()-12h`, or pass --default-timeframe-start/--default-timeframe-end"}
+	}
+	advice := "# empty result from the DEFAULT query window (the last 2h) — if data may exist outside it, widen the window explicitly, e.g. `, from:now()-7d`, before concluding the count is 0"
+	if strings.Contains(query, "metric.series") {
+		advice = "# empty result from the DEFAULT query window (the last 2h): metric.series lists only series with datapoints INSIDE the window — widen it for discovery, e.g. `fetch metric.series, from:now()-7d`"
+	}
+	return []string{advice}
+}
+
+// entityFetchRe spots a query fetching a classic dt.entity.* table, and
+// captures the type suffix for a concrete smartscapeNodes suggestion.
+var entityFetchRe = regexp.MustCompile(`(?i)\bfetch\s+dt\.entity\.([a-z0-9_]+)`)
+
+// lookbackAdvice rides SUCCESSFUL dt.entity.* fetches. The error-side
+// redirect (dqlErrorAdvice) cannot help here: dt.entity.<type> queries
+// SUCCEED and return the lookback population (entities that reported events
+// in the window), which diverges from the live topology — agents reported a
+// 17-host census against 12 currently monitored hosts in five consecutive
+// eval batches, every time via a query that returned rc 0.
+func lookbackAdvice(query string) []string {
+	m := entityFetchRe.FindStringSubmatch(query)
+	if m == nil {
+		return nil
+	}
+	t := strings.ToUpper(m[1])
+	return []string{fmt.Sprintf("# dt.entity.%s is an event-LOOKBACK view (entities seen in the query window), not the live topology — for a current-state census or inventory use: dtctl query 'smartscapeNodes \"%s\" | summarize count()'", m[1], t)}
+}
+
+// allAggregatesZero reports whether a single result row carries only zero
+// numeric values (DQL long aggregates arrive as JSON strings) — the shape a
+// `summarize count()` produces when nothing matched.
+func allAggregatesZero(rec map[string]interface{}) bool {
+	zeros := 0
+	for _, v := range rec {
+		switch x := v.(type) {
+		case float64:
+			if x != 0 {
+				return false
+			}
+			zeros++
+		case json.Number:
+			if f, err := x.Float64(); err == nil && f != 0 {
+				return false
+			}
+			zeros++
+		case string:
+			if f, err := strconv.ParseFloat(x, 64); err == nil {
+				if f != 0 {
+					return false
+				}
+				zeros++
+			}
+		}
+	}
+	return zeros > 0
 }
 
 // PrintNotifications prints query notifications/warnings to stderr

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -2799,3 +2799,76 @@ func TestDQLExecutor_ClientContextHeader_OnInternalCancel(t *testing.T) {
 		t.Errorf("context = %q, want %q", m["context"], "incident-response")
 	}
 }
+
+func TestWindowAdvice(t *testing.T) {
+	trap := `fetch logs | filter timestamp >= now() - 24h and timestamp < now() - 12h | summarize count()`
+	cases := []struct {
+		name    string
+		query   string
+		records []map[string]interface{}
+		opts    DQLExecuteOptions
+		want    bool
+	}{
+		{"trap query, no rows", trap, nil, DQLExecuteOptions{}, true},
+		{"trap query, single zero-count row", trap, []map[string]interface{}{{"count()": "0"}}, DQLExecuteOptions{}, true},
+		{"trap query, nonzero count row", trap, []map[string]interface{}{{"count()": "4136117"}}, DQLExecuteOptions{}, false},
+		{"trap query, many rows", trap, []map[string]interface{}{{"a": "1"}, {"a": "2"}}, DQLExecuteOptions{}, false},
+		{"explicit from: in query", `fetch logs, from:now()-24h | filter timestamp < now()-12h | summarize c = count()`, nil, DQLExecuteOptions{}, false},
+		{"timeframe flag set", trap, nil, DQLExecuteOptions{DefaultTimeframeStart: "2026-01-01T00:00:00Z"}, false},
+		// Since the t9 trap fix, an empty result WITHOUT a timestamp filter
+		// also fires (default-window wording) as long as no explicit window
+		// was set anywhere.
+		{"no timestamp filter", `fetch logs | summarize count()`, nil, DQLExecuteOptions{}, true},
+		{"filter on another field only", `fetch logs | filter loglevel == "ERROR"`, nil, DQLExecuteOptions{}, true},
+		{"no timestamp filter, explicit window", `fetch logs, from:now()-7d | summarize count()`, nil, DQLExecuteOptions{}, false},
+		{"no timestamp filter, nonempty result", `fetch logs | summarize count()`, []map[string]interface{}{{"count()": "42"}}, DQLExecuteOptions{}, false},
+		{"metric.series discovery, empty", `fetch metric.series | filter contains(metric.key, "oom")`, nil, DQLExecuteOptions{}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := windowAdvice(tc.query, tc.records, tc.opts)
+			if (len(got) > 0) != tc.want {
+				t.Errorf("windowAdvice(%q, %v) = %v, want fired=%v", tc.query, tc.records, got, tc.want)
+			}
+		})
+	}
+	// The two empty-result shapes carry distinct wording: the timestamp-filter
+	// trap names the filter; the plain default-window one suggests widening;
+	// metric.series gets the discovery-specific line.
+	tsAdvice := windowAdvice(trap, nil, DQLExecuteOptions{})
+	if len(tsAdvice) == 0 || !strings.Contains(tsAdvice[0], "filter timestamp") {
+		t.Errorf("timestamp-trap advice = %v", tsAdvice)
+	}
+	defAdvice := windowAdvice(`fetch logs | summarize count()`, nil, DQLExecuteOptions{})
+	if len(defAdvice) == 0 || !strings.Contains(defAdvice[0], "DEFAULT query window") {
+		t.Errorf("default-window advice = %v", defAdvice)
+	}
+	msAdvice := windowAdvice(`fetch metric.series | filter contains(metric.key, "oom")`, nil, DQLExecuteOptions{})
+	if len(msAdvice) == 0 || !strings.Contains(msAdvice[0], "metric.series") {
+		t.Errorf("metric.series advice = %v", msAdvice)
+	}
+}
+
+// TestLookbackAdvice locks the note riding SUCCESSFUL dt.entity.* fetches
+// (evals: 17-host lookback census reported against 12 live hosts in five
+// consecutive control batches — via queries that returned rc 0, so the
+// error-side redirect never fired).
+func TestLookbackAdvice(t *testing.T) {
+	s := lookbackAdvice(`fetch dt.entity.host | summarize count()`)
+	if len(s) != 1 || !strings.Contains(s[0], `smartscapeNodes "HOST"`) || !strings.Contains(s[0], "LOOKBACK") {
+		t.Errorf("advice = %v", s)
+	}
+	s = lookbackAdvice(`fetch dt.entity.aws_lambda_function | limit 10`)
+	if len(s) != 1 || !strings.Contains(s[0], `smartscapeNodes "AWS_LAMBDA_FUNCTION"`) {
+		t.Errorf("advice = %v", s)
+	}
+	for _, q := range []string{
+		`fetch logs | summarize count()`,
+		`smartscapeNodes "HOST" | summarize count()`,
+		`fetch dt.davis.events`,
+	} {
+		if s := lookbackAdvice(q); len(s) != 0 {
+			t.Errorf("unexpected advice for %q: %v", q, s)
+		}
+	}
+}

--- a/pkg/exec/spill_exec.go
+++ b/pkg/exec/spill_exec.go
@@ -195,6 +195,11 @@ func (e *DQLExecutor) buildSpillResponse(query string, result *DQLQueryResponse,
 	notifWarnings, notifSuggestions := notificationAdvice(result.GetNotifications())
 	warnings = append(warnings, notifWarnings...)
 	suggestions = append(notifSuggestions, suggestions...)
+	scanWarnings, scanSuggestions := heavyScanAdvice(result)
+	warnings = append(warnings, scanWarnings...)
+	suggestions = append(suggestions, scanSuggestions...)
+	suggestions = append(suggestions, windowAdvice(query, records, opts)...)
+	suggestions = append(suggestions, lookbackAdvice(query)...)
 
 	total := len(records)
 	ctx := &output.ResponseContext{
@@ -248,6 +253,11 @@ func (e *DQLExecutor) inlineRecordsResponse(query string, result *DQLQueryRespon
 	// few rows. Surface the same notification advice so the agent isn't misled
 	// into treating a truncated scan as the complete answer.
 	notifWarnings, notifSuggestions := notificationAdvice(result.GetNotifications())
+	scanWarnings, scanSuggestions := heavyScanAdvice(result)
+	notifWarnings = append(notifWarnings, scanWarnings...)
+	notifSuggestions = append(notifSuggestions, scanSuggestions...)
+	notifSuggestions = append(notifSuggestions, windowAdvice(query, records, opts)...)
+	notifSuggestions = append(notifSuggestions, lookbackAdvice(query)...)
 
 	total := len(records)
 	ctx := &output.ResponseContext{

--- a/sdk/api/query/query.go
+++ b/sdk/api/query/query.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -610,6 +611,7 @@ func parseError(statusCode int, body []byte) error {
 			StatusCode: statusCode,
 			Message:    apiErr.Error.Message,
 			ErrorType:  apiErr.Error.Details.ErrorType,
+			Detail:     apiErr.Error.Details.ErrorMessage,
 			Arguments:  apiErr.Error.Details.Arguments,
 		}
 	}
@@ -623,12 +625,28 @@ type QueryError struct {
 	StatusCode int
 	Message    string
 	ErrorType  string
+	Detail     string
 	Arguments  []string
 }
 
 func (e *QueryError) Error() string {
 	if e.ErrorType != "" {
-		return fmt.Sprintf("query failed (%s): %s", e.ErrorType, e.Message)
+		// The top-level message often just repeats the error type
+		// (e.g. "UNKNOWN_COMMAND"); details.errorMessage and the arguments
+		// carry the actionable part (offending token, position), so include
+		// whatever adds information.
+		msg := e.Message
+		if e.Detail != "" && e.Detail != msg {
+			if msg == e.ErrorType || msg == "" {
+				msg = e.Detail
+			} else {
+				msg += " — " + e.Detail
+			}
+		}
+		if len(e.Arguments) > 0 && !strings.Contains(msg, e.Arguments[0]) {
+			msg += " [" + strings.Join(e.Arguments, ", ") + "]"
+		}
+		return fmt.Sprintf("query failed (%s): %s", e.ErrorType, msg)
 	}
 	return fmt.Sprintf("query failed with status %d: %s", e.StatusCode, e.Message)
 }

--- a/sdk/api/query/query.go
+++ b/sdk/api/query/query.go
@@ -434,8 +434,11 @@ func (h *Handler) ExecuteAndPollWithOptions(ctx context.Context, req ExecuteRequ
 		return nil, ctx.Err()
 	}
 
-	// If query completed synchronously, return.
-	if result.State != "RUNNING" {
+	// If query completed synchronously, return. NOT_STARTED is a queued query
+	// on a congested tenant — terminal-looking but in-flight; returning it here
+	// would hand the caller the raw {"state":"NOT_STARTED"} envelope as a
+	// success (observed live: three leaks in a row on a busy dev tenant).
+	if result.State != "RUNNING" && result.State != "NOT_STARTED" {
 		return result, nil
 	}
 
@@ -492,7 +495,7 @@ func (h *Handler) ExecuteAndPollWithOptions(ctx context.Context, req ExecuteRequ
 			return pollResult, nil
 		case "FAILED":
 			return pollResult, fmt.Errorf("query execution failed")
-		case "RUNNING":
+		case "RUNNING", "NOT_STARTED":
 			emitUpdate(opts.OnUpdate, req.EnablePreview, pollResult)
 			continue
 		default:

--- a/sdk/api/query/query_test.go
+++ b/sdk/api/query/query_test.go
@@ -170,6 +170,48 @@ func TestExecute_AsyncWithPoll(t *testing.T) {
 	}
 }
 
+// TestExecute_NotStartedIsPolled locks the congested-tenant path: a queued
+// query answers execute (and early polls) with state NOT_STARTED, which is
+// in-flight, not terminal — returning it as success hands the caller the raw
+// {"state":"NOT_STARTED","requestToken":...} envelope with rc 0 (observed
+// live three times in a row on a busy dev tenant).
+func TestExecute_NotStartedIsPolled(t *testing.T) {
+	var pollCount atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/storage/query/v1/query:execute", func(w http.ResponseWriter, r *http.Request) {
+		resp := Response{State: "NOT_STARTED", RequestToken: "tok-ns"}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/platform/storage/query/v1/query:poll", func(w http.ResponseWriter, r *http.Request) {
+		n := pollCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			// still queued on the first poll
+			json.NewEncoder(w).Encode(Response{State: "NOT_STARTED", RequestToken: "tok-ns"})
+			return
+		}
+		json.NewEncoder(w).Encode(Response{
+			State:  "SUCCEEDED",
+			Result: &Result{Records: []map[string]interface{}{{"c": "1"}}},
+		})
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.ExecuteAndPoll(context.Background(), ExecuteRequest{Query: "fetch logs"}, nil)
+	if err != nil {
+		t.Fatalf("ExecuteAndPoll() error: %v", err)
+	}
+	if result.State != "SUCCEEDED" {
+		t.Errorf("State = %q, want SUCCEEDED (NOT_STARTED must be polled, not returned)", result.State)
+	}
+	if pollCount.Load() < 2 {
+		t.Errorf("expected at least 2 polls, got %d", pollCount.Load())
+	}
+}
+
 func TestPoll_Success(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/platform/storage/query/v1/query:poll", func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/api/query/query_test.go
+++ b/sdk/api/query/query_test.go
@@ -962,6 +962,35 @@ func TestQueryError_ErrorFormatting(t *testing.T) {
 			t.Errorf("Error() = %q, want %q", e.Error(), want)
 		}
 	})
+
+	// The API often repeats the error type as the message and puts the
+	// actionable text in details.errorMessage — that detail must surface.
+	t.Run("detail replaces a type-echo message", func(t *testing.T) {
+		e := &QueryError{StatusCode: 400, Message: "UNKNOWN_COMMAND", ErrorType: "UNKNOWN_COMMAND",
+			Detail: "There's no command `dqll`."}
+		want := "query failed (UNKNOWN_COMMAND): There's no command `dqll`."
+		if e.Error() != want {
+			t.Errorf("Error() = %q, want %q", e.Error(), want)
+		}
+	})
+
+	t.Run("detail appends to a distinct message", func(t *testing.T) {
+		e := &QueryError{StatusCode: 400, Message: "invalid query", ErrorType: "SYNTAX_ERROR",
+			Detail: "token `|` unexpected", Arguments: []string{"line 1"}}
+		want := "query failed (SYNTAX_ERROR): invalid query — token `|` unexpected [line 1]"
+		if e.Error() != want {
+			t.Errorf("Error() = %q, want %q", e.Error(), want)
+		}
+	})
+
+	t.Run("arguments skipped when already in message", func(t *testing.T) {
+		e := &QueryError{StatusCode: 400, Message: "field `foo` missing", ErrorType: "FIELD_DOES_NOT_EXIST",
+			Arguments: []string{"foo"}}
+		want := "query failed (FIELD_DOES_NOT_EXIST): field `foo` missing"
+		if e.Error() != want {
+			t.Errorf("Error() = %q, want %q", e.Error(), want)
+		}
+	})
 }
 
 // TestExecuteAndPoll_SetsRequestTimeout verifies that ExecuteAndPoll sets the


### PR DESCRIPTION
## Description

Fixes and ergonomics mined from live agent evaluations (headless AI agents driving dtctl against real environments, scored against measured ground truth). Four commits, most severe first:

1. **fix(agent): keep auto-detected agent mode with an explicit `-o json`** — auto-detection treated *any* explicit `--output` as an opt-out. Agents append `-o json` to nearly every call, so the entire agent envelope (suggestions, warnings, structured errors) was silently disabled for exactly its target audience. Explicit `json` now keeps agent mode; explicit `yaml`/`table` still opts out.
2. **fix(sdk/query): poll through NOT_STARTED** — a queued query on a congested tenant returns `state: NOT_STARTED`, which was treated as terminal: the raw `{"state":"NOT_STARTED","requestToken":…}` envelope came back with exit code 0 (observed live three times in a row). It now polls like RUNNING.
3. **feat(sdk/query): surface the actionable detail in QueryError** — the API often repeats the error type as the message and hides the useful part in `details.errorMessage`/`arguments`; those now surface.
4. **feat(query): recovery guidance for recurring DQL/CLI mistakes** — targeted envelope hints for the failure classes that recur in evals and mostly end in *silently wrong answers*, not errors: unknown data-object guesses (closest-stream suggestions + catalog pointer), classic `toRelationships` idiom → smartscapeEdges, the silent default-query-window trap on empty results, the `dt.entity.*` lookback-vs-live-topology divergence on *successful* queries, heavy-scan cost visibility, verb/flag synonyms from other CLIs (`list`, `--limit`, `--format`), hallucinated `query dql <text>` subcommands, and a clearer `get extension-configs` arg error.

Measured effect (32-task eval suite incl. 8 held-out tasks, agent-driven against a live tenant): empty-result calls −96%, dtctl calls −27%, and the baseline arm went from repeated silent-wrong answers to 32/32 correct with these changes armed.

> ~~**Note for maintainers:** current `main` appears to have lost the merged PRs #360 and #363.~~ **Resolved:** `main` has since been restored (#360, #363, and #364 are back on it); this branch merges cleanly against the restored `main` — no conflicts.

## Related Issues

—

## Testing

- `go test ./...` green in both modules (root + sdk); new unit tests for every behavior: agent-mode matrix, NOT_STARTED polling (mock server), QueryError formatting, stream near-miss routing, relationship redirect, window/lookback advice, verb/flag synonyms
- [x] Tests pass (`make test`)
- [x] Linting passes — `gofmt`/`go vet` clean, golangci-lint v2.11.1 (CI's version) reports 0 issues
