### PR TITLE
fix(apply): detect and apply aws_monitoring_config from YAML/JSON

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -152,6 +152,7 @@ const (
 	ResourceSLO                   ResourceType = "slo"
 	ResourceBucket                ResourceType = "bucket"
 	ResourceSettings              ResourceType = "settings"
+	ResourceAWSMonitoringConfig   ResourceType = "aws_monitoring_config"
 	ResourceAzureConnection       ResourceType = "azure_connection"
 	ResourceAzureMonitoringConfig ResourceType = "azure_monitoring_config"
 	ResourceGCPConnection         ResourceType = "gcp_connection"
@@ -328,6 +329,8 @@ func (a *Applier) applySingle(resourceType ResourceType, jsonData []byte, opts A
 		result, err = a.applyBucket(jsonData)
 	case ResourceSettings:
 		result, err = a.applySettings(jsonData)
+	case ResourceAWSMonitoringConfig:
+		result, err = a.applyAWSMonitoringConfig(jsonData)
 	case ResourceAzureMonitoringConfig:
 		result, err = a.applyAzureMonitoringConfig(jsonData)
 	case ResourceGCPMonitoringConfig:
@@ -476,6 +479,11 @@ func detectResourceType(data []byte) (ResourceType, bool, error) {
 		return ResourceGCPMonitoringConfig, false, nil
 	}
 
+	// AWS Monitoring Config detection
+	if scope, ok := raw["scope"].(string); ok && scope == "integration-aws" {
+		return ResourceAWSMonitoringConfig, false, nil
+	}
+
 	// Check for explicit type field
 	if typeField, ok := raw["type"].(string); ok {
 		switch typeField {
@@ -582,6 +590,9 @@ func detectResourceType(data []byte) (ResourceType, bool, error) {
 				}
 				if scope, ok := raw["scope"].(string); ok && scope == "integration-azure" {
 					return ResourceAzureMonitoringConfig, false, nil
+				}
+				if scope, ok := raw["scope"].(string); ok && scope == "integration-aws" {
+					return ResourceAWSMonitoringConfig, false, nil
 				}
 				return ResourceSettings, false, nil
 			}

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -138,6 +138,21 @@ func TestDetectResourceType(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "aws monitoring config",
+			input: `{
+				"scope": "integration-aws",
+				"value": {
+					"description": "aws-monitoring",
+					"enabled": true,
+					"aws": {
+						"credentials": []
+					}
+				}
+			}`,
+			expected: ResourceAWSMonitoringConfig,
+			wantErr:  false,
+		},
+		{
 			name: "unknown resource",
 			input: `{
 				"random": "field"

--- a/pkg/apply/apply_aws.go
+++ b/pkg/apply/apply_aws.go
@@ -1,0 +1,97 @@
+package apply
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/dynatrace-oss/dtctl/pkg/resources/awsmonitoringconfig"
+)
+
+// applyAWSMonitoringConfig applies AWS monitoring configuration
+func (a *Applier) applyAWSMonitoringConfig(data []byte) (ApplyResult, error) {
+	handler := awsmonitoringconfig.NewHandler(a.client)
+
+	var config awsmonitoringconfig.AWSMonitoringConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse AWS monitoring config JSON: %w", err)
+	}
+
+	objectID := config.ObjectID
+
+	if config.Value.Version == "" && config.Version != "" {
+		config.Value.Version = config.Version
+	}
+
+	var warnings []string
+
+	if objectID == "" && config.Value.Description != "" {
+		existing, err := handler.FindByName(config.Value.Description)
+		if err == nil && existing != nil {
+			stderrWarn(&warnings, "Found existing AWS monitoring config %q with ID: %s", config.Value.Description, existing.ObjectID)
+			objectID = existing.ObjectID
+			config.ObjectID = objectID
+		}
+	}
+
+	if objectID == "" {
+		if config.Value.Version == "" {
+			latestVersion, err := handler.GetLatestVersion()
+			if err != nil {
+				return nil, fmt.Errorf("failed to determine extension version for aws_monitoring_config: %w", err)
+			}
+			config.Value.Version = latestVersion
+			config.Version = latestVersion
+			stderrWarn(&warnings, "Using latest extension version: %s", latestVersion)
+		}
+
+		cleanData, err := json.Marshal(config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal clean config: %w", err)
+		}
+
+		res, err := handler.Create(cleanData)
+		if err != nil {
+			return nil, err
+		}
+		return &MonitoringConfigApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       ActionCreated,
+				ResourceType: "aws_monitoring_config",
+				ID:           res.ObjectID,
+				Name:         config.Value.Description,
+				Warnings:     warnings,
+			},
+			Scope: config.Scope,
+		}, nil
+	}
+
+	if config.Value.Version == "" {
+		existing, err := handler.Get(objectID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch existing config to preserve version: %w", err)
+		}
+		stderrWarn(&warnings, "Preserving existing version: %s", existing.Value.Version)
+		config.Value.Version = existing.Value.Version
+		config.Version = existing.Value.Version
+	}
+
+	cleanData, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal clean config: %w", err)
+	}
+
+	res, err := handler.Update(objectID, cleanData)
+	if err != nil {
+		return nil, err
+	}
+	return &MonitoringConfigApplyResult{
+		ApplyResultBase: ApplyResultBase{
+			Action:       ActionUpdated,
+			ResourceType: "aws_monitoring_config",
+			ID:           res.ObjectID,
+			Name:         config.Value.Description,
+			Warnings:     warnings,
+		},
+		Scope: config.Scope,
+	}, nil
+}


### PR DESCRIPTION
## Summary

- `dtctl apply -f` failed with `could not detect resource type from file content` for files with `scope: integration-aws`
- Added `ResourceAWSMonitoringConfig` constant alongside the existing Azure/GCP variants
- Added detection in both the primary scope-based path and the secondary schemaId-based path in `detectResourceType`
- Added `applyAWSMonitoringConfig` handler in a new `apply_aws.go` (mirrors the Azure/GCP pattern: name-based lookup, version auto-fetch, create/update)

## Test plan

- [ ] `TestDetectResourceType/aws_monitoring_config` — new unit test confirms `scope: integration-aws` is detected correctly
- [ ] Full test suite passes (`go test ./...`)
- [ ] `dtctl apply -f <aws-monitoring-config.yaml>` no longer returns "could not detect resource type from file content"

🤖 Generated with [Claude Code](https://claude.com/claude-code)