### PR TITLE
feat(query): add --typed to cast scalar columns to native JSON/YAML types

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -264,10 +264,16 @@ Examples:
 		noProgress, _ := cmd.Flags().GetBool("no-progress")
 		enforceQueryConsumptionLimit, _ := cmd.Flags().GetBool("enforce-query-consumption-limit")
 		includeTypes, _ := cmd.Flags().GetBool("include-types")
+		typed, _ := cmd.Flags().GetBool("typed")
 		// Parquet derives its column schema from DQL types, so request them even
 		// if the user did not pass --include-types. The type metadata is consumed
 		// to build the schema and is not added to the output rows.
 		if formatRequiresIncludeTypes(outputFormat) {
+			includeTypes = true
+		}
+		// --typed casts scalar columns using the DQL type metadata, so it likewise
+		// needs the types requested even without an explicit --include-types.
+		if typed {
 			includeTypes = true
 		}
 		includeContributions, _ := cmd.Flags().GetBool("include-contributions")
@@ -402,6 +408,7 @@ Examples:
 			EnforceQueryConsumptionLimit: enforceQueryConsumptionLimit,
 			IncludeTypes:                 includeTypes,
 			IncludeContributions:         includeContributions,
+			Typed:                        typed,
 			DefaultTimeframeStart:        defaultTimeframeStart,
 			DefaultTimeframeEnd:          defaultTimeframeEnd,
 			Locale:                       locale,
@@ -432,6 +439,9 @@ Examples:
 			}
 			if includeContributions {
 				output.PrintWarning("--include-contributions is ignored in live mode (contribution data is not displayed during live updates)")
+			}
+			if typed {
+				output.PrintWarning("--typed is ignored in live mode (live mode renders a table, where the API's string encoding is not surfaced)")
 			}
 			if dryRun {
 				output.PrintWarning("--dry-run is ignored in live mode (live mode always executes queries)")
@@ -763,6 +773,7 @@ func init() {
 	queryCmd.Flags().Bool("enforce-query-consumption-limit", false, "enforce query consumption limit")
 	queryCmd.Flags().Bool("include-types", false, "include type information in query results")
 	queryCmd.Flags().Bool("include-contributions", false, "include bucket contribution information in query results")
+	queryCmd.Flags().Bool("typed", false, "cast scalar columns (long, double, duration, boolean) to native JSON/YAML types instead of the API's string encoding; opt-in, implies --include-types")
 
 	// Timeframe flags
 	queryCmd.Flags().String("default-timeframe-start", "", "query timeframe start timestamp (ISO-8601/RFC3339, e.g., '2022-04-20T12:10:04.123Z')")

--- a/docs/site/_docs/output-formats.md
+++ b/docs/site/_docs/output-formats.md
@@ -124,6 +124,44 @@ Notes:
   otherwise a single placeholder column so the file stays readable by mainstream
   tooling (a column-less file is rejected by DuckDB, pyarrow, and pandas).
 
+## Numeric typing (`--typed`)
+
+The Grail query API deliberately serialises integer-valued columns (`long`,
+`duration`) as JSON **strings** to preserve full int64 precision for
+JavaScript/TypeScript consumers. dtctl's `json`, `yaml`, and `jsonl` output
+faithfully passes that through, so a `count()` reads as `"42"` (a string):
+
+```bash
+dtctl query 'fetch logs | summarize c = count()' -o json
+# [ { "c": "42" } ]
+```
+
+Pass `--typed` to cast scalar columns to their native types using the DQL type
+metadata — `long`/`duration` become JSON numbers, `boolean` becomes a real
+boolean — so the output is ready for `jq`, pandas, or DuckDB without a
+`tonumber` step:
+
+```bash
+dtctl query 'fetch logs | summarize c = count()' -o json --typed
+# [ { "c": 42 } ]
+```
+
+Notes:
+
+- **Opt-in by design.** The default output stays faithful to the API's wire
+  encoding. `--typed` implies `--include-types` so the type metadata is
+  available.
+- **Precision-safe in dtctl.** A `long` is emitted as its full decimal digits,
+  unquoted and lossless (never routed through a float). The only precision risk
+  is in a downstream consumer that parses JSON numbers as 64-bit floats (browser
+  `JSON.parse`, older `jq`) — which is exactly why it is opt-in.
+- **Timestamps stay strings.** JSON/YAML have no native date type, so `timestamp`
+  columns keep their portable RFC3339 string form. `string`, `ip`, `timeframe`,
+  and nested record/array columns are left unchanged.
+- Values that do not cleanly parse to their declared type (including non-finite
+  doubles such as `"NaN"`/`"Infinity"`, which JSON cannot represent) are left as
+  strings rather than failing the output.
+
 ## Plain Mode
 
 The `--plain` flag disables colors, progress indicators, and interactive prompts. This is useful for piping output or running in non-interactive environments:

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -124,6 +124,13 @@ type DQLExecuteOptions struct {
 	IncludeTypes                 bool    // Include type information in results (default: true)
 	IncludeContributions         bool    // Include bucket contribution information in results
 
+	// Typed opts in to casting scalar columns (long, double, duration, boolean)
+	// to their native JSON/YAML types using the DQL type metadata, instead of the
+	// wire form where integer-valued columns arrive as strings. Off by default so
+	// output stays faithful to the API; implies IncludeTypes so the mapping is
+	// available. See output.ApplyTrueTypes.
+	Typed bool
+
 	// Timeframe options
 	DefaultTimeframeStart string // Query timeframe start timestamp (ISO-8601/RFC3339)
 	DefaultTimeframeEnd   string // Query timeframe end timestamp (ISO-8601/RFC3339)
@@ -729,6 +736,16 @@ func (e *DQLExecutor) printResults(query string, result *DQLQueryResponse, opts 
 		}
 	}
 
+	// --typed: cast scalar columns (long/double/duration → number, boolean →
+	// bool) to their native types using the DQL type metadata, so structured
+	// output is math-ready instead of carrying the API's string-encoded integers.
+	// Opt-in; a no-op when types are absent. Applied before the spill/agent branch
+	// so the agent envelope and spilled files see the same typed records.
+	colTypes := columnTypeMappings(result)
+	if opts.Typed {
+		output.ApplyTrueTypes(records, colTypes)
+	}
+
 	// Spill path (D2/D3/D19-buffered): when spilling is enabled, a large result
 	// is written to disk and a compact summary is emitted in place of the rows.
 	// This is strictly additive — when it decides "inline" (or spilling is
@@ -763,7 +780,7 @@ func (e *DQLExecutor) printResults(query string, result *DQLQueryResponse, opts 
 		Width:      opts.Width,
 		Height:     opts.Height,
 		Fullscreen: opts.Fullscreen,
-		Types:      columnTypeMappings(result),
+		Types:      colTypes,
 	})
 
 	switch effectiveFormat {

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -2480,6 +2480,27 @@ func TestDQLExecutor_OutputFormats_Integration(t *testing.T) {
 			t.Errorf("unexpected jsonl line: %q", line)
 		}
 	})
