### PR TITLE
feat: add OpenAI Codex CLI as supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ dtctl skills install --global     # User-wide installation
 cp -r skills/dtctl ~/.agents/skills/   # Cross-client (any agent)
 ```
 
-Compatible with GitHub Copilot, Claude Code, Cursor, Kiro, Junie, OpenCode, OpenClaw, and other [Agent Skills](https://agentskills.io)-compatible tools. See the **[AI Agent Mode docs](https://dynatrace-oss.github.io/dtctl/docs/ai-agent-mode/)** for details on the structured JSON envelope and agent auto-detection.
+Compatible with GitHub Copilot, Claude Code, OpenAI Codex CLI, Cursor, Kiro, Junie, OpenCode, OpenClaw, and other [Agent Skills](https://agentskills.io)-compatible tools. See the **[AI Agent Mode docs](https://dynatrace-oss.github.io/dtctl/docs/ai-agent-mode/)** for details on the structured JSON envelope and agent auto-detection.
 
 ### Dynatrace domain skills
 

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -20,7 +20,7 @@ var skillsCmd = &cobra.Command{
 
 Skill files teach your AI assistant how to use dtctl effectively.
 Follows the agentskills.io open standard for skill installation.
-Supported agents: claude, copilot, cursor, junie, kiro, opencode, openclaw.
+Supported agents: claude, codex, copilot, cursor, junie, kiro, opencode, openclaw.
 
 Use --cross-client to install to the shared ~/.agents/skills/ directory,
 which is automatically discovered by any agentskills.io-compatible agent.`,
