### PR TITLE
fix(query): surface DQL type block with --include-types (#376)

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -265,6 +265,11 @@ Examples:
 		enforceQueryConsumptionLimit, _ := cmd.Flags().GetBool("enforce-query-consumption-limit")
 		includeTypes, _ := cmd.Flags().GetBool("include-types")
 		typed, _ := cmd.Flags().GetBool("typed")
+		// Only an explicit --include-types surfaces the DQL type block as a
+		// top-level "types" key in structured output. Parquet/--typed force
+		// includeTypes on below to *consume* the metadata internally, but that
+		// must not start emitting the block, so capture intent before forcing.
+		emitTypes := cmd.Flags().Changed("include-types")
 		// Parquet derives its column schema from DQL types, so request them even
 		// if the user did not pass --include-types. The type metadata is consumed
 		// to build the schema and is not added to the output rows.
@@ -407,6 +412,7 @@ Examples:
 			EnablePreview:                enablePreview,
 			EnforceQueryConsumptionLimit: enforceQueryConsumptionLimit,
 			IncludeTypes:                 includeTypes,
+			EmitTypes:                    emitTypes,
 			IncludeContributions:         includeContributions,
 			Typed:                        typed,
 			DefaultTimeframeStart:        defaultTimeframeStart,
@@ -771,7 +777,7 @@ func init() {
 	queryCmd.Flags().Bool("enable-preview", false, "request preview results if available within timeout")
 	queryCmd.Flags().Bool("no-progress", false, "disable the live progress bar shown on stderr for long queries")
 	queryCmd.Flags().Bool("enforce-query-consumption-limit", false, "enforce query consumption limit")
-	queryCmd.Flags().Bool("include-types", false, "include type information in query results")
+	queryCmd.Flags().Bool("include-types", false, "surface DQL per-column type info as a top-level \"types\" key (json/yaml output)")
 	queryCmd.Flags().Bool("include-contributions", false, "include bucket contribution information in query results")
 	queryCmd.Flags().Bool("typed", false, "cast scalar columns (long, double, duration, boolean) to native JSON/YAML types instead of the API's string encoding; opt-in, implies --include-types")
 

--- a/docs/site/_docs/output-formats.md
+++ b/docs/site/_docs/output-formats.md
@@ -124,6 +124,40 @@ Notes:
   otherwise a single placeholder column so the file stays readable by mainstream
   tooling (a column-less file is rejected by DuckDB, pyarrow, and pandas).
 
+## Column types (`--include-types`)
+
+Pass `--include-types` to surface the DQL per-column type information the query
+API returns. In `json` and `yaml` output it appears as a top-level `types` key
+alongside `records`, preserving the API's shape (`indexRange` + `mappings`):
+
+```bash
+dtctl query 'fetch logs | limit 1' -o json --include-types
+# {
+#   "records": [ { "content": "...", "loglevel": "INFO", "status.code": "200" } ],
+#   "types": [
+#     {
+#       "indexRange": [0, 0],
+#       "mappings": {
+#         "content":     { "type": "string" },
+#         "loglevel":    { "type": "string" },
+#         "status.code": { "type": "long" }
+#       }
+#     }
+#   ]
+# }
+```
+
+Notes:
+
+- **Only with an explicit flag.** The block is emitted only when you pass
+  `--include-types` yourself. `--typed` and Parquet output request the same
+  metadata internally to do their work, but that does not add the `types` key.
+- **`json`/`yaml` only.** `jsonl` (one record per line) and `csv` (tabular) have
+  no place for a document-level sibling, so the block is not emitted there.
+- Note the distinction from `--typed` below: `--include-types` reports the
+  declared type while leaving values in their wire form (so a `long` still reads
+  as `"200"`), whereas `--typed` uses the same metadata to rewrite the values.
+
 ## Numeric typing (`--typed`)
 
 The Grail query API deliberately serialises integer-valued columns (`long`,

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -124,6 +124,13 @@ type DQLExecuteOptions struct {
 	IncludeTypes                 bool    // Include type information in results (default: true)
 	IncludeContributions         bool    // Include bucket contribution information in results
 
+	// EmitTypes surfaces the DQL per-column type block as a top-level "types"
+	// key alongside "records" in structured (json/yaml) output. It is set only
+	// when the user explicitly passed --include-types, so the metadata that
+	// parquet/--typed request internally is not accidentally emitted. Has no
+	// effect unless the API actually returned type information.
+	EmitTypes bool
+
 	// Typed opts in to casting scalar columns (long, double, duration, boolean)
 	// to their native JSON/YAML types using the DQL type metadata, instead of the
 	// wire form where integer-valued columns arrive as strings. Off by default so
@@ -842,6 +849,15 @@ func (e *DQLExecutor) printResults(query string, result *DQLQueryResponse, opts 
 		}
 		if meta != nil {
 			out["metadata"] = output.MetadataToMap(meta, opts.MetadataFields)
+		}
+		// Surface the DQL per-column type block (indexRange + mappings) as a
+		// sibling of "records" when the user explicitly asked for it via
+		// --include-types. JSONL has no place for a document-level sibling, so
+		// it is skipped there; json/yaml carry it inline.
+		if opts.EmitTypes && effectiveFormat != "jsonl" {
+			if types := result.GetTypes(); len(types) > 0 {
+				out["types"] = types
+			}
 		}
 		if len(out) > 0 {
 			return printer.Print(out)

--- a/pkg/exec/dql_test.go
+++ b/pkg/exec/dql_test.go
@@ -2501,6 +2501,48 @@ func TestDQLExecutor_OutputFormats_Integration(t *testing.T) {
 			t.Errorf("string column should be unchanged: %q", line)
 		}
 	})
+
+	t.Run("EmitTypes surfaces a top-level types block in json", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			if err := executor.ExecuteWithContext(context.Background(), "fetch logs",
+				DQLExecuteOptions{OutputFormat: "json", IncludeTypes: true, EmitTypes: true}); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+		})
+		var doc map[string]json.RawMessage
+		if err := json.Unmarshal(out, &doc); err != nil {
+			t.Fatalf("output is not valid JSON: %v — %s", err, out)
+		}
+		if _, ok := doc["records"]; !ok {
+			t.Errorf("expected a records key alongside types, got: %s", out)
+		}
+		raw, ok := doc["types"]
+		if !ok {
+			t.Fatalf("expected a top-level types key with EmitTypes, got: %s", out)
+		}
+		// The block must preserve the raw API shape: [{indexRange, mappings}].
+		var groups []sdkquery.ColumnTypes
+		if err := json.Unmarshal(raw, &groups); err != nil {
+			t.Fatalf("types block is not the expected shape: %v — %s", err, raw)
+		}
+		if len(groups) != 1 || groups[0].Mappings["count"].Type != "long" {
+			t.Errorf("unexpected types block: %s", raw)
+		}
+	})
+
+	t.Run("types block is omitted without an explicit --include-types", func(t *testing.T) {
+		// --typed forces IncludeTypes on internally, but EmitTypes stays false, so
+		// the block must not leak into output.
+		out := captureStdout(t, func() {
+			if err := executor.ExecuteWithContext(context.Background(), "fetch logs",
+				DQLExecuteOptions{OutputFormat: "json", Typed: true}); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+		})
+		if bytes.Contains(out, []byte(`"types"`)) {
+			t.Errorf("types block leaked into output without --include-types: %s", out)
+		}
+	})
 }
 
 // parseDTClientContext unmarshals the dt-client-context header value into a map.