+
+	t.Run("typed casts the long to an unquoted number end-to-end", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			if err := executor.ExecuteWithContext(context.Background(), "fetch logs",
+				DQLExecuteOptions{OutputFormat: "jsonl", Typed: true}); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+		})
+		line := strings.TrimSpace(string(out))
+		// With --typed the DQL long "count" must render as a bare JSON number, not
+		// the API's string encoding; the string column stays quoted.
+		if !strings.Contains(line, `"count":194414758`) {
+			t.Errorf("expected unquoted count with --typed, got: %q", line)
+		}
+		if strings.Contains(line, `"count":"194414758"`) {
+			t.Errorf("count is still string-encoded despite --typed: %q", line)
+		}
+		if !strings.Contains(line, `"host":"web-01"`) {
+			t.Errorf("string column should be unchanged: %q", line)
+		}
+	})
 }
 
 // parseDTClientContext unmarshals the dt-client-context header value into a map.

--- a/pkg/output/typed.go
+++ b/pkg/output/typed.go
@@ -1,0 +1,118 @@
+package output
+
+import (
+	"encoding/json"
+	"math"
+	"strconv"
+)
+
+// ApplyTrueTypes rewrites scalar record cells from their wire form into native
+// Go scalar types, driven by the DQL column type metadata. It exists because the
+// Grail query API deliberately serialises integer-valued columns (`long`,
+// `duration`) as JSON strings to preserve int64 precision for JavaScript/
+// TypeScript consumers (see GRAIL-545). dtctl's JSON/YAML output faithfully
+// passes those strings through, which is honest to the wire but surprises
+// jq/pandas/DuckDB users, for whom a `count()` reading `"42"` is a string.
+//
+// This transform is opt-in (the `--typed` flag). It is precision-safe on the
+// dtctl side: a DQL `long` is an int64, and both encoding/json and yaml.v3
+// marshal a Go int64 as its full decimal digits, unquoted and lossless — never
+// via a lossy float64. The only precision risk lives in a downstream consumer
+// that parses JSON numbers as 64-bit floats (browser JSON.parse, old jq), which
+// is exactly why the default output stays string-faithful and this is opt-in.
+//
+// The rewrite is in place: cells are terminal at the point this is called, so no
+// second copy of the (potentially large) result set is held. Columns not present
+// in types, non-scalar values, nulls, and any value that does not cleanly parse
+// to its declared type are left untouched — the transform never fails an export
+// and never fabricates a value.
+func ApplyTrueTypes(records []map[string]interface{}, types []ColumnTypeMapping) {
+	if len(records) == 0 || len(types) == 0 {
+		return
+	}
+	dqlTypes := make(map[string]string, len(types))
+	for _, t := range types {
+		dqlTypes[t.Name] = t.Type
+	}
+	for _, rec := range records {
+		for name, dqlType := range dqlTypes {
+			v, ok := rec[name]
+			if !ok || v == nil {
+				continue
+			}
+			if cast, ok := castScalar(v, dqlType); ok {
+				rec[name] = cast
+			}
+		}
+	}
+}
+
+// castScalar converts a single wire value to the native Go type implied by its
+// DQL type. It returns ok=false (leaving the original value in place) for any
+// value it cannot losslessly and safely represent — including non-finite doubles,
+// which encoding/json cannot marshal and which must therefore stay strings.
+//
+// Timestamps are intentionally NOT cast: JSON/YAML have no native temporal type,
+// and the RFC3339 string is the honest, portable representation. string/ip/
+// timeframe and nested record/array values (already real JSON structures) are
+// likewise left as-is.
+func castScalar(v interface{}, dqlType string) (interface{}, bool) {
+	switch dqlType {
+	case "long", "duration":
+		// Integer-valued. DQL delivers these as JSON strings; the float64 and
+		// json.Number arms are defensive (a value decoded as a number still casts
+		// cleanly) and never truncate a fractional or non-finite value.
+		switch n := v.(type) {
+		case string:
+			if i, err := strconv.ParseInt(n, 10, 64); err == nil {
+				return i, true
+			}
+		case json.Number:
+			if i, err := n.Int64(); err == nil {
+				return i, true
+			}
+		case float64:
+			if !math.IsNaN(n) && !math.IsInf(n, 0) && n == math.Trunc(n) &&
+				n >= math.MinInt64 && n < 9223372036854775808.0 {
+				return int64(n), true
+			}
+		}
+		return nil, false
+
+	case "double":
+		switch n := v.(type) {
+		case float64:
+			return n, true
+		case json.Number:
+			if f, err := n.Float64(); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
+				return f, true
+			}
+		case string:
+			// A non-finite double (DQL sends "NaN"/"Infinity" as strings) must stay
+			// a string: encoding/json refuses to marshal NaN/Inf and would fail the
+			// whole output.
+			if f, err := strconv.ParseFloat(n, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
+				return f, true
+			}
+		}
+		return nil, false
+
+	case "boolean":
+		switch b := v.(type) {
+		case bool:
+			return b, true
+		case string:
+			if b == "true" {
+				return true, true
+			}
+			if b == "false" {
+				return false, true
+			}
+		}
+		return nil, false
+
+	default:
+		// string, timestamp, ip, timeframe, record, array, variant, unknown → as-is.
+		return nil, false
+	}
+}

