### PR TITLE
fix(account): use account API host for IAM access-info discovery

### DIFF
--- a/pkg/client/account.go
+++ b/pkg/client/account.go
@@ -14,14 +14,10 @@ func AccountBaseURLForEnvironment(env auth.Environment) string {
 	}
 }
 
-// IAMBaseURLForEnvironment maps a tier to the IAM service URL (for access-info).
+// IAMBaseURLForEnvironment maps a tier to the base URL hosting the IAM
+// access-info endpoint (/iam/v1/access-info). This endpoint lives on the
+// Account Management API host, not on a separate iam.* host — so it returns
+// the same hosts as AccountBaseURLForEnvironment.
 func IAMBaseURLForEnvironment(env auth.Environment) string {
-	switch env {
-	case auth.EnvironmentDev:
-		return "https://iam-dev.dynatracelabs.com"
-	case auth.EnvironmentHard:
-		return "https://iam-hardening.dynatracelabs.com"
-	default: // prod
-		return "https://iam.dynatrace.com"
-	}
+	return AccountBaseURLForEnvironment(env)
 }

--- a/pkg/client/account_test.go
+++ b/pkg/client/account_test.go
@@ -31,9 +31,9 @@ func TestIAMBaseURLForEnvironment(t *testing.T) {
 		env  auth.Environment
 		want string
 	}{
-		{auth.EnvironmentProd, "https://iam.dynatrace.com"},
-		{auth.EnvironmentDev, "https://iam-dev.dynatracelabs.com"},
-		{auth.EnvironmentHard, "https://iam-hardening.dynatracelabs.com"},
+		{auth.EnvironmentProd, "https://api.dynatrace.com"},
+		{auth.EnvironmentDev, "https://api-dev.internal.dynatracelabs.com"},
+		{auth.EnvironmentHard, "https://api-hardening.internal.dynatracelabs.com"},
 	}
 	for _, tt := range tests {
 		got := client.IAMBaseURLForEnvironment(tt.env)


### PR DESCRIPTION
## Problem

Account UUID auto-discovery (`dtctl ctx discover-account` and the auto-discovery on `dtctl account login`) always failed:

```
Error: could not discover account for environment "…": access-info returned 404
```

The `access-info` endpoint (`/iam/v1/access-info`) is called against the host returned by `IAMBaseURLForEnvironment`, which pointed at dedicated `iam.*` hosts:

| tier | host used (before) | result |
|------|--------------------|--------|
| prod | `https://iam.dynatrace.com` | **404** — path not served here |
| dev  | `https://iam-dev.dynatracelabs.com` | does not resolve |
| hardening | `https://iam-hardening.dynatracelabs.com` | — |

That endpoint actually lives on the **Account Management API host** — the same hosts `AccountBaseURLForEnvironment` already returns. Verified:

- `https://iam.dynatrace.com/iam/v1/access-info` → `404`
- `https://api.dynatrace.com/iam/v1/access-info` → `401` (endpoint exists, needs a valid token)

This affected every context, not a specific environment.

## Fix

`IAMBaseURLForEnvironment` now delegates to `AccountBaseURLForEnvironment` (`api.dynatrace.com` / `api-dev.internal.dynatracelabs.com` / `api-hardening.internal.dynatracelabs.com`), keeping the `/iam/v1/access-info` path. Test expectations updated accordingly.

## Testing

- `go test ./pkg/client/` ✅
- Confirmed the corrected hosts serve the endpoint (401 vs 404) via direct probes.