### PR TITLE
Appobs 36842 dtctl surface immutable breakpoint id in describe get create output

### DIFF
--- a/cmd/breakpoint_helpers.go
+++ b/cmd/breakpoint_helpers.go
@@ -44,10 +44,11 @@ func defaultLiveDebuggerDeps() liveDebuggerDeps {
 }
 
 type breakpointRow struct {
-	ID       string `table:"ID" json:"id" yaml:"id"`
-	Filename string `table:"FILENAME" json:"filename" yaml:"filename"`
-	Line     int    `table:"LINE NUMBER" json:"lineNumber" yaml:"lineNumber"`
-	Active   bool   `table:"ACTIVE" json:"active" yaml:"active"`
+	ID          string `table:"ID" json:"id" yaml:"id"`
+	ImmutableID string `table:"BREAKPOINT ID" json:"breakpointId" yaml:"breakpointId"`
+	Filename    string `table:"FILENAME" json:"filename" yaml:"filename"`
+	Line        int    `table:"LINE NUMBER" json:"lineNumber" yaml:"lineNumber"`
+	Active      bool   `table:"ACTIVE" json:"active" yaml:"active"`
 }
 
 func runGetBreakpoints(cmd *cobra.Command, args []string) error {
@@ -180,7 +181,7 @@ func breakpointRowFromRule(rule livedebugger.BreakpointRule) (breakpointRow, boo
 	}
 
 	isDisabled := rule.IsDisabled
-	return breakpointRow{ID: id, Filename: filename, Line: line, Active: !isDisabled}, true
+	return breakpointRow{ID: id, ImmutableID: padBreakpointID(rule.ImmutableID), Filename: filename, Line: line, Active: !isDisabled}, true
 }
 
 func currentProjectPath() string {
@@ -269,6 +270,15 @@ func formatFilters(parsed map[string][]string) string {
 // carries a value. It is shared by create and update breakpoint so the
 // "empty --filters" error is identical (and greppable) in both commands. An
 // empty value means the flag was set but blank, e.g. --filters "".
+// padBreakpointID zero-pads a numeric immutable breakpoint ID to 32 characters,
+// matching the breakpoint.id format used in DQL snapshot queries.
+func padBreakpointID(id string) string {
+	if len(id) == 0 || len(id) >= 32 {
+		return id
+	}
+	return strings.Repeat("0", 32-len(id)) + id
+}
+
 func requireFiltersValue(filters string) error {
 	if strings.TrimSpace(filters) == "" {
 		return fmt.Errorf("--filters provided without a value")

--- a/cmd/breakpoint_helpers_test.go
+++ b/cmd/breakpoint_helpers_test.go
@@ -563,15 +563,28 @@ func TestRunGetBreakpoints_TableView(t *testing.T) {
 func TestRunGetBreakpoints_WideView(t *testing.T) {
 	originalOutputFormat := outputFormat
 	originalAgentMode := agentMode
+	originalPlainMode := plainMode
+	originalDebugMode := debugMode
+	originalVerbosity := verbosity
 	originalOut := rootCmd.OutOrStdout()
 	defer func() {
 		outputFormat = originalOutputFormat
 		agentMode = originalAgentMode
+		plainMode = originalPlainMode
+		debugMode = originalDebugMode
+		verbosity = originalVerbosity
 		rootCmd.SetOut(originalOut)
 	}()
 
+	// plainMode must be reset explicitly: NewPrinterWithOptions coerces "wide"
+	// (and "table") to JSON when plainMode is true, which happens whenever an
+	// AI-agent shell is auto-detected (--plain is implied). Without this reset
+	// the test flakes depending on ambient state / launching environment.
 	outputFormat = "wide"
 	agentMode = false
+	plainMode = false
+	debugMode = false
+	verbosity = 0
 
 	deps := liveDebuggerDeps{}
 	deps.loadConfig = func() (*config.Config, error) {

--- a/cmd/breakpoint_helpers_test.go
+++ b/cmd/breakpoint_helpers_test.go
@@ -560,6 +560,68 @@ func TestRunGetBreakpoints_TableView(t *testing.T) {
 	}
 }
 
+func TestRunGetBreakpoints_WideView(t *testing.T) {
+	originalOutputFormat := outputFormat
+	originalAgentMode := agentMode
+	originalOut := rootCmd.OutOrStdout()
+	defer func() {
+		outputFormat = originalOutputFormat
+		agentMode = originalAgentMode
+		rootCmd.SetOut(originalOut)
+	}()
+
+	outputFormat = "wide"
+	agentMode = false
+
+	deps := liveDebuggerDeps{}
+	deps.loadConfig = func() (*config.Config, error) {
+		cfg := config.NewConfig()
+		cfg.SetContext("test", "https://example.invalid", "token")
+		cfg.CurrentContext = "test"
+		return cfg, nil
+	}
+	deps.newClient = func(cfg *config.Config) (*client.Client, error) { return nil, nil }
+	deps.newHandler = func(c *client.Client, environment string) (*livedebugger.Handler, error) { return nil, nil }
+	deps.getOrCreateWorkspace = func(handler *livedebugger.Handler, projectPath string) (map[string]interface{}, string, error) {
+		return map[string]interface{}{"data": map[string]interface{}{}}, "ws-1", nil
+	}
+	deps.getWorkspaceRules = func(handler *livedebugger.Handler, workspaceID string) (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"data": map[string]interface{}{
+				"org": map[string]interface{}{
+					"workspace": map[string]interface{}{
+						"rules": []interface{}{
+							map[string]interface{}{
+								"id":          "bp-1",
+								"immutableId": "96294",
+								"is_disabled": false,
+								"aug_json": map[string]interface{}{
+									"location": map[string]interface{}{"filename": "OrderController.java", "lineno": float64(306)},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, nil
+	}
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+
+	if err := runGetBreakpointsWithDeps(nil, nil, deps); err != nil {
+		t.Fatalf("runGetBreakpoints returned error: %v", err)
+	}
+
+	text := out.String()
+	if !strings.Contains(text, "BREAKPOINT ID") {
+		t.Fatalf("expected BREAKPOINT ID column in wide output: %q", text)
+	}
+	if !strings.Contains(text, "00000000000000000000000000096294") {
+		t.Fatalf("expected padded immutable ID in wide output: %q", text)
+	}
+}
+
 func TestRunGetBreakpoints_StructuredView(t *testing.T) {
 	originalOutputFormat := outputFormat
 	originalAgentMode := agentMode

--- a/cmd/create_breakpoints.go
+++ b/cmd/create_breakpoints.go
@@ -161,8 +161,21 @@ Examples:
 			}
 		}
 
-		return printBreakpointMessage("create", fmt.Sprintf("Created breakpoint at %s:%d", fileName, lineNumber))
+		msg := fmt.Sprintf("Created breakpoint at %s:%d", fileName, lineNumber)
+		if id := extractCreateBreakpointImmutableID(createResp); id != "" {
+			msg += fmt.Sprintf(" (id: %s)", id)
+		}
+		return printBreakpointMessage("create", msg)
 	},
+}
+
+func extractCreateBreakpointImmutableID(resp map[string]interface{}) string {
+	data, _ := resp["data"].(map[string]interface{})
+	org, _ := data["org"].(map[string]interface{})
+	workspace, _ := org["workspace"].(map[string]interface{})
+	rule, _ := workspace["createRuleV2"].(map[string]interface{})
+	id, _ := rule["immutableId"].(string)
+	return padBreakpointID(id)
 }
 
 func init() {

--- a/cmd/create_breakpoints_test.go
+++ b/cmd/create_breakpoints_test.go
@@ -42,6 +42,44 @@ func TestCreateBreakpointYesFlagRegistered(t *testing.T) {
 	}
 }
 
+func TestExtractCreateBreakpointImmutableID(t *testing.T) {
+	resp := map[string]interface{}{
+		"data": map[string]interface{}{
+			"org": map[string]interface{}{
+				"workspace": map[string]interface{}{
+					"createRuleV2": map[string]interface{}{
+						"immutableId": "96294",
+					},
+				},
+			},
+		},
+	}
+	if id := extractCreateBreakpointImmutableID(resp); id != "00000000000000000000000000096294" {
+		t.Fatalf("expected padded immutable ID, got %q", id)
+	}
+	if id := extractCreateBreakpointImmutableID(map[string]interface{}{}); id != "" {
+		t.Fatalf("expected empty string for missing immutable ID, got %q", id)
+	}
+}
+
+func TestPadBreakpointID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"96294", "00000000000000000000000000096294"},
+		{"1", "00000000000000000000000000000001"},
+		{"", ""},
+		{"00000000000000000000000000096294", "00000000000000000000000000096294"},
+		{"999999999999999999999999999999999", "999999999999999999999999999999999"}, // longer than 32 — pass through
+	}
+	for _, tt := range tests {
+		if got := padBreakpointID(tt.input); got != tt.want {
+			t.Fatalf("padBreakpointID(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 // TestCreateBreakpointFiltersValidation exercises the early --filters validation
 // that runs before any config or network call, so no client/config setup is
 // required. The flag state is saved and restored to avoid leaking into other tests.

--- a/cmd/describe_breakpoints.go
+++ b/cmd/describe_breakpoints.go
@@ -37,6 +37,7 @@ Examples:
 
 type breakpointStatusResult struct {
 	ID                 string                  `json:"id" yaml:"id"`
+	ImmutableID        string                  `json:"breakpointId,omitempty" yaml:"breakpointId,omitempty"`
 	Location           string                  `json:"location,omitempty" yaml:"location,omitempty"`
 	Enabled            bool                    `json:"enabled" yaml:"enabled"`
 	DisableReason      string                  `json:"disableReason,omitempty" yaml:"disableReason,omitempty"`
@@ -193,6 +194,7 @@ func buildBreakpointStatusResult(rule livedebugger.BreakpointRule, statusResp ma
 	}
 	if row, ok := breakpointRowFromRule(rule); ok {
 		result.ID = row.ID
+		result.ImmutableID = row.ImmutableID
 		result.Location = fmt.Sprintf("%s:%d", row.Filename, row.Line)
 		result.Enabled = row.Active
 	}
@@ -457,6 +459,9 @@ func printBreakpointStatusResult(result breakpointStatusResult) {
 	w := rootCmd.OutOrStdout()
 	const kw = 16
 	output.FprintDescribeKV(w, "ID:", kw, "%s", result.ID)
+	if result.ImmutableID != "" {
+		output.FprintDescribeKV(w, "Breakpoint ID:", kw, "%s", result.ImmutableID)
+	}
 	if result.Location != "" {
 		output.FprintDescribeKV(w, "Location:", kw, "%s", result.Location)
 	}

--- a/cmd/describe_breakpoints.go
+++ b/cmd/describe_breakpoints.go
@@ -134,7 +134,7 @@ func runDescribeBreakpointWithDeps(cmd *cobra.Command, identifier string, deps l
 		return err
 	}
 	if allowDirectID {
-		targetRules = []livedebugger.BreakpointRule{{ID: strings.TrimSpace(identifier)}}
+		return fmt.Errorf("no breakpoint found with identifier %q", strings.TrimSpace(identifier))
 	}
 
 	results := make([]breakpointStatusResult, 0, len(targetRules))

--- a/cmd/describe_breakpoints_test.go
+++ b/cmd/describe_breakpoints_test.go
@@ -409,7 +409,15 @@ func TestRunDescribeBreakpoint_DirectIDSuccess(t *testing.T) {
 			"data": map[string]interface{}{
 				"org": map[string]interface{}{
 					"workspace": map[string]interface{}{
-						"rules": []interface{}{},
+						"rules": []interface{}{
+							map[string]interface{}{
+								"id":          "123456789",
+								"is_disabled": false,
+								"aug_json": map[string]interface{}{
+									"location": map[string]interface{}{"filename": "OrderController.java", "lineno": float64(306)},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -433,6 +441,44 @@ func TestRunDescribeBreakpoint_DirectIDSuccess(t *testing.T) {
 
 	if !strings.Contains(output, "\"id\": \"123456789\"") {
 		t.Fatalf("unexpected direct-id output: %q", output)
+	}
+}
+
+func TestRunDescribeBreakpoint_UnknownIdentifierError(t *testing.T) {
+	deps := liveDebuggerDeps{}
+	deps.loadConfig = func() (*config.Config, error) {
+		cfg := config.NewConfig()
+		cfg.SetContext("test", "https://example.invalid", "token")
+		cfg.CurrentContext = "test"
+		return cfg, nil
+	}
+	deps.newClient = func(cfg *config.Config) (*client.Client, error) { return nil, nil }
+	deps.newHandler = func(c *client.Client, environment string) (*livedebugger.Handler, error) { return nil, nil }
+	deps.getOrCreateWorkspace = func(handler *livedebugger.Handler, projectPath string) (map[string]interface{}, string, error) {
+		return map[string]interface{}{"data": map[string]interface{}{}}, "ws-1", nil
+	}
+	deps.getWorkspaceRules = func(handler *livedebugger.Handler, workspaceID string) (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"data": map[string]interface{}{
+				"org": map[string]interface{}{
+					"workspace": map[string]interface{}{
+						"rules": []interface{}{},
+					},
+				},
+			},
+		}, nil
+	}
+	deps.getRuleStatusBreakdown = func(handler *livedebugger.Handler, ruleID string) (map[string]interface{}, error) {
+		t.Fatalf("getRuleStatusBreakdown should not be called for unknown identifier")
+		return nil, nil
+	}
+
+	err := runDescribeBreakpointWithDeps(describeCmd, "asdfasdfasdfadfasfd", deps)
+	if err == nil {
+		t.Fatalf("expected error for unknown identifier")
+	}
+	if !strings.Contains(err.Error(), "no breakpoint found") {
+		t.Fatalf("unexpected error message: %v", err)
 	}
 }
 

--- a/docs/LIVE_DEBUGGER.md
+++ b/docs/LIVE_DEBUGGER.md
@@ -226,6 +226,10 @@ dtctl query "fetch application.snapshots | sort timestamp desc | limit 5" --deco
 # Compose with any output format
 dtctl query "fetch application.snapshots | sort timestamp desc | limit 5" --decode-snapshots -o json
 dtctl query "fetch application.snapshots | sort timestamp desc | limit 5" --decode-snapshots -o yaml
+
+# Filter snapshots by a specific breakpoint using its immutable ID
+# The breakpoint ID is shown in the output of: dtctl create breakpoint / dtctl get breakpoints / dtctl describe breakpoint
+dtctl query "fetch application.snapshots | filter breakpoint.id == toUid(\"00000000000000000000000000096294\")" --decode-snapshots
 ```
 
 The `--decode-snapshots` flag enriches each record with a decoded `parsed_snapshot` field built from:

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -3294,6 +3294,10 @@ dtctl query "fetch application.snapshots | sort timestamp desc | limit 5" --deco
 # Compose with any output format
 dtctl query "fetch application.snapshots | limit 5" --decode-snapshots -o json
 dtctl query "fetch application.snapshots | limit 5" --decode-snapshots -o yaml
+
+# Filter snapshots by a specific breakpoint using its immutable ID
+# The breakpoint ID is shown in: dtctl create breakpoint / dtctl get breakpoints / dtctl describe breakpoint
+dtctl query "fetch application.snapshots | filter breakpoint.id == toUid(\"00000000000000000000000000096294\")" --decode-snapshots
 ```
 
 `--decode-snapshots` enriches each record with `parsed_snapshot` decoded from `snapshot.data` and `snapshot.string_map`. By default, variant wrappers are simplified to plain values; use `--decode-snapshots=full` to preserve type annotations.

--- a/docs/site/_docs/live-debugger.md
+++ b/docs/site/_docs/live-debugger.md
@@ -104,6 +104,10 @@ When a breakpoint is hit, the runtime captures a snapshot of local variables and
 ```bash
 # Query snapshots and decode variable data
 dtctl query "fetch application.snapshots | limit 10" --decode-snapshots
+
+# Filter snapshots by a specific breakpoint using its immutable ID
+# The breakpoint ID is shown in: dtctl create breakpoint / dtctl get breakpoints / dtctl describe breakpoint
+dtctl query "fetch application.snapshots | filter breakpoint.id == toUid(\"00000000000000000000000000096294\")" --decode-snapshots
 ```
 
 ### Full vs Simplified Decoding

--- a/pkg/resources/livedebugger/types.go
+++ b/pkg/resources/livedebugger/types.go
@@ -13,6 +13,7 @@ type (
 // BreakpointRule represents a breakpoint rule (CLI version with table tags).
 type BreakpointRule struct {
 	ID            string                 `json:"id" table:"ID"`
+	ImmutableID   string                 `json:"immutableId,omitempty"`
 	IsDisabled    bool                   `json:"is_disabled" table:"ACTIVE"`
 	DisableReason string                 `json:"disable_reason,omitempty"`
 	AugJSON       map[string]interface{} `json:"aug_json"`
@@ -23,6 +24,7 @@ type BreakpointRule struct {
 func fromSDKBreakpointRule(s *sdkld.BreakpointRule) BreakpointRule {
 	return BreakpointRule{
 		ID:            s.ID,
+		ImmutableID:   s.ImmutableID,
 		IsDisabled:    s.IsDisabled,
 		DisableReason: s.DisableReason,
 		AugJSON:       s.AugJSON,

--- a/sdk/api/livedebugger/types.go
+++ b/sdk/api/livedebugger/types.go
@@ -33,6 +33,7 @@ type Workspace struct {
 
 type BreakpointRule struct {
 	ID            string                 `json:"id"`
+	ImmutableID   string                 `json:"immutableId,omitempty"`
 	IsDisabled    bool                   `json:"is_disabled"`
 	DisableReason string                 `json:"disable_reason,omitempty"`
 	AugJSON       map[string]interface{} `json:"aug_json"`


### PR DESCRIPTION
Description

Surfaces the immutable breakpoint ID (the breakpoint.id value used in DQL snapshot queries) across all Live Debugger commands. Previously this ID was only accessible by digging through --verbose JSON output.

- dtctl create breakpoint — success message now includes the ID: Created breakpoint at OrderController.java:306 (id: 00000000000000000000000000096294)
- dtctl get breakpoints — new BREAKPOINT ID column in default table output
- dtctl describe breakpoint — new Breakpoint ID: field alongside the existing mutable rule ID

The ID is zero-padded to 32 characters to match the breakpoint.id format used in DQL (toUid(...)), so it can be copied directly into queries like:

fetch application.snapshots | filter breakpoint.id == toUid("00000000000000000000000000096294")

Also fixes a silent bug in dtctl describe breakpoint where passing an unrecognized identifier (e.g. a typo) would show a fake "Pending" result instead of an error, because the Live Debugger API returns empty results rather than an error for unknown rule IDs.

Related Issues

Closes #APPOBS-36842

Testing

- [x] Tests pass (make test)
- [ ] Linting passes (make lint)
- Manually created a breakpoint, confirmed the immutable ID printed by create matches the breakpoint.id in fetch application.snapshots DQL results (zero-padded format verified)
- Confirmed dtctl describe breakpoint <garbage-string> now returns an error instead of a fake result