### PR TITLE
feat(account): auto-discover account UUID on login and via ctx discover-account

### DIFF
--- a/cmd/account_login.go
+++ b/cmd/account_login.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/auth"
+	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 )
@@ -22,8 +23,11 @@ Opens a browser window to complete login. On success, the account token is store
 in the system keyring (or DTCTL_TOKEN_STORAGE=file fallback) so subsequent
 account commands work without DTCTL_ACCOUNT_TOKEN.
 
-The account UUID is resolved from: --account-uuid flag > DTCTL_ACCOUNT_UUID > context config.`,
-	Example: `  # Login (UUID from DTCTL_ACCOUNT_UUID or context account-uuid)
+The account UUID is resolved from: --account-uuid flag > DTCTL_ACCOUNT_UUID >
+context account-uuid > auto-discovery via the IAM access-info endpoint. Auto-discovery
+requires a prior 'dtctl auth login' so an environment token is available.`,
+	Example: `  # Login, auto-discovering the account UUID from the environment
+  # (run 'dtctl auth login' first)
   dtctl account login
 
   # Login with explicit account UUID
@@ -46,13 +50,22 @@ The account UUID is resolved from: --account-uuid flag > DTCTL_ACCOUNT_UUID > co
 			return err
 		}
 
-		// Resolve UUID: flag > env > config. Skip discovery — no token yet.
-		accountUUID := resolveUUIDNoDiscovery(ctx, uuidFlag)
-		if accountUUID == "" {
-			return fmt.Errorf("account UUID required: pass --account-uuid or set DTCTL_ACCOUNT_UUID")
+		env := auth.DetectEnvironment(ctx.Environment)
+
+		// Resolve UUID: flag > DTCTL_ACCOUNT_UUID > context config > auto-discovery.
+		// Auto-discovery uses the environment token (from 'dtctl auth login')
+		// against the IAM access-info endpoint; the account-plane token does not
+		// exist yet at this point and is rejected by that endpoint anyway.
+		envToken, _ := client.GetTokenWithOAuthSupport(cfg, ctx.TokenRef)
+		iamBase := client.IAMBaseURLForEnvironment(env)
+		accountUUID, discoveredName, err := resolveLoginAccountUUID(ctx, uuidFlag, envToken, iamBase)
+		if err != nil {
+			return fmt.Errorf("account UUID required: pass --account-uuid, set DTCTL_ACCOUNT_UUID, or run 'dtctl auth login' first so dtctl can auto-discover the account for environment %q (%v)", extractEnvironmentID(ctx.Environment), err)
+		}
+		if discoveredName != "" {
+			output.PrintInfo("Auto-discovered account %q (%s) for environment %s", discoveredName, accountUUID, extractEnvironmentID(ctx.Environment))
 		}
 
-		env := auth.DetectEnvironment(ctx.Environment)
 		oauthConfig := auth.AccountOAuthConfig(env, ctx.SafetyLevel, accountUUID)
 
 		// Ensure token storage is available (mirrors auth login).

--- a/cmd/account_login_test.go
+++ b/cmd/account_login_test.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+)
+
+// TestResolveLoginAccountUUID exercises the resolution order used by
+// `dtctl account login`: flag > DTCTL_ACCOUNT_UUID > context config >
+// auto-discovery via the IAM access-info endpoint.
+func TestResolveLoginAccountUUID(t *testing.T) {
+	canned := client.AccessInfoResponse{
+		Accounts: []client.AccessInfoAccount{
+			{
+				UUID: "11111111-2222-3333-4444-555555555555",
+				Name: "Acme Corp",
+				Environments: []client.AccessInfoEnvironment{
+					{ID: "abc12345", Name: "Production"},
+				},
+			},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/iam/v1/access-info" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(canned)
+	}))
+	defer srv.Close()
+
+	prodCtx := func() *config.Context {
+		return &config.Context{Environment: "https://abc12345.apps.dynatrace.com"}
+	}
+
+	t.Run("flag wins over env and config", func(t *testing.T) {
+		t.Setenv("DTCTL_ACCOUNT_UUID", "env-uuid")
+		ctx := &config.Context{Environment: "https://abc12345.apps.dynatrace.com", AccountUUID: "cfg-uuid"}
+		uuid, name, err := resolveLoginAccountUUID(ctx, "flag-uuid", "envtok", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if uuid != "flag-uuid" {
+			t.Errorf("uuid = %q, want flag-uuid", uuid)
+		}
+		if name != "" {
+			t.Errorf("discoveredName should be empty for a non-discovered UUID, got %q", name)
+		}
+	})
+
+	t.Run("env var when no flag", func(t *testing.T) {
+		t.Setenv("DTCTL_ACCOUNT_UUID", "env-uuid")
+		ctx := &config.Context{Environment: "https://abc12345.apps.dynatrace.com", AccountUUID: "cfg-uuid"}
+		uuid, name, err := resolveLoginAccountUUID(ctx, "", "envtok", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if uuid != "env-uuid" {
+			t.Errorf("uuid = %q, want env-uuid", uuid)
+		}
+		if name != "" {
+			t.Errorf("discoveredName should be empty, got %q", name)
+		}
+	})
+
+	t.Run("context config when no flag or env", func(t *testing.T) {
+		t.Setenv("DTCTL_ACCOUNT_UUID", "")
+		ctx := &config.Context{Environment: "https://abc12345.apps.dynatrace.com", AccountUUID: "cfg-uuid"}
+		uuid, name, err := resolveLoginAccountUUID(ctx, "", "envtok", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if uuid != "cfg-uuid" {
+			t.Errorf("uuid = %q, want cfg-uuid", uuid)
+		}
+		if name != "" {
+			t.Errorf("discoveredName should be empty, got %q", name)
+		}
+	})
+
+	t.Run("auto-discovery when nothing else set", func(t *testing.T) {
+		t.Setenv("DTCTL_ACCOUNT_UUID", "")
+		uuid, name, err := resolveLoginAccountUUID(prodCtx(), "", "envtok", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if uuid != "11111111-2222-3333-4444-555555555555" {
+			t.Errorf("uuid = %q, want discovered UUID", uuid)
+		}
+		if name != "Acme Corp" {
+			t.Errorf("discoveredName = %q, want Acme Corp", name)
+		}
+	})
+
+	t.Run("error when no environment token for discovery", func(t *testing.T) {
+		t.Setenv("DTCTL_ACCOUNT_UUID", "")
+		_, _, err := resolveLoginAccountUUID(prodCtx(), "", "", srv.URL)
+		if err == nil {
+			t.Fatal("expected error when no environment token is available")
+		}
+	})
+
+	t.Run("discovery error propagates", func(t *testing.T) {
+		t.Setenv("DTCTL_ACCOUNT_UUID", "")
+		ctx := &config.Context{Environment: "https://unknown99.apps.dynatrace.com"}
+		_, _, err := resolveLoginAccountUUID(ctx, "", "envtok", srv.URL)
+		if err == nil {
+			t.Fatal("expected error when environment is not found in any account")
+		}
+	})
+}

--- a/cmd/ctx.go
+++ b/cmd/ctx.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtctl/pkg/auth"
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/config"
 	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
@@ -191,6 +192,82 @@ var ctxDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteContext(args[0])
 	},
+}
+
+// ctxDiscoverAccountCmd resolves the account UUID for the current context's
+// environment and optionally persists it into the context config.
+var ctxDiscoverAccountCmd = &cobra.Command{
+	Use:   "discover-account",
+	Short: "Discover the account UUID for the current context's environment",
+	Long: `Resolve the Dynatrace account UUID that owns the current context's environment
+by querying the IAM access-info endpoint, using the environment token stored for
+the context (run 'dtctl auth login' first).
+
+With --save, the discovered UUID is written to the current context's account-uuid
+field so account commands no longer need --account-uuid or DTCTL_ACCOUNT_UUID.`,
+	Example: `  # Show the account UUID for the current environment
+  dtctl ctx discover-account
+
+  # Discover and persist it into the current context
+  dtctl ctx discover-account --save`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		save, _ := cmd.Flags().GetBool("save")
+		return discoverAccount(save)
+	},
+}
+
+// discoverAccount resolves the account UUID for the current context's environment
+// via the IAM access-info endpoint. When save is true, the UUID is persisted to
+// the current context's account-uuid field.
+func discoverAccount(save bool) error {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+	ctx, err := cfg.CurrentContextObj()
+	if err != nil {
+		return err
+	}
+	if ctx.Environment == "" {
+		return fmt.Errorf("current context has no environment URL; auto-discovery needs an environment to match against")
+	}
+
+	envToken, err := client.GetTokenWithOAuthSupport(cfg, ctx.TokenRef)
+	if err != nil || envToken == "" {
+		return fmt.Errorf("no environment token available; run 'dtctl auth login' first")
+	}
+
+	env := auth.DetectEnvironment(ctx.Environment)
+	iamBase := client.IAMBaseURLForEnvironment(env)
+	envID := extractEnvironmentID(ctx.Environment)
+
+	uuid, name, err := client.DiscoverAccountUUID(iamBase, envToken, envID)
+	if err != nil {
+		return fmt.Errorf("could not discover account for environment %q: %w", envID, err)
+	}
+
+	if name != "" {
+		output.PrintInfo("Environment %s belongs to account %q (%s)", envID, name, uuid)
+	} else {
+		output.PrintInfo("Environment %s belongs to account %s", envID, uuid)
+	}
+
+	if !save {
+		output.PrintHint("Re-run with --save to persist this account-uuid into context %q", cfg.CurrentContext)
+		return nil
+	}
+
+	nc, err := cfg.GetContext(cfg.CurrentContext)
+	if err != nil {
+		return err
+	}
+	nc.Context.AccountUUID = uuid
+	if err := cfg.Save(); err != nil {
+		return fmt.Errorf("failed to persist account-uuid: %w", err)
+	}
+	output.PrintSuccess("Saved account-uuid %s to context %q", uuid, cfg.CurrentContext)
+	return nil
 }
 
 // listContexts lists all available contexts (shared logic)
