### PR TITLE
feat(translate)!: introduce translate verb with lql-to-dql and classic-pipelines subcommands

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -39,7 +39,7 @@ Supported resources:
   lookup-tables (lu)      trash                     workflow-executions (wfe)
   wfe-task-result         extensions (ext)          extension-configs (extcfg)
   documents (doc)         anomaly-detectors (ad)    hub-extensions
-  hub-extension-releases  classic-pipelines-translation
+  hub-extension-releases
 
 Use 'dtctl get <resource> --help' for resource-specific options.`,
 	Example: `  # List all workflows
@@ -151,5 +151,4 @@ func init() {
 	getCmd.AddCommand(getAnomalyDetectorsCmd)
 	getCmd.AddCommand(getHubExtensionsCmd)
 	getCmd.AddCommand(getHubExtensionReleasesCmd)
-	getCmd.AddCommand(getClassicPipelinesTranslationCmd)
 }

--- a/cmd/translate.go
+++ b/cmd/translate.go
@@ -14,4 +14,5 @@ Available subcommands:
 func init() {
 	rootCmd.AddCommand(translateCmd)
 	translateCmd.AddCommand(translateLqlToDqlCmd)
+	translateCmd.AddCommand(translateClassicPipelinesCmd)
 }

--- a/cmd/translate.go
+++ b/cmd/translate.go
@@ -1,0 +1,17 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var translateCmd = &cobra.Command{
+	Use:   "translate",
+	Short: "Translate expressions between formats",
+	Long: `Translate expressions and configurations between formats.
+
+Available subcommands:
+  lql-to-dql   Translate an LQL matcher expression into a DQL matcher expression`,
+}
+
+func init() {
+	rootCmd.AddCommand(translateCmd)
+	translateCmd.AddCommand(translateLqlToDqlCmd)
+}

--- a/cmd/translate.go
+++ b/cmd/translate.go
@@ -8,7 +8,8 @@ var translateCmd = &cobra.Command{
 	Long: `Translate expressions and configurations between formats.
 
 Available subcommands:
-  lql-to-dql   Translate an LQL matcher expression into a DQL matcher expression`,
+  lql-to-dql         Translate an LQL matcher expression into a DQL matcher expression
+  classic-pipelines  Translate a Classic pipeline into an OpenPipeline configuration pipeline`,
 }
 
 func init() {

--- a/cmd/translate_classic_pipelines.go
+++ b/cmd/translate_classic_pipelines.go
@@ -11,10 +11,10 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/resources/classicpipelinestranslate"
 )
 
-// getClassicPipelinesTranslationCmd translates a Classic pipeline into an
+// translateClassicPipelinesCmd translates a Classic pipeline into an
 // OpenPipeline configuration pipeline.
-var getClassicPipelinesTranslationCmd = &cobra.Command{
-	Use:   "classic-pipelines-translation <logs|bizevents>",
+var translateClassicPipelinesCmd = &cobra.Command{
+	Use:   "classic-pipelines <logs|bizevents>",
 	Short: "Translate a Classic pipeline into an OpenPipeline configuration pipeline",
 	Long: `Translate the tenant's Classic pipeline for a configuration scope into an
 OpenPipeline configuration pipeline (Settings shape).
@@ -32,16 +32,16 @@ Note: the underlying API is public but early-adopter and may change.
 
 Examples:
   # Translate the logs Classic pipeline (pretty-printed pipeline document)
-  dtctl get classic-pipelines-translation logs
+  dtctl translate classic-pipelines logs
 
   # Translate bizevents and export the document as YAML for review/editing
-  dtctl get classic-pipelines-translation bizevents -o yaml > reference-pipeline.yaml
+  dtctl translate classic-pipelines bizevents -o yaml > reference-pipeline.yaml
 
   # Print the translated pipeline as JSON
-  dtctl get classic-pipelines-translation logs -o json
+  dtctl translate classic-pipelines logs -o json
 
   # Skip disabled rules in the translation (overrides the server default)
-  dtctl get classic-pipelines-translation logs --skip-disabled-rules=true`,
+  dtctl translate classic-pipelines logs --skip-disabled-rules=true`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		scope := args[0]
@@ -72,7 +72,7 @@ Examples:
 			return err
 		}
 
-		ap := enrichAgent(printer, "get", "classic-pipelines-translation")
+		ap := enrichAgent(printer, "translate", "classic-pipelines")
 
 		// Surface the partial-translation warning out-of-band so it never
 		// pollutes the deliverable on stdout: on stderr for humans, via the
@@ -130,7 +130,7 @@ func printValueAsJSON(v any) error {
 }
 
 func init() {
-	getClassicPipelinesTranslationCmd.Flags().Bool("include-sample-data", true, "Include processor sample data in the translation")
-	getClassicPipelinesTranslationCmd.Flags().Bool("skip-disabled-rules", false, "Skip disabled rules during translation")
-	getClassicPipelinesTranslationCmd.Flags().Bool("skip-builtin-processing-rules", true, "Skip built-in processing rules during translation")
+	translateClassicPipelinesCmd.Flags().Bool("include-sample-data", true, "Include processor sample data in the translation")
+	translateClassicPipelinesCmd.Flags().Bool("skip-disabled-rules", false, "Skip disabled rules during translation")
+	translateClassicPipelinesCmd.Flags().Bool("skip-builtin-processing-rules", true, "Skip built-in processing rules during translation")
 }

--- a/cmd/translate_classic_pipelines_test.go
+++ b/cmd/translate_classic_pipelines_test.go
@@ -13,7 +13,7 @@ const classicPipelinesTranslateEndpoint = "/platform/openpipeline/v1/classic-pip
 // captureStdout (defined in breakpoint_output_test.go) runs a function with
 // os.Stdout redirected to a pipe and returns what was written.
 