@@ -173,7 +173,7 @@ func init() {
 	skillsCmd.AddCommand(skillsStatusCmd)
 
 	// Flags for install
-	skillsInstallCmd.Flags().String("for", "", "install for a specific agent (claude, copilot, cursor, junie, kiro, opencode, openclaw)")
+	skillsInstallCmd.Flags().String("for", "", "install for a specific agent (claude, codex, copilot, cursor, junie, kiro, opencode, openclaw)")
 	skillsInstallCmd.Flags().Bool("cross-client", false, "install to the shared .agents/skills/ directory (agentskills.io convention)")
 	skillsInstallCmd.Flags().Bool("global", false, "install to user-wide location instead of project directory")
 	skillsInstallCmd.Flags().Bool("force", false, "overwrite existing files without prompting")

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -36,7 +36,7 @@ func resetSkillsFlags(t *testing.T) {
 func clearAgentEnvVars(t *testing.T) {
 	t.Helper()
 	for _, env := range []string{
-		"CLAUDECODE", "CURSOR_AGENT", "GITHUB_COPILOT", "JUNIE", "KIRO", "OPENCODE", "OPENCLAW",
+		"CLAUDECODE", "CODEX", "CURSOR_AGENT", "GITHUB_COPILOT", "JUNIE", "KIRO", "OPENCODE", "OPENCLAW",
 		"CODEIUM_AGENT", "TABNINE_AGENT", "AMAZON_Q", "AI_AGENT",
 	} {
 		t.Setenv(env, "")

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -3659,7 +3659,7 @@ dtctl skills uninstall --cross-client
 dtctl skills install --list
 ```
 
-Supported agents: **claude**, **copilot**, **cursor**, **junie**, **kiro**, **opencode**, **openclaw**.
+Supported agents: **claude**, **codex**, **copilot**, **cursor**, **junie**, **kiro**, **opencode**, **openclaw**.
 
 ---
 
@@ -4040,6 +4040,7 @@ The detection is automatic and doesn't affect functionality. Supported AI agents
 - Kiro (`KIRO` env var)
 - Junie (`JUNIE` env var)
 - OpenClaw (`OPENCLAW` env var)
+- OpenAI Codex CLI (`CODEX` env var)
 - Codeium (`CODEIUM_AGENT` env var)
 - TabNine (`TABNINE_AGENT` env var)
 - Amazon Q (`AMAZON_Q` env var)

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -313,6 +313,7 @@ dtctl automatically detects when running under AI coding assistants and includes
 - **Kiro**: Detected via `KIRO` environment variable
 - **Junie**: Detected via `JUNIE` environment variable
 - **OpenClaw**: Detected via `OPENCLAW` environment variable
+- **OpenAI Codex CLI**: Detected via `CODEX` environment variable
 - **Codeium**: Detected via `CODEIUM_AGENT` environment variable
 - **TabNine**: Detected via `TABNINE_AGENT` environment variable
 - **Amazon Q**: Detected via `AMAZON_Q` environment variable
@@ -325,7 +326,7 @@ This telemetry helps improve the CLI experience for AI-assisted workflows. Detec
 
 dtctl includes a `skills` command for installing skill files that teach AI coding assistants how to use dtctl effectively. Skills follow the [agentskills.io](https://agentskills.io) open standard.
 
-**Supported agents**: claude, copilot, cursor, junie, kiro, opencode, openclaw
+**Supported agents**: claude, codex, copilot, cursor, junie, kiro, opencode, openclaw
 
 **Installation modes**:
 

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -51,7 +51,7 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] `doctor` - Health check (config, context, token, connectivity, auth)
 - [x] `inventory` - Environment data inventory: fetchable data objects, buckets, entity census, capabilities present/absent with evidence; customizable via `--definitions`
 - [x] `commands` - Machine-readable command catalog (JSON/YAML, `--brief`, resource filter, `howto` subcommand)
-- [x] `skills` - AI agent skill file management (install, uninstall, status for Claude, Copilot, Cursor, Kiro, Junie, OpenCode, OpenClaw; cross-client via `--cross-client`)
+- [x] `skills` - AI agent skill file management (install, uninstall, status for Claude, Codex, Copilot, Cursor, Kiro, Junie, OpenCode, OpenClaw; cross-client via `--cross-client`)
 - [x] `plugin` - kubectl-style exec plugins: unknown commands dispatch to `dtctl-<name>` binaries on PATH (`plugin list`, catalog integration; see [PLUGIN_CONVENTIONS.md](PLUGIN_CONVENTIONS.md))
 
 ### Resources

--- a/pkg/aidetect/detect.go
+++ b/pkg/aidetect/detect.go
@@ -15,6 +15,7 @@ func Detect() AgentInfo {
 // knownAgents is kept for test compatibility — mirrors the SDK's internal list.
 var knownAgents = map[string]string{
 	"CLAUDECODE":     "claude-code",
+	"CODEX":          "codex",
 	"CURSOR_AGENT":   "cursor",
 	"GITHUB_COPILOT": "github-copilot",
 	"CODEIUM_AGENT":  "codeium",

--- a/pkg/aidetect/detect_test.go
+++ b/pkg/aidetect/detect_test.go
@@ -120,6 +120,16 @@ func TestDetect(t *testing.T) {
 			},
 		},
 		{
+			name: "OpenAI Codex CLI detected",
+			envVars: map[string]string{
+				"CODEX": "1",
+			},
+			expected: AgentInfo{
+				Detected: true,
+				Name:     "codex",
+			},
+		},
+		{
 			name: "generic AI agent detected",
 			envVars: map[string]string{
 				"AI_AGENT": "custom",

--- a/pkg/skills/installer.go
+++ b/pkg/skills/installer.go
@@ -59,6 +59,14 @@ var agents = []Agent{
 		DetectName:  "claude-code",
 	},
 	{
+		Name:        "codex",
+		DisplayName: "OpenAI Codex CLI",
+		ProjectPath: filepath.Join(".codex", "skills", "dtctl"),
+		GlobalPath:  filepath.Join(".codex", "skills", "dtctl"),
+		EnvVar:      "CODEX",
+		DetectName:  "codex",
+	},
+	{
 		Name:        "copilot",
 		DisplayName: "GitHub Copilot",
 		ProjectPath: filepath.Join(".github", "skills", "dtctl"),

--- a/pkg/skills/installer_test.go
+++ b/pkg/skills/installer_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSupportedAgents(t *testing.T) {
 	agents := SupportedAgents()
-	expected := []string{"claude", "copilot", "cursor", "kiro", "junie", "opencode", "openclaw"}
+	expected := []string{"claude", "codex", "copilot", "cursor", "kiro", "junie", "opencode", "openclaw"}
 	if len(agents) != len(expected) {
 		t.Fatalf("expected %d agents, got %d: %v", len(expected), len(agents), agents)
 	}
@@ -26,6 +26,7 @@ func TestFindAgent(t *testing.T) {
 		found bool
 	}{
 		{"claude", true},
+		{"codex", true},
 		{"copilot", true},
 		{"cursor", true},
 		{"kiro", true},
@@ -52,7 +53,7 @@ func TestFindAgent(t *testing.T) {
 func TestDetectAgent(t *testing.T) {
 	// Each subtest clears ALL agent env vars to ensure full isolation.
 	allEnvVars := []string{
-		"CLAUDECODE", "CURSOR_AGENT", "GITHUB_COPILOT", "JUNIE", "KIRO", "OPENCODE", "OPENCLAW",
+		"CLAUDECODE", "CODEX", "CURSOR_AGENT", "GITHUB_COPILOT", "JUNIE", "KIRO", "OPENCODE", "OPENCLAW",
 		"CODEIUM_AGENT", "TABNINE_AGENT", "AMAZON_Q", "AI_AGENT",
 	}
 
@@ -80,6 +81,18 @@ func TestDetectAgent(t *testing.T) {
 		}
 		if agent.Name != "claude" {
 			t.Errorf("expected claude, got %q", agent.Name)
+		}
+	})
+
+	t.Run("detects codex", func(t *testing.T) {
+		clearAllEnvVars(t)
+		t.Setenv("CODEX", "1")
+		agent, detected := DetectAgent()
+		if !detected {
+			t.Fatal("expected agent detected")
+		}
+		if agent.Name != "codex" {
+			t.Errorf("expected codex, got %q", agent.Name)
 		}
 	})
 
@@ -497,6 +510,7 @@ func TestAgentPaths(t *testing.T) {
 		pathPart string
 	}{
 		{"claude", ".claude/skills/dtctl"},
+		{"codex", ".codex/skills/dtctl"},
 		{"copilot", ".github/skills/dtctl"},
 		{"cursor", ".cursor/skills/dtctl"},
 		{"kiro", ".kiro/skills/dtctl"},
@@ -528,6 +542,7 @@ func TestAgentGlobalPaths(t *testing.T) {
 		supported  bool
 	}{
 		{"claude", ".claude/skills/dtctl", true},
+		{"codex", ".codex/skills/dtctl", true},
 		{"copilot", ".copilot/skills/dtctl", true},
 		{"cursor", "", false},
 		{"kiro", "", false},

--- a/sdk/agentmode/detect.go
+++ b/sdk/agentmode/detect.go
@@ -16,6 +16,7 @@ type AgentInfo struct {
 // knownAgents maps environment variables to AI agent names.
 var knownAgents = map[string]string{
 	"CLAUDECODE":   "claude-code",
+	"CODEX":        "codex",
 	"CURSOR_AGENT": "cursor",
 	// GitHub Copilot: the copilot CLI (and VS Code's bundled Copilot, which shares
 	// the @github/copilot SDK) sets COPILOT_CLI=1 — verified on copilot v1.0.63.


### PR DESCRIPTION
## Summary

- Adds `codex` as a supported agent for `dtctl skills install --for codex`
- Detection via `CODEX` environment variable
- Project path: `.codex/skills/dtctl`; global path: `~/.codex/skills/dtctl`
- Follows the same pattern as `claude` and `opencode` agents

## Test plan

- [ ] `TestSupportedAgents` — codex in ordered list
- [ ] `TestFindAgent` — codex resolves correctly
- [ ] `TestDetectAgent` — CODEX env var detected
- [ ] `TestAgentPaths` / `TestAgentGlobalPaths` — paths verified
- [ ] `TestSkillsInstall_AllAgents` — codex exercised automatically
- [ ] `TestResolveAgent_Valid` — codex resolves via --for
- [ ] `pkg/aidetect/detect_test.go` — OpenAI Codex CLI detection test

🤖 Generated with [Claude Code](https://claude.com/claude-code)