@@ -422,6 +499,8 @@ func init() {
 	ctxCmd.AddCommand(ctxDescribeCmd)
 	ctxCmd.AddCommand(ctxSetCmd)
 	ctxCmd.AddCommand(ctxDeleteCmd)
+	ctxCmd.AddCommand(ctxDiscoverAccountCmd)
+	ctxDiscoverAccountCmd.Flags().Bool("save", false, "persist the discovered account-uuid into the current context")
 
 	// Flags for ctx set
 	ctxSetCmd.Flags().String("environment", "", "environment URL")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1017,6 +1017,35 @@ func resolveUUIDNoDiscovery(ctx *config.Context, flagValue string) string {
 	return ctx.AccountUUID
 }
 
+// resolveLoginAccountUUID resolves the account UUID for `dtctl account login`
+// in priority order: explicit flag > DTCTL_ACCOUNT_UUID > context account-uuid >
+// auto-discovery via the IAM access-info endpoint (using the environment token).
+//
+// discoveredName is non-empty only when the UUID was obtained via auto-discovery,
+// letting the caller surface an informational message. envToken and iamBaseURL
+// are passed in (rather than resolved internally) to keep the function unit-testable.
+func resolveLoginAccountUUID(ctx *config.Context, flagValue, envToken, iamBaseURL string) (uuid, discoveredName string, err error) {
+	if flagValue != "" {
+		return flagValue, "", nil
+	}
+	if v := os.Getenv("DTCTL_ACCOUNT_UUID"); v != "" {
+		return v, "", nil
+	}
+	if ctx.AccountUUID != "" {
+		return ctx.AccountUUID, "", nil
+	}
+	// Fall back to auto-discovery. This needs the environment token (openid scope);
+	// the account-plane token does not exist yet and is rejected by access-info.
+	if envToken == "" {
+		return "", "", fmt.Errorf("no environment token available for auto-discovery")
+	}
+	u, name, derr := client.DiscoverAccountUUID(iamBaseURL, envToken, extractEnvironmentID(ctx.Environment))
+	if derr != nil {
+		return "", "", derr
+	}
+	return u, name, nil
+}
+
 // resolveAccountToken resolves the account token using:
 // 1. DTCTL_ACCOUNT_TOKEN env var
 // 2. Keyring (if accountUUID is known) — stored by `dtctl account login`

--- a/pkg/auth/resource_scopes.go
+++ b/pkg/auth/resource_scopes.go
@@ -158,7 +158,7 @@ var localResources = map[string]bool{
 	"set-credentials": true, "migrate-tokens": true, "init": true,
 	"view": true, "current": true, "set": true,
 	// ctx aliases
-	"describe": true, "delete": true, "token": true,
+	"describe": true, "delete": true, "token": true, "discover-account": true,
 	// auth (local token storage / introspection)
 	"login": true, "logout": true, "refresh": true, "status": true, "whoami": true,
 	// alias management


### PR DESCRIPTION
## Problem

`dtctl account login` requires the account UUID up front and errors otherwise:

```
Error: account UUID required: pass --account-uuid or set DTCTL_ACCOUNT_UUID
```

…even though the discovery helper (`DiscoverAccountUUID`, over the IAM
`/iam/v1/access-info` endpoint) already exists and is used by every account
*subcommand* via `setupAccountClient`. Only `login` itself skipped discovery,
with a `// Skip discovery — no token yet` note. That reasoning was imprecise:
discovery needs the **environment** token (from `dtctl auth login`), not the
account-plane token — and the environment token is available at login time.

This realizes the auto-discovery step already described in the account
management design doc.

## Changes

- **`account login` auto-discovery.** UUID resolution is now:

  `--account-uuid` flag → `DTCTL_ACCOUNT_UUID` → context `account-uuid` →
  **auto-discovery via access-info** (using the environment token).

  On success the discovered account is reported and (as before) persisted to
  the context, so follow-up commands need no flag. If discovery can't run
  (no environment token) the error now points at `dtctl auth login`.

- **`dtctl ctx discover-account [--save]`.** Diagnostic that resolves the
  account UUID for the current context's environment; with `--save` it persists
  the UUID into the context config. Marked *local* in the scope catalog (it uses
  only the existing environment token, `openid` scope).

- Resolution order extracted into `resolveLoginAccountUUID` with unit tests
  covering flag/env/config/discovery precedence and the no-token / not-found
  error paths.

## Notes

- Discovery deliberately uses the environment token; the IAM access-info
  endpoint rejects account-plane tokens (already noted in `setupAccountClient`).
- No new scopes required.
- `ctx discover-account` intentionally reports the single account owning the
  current environment. Listing *all* accessible accounts as a table (also in the
  design doc) is a natural follow-up, left out here to keep the change focused.

## Testing

- `go test ./cmd/ ./pkg/output/ ./pkg/client/ ./pkg/auth/` — pass (incl. golden
  and command-catalog completeness tests).
- New `TestResolveLoginAccountUUID` covers all four resolution paths + error cases.