-func TestGetClassicPipelinesTranslationCmd_Success(t *testing.T) {
+func TestTranslateClassicPipelinesCmd_Success(t *testing.T) {
 	var gotConfiguration string
 	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
 		classicPipelinesTranslateEndpoint: func(w http.ResponseWriter, r *http.Request) {
@@ -40,9 +40,9 @@ func TestGetClassicPipelinesTranslationCmd_Success(t *testing.T) {
 	plainMode = true
 	agentMode = false
 
-	testutil.ResetCommandFlags(getClassicPipelinesTranslationCmd)
+	testutil.ResetCommandFlags(translateClassicPipelinesCmd)
 
-	if err := getClassicPipelinesTranslationCmd.RunE(getClassicPipelinesTranslationCmd, []string{"logs"}); err != nil {
+	if err := translateClassicPipelinesCmd.RunE(translateClassicPipelinesCmd, []string{"logs"}); err != nil {
 		t.Fatalf("RunE() error = %v", err)
 	}
 	if gotConfiguration != "logs" {
@@ -50,7 +50,7 @@ func TestGetClassicPipelinesTranslationCmd_Success(t *testing.T) {
 	}
 }
 
-func TestGetClassicPipelinesTranslationCmd_PassesFlags(t *testing.T) {
+func TestTranslateClassicPipelinesCmd_PassesFlags(t *testing.T) {
 	gotParams := map[string]string{}
 	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
 		classicPipelinesTranslateEndpoint: func(w http.ResponseWriter, r *http.Request) {
@@ -77,12 +77,12 @@ func TestGetClassicPipelinesTranslationCmd_PassesFlags(t *testing.T) {
 	cfgFile = configPath
 	plainMode = true
 
-	testutil.ResetCommandFlags(getClassicPipelinesTranslationCmd)
-	_ = getClassicPipelinesTranslationCmd.Flags().Set("include-sample-data", "true")
-	_ = getClassicPipelinesTranslationCmd.Flags().Set("skip-disabled-rules", "false")
-	_ = getClassicPipelinesTranslationCmd.Flags().Set("skip-builtin-processing-rules", "true")
+	testutil.ResetCommandFlags(translateClassicPipelinesCmd)
+	_ = translateClassicPipelinesCmd.Flags().Set("include-sample-data", "true")
+	_ = translateClassicPipelinesCmd.Flags().Set("skip-disabled-rules", "false")
+	_ = translateClassicPipelinesCmd.Flags().Set("skip-builtin-processing-rules", "true")
 
-	if err := getClassicPipelinesTranslationCmd.RunE(getClassicPipelinesTranslationCmd, []string{"bizevents"}); err != nil {
+	if err := translateClassicPipelinesCmd.RunE(translateClassicPipelinesCmd, []string{"bizevents"}); err != nil {
 		t.Fatalf("RunE() error = %v", err)
 	}
 
@@ -99,7 +99,7 @@ func TestGetClassicPipelinesTranslationCmd_PassesFlags(t *testing.T) {
 	}
 }
 
-func TestGetClassicPipelinesTranslationCmd_InvalidScope(t *testing.T) {
+func TestTranslateClassicPipelinesCmd_InvalidScope(t *testing.T) {
 	// An invalid scope must fail fast without making an HTTP call.
 	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
 		classicPipelinesTranslateEndpoint: func(w http.ResponseWriter, _ *http.Request) {
@@ -122,9 +122,9 @@ func TestGetClassicPipelinesTranslationCmd_InvalidScope(t *testing.T) {
 	cfgFile = configPath
 	plainMode = true
 
-	testutil.ResetCommandFlags(getClassicPipelinesTranslationCmd)
+	testutil.ResetCommandFlags(translateClassicPipelinesCmd)
 
-	err := getClassicPipelinesTranslationCmd.RunE(getClassicPipelinesTranslationCmd, []string{"metrics"})
+	err := translateClassicPipelinesCmd.RunE(translateClassicPipelinesCmd, []string{"metrics"})
 	if err == nil {
 		t.Fatal("expected an error for an invalid scope")
 	}
@@ -164,16 +164,16 @@ func runWithOutput(t *testing.T, format, body string, args []string) string {
 	agentMode = false
 	outputFormat = format
 
-	testutil.ResetCommandFlags(getClassicPipelinesTranslationCmd)
+	testutil.ResetCommandFlags(translateClassicPipelinesCmd)
 
 	return captureStdout(t, func() {
-		if err := getClassicPipelinesTranslationCmd.RunE(getClassicPipelinesTranslationCmd, args); err != nil {
+		if err := translateClassicPipelinesCmd.RunE(translateClassicPipelinesCmd, args); err != nil {
 			t.Fatalf("RunE() error = %v", err)
 		}
 	})
 }
 
-func TestGetClassicPipelinesTranslationCmd_DefaultPrintsValueOnly(t *testing.T) {
+func TestTranslateClassicPipelinesCmd_DefaultPrintsValueOnly(t *testing.T) {
 	out := runWithOutput(t, "table",
 		`{"value":{"id":"pipe-1","processors":[]},"withWarning":false}`,
 		[]string{"logs"})
@@ -188,7 +188,7 @@ func TestGetClassicPipelinesTranslationCmd_DefaultPrintsValueOnly(t *testing.T) 
 	}
 }
 
-func TestGetClassicPipelinesTranslationCmd_JSONPrintsValueOnly(t *testing.T) {
+func TestTranslateClassicPipelinesCmd_JSONPrintsValueOnly(t *testing.T) {
 	out := runWithOutput(t, "json",
 		`{"value":{"id":"pipe-1"},"withWarning":true}`,
 		[]string{"logs"})
@@ -203,7 +203,7 @@ func TestGetClassicPipelinesTranslationCmd_JSONPrintsValueOnly(t *testing.T) {
 	}
 }
 
-func TestGetClassicPipelinesTranslationCmd_YAMLRendersStructured(t *testing.T) {
+func TestTranslateClassicPipelinesCmd_YAMLRendersStructured(t *testing.T) {
 	out := runWithOutput(t, "yaml",
 		`{"value":{"id":"pipe-1","processors":[{"type":"fieldsAdd"}]},"withWarning":false}`,
 		[]string{"bizevents"})
@@ -219,7 +219,7 @@ func TestGetClassicPipelinesTranslationCmd_YAMLRendersStructured(t *testing.T) {
 	}
 }
 
-func TestGetClassicPipelinesTranslationCmd_TOONRendersStructured(t *testing.T) {
+func TestTranslateClassicPipelinesCmd_TOONRendersStructured(t *testing.T) {
 	out := runWithOutput(t, "toon",
 		`{"value":{"id":"pipe-1","processors":[{"type":"fieldsAdd"}]},"withWarning":false}`,
 		[]string{"logs"})
@@ -239,7 +239,7 @@ func TestGetClassicPipelinesTranslationCmd_TOONRendersStructured(t *testing.T) {
 	}
 }
 
-func TestGetClassicPipelinesTranslationCmd_NullValue(t *testing.T) {
+func TestTranslateClassicPipelinesCmd_NullValue(t *testing.T) {
 	// A scope with no Classic pipeline configured yields a null document; the
 	// command must succeed and emit a consistent null on stdout (the human note
 	// goes to stderr).
@@ -252,7 +252,7 @@ func TestGetClassicPipelinesTranslationCmd_NullValue(t *testing.T) {
 	}
 }
 
-func TestGetClassicPipelinesTranslationCmd_AgentMode(t *testing.T) {
+func TestTranslateClassicPipelinesCmd_AgentMode(t *testing.T) {
 	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
 		classicPipelinesTranslateEndpoint: func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -277,10 +277,10 @@ func TestGetClassicPipelinesTranslationCmd_AgentMode(t *testing.T) {
 	plainMode = true
 	agentMode = true
 
-	testutil.ResetCommandFlags(getClassicPipelinesTranslationCmd)
+	testutil.ResetCommandFlags(translateClassicPipelinesCmd)
 
 	out := captureStdout(t, func() {
-		if err := getClassicPipelinesTranslationCmd.RunE(getClassicPipelinesTranslationCmd, []string{"logs"}); err != nil {
+		if err := translateClassicPipelinesCmd.RunE(translateClassicPipelinesCmd, []string{"logs"}); err != nil {
 			t.Fatalf("RunE() error = %v", err)
 		}
 	})

--- a/cmd/translate_lql_to_dql.go
+++ b/cmd/translate_lql_to_dql.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/resources/appengine"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/matcherlqltodql"
+)
+
+var translateLqlToDqlCmd = &cobra.Command{
+	Use:   "lql-to-dql [lql-expression]",
+	Short: "Translate an LQL matcher expression into a DQL matcher expression",
+	Long: `Translate a single LQL matcher expression into its semantically equivalent
+DQL matcher expression using the OpenPipeline translation endpoint.
+
+The translated DQL expression is returned verbatim. By default it is printed as
+plain text, ready to copy-paste or pipe into another command. Use -o json or
+-o yaml for structured output; -o table for a single-row table.
+
+The LQL expression can be supplied as a positional argument or read from a file
+(or stdin with "-"). Exactly one of the two forms must be given.
+
+Required OAuth scope: openpipeline:configurations:read
+
+Examples:
+  # Translate an inline LQL expression
+  dtctl translate lql-to-dql 'log.source="snmptraps" AND snmp.trap_oid="F5-BIGIP-COMMON-MIB"'
+
+  # Read the LQL expression from a file
+  dtctl translate lql-to-dql -f matcher.lql
+
+  # Read from stdin
+  echo 'log.source="snmptraps"' | dtctl translate lql-to-dql -f -
+
+  # Output as JSON
+  dtctl translate lql-to-dql 'log.source="snmptraps"' -o json
+
+  # Use in agent mode
+  dtctl translate lql-to-dql 'log.source="snmptraps"' -A`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		filePath, _ := cmd.Flags().GetString("file")
+
+		hasArg := len(args) == 1
+		hasFile := filePath != ""
+
+		if hasArg && hasFile {
+			return fmt.Errorf("provide either a positional LQL expression or --file, not both")
+		}
+		if !hasArg && !hasFile {
+			return fmt.Errorf("provide an LQL expression as an argument or via --file (use \"-\" for stdin)")
+		}
+
+		var lql string
+		if hasFile {
+			content, err := appengine.ReadFileOrStdin(filePath)
+			if err != nil {
+				return fmt.Errorf("read LQL expression: %w", err)
+			}
+			lql = strings.TrimSpace(content)
+		} else {
+			lql = args[0]
+		}
+
+		_, c, printer, err := Setup()
+		if err != nil {
+			return err
+		}
+
+		handler := matcherlqltodql.NewHandler(c)
+		result, err := handler.Translate(lql)
+		if err != nil {
+			return err
+		}
+
+		ap := enrichAgent(printer, "translate", "lql-to-dql")
+		if ap != nil {
+			ap.SetSuggestions([]string{
+				"Exchange your LQL matcher with the translated DQL matcher",
+			})
+			return printer.Print(result)
+		}
+
+		// Default (no explicit -o): print the raw DQL string, ready to pipe.
+		// An explicit -o flag routes to the structured printer.
+		outputFlag := cmd.Root().PersistentFlags().Lookup("output")
+		if outputFlag != nil && outputFlag.Changed {
+			return printer.Print(result)
+		}
+		_, err = fmt.Println(result.Query)
+		return err
+	},
+}
+
+func init() {
+	translateLqlToDqlCmd.Flags().StringP("file", "f", "", `Read the LQL expression from a file ("-" for stdin)`)
+}

--- a/cmd/translate_lql_to_dql.go
+++ b/cmd/translate_lql_to_dql.go
@@ -84,8 +84,9 @@ Examples:
 			return printer.Print(result)
 		}
 
-		// Default (no explicit -o): print the raw DQL string, ready to pipe.
-		// An explicit -o flag routes to the structured printer.
+		// Use .Changed (not outputFormat) to distinguish "user passed -o" from
+		// "defaulted to table" — outputFormat defaults to "table", so checking
+		// its value alone can't tell whether the user asked for it explicitly.
 		outputFlag := cmd.Root().PersistentFlags().Lookup("output")
 		if outputFlag != nil && outputFlag.Changed {
 			return printer.Print(result)

--- a/cmd/translate_lql_to_dql_test.go
+++ b/cmd/translate_lql_to_dql_test.go
@@ -1,0 +1,260 @@
+package cmd
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
+)
+
+const lqlToDqlEndpoint = "/platform/openpipeline/v1/matcher/lqlToDql"
+
+const lqlToDqlResponse = `{"query":"matchesValue(log.source, \"snmptraps\")"}`
+
+func setupLqlToDqlServer(t *testing.T, responseBody string) (*testutil.MockServer, string, func()) {
+	t.Helper()
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		lqlToDqlEndpoint: func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(responseBody))
+		},
+	})
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	return ms, configPath, func() {
+		ms.Close()
+		cleanup()
+	}
+}
+
+func withLqlToDqlGlobals(t *testing.T, configPath string, fn func()) {
+	t.Helper()
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	origAgent := agentMode
+	origFormat := outputFormat
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+		agentMode = origAgent
+		outputFormat = origFormat
+	}()
+	cfgFile = configPath
+	plainMode = true
+	agentMode = false
+	outputFormat = ""
+	fn()
+}
+
+func TestTranslateLqlToDqlCmd_BothArgAndFile(t *testing.T) {
+	_, configPath, cleanup := setupLqlToDqlServer(t, lqlToDqlResponse)
+	defer cleanup()
+
+	withLqlToDqlGlobals(t, configPath, func() {
+		testutil.ResetCommandFlags(translateLqlToDqlCmd)
+		_ = translateLqlToDqlCmd.Flags().Set("file", "some.lql")
+
+		err := translateLqlToDqlCmd.RunE(translateLqlToDqlCmd, []string{"log.source=\"snmptraps\""})
+		if err == nil {
+			t.Fatal("expected error when both arg and --file are given")
+		}
+		if !strings.Contains(err.Error(), "not both") {
+			t.Errorf("error = %q, want mention of 'not both'", err.Error())
+		}
+	})
+}
+
+func TestTranslateLqlToDqlCmd_NeitherArgNorFile(t *testing.T) {
+	_, configPath, cleanup := setupLqlToDqlServer(t, lqlToDqlResponse)
+	defer cleanup()
+
+	withLqlToDqlGlobals(t, configPath, func() {
+		testutil.ResetCommandFlags(translateLqlToDqlCmd)
+
+		err := translateLqlToDqlCmd.RunE(translateLqlToDqlCmd, []string{})
+		if err == nil {
+			t.Fatal("expected error when neither arg nor --file is given")
+		}
+		if !strings.Contains(err.Error(), "--file") {
+			t.Errorf("error = %q, want mention of '--file'", err.Error())
+		}
+	})
+}
+
+func TestTranslateLqlToDqlCmd_InlineArg(t *testing.T) {
+	_, configPath, cleanup := setupLqlToDqlServer(t, lqlToDqlResponse)
+	defer cleanup()
+
+	withLqlToDqlGlobals(t, configPath, func() {
+		testutil.ResetCommandFlags(translateLqlToDqlCmd)
+
+		out := captureStdout(t, func() {
+			if err := translateLqlToDqlCmd.RunE(translateLqlToDqlCmd, []string{`log.source="snmptraps"`}); err != nil {
+				t.Fatalf("RunE() error = %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "matchesValue") {
+			t.Errorf("output missing translated DQL; got: %q", out)
+		}
+	})
+}
+
+func TestTranslateLqlToDqlCmd_FileArg(t *testing.T) {
+	_, configPath, cleanup := setupLqlToDqlServer(t, lqlToDqlResponse)
+	defer cleanup()
+
+	lqlFile := testutil.CreateTempFile(t, `log.source="snmptraps"`, "*.lql")
+
+	withLqlToDqlGlobals(t, configPath, func() {
+		testutil.ResetCommandFlags(translateLqlToDqlCmd)
+		_ = translateLqlToDqlCmd.Flags().Set("file", lqlFile)
+
+		out := captureStdout(t, func() {
+			if err := translateLqlToDqlCmd.RunE(translateLqlToDqlCmd, []string{}); err != nil {
+				t.Fatalf("RunE() error = %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "matchesValue") {
+			t.Errorf("output missing translated DQL; got: %q", out)
+		}
+	})
+}
+
+func TestTranslateLqlToDqlCmd_FileArgMissing(t *testing.T) {
+	_, configPath, cleanup := setupLqlToDqlServer(t, lqlToDqlResponse)
+	defer cleanup()
+
+	withLqlToDqlGlobals(t, configPath, func() {
+		testutil.ResetCommandFlags(translateLqlToDqlCmd)
+		_ = translateLqlToDqlCmd.Flags().Set("file", "/nonexistent/path.lql")
+
+		err := translateLqlToDqlCmd.RunE(translateLqlToDqlCmd, []string{})
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+}
+
+func TestTranslateLqlToDqlCmd_StdinArg(t *testing.T) {
+	_, configPath, cleanup := setupLqlToDqlServer(t, lqlToDqlResponse)
+	defer cleanup()
+
+	// Redirect stdin to a pipe with LQL content.
+	origStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdin = r
+	_, _ = w.WriteString(`log.source="snmptraps"`)
+	_ = w.Close()
+	defer func() { os.Stdin = origStdin }()
+
+	withLqlToDqlGlobals(t, configPath, func() {
+		testutil.ResetCommandFlags(translateLqlToDqlCmd)
+		_ = translateLqlToDqlCmd.Flags().Set("file", "-")
+
+		out := captureStdout(t, func() {
+			if err := translateLqlToDqlCmd.RunE(translateLqlToDqlCmd, []string{}); err != nil {
+				t.Fatalf("RunE() error = %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "matchesValue") {
+			t.Errorf("output missing translated DQL; got: %q", out)
+		}
+	})
+}
+
+func TestTranslateLqlToDqlCmd_ExplicitOutputFormat(t *testing.T) {
+	_, configPath, cleanup := setupLqlToDqlServer(t, lqlToDqlResponse)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	origAgent := agentMode
+	origFormat := outputFormat
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+		agentMode = origAgent
+		outputFormat = origFormat
+	}()
+	cfgFile = configPath
+	plainMode = true
+	agentMode = false
+	outputFormat = "json"
+
+	testutil.ResetCommandFlags(translateLqlToDqlCmd)
+
+	// Mark the output flag as changed to simulate an explicit -o json.
+	rootCmd.PersistentFlags().Lookup("output").Changed = true
+	defer func() {
+		rootCmd.PersistentFlags().Lookup("output").Changed = false
+	}()
+
+	out := captureStdout(t, func() {
+		if err := translateLqlToDqlCmd.RunE(translateLqlToDqlCmd, []string{`log.source="snmptraps"`}); err != nil {
+			t.Fatalf("RunE() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "matchesValue") {
+		t.Errorf("json output missing DQL; got: %q", out)
+	}
+}
+
+func TestTranslateLqlToDqlCmd_AgentMode(t *testing.T) {
+	_, configPath, cleanup := setupLqlToDqlServer(t, lqlToDqlResponse)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	origAgent := agentMode
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+		agentMode = origAgent
+	}()
+	cfgFile = configPath
+	plainMode = true
+	agentMode = true
+
+	testutil.ResetCommandFlags(translateLqlToDqlCmd)
+
+	out := captureStdout(t, func() {
+		if err := translateLqlToDqlCmd.RunE(translateLqlToDqlCmd, []string{`log.source="snmptraps"`}); err != nil {
+			t.Fatalf("RunE() error = %v", err)
+		}
+	})
+
+	for _, want := range []string{`"ok":true`, "matchesValue", `"suggestions"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("agent envelope missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestTranslateLqlToDqlCmd_APIError(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		lqlToDqlEndpoint: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"code":400,"message":"invalid LQL"}}`))
+		},
+	})
+	defer ms.Close()
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	withLqlToDqlGlobals(t, configPath, func() {
+		testutil.ResetCommandFlags(translateLqlToDqlCmd)
+
+		err := translateLqlToDqlCmd.RunE(translateLqlToDqlCmd, []string{`INVALID`})
+		if err == nil {
+			t.Fatal("expected error for 400 API response")
+		}
+	})
+}

--- a/cmd/translate_lql_to_dql_test.go
+++ b/cmd/translate_lql_to_dql_test.go
@@ -173,38 +173,27 @@ func TestTranslateLqlToDqlCmd_ExplicitOutputFormat(t *testing.T) {
 	_, configPath, cleanup := setupLqlToDqlServer(t, lqlToDqlResponse)
 	defer cleanup()
 
-	origCfgFile := cfgFile
-	origPlain := plainMode
-	origAgent := agentMode
-	origFormat := outputFormat
-	defer func() {
-		cfgFile = origCfgFile
-		plainMode = origPlain
-		agentMode = origAgent
-		outputFormat = origFormat
-	}()
-	cfgFile = configPath
-	plainMode = true
-	agentMode = false
-	outputFormat = "json"
+	withLqlToDqlGlobals(t, configPath, func() {
+		outputFormat = "json"
 
-	testutil.ResetCommandFlags(translateLqlToDqlCmd)
+		testutil.ResetCommandFlags(translateLqlToDqlCmd)
 
-	// Mark the output flag as changed to simulate an explicit -o json.
-	rootCmd.PersistentFlags().Lookup("output").Changed = true
-	defer func() {
-		rootCmd.PersistentFlags().Lookup("output").Changed = false
-	}()
+		// Mark the output flag as changed to simulate an explicit -o json.
+		rootCmd.PersistentFlags().Lookup("output").Changed = true
+		defer func() {
+			rootCmd.PersistentFlags().Lookup("output").Changed = false
+		}()
 
-	out := captureStdout(t, func() {
-		if err := translateLqlToDqlCmd.RunE(translateLqlToDqlCmd, []string{`log.source="snmptraps"`}); err != nil {
-			t.Fatalf("RunE() error = %v", err)
+		out := captureStdout(t, func() {
+			if err := translateLqlToDqlCmd.RunE(translateLqlToDqlCmd, []string{`log.source="snmptraps"`}); err != nil {
+				t.Fatalf("RunE() error = %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "matchesValue") {
+			t.Errorf("json output missing DQL; got: %q", out)
 		}
 	})
-
-	if !strings.Contains(out, "matchesValue") {
-		t.Errorf("json output missing DQL; got: %q", out)
-	}
 }
 
 func TestTranslateLqlToDqlCmd_AgentMode(t *testing.T) {

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2073,20 +2073,20 @@ The two `verify` commands **exit non-zero on an invalid verdict** in every outpu
 
 ### Translate Classic Pipelines to OpenPipeline
 
-Migrating from Classic pipelines to OpenPipeline? `dtctl get classic-pipelines-translation` converts your tenant's Classic pipeline configuration for a scope into an OpenPipeline configuration pipeline (Settings shape). It is a read-only call that returns the translated pipeline verbatim — the reliable starting point you then review and apply via the Settings API.
+Migrating from Classic pipelines to OpenPipeline? `dtctl translate classic-pipelines` converts your tenant's Classic pipeline configuration for a scope into an OpenPipeline configuration pipeline (Settings shape). It is a read-only call that returns the translated pipeline verbatim — the reliable starting point you then review and apply via the Settings API.
 
 ```bash
 # Translate the logs Classic pipeline (pretty-printed pipeline document)
-dtctl get classic-pipelines-translation logs
+dtctl translate classic-pipelines logs
 
 # Translate business events and export as YAML for review/editing
-dtctl get classic-pipelines-translation bizevents -o yaml > reference-pipeline.yaml
+dtctl translate classic-pipelines bizevents -o yaml > reference-pipeline.yaml
 
 # Print the translated pipeline as JSON
-dtctl get classic-pipelines-translation logs -o json
+dtctl translate classic-pipelines logs -o json
 
 # Skip disabled rules in the translation (overrides the server default)
-dtctl get classic-pipelines-translation logs --skip-disabled-rules=true
+dtctl translate classic-pipelines logs --skip-disabled-rules=true
 ```
 
 The scope is a positional argument and must be `logs` or `bizevents`. Every output format emits the translated pipeline document directly (no `{value, withWarning}` wrapper), so the exported file is applyable as-is. The translation is deterministic where possible; when a processing rule's definition script could not be translated automatically (`withWarning=true`), a warning is printed to stderr (and carried in the agent envelope under `-A`) and that part needs a manual rewrite. Apply the reviewed result with `dtctl create settings --schema builtin:openpipeline.<scope>.pipelines -f <file>`.

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -83,13 +83,6 @@ This document tracks the current implementation status of dtctl. For future plan
 | intent | ✅ | ✅ | - | - | - | - |
 | segment | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | anomaly-detector | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| classic-pipelines-translation | ✅ | - | - | - | - | - |
-
-#### Translate
-
-| Command | translate |
-|---------|-----------|
-| lql-to-dql | ✅ |
 
 #### Account Management
 
@@ -107,6 +100,13 @@ This document tracks the current implementation status of dtctl. For future plan
 | aws monitoring | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ enable |
 | gcp connection (Preview) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | gcp monitoring (Preview) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ enable |
+
+#### OpenPipeline
+
+| Resource | translate |
+|----------|-----------|
+| classic-pipelines | ✅ |
+| lql-to-dql | ✅ |
 
 #### Advanced Operations
 

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -85,6 +85,12 @@ This document tracks the current implementation status of dtctl. For future plan
 | anomaly-detector | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | classic-pipelines-translation | ✅ | - | - | - | - | - |
 
+#### Translate
+
+| Command | translate |
+|---------|-----------|
+| lql-to-dql | ✅ |
+
 #### Account Management
 
 | Resource | list | create | revoke |

--- a/pkg/auth/resource_scopes.go
+++ b/pkg/auth/resource_scopes.go
@@ -137,6 +137,11 @@ var ResourceScopes = map[string]AccessScopes{
 	// call that returns the translated pipeline document.
 	"classic-pipelines-translation": {Read: []string{"openpipeline:configurations:read"}},
 
+	// LQL-to-DQL matcher translation
+	// (/platform/openpipeline/v1/matcher/lqlToDql) is a read-only stateless
+	// call that converts a single LQL matcher expression into its DQL equivalent.
+	"lql-to-dql": {Read: []string{"openpipeline:configurations:read"}},
+
 	// OpenPipeline verify and preview endpoints — all read-only; they validate
 	// or preview pipeline definitions without persisting any changes.
 	"openpipeline-matcher":       {Read: []string{"openpipeline:configurations:read"}},

--- a/pkg/auth/resource_scopes.go
+++ b/pkg/auth/resource_scopes.go
@@ -135,7 +135,7 @@ var ResourceScopes = map[string]AccessScopes{
 	// OpenPipeline. The classic-pipelines translation endpoint
 	// (/platform/openpipeline/v1/classic-pipelines/translate) is a read-only
 	// call that returns the translated pipeline document.
-	"classic-pipelines": {Read: []string{"openpipeline:configurations:read"}},
+	"classic-pipelines": {Read: []string{"settings:objects:read"}},
 
 	// LQL-to-DQL matcher translation
 	// (/platform/openpipeline/v1/matcher/lqlToDql) is a read-only stateless
@@ -297,6 +297,7 @@ func (s *scopeSet) addReadTier(extended bool) {
 	s.addResource("notification", AccessRead)
 	s.add("hub:catalog:read")
 	s.addResource("classic-pipelines", AccessRead)
+	s.addResource("lql-to-dql", AccessRead)
 	s.addResource("openpipeline-matcher", AccessRead)
 	s.addResource("openpipeline-dql-processor", AccessRead)
 	s.addResource("preview-processor", AccessRead)
@@ -361,6 +362,7 @@ func (s *scopeSet) addUnrestricted() {
 	s.addResource("notification", AccessRead)
 	s.add("hub:catalog:read")
 	s.addResource("classic-pipelines", AccessRead)
+	s.addResource("lql-to-dql", AccessRead)
 	s.addResource("openpipeline-matcher", AccessRead)
 	s.addResource("openpipeline-dql-processor", AccessRead)
 	s.addResource("preview-processor", AccessRead)

--- a/pkg/auth/resource_scopes.go
+++ b/pkg/auth/resource_scopes.go
@@ -135,7 +135,7 @@ var ResourceScopes = map[string]AccessScopes{
 	// OpenPipeline. The classic-pipelines translation endpoint
 	// (/platform/openpipeline/v1/classic-pipelines/translate) is a read-only
 	// call that returns the translated pipeline document.
-	"classic-pipelines-translation": {Read: []string{"openpipeline:configurations:read"}},
+	"classic-pipelines": {Read: []string{"openpipeline:configurations:read"}},
 
 	// LQL-to-DQL matcher translation
 	// (/platform/openpipeline/v1/matcher/lqlToDql) is a read-only stateless
@@ -296,7 +296,7 @@ func (s *scopeSet) addReadTier(extended bool) {
 	s.addResource("edgeconnect", AccessRead)
 	s.addResource("notification", AccessRead)
 	s.add("hub:catalog:read")
-	s.addResource("classic-pipelines-translation", AccessRead)
+	s.addResource("classic-pipelines", AccessRead)
 	s.addResource("openpipeline-matcher", AccessRead)
 	s.addResource("openpipeline-dql-processor", AccessRead)
 	s.addResource("preview-processor", AccessRead)
@@ -360,7 +360,7 @@ func (s *scopeSet) addUnrestricted() {
 	s.addResource("edgeconnect", AccessRead)
 	s.addResource("notification", AccessRead)
 	s.add("hub:catalog:read")
-	s.addResource("classic-pipelines-translation", AccessRead)
+	s.addResource("classic-pipelines", AccessRead)
 	s.addResource("openpipeline-matcher", AccessRead)
 	s.addResource("openpipeline-dql-processor", AccessRead)
 	s.addResource("preview-processor", AccessRead)

--- a/pkg/output/golden_test.go
+++ b/pkg/output/golden_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/resources/gcpmonitoringconfig"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/hub"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/iam"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/matcherlqltodql"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/matcherverify"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/platformtoken"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/previewprocessor"
@@ -2654,6 +2655,34 @@ func TestGolden_DescribeExtensionAssets(t *testing.T) {
 				t.Fatalf("Print failed: %v", err)
 			}
 			assertGolden(t, "describe/extension-assets-"+name, buf.String())
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Translate: lql-to-dql
+// ---------------------------------------------------------------------------
+
+func TestGolden_TranslateLqlToDql(t *testing.T) {
+	result := matcherlqltodql.TranslationResult{
+		Query: `matchesValue(log.source, "snmptraps") and matchesValue(snmp.trap_oid, "F5-BIGIP-COMMON-MIB")`,
+	}
+
+	formats := map[string]string{
+		"table": "table",
+		"json":  "json",
+		"yaml":  "yaml",
+		"toon":  "toon",
+	}
+
+	for name, format := range formats {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printer := NewPrinterWithWriter(format, &buf)
+			if err := printer.Print(result); err != nil {
+				t.Fatalf("Print failed: %v", err)
+			}
+			assertGolden(t, "translate/lql-to-dql-"+name, buf.String())
 		})
 	}
 }

--- a/pkg/output/testdata/golden/translate/lql-to-dql-json.golden
+++ b/pkg/output/testdata/golden/translate/lql-to-dql-json.golden
@@ -1,0 +1,3 @@
+{
+  "query": "matchesValue(log.source, \"snmptraps\") and matchesValue(snmp.trap_oid, \"F5-BIGIP-COMMON-MIB\")"
+}

--- a/pkg/output/testdata/golden/translate/lql-to-dql-table.golden
+++ b/pkg/output/testdata/golden/translate/lql-to-dql-table.golden
@@ -1,0 +1,2 @@
+QUERY                                                                                          
+matchesValue(log.source, "snmptraps") and matchesValue(snmp.trap_oid, "F5-BIGIP-COMMON-MIB")   

--- a/pkg/output/testdata/golden/translate/lql-to-dql-toon.golden
+++ b/pkg/output/testdata/golden/translate/lql-to-dql-toon.golden
@@ -1,0 +1,1 @@
+query: "matchesValue(log.source, \"snmptraps\") and matchesValue(snmp.trap_oid, \"F5-BIGIP-COMMON-MIB\")"

--- a/pkg/output/testdata/golden/translate/lql-to-dql-yaml.golden
+++ b/pkg/output/testdata/golden/translate/lql-to-dql-yaml.golden
@@ -1,0 +1,1 @@
+query: matchesValue(log.source, "snmptraps") and matchesValue(snmp.trap_oid, "F5-BIGIP-COMMON-MIB")

--- a/pkg/resources/matcherlqltodql/matcherlqltodql.go
+++ b/pkg/resources/matcherlqltodql/matcherlqltodql.go
@@ -1,0 +1,36 @@
+// Package matcherlqltodql is the CLI resource layer for the OpenPipeline
+// LQL-to-DQL matcher translation endpoint. It delegates HTTP calls to the SDK
+// and exposes the translated DQL expression as a typed result ready for display.
+package matcherlqltodql
+
+import (
+	"context"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	sdkapi "github.com/dynatrace-oss/dtctl/sdk/api/matcherlqltodql"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+// TranslationResult is the CLI read-model for a translated LQL matcher.
+type TranslationResult struct {
+	Query string `json:"query" yaml:"query" table:"QUERY"`
+}
+
+// Handler translates LQL matcher expressions into DQL matcher expressions.
+type Handler struct {
+	sdk *sdkapi.Handler
+}
+
+// NewHandler creates a new LQL-to-DQL translation handler.
+func NewHandler(c *client.Client) *Handler {
+	return &Handler{sdk: sdkapi.NewHandler(httpclient.Wrap(c.HTTP()))}
+}
+
+// Translate calls the translation endpoint and returns the DQL result.
+func (h *Handler) Translate(lql string) (*TranslationResult, error) {
+	result, err := h.sdk.Translate(context.Background(), lql)
+	if err != nil {
+		return nil, err
+	}
+	return &TranslationResult{Query: result.Query}, nil
+}

--- a/pkg/resources/matcherlqltodql/matcherlqltodql.go
+++ b/pkg/resources/matcherlqltodql/matcherlqltodql.go
@@ -1,6 +1,4 @@
-// Package matcherlqltodql is the CLI resource layer for the OpenPipeline
-// LQL-to-DQL matcher translation endpoint. It delegates HTTP calls to the SDK
-// and exposes the translated DQL expression as a typed result ready for display.
+// Package matcherlqltodql is the CLI resource layer for the LQL-to-DQL translation endpoint.
 package matcherlqltodql
 
 import (

--- a/pkg/resources/matcherlqltodql/matcherlqltodql_test.go
+++ b/pkg/resources/matcherlqltodql/matcherlqltodql_test.go
@@ -1,0 +1,52 @@
+package matcherlqltodql
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+)
+
+func newTestHandler(t *testing.T, fn http.HandlerFunc) (*Handler, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(fn)
+	c, err := client.NewForTesting(srv.URL, "test-token")
+	if err != nil {
+		srv.Close()
+		t.Fatalf("client.NewForTesting: %v", err)
+	}
+	return NewHandler(c), srv
+}
+
+func TestTranslate_Success(t *testing.T) {
+	const dql = `matchesValue(log.source, "snmptraps") and matchesValue(snmp.trap_oid, "F5-BIGIP-COMMON-MIB")`
+
+	h, srv := newTestHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body, _ := json.Marshal(map[string]string{"query": dql})
+		_, _ = w.Write(body)
+	})
+	defer srv.Close()
+
+	result, err := h.Translate(`log.source="snmptraps" AND snmp.trap_oid="F5-BIGIP-COMMON-MIB"`)
+	if err != nil {
+		t.Fatalf("Translate() error: %v", err)
+	}
+	if result.Query != dql {
+		t.Errorf("Query = %q, want %q", result.Query, dql)
+	}
+}
+
+func TestTranslate_APIError(t *testing.T) {
+	h, srv := newTestHandler(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":400,"message":"invalid LQL expression"}}`))
+	})
+	defer srv.Close()
+
+	if _, err := h.Translate(`INVALID`); err == nil {
+		t.Fatal("Translate() expected error for 400 response")
+	}
+}

--- a/sdk/api/matcherlqltodql/matcherlqltodql.go
+++ b/sdk/api/matcherlqltodql/matcherlqltodql.go
@@ -1,0 +1,59 @@
+// Package matcherlqltodql is a thin, read-only SDK client for the OpenPipeline
+// matcher LQL-to-DQL translation endpoint, which converts a single LQL matcher
+// expression into its semantically equivalent DQL matcher expression.
+//
+// The translated DQL string is forwarded verbatim; this package does not
+// interpret, reshape, or validate the result.
+package matcherlqltodql
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+const basePath = "/platform/openpipeline/v1/matcher/lqlToDql"
+
+// Handler calls the LQL-to-DQL translation endpoint.
+type Handler struct {
+	client *httpclient.Client
+}
+
+// NewHandler creates a new LQL-to-DQL translation handler.
+func NewHandler(c *httpclient.Client) *Handler {
+	return &Handler{client: c}
+}
+
+// TranslationResult holds the translated DQL matcher expression.
+type TranslationResult struct {
+	Query string `json:"query"`
+}
+
+// Translate POSTs the given LQL matcher expression to the translation endpoint
+// and returns the DQL equivalent verbatim.
+func (h *Handler) Translate(ctx context.Context, lql string) (*TranslationResult, error) {
+	body, err := json.Marshal(map[string]string{"query": lql})
+	if err != nil {
+		return nil, fmt.Errorf("translate lql-to-dql: marshal request: %w", err)
+	}
+
+	resp, err := h.client.HTTP().R().SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		Post(basePath)
+	if err != nil {
+		return nil, fmt.Errorf("translate lql-to-dql: %w", err)
+	}
+	if err := httpclient.CheckResponse(resp); err != nil {
+		return nil, fmt.Errorf("translate lql-to-dql: %w", err)
+	}
+
+	var result TranslationResult
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, fmt.Errorf("translate lql-to-dql: parse response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/sdk/api/matcherlqltodql/matcherlqltodql.go
+++ b/sdk/api/matcherlqltodql/matcherlqltodql.go
@@ -1,9 +1,4 @@
-// Package matcherlqltodql is a thin, read-only SDK client for the OpenPipeline
-// matcher LQL-to-DQL translation endpoint, which converts a single LQL matcher
-// expression into its semantically equivalent DQL matcher expression.
-//
-// The translated DQL string is forwarded verbatim; this package does not
-// interpret, reshape, or validate the result.
+// Package matcherlqltodql is a thin SDK client for the OpenPipeline LQL-to-DQL translation endpoint.
 package matcherlqltodql
 
 import (

--- a/sdk/api/matcherlqltodql/matcherlqltodql_test.go
+++ b/sdk/api/matcherlqltodql/matcherlqltodql_test.go
@@ -1,0 +1,117 @@
+package matcherlqltodql
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *httpclient.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c, err := httpclient.New(srv.URL, httpclient.WithToken("dt0c01.test"))
+	if err != nil {
+		t.Fatalf("httpclient.New: %v", err)
+	}
+	return c
+}
+
+func TestTranslate_Success(t *testing.T) {
+	const dql = `matchesValue(log.source, "snmptraps") and matchesValue(snmp.trap_oid, "F5-BIGIP-COMMON-MIB")`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req["query"] == "" {
+			t.Error("request body missing query field")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		body, _ := json.Marshal(map[string]string{"query": dql})
+		_, _ = w.Write(body)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.Translate(context.Background(), `log.source="snmptraps" AND snmp.trap_oid="F5-BIGIP-COMMON-MIB"`)
+	if err != nil {
+		t.Fatalf("Translate() error: %v", err)
+	}
+	if result.Query != dql {
+		t.Errorf("Query = %q, want %q", result.Query, dql)
+	}
+}
+
+func TestTranslate_ForwardsLQLInRequestBody(t *testing.T) {
+	const lql = `log.source="test" AND level="ERROR"`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if got := req["query"]; got != lql {
+			t.Errorf("body query = %q, want %q", got, lql)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		body, _ := json.Marshal(map[string]string{"query": `matchesValue(log.source, "test") and matchesValue(loglevel, "ERROR")`})
+		_, _ = w.Write(body)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.Translate(context.Background(), lql); err != nil {
+		t.Fatalf("Translate() error: %v", err)
+	}
+}
+
+func TestTranslate_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"message":"internal error"}}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.Translate(context.Background(), `log.source="test"`); err == nil {
+		t.Fatal("Translate() expected error for 500")
+	}
+}
+
+func TestTranslate_BadRequest(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":400,"message":"invalid LQL expression"}}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.Translate(context.Background(), `INVALID @@@ LQL`); err == nil {
+		t.Fatal("Translate() expected error for 400")
+	}
+}
+
+func TestTranslate_InvalidJSON(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`not json`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.Translate(context.Background(), `log.source="test"`); err == nil {
+		t.Fatal("Translate() expected parse error for malformed body")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds new `translate` verb grouping OpenPipeline translation commands
- `dtctl translate lql-to-dql [expr]` — translates an LQL matcher expression to DQL via `POST /platform/openpipeline/v1/matcher/lqlToDql`; accepts a positional arg or `-f file`; default output is the raw DQL string (pipeable), `-o json`/`-o yaml`/`-o table` render structured output
- **Breaking**: removes `dtctl get classic-pipelines-translation` and replaces it with `dtctl translate classic-pipelines <logs|bizevents>` backed by `GET /platform/openpipeline/v1/classic-pipelines/translate`
- Fixes OAuth scope for `classic-pipelines`: was `openpipeline:configurations:read`, corrected to `settings:objects:read` per the OpenPipeline spec
- Wires `lql-to-dql` into OAuth scope tiers so `openpipeline:configurations:read` is included in token requests
- Updates `docs/dev/IMPLEMENTATION_STATUS.md`: OpenPipeline section with `translate` verb added
- Updates `docs/QUICK_START.md`: replaces all references to the removed `dtctl get classic-pipelines-translation` command with `dtctl translate classic-pipelines`

## Test plan

- [ ] `sdk/api/matcherlqltodql` — unit tests: success, request body forwarding, server error, bad request, invalid JSON
- [ ] `cmd` — `TestTranslateLqlToDqlCmd_*` and `TestTranslateClassicPipelinesCmd_*` pass
- [ ] `pkg/auth` — `TestRequiredScopesMatchSafetyLevels` passes with corrected scopes
- [ ] `pkg/output` — `TestGolden_TranslateLqlToDql` golden files match
- [ ] `dtctl get classic-pipelines-translation` returns unknown subcommand
- [ ] `dtctl translate lql-to-dql 'log.source="x"'` returns DQL string on stdout
- [ ] `dtctl translate classic-pipelines logs` returns pipeline document

🤖 Generated with [Claude Code](https://claude.com/claude-code)