--- a/pkg/output/typed_test.go
+++ b/pkg/output/typed_test.go
@@ -1,0 +1,166 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestApplyTrueTypes_ScalarCasts(t *testing.T) {
+	types := []ColumnTypeMapping{
+		{Name: "count", Type: "long"},
+		{Name: "dur", Type: "duration"},
+		{Name: "ratio", Type: "double"},
+		{Name: "ok", Type: "boolean"},
+		{Name: "host", Type: "string"},
+		{Name: "ts", Type: "timestamp"},
+	}
+	records := []map[string]interface{}{
+		{
+			"count": "194414758",            // long as JSON string → int64
+			"dur":   "598600",               // duration ns string → int64
+			"ratio": float64(0.5),           // double already a number → unchanged
+			"ok":    "true",                 // boolean as string → bool
+			"host":  "web-01",               // string → unchanged
+			"ts":    "2025-03-15T10:30:00Z", // timestamp → left as RFC3339 string
+		},
+	}
+	ApplyTrueTypes(records, types)
+
+	r := records[0]
+	if got, ok := r["count"].(int64); !ok || got != 194414758 {
+		t.Errorf("count = %#v, want int64(194414758)", r["count"])
+	}
+	if got, ok := r["dur"].(int64); !ok || got != 598600 {
+		t.Errorf("dur = %#v, want int64(598600)", r["dur"])
+	}
+	if got, ok := r["ratio"].(float64); !ok || got != 0.5 {
+		t.Errorf("ratio = %#v, want float64(0.5)", r["ratio"])
+	}
+	if got, ok := r["ok"].(bool); !ok || got != true {
+		t.Errorf("ok = %#v, want bool(true)", r["ok"])
+	}
+	if r["host"] != "web-01" {
+		t.Errorf("host = %#v, want string unchanged", r["host"])
+	}
+	// Timestamps are intentionally left as RFC3339 strings (JSON has no date type).
+	if r["ts"] != "2025-03-15T10:30:00Z" {
+		t.Errorf("ts = %#v, want RFC3339 string unchanged", r["ts"])
+	}
+}
+
+func TestApplyTrueTypes_BigIntPrecisionThroughJSONAndYAML(t *testing.T) {
+	// The whole point: a full-range int64 must survive casting AND marshaling
+	// unquoted and lossless — never routed through a float64.
+	types := []ColumnTypeMapping{{Name: "count", Type: "long"}}
+	records := []map[string]interface{}{{"count": "9223372036854775807"}} // math.MaxInt64
+	ApplyTrueTypes(records, types)
+
+	var jb bytes.Buffer
+	if err := json.NewEncoder(&jb).Encode(records[0]); err != nil {
+		t.Fatalf("json encode: %v", err)
+	}
+	if got, want := jb.String(), "{\"count\":9223372036854775807}\n"; got != want {
+		t.Errorf("JSON = %q, want %q (unquoted, lossless)", got, want)
+	}
+
+	var yb bytes.Buffer
+	ye := yaml.NewEncoder(&yb)
+	ye.SetIndent(2)
+	if err := ye.Encode(records[0]); err != nil {
+		t.Fatalf("yaml encode: %v", err)
+	}
+	if got, want := yb.String(), "count: 9223372036854775807\n"; got != want {
+		t.Errorf("YAML = %q, want %q (unquoted, lossless)", got, want)
+	}
+}
+
+func TestApplyTrueTypes_NonFiniteDoubleStaysString(t *testing.T) {
+	// encoding/json cannot marshal NaN/Inf; a double delivered as "NaN"/"Infinity"
+	// must stay a string so the whole output does not fail.
+	types := []ColumnTypeMapping{{Name: "d", Type: "double"}}
+	for _, s := range []string{"NaN", "Infinity", "-Infinity"} {
+		records := []map[string]interface{}{{"d": s}}
+		ApplyTrueTypes(records, types)
+		if records[0]["d"] != s {
+			t.Errorf("double %q was cast to %#v, want left as string", s, records[0]["d"])
+		}
+		// And it must still be JSON-marshalable.
+		if _, err := json.Marshal(records[0]); err != nil {
+			t.Errorf("json.Marshal failed for %q: %v", s, err)
+		}
+	}
+}
+
+func TestApplyTrueTypes_LeavesUncastableAlone(t *testing.T) {
+	types := []ColumnTypeMapping{
+		{Name: "n", Type: "long"},
+		{Name: "d", Type: "double"},
+		{Name: "b", Type: "boolean"},
+		{Name: "nested", Type: "record"},
+	}
+	records := []map[string]interface{}{
+		{
+			"n":      "not-a-number",                          // unparseable long → unchanged string
+			"d":      "1.2.3",                                 // unparseable double → unchanged string
+			"b":      "yes",                                   // not true/false → unchanged string
+			"nested": map[string]interface{}{"a": float64(1)}, // complex → unchanged
+			"absent": nil,                                     // explicit null → untouched
+		},
+	}
+	ApplyTrueTypes(records, types)
+	r := records[0]
+	if r["n"] != "not-a-number" {
+		t.Errorf("n = %#v, want unchanged", r["n"])
+	}
+	if r["d"] != "1.2.3" {
+		t.Errorf("d = %#v, want unchanged", r["d"])
+	}
+	if r["b"] != "yes" {
+		t.Errorf("b = %#v, want unchanged", r["b"])
+	}
+	if _, ok := r["nested"].(map[string]interface{}); !ok {
+		t.Errorf("nested = %#v, want unchanged map", r["nested"])
+	}
+	if r["absent"] != nil {
+		t.Errorf("absent = %#v, want nil", r["absent"])
+	}
+}
+
+func TestApplyTrueTypes_LongRejectsFractionalFloat(t *testing.T) {
+	// A long delivered as a numeric float must not be truncated: an integral
+	// value casts, a fractional one is left untouched.
+	types := []ColumnTypeMapping{{Name: "n", Type: "long"}}
+	records := []map[string]interface{}{
+		{"n": float64(42)},
+		{"n": float64(7.5)},
+	}
+	ApplyTrueTypes(records, types)
+	if got, ok := records[0]["n"].(int64); !ok || got != 42 {
+		t.Errorf("row0 n = %#v, want int64(42)", records[0]["n"])
+	}
+	if got, ok := records[1]["n"].(float64); !ok || got != 7.5 {
+		t.Errorf("row1 n = %#v, want float64(7.5) left untouched", records[1]["n"])
+	}
+}
+
+func TestApplyTrueTypes_NoTypesOrNoRecordsIsNoOp(t *testing.T) {
+	records := []map[string]interface{}{{"count": "42"}}
+	ApplyTrueTypes(records, nil) // no types → no-op
+	if records[0]["count"] != "42" {
+		t.Errorf("count = %#v, want unchanged string when no types", records[0]["count"])
+	}
+	ApplyTrueTypes(nil, []ColumnTypeMapping{{Name: "x", Type: "long"}}) // no records → no panic
+}
+
+func TestApplyTrueTypes_Idempotent(t *testing.T) {
+	types := []ColumnTypeMapping{{Name: "n", Type: "long"}}
+	records := []map[string]interface{}{{"n": "42"}}
+	ApplyTrueTypes(records, types)
+	ApplyTrueTypes(records, types) // second pass: int64 already, must stay int64(42)
+	if got, ok := records[0]["n"].(int64); !ok || got != 42 {
+		t.Errorf("n = %#v, want stable int64(42) across repeated calls", records[0]["n"])
+	}
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `--typed` flag to `dtctl query` that casts scalar columns to their native JSON/YAML types, so structured output is math-ready instead of carrying the API's string-encoded integers.

### Background

The Grail query API deliberately serialises integer-valued columns (`long`, `duration`) as JSON **strings** to preserve full int64 precision for JavaScript/TypeScript consumers — this is intentional and documented (GRAIL-545), *not* a bug. dtctl's `json`/`yaml`/`jsonl` output faithfully passes that through, which is honest to the wire but surprises downstream tooling:

```bash
dtctl query 'fetch logs | summarize c = count()' -o json
# [ { "c": "42" } ]   ← string; `jq '.[].c + 1'` fails without tonumber
```

### What `--typed` does

```bash
dtctl query 'fetch logs | summarize c = count()' -o json --typed
# [ { "c": 42 } ]
```

- Casts `long`/`duration` → JSON number, `boolean` → real boolean, using the DQL type metadata.
- **Precision-safe in dtctl:** a `long` is emitted as its full decimal digits, unquoted and lossless — never routed through a float64. The only precision risk is a downstream 64-bit-float JSON parser (browser `JSON.parse`, older `jq`), which is exactly why it is **opt-in and off by default** — the default output stays faithful to the API's wire encoding.
- **Timestamps stay RFC3339 strings** (JSON/YAML have no native date type); `string`, `ip`, `timeframe`, and nested record/array columns are untouched.
- Values that don't cleanly parse to their declared type — including non-finite doubles (`"NaN"`/`"Infinity"`) that JSON cannot represent — are left as strings rather than failing the output.
- `--typed` implies `--include-types`, and is applied before the spill/agent branch, so the agent envelope and spilled files see the same typed records.

## Implementation

- `pkg/output/typed.go` — `ApplyTrueTypes(records, types)`, a pure in-place transform (no second copy of the result set).
- `pkg/exec/dql.go` — apply in `printResults` when `opts.Typed`; new `DQLExecuteOptions.Typed`.
- `cmd/query.go` — `--typed` flag, forces `includeTypes`, live-mode warning.
- Docs: new "Numeric typing" section in `output-formats.md`.

## Tests

- `pkg/output/typed_test.go` — scalar casts, big-int precision through JSON **and** YAML (unquoted/lossless), non-finite doubles stay strings & remain marshalable, uncastable/null left alone, fractional-float long not truncated, no-types/no-records no-op, idempotency.
- `pkg/exec/dql_test.go` — end-to-end subtest asserting the `long` renders as an unquoted number with `--typed`.
- Full `go test ./...` green; golden tests unaffected (default output unchanged).