### PR DESCRIPTION
## Summary

Fixes #376. `--include-types` requested the per-column type metadata from the query API but silently discarded it in every non-Parquet output format, so the flag had no observable effect for `json`/`yaml`/`jsonl`/`csv`.

The `default` branch of `printResults` (`pkg/exec/dql.go`) built its output map from `records` and `metadata` only — the deserialized `result.Result.Types` was never inserted.

## What changed

- Emit the API's type block as a **top-level `types` key** alongside `records` in `json`/`yaml` output, preserving the wire shape (`[{indexRange, mappings}]`) that the issue's expected output shows.
- Gate emission on an **explicit** `--include-types`. Parquet and `--typed` force `includeTypes` on internally to consume the metadata for their own work; that must not start leaking the block into output. A new `EmitTypes` option carries the explicit intent, captured via `cmd.Flags().Changed("include-types")` before the forcing.
- `jsonl` (one record per line) and `csv` (tabular) have no place for a document-level sibling, so the block is skipped there.

## Behavior

| Invocation | `types` key emitted? | Values |
|---|---|---|
| `--include-types` | ✅ (json/yaml) | wire form (`"200"`) |
| `--typed` (alone) | ❌ | cast (`200`) |
| `--typed --include-types` | ✅ | cast (`200`) |
| default | ❌ | wire form |

## Relationship to `--typed` (#380)

Orthogonal and complementary: `--include-types` *reports* the declared type while leaving values untouched; `--typed` *rewrites* values using the same metadata. Notably this also unblocks the minigrail#17 use case, which needs the raw type + wire-value distinction preserved (something `--typed` deliberately collapses).

## Tests

- Extended `TestDQLExecutor_OutputFormats_Integration` with two end-to-end subtests: `types` block present with `--include-types -o json` (asserting the raw `[]ColumnTypes` shape), and absent under `--typed` alone.
- Docs: new "Column types (`--include-types`)" section in `output-formats.md`; updated flag help.

`go build ./...`, `go vet`, and `go test ./cmd/ ./pkg/exec/ ./pkg/output/` all pass.