### PR TITLE
feat(query): persist DQL column types in Parquet file footer

### DIFF
--- a/docs/site/_docs/output-formats.md
+++ b/docs/site/_docs/output-formats.md
@@ -123,6 +123,16 @@ Notes:
   file (never a zero-byte file): it carries the DQL schema when types are known,
   otherwise a single placeholder column so the file stays readable by mainstream
   tooling (a column-less file is rejected by DuckDB, pyarrow, and pandas).
+- **Parquet files also carry the DQL types in the file footer**, under the
+  key-value metadata key `dtctl.dql.types` (a JSON object mapping column name to
+  DQL type, e.g. `{"status.code":"long","content":"string"}`). This lets a reader
+  recover type information the physical schema alone loses — a Grail `long` is
+  stored as `INT64`, but Grail's own JSON serialiser emits it as a quoted string,
+  so a consumer reproducing Grail's wire form needs the declared type to know
+  which columns to stringify. The footer records **every** declared column,
+  including ones that were null in every row (Grail omits null fields from
+  records, so such a column has no physical column in the file). Read it with
+  DuckDB's `parquet_kv_metadata()` or any Parquet footer reader.
 
 ## Column types (`--include-types`)
 

--- a/pkg/output/parquet.go
+++ b/pkg/output/parquet.go
@@ -45,6 +45,14 @@ import (
 //
 // Cells that cannot be coerced to their column's physical type are written as
 // null rather than failing the whole export.
+//
+// # DQL types in the footer
+//
+// The full DQL type block is also persisted in the file footer under
+// dqlTypesMetadataKey, so a reader can recover the declared Grail type of every
+// column — including the disambiguation the physical schema loses (long vs
+// string, both numeric on the wire) and columns that were null in every row (and
+// so absent from the physical schema entirely). See dqlTypesMetadata.
 type ParquetPrinter struct {
 	writer io.Writer
 	// types carries the DQL column type mappings (from Response.GetTypes()).
@@ -90,6 +98,37 @@ const parquetRowsPerRowGroup = 100_000
 // file"), so we emit one nullable placeholder column to keep the file portable.
 const parquetEmptyResultColumn = "_dtctl_empty"
 
+// dqlTypesMetadataKey is the parquet file-footer key under which the DQL column
+// types are stored, as a JSON object mapping column name to DQL type name
+// (e.g. {"status.code":"long","content":"string"}). A reader (e.g. a snapshot
+// server reproducing Grail's JSON serialisation) consults it to recover types
+// the physical schema loses: a Grail `long` is written as INT64, but Grail's own
+// JSON serialiser emits it as a quoted string, so a reader needs the declared
+// type to decide whether to stringify. The key is namespaced to avoid clashing
+// with unrelated writer metadata.
+const dqlTypesMetadataKey = "dtctl.dql.types"
+
+// dqlTypesMetadata renders the full DQL type block as a JSON object for the file
+// footer, or "" when no types are known (nothing to record). It intentionally
+// serialises every declared column — not just the ones that materialised as
+// physical columns — so a reader recovers columns that were null in every row
+// and thus absent from the record-key union the schema is built from.
+// encoding/json marshals maps with sorted keys, so the output is deterministic.
+func (p *ParquetPrinter) dqlTypesMetadata() string {
+	if len(p.types) == 0 {
+		return ""
+	}
+	m := make(map[string]string, len(p.types))
+	for _, t := range p.types {
+		m[t.Name] = t.Type
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
 // Print writes a single object as a one-row Parquet file.
 func (p *ParquetPrinter) Print(obj interface{}) error {
 	return p.PrintList([]interface{}{obj})
@@ -132,7 +171,19 @@ func (p *ParquetPrinter) PrintList(obj interface{}) error {
 	}
 	schema := parquet.NewSchema("dtctl", group)
 
-	w := parquet.NewWriter(p.writer, schema, parquet.MaxRowsPerRowGroup(parquetRowsPerRowGroup))
+	writerOpts := []parquet.WriterOption{schema, parquet.MaxRowsPerRowGroup(parquetRowsPerRowGroup)}
+	// Persist the DQL column types into the file footer. The physical schema
+	// above can only carry the columns that materialised (the union of record
+	// keys — and Grail omits null-valued fields from records, so a field that is
+	// null in every returned row produces no column). The footer instead carries
+	// the FULL DQL type block, so a reader recovers the complete declared schema,
+	// including all-null columns absent from the physical schema, and the exact
+	// Grail type of each column (e.g. long vs string) that INT64/DOUBLE alone
+	// cannot disambiguate. See dqlTypesMetadata.
+	if meta := p.dqlTypesMetadata(); meta != "" {
+		writerOpts = append(writerOpts, parquet.KeyValueMetadata(dqlTypesMetadataKey, meta))
+	}
+	w := parquet.NewWriter(p.writer, writerOpts...)
 	for _, rec := range records {
 		row := make(map[string]interface{}, len(columns))
 		for _, name := range columns {

--- a/pkg/output/parquet_test.go
+++ b/pkg/output/parquet_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"bytes"
+	"encoding/json"
 	"math"
 	"testing"
 	"time"
@@ -108,6 +109,83 @@ func TestParquetPrinter_DQLTypes(t *testing.T) {
 	}
 	if rows[1]["duration"] != int64(4781900) {
 		t.Errorf("duration = %#v, want int64(4781900)", rows[1]["duration"])
+	}
+}
+
+// TestParquetPrinter_DQLTypesFooter verifies the DQL type block is persisted
+// into the file footer (dtctl.dql.types), and — critically for reproducing
+// Grail's serialisation — that it carries EVERY declared column, including one
+// that is null in every record and therefore has no physical parquet column.
+func TestParquetPrinter_DQLTypesFooter(t *testing.T) {
+	var buf bytes.Buffer
+	p := &ParquetPrinter{
+		writer: &buf,
+		types: []ColumnTypeMapping{
+			{Name: "count", Type: "long"},
+			{Name: "host", Type: "string"},
+			// Declared by the DQL schema but null in every record below. Grail
+			// omits null fields from JSON records, so this never becomes a
+			// physical column — yet the footer must still report it and its type.
+			{Name: "duration_ns", Type: "duration"},
+		},
+	}
+	records := []map[string]interface{}{
+		{"count": "42", "host": "web-01"},
+		{"count": "7", "host": "web-02"},
+	}
+	if err := p.PrintList(records); err != nil {
+		t.Fatalf("PrintList: %v", err)
+	}
+
+	f, err := parquet.OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("open parquet: %v", err)
+	}
+
+	// Sanity: the all-null column is absent from the physical schema...
+	physical := map[string]bool{}
+	for _, path := range f.Schema().Columns() {
+		physical[path[len(path)-1]] = true
+	}
+	if physical["duration_ns"] {
+		t.Fatalf("did not expect an all-null column in the physical schema: %v", physical)
+	}
+
+	// ...but the footer still records its declared type.
+	raw, ok := f.Lookup(dqlTypesMetadataKey)
+	if !ok {
+		t.Fatalf("footer key %q missing", dqlTypesMetadataKey)
+	}
+	var got map[string]string
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("footer value is not JSON: %v — %q", err, raw)
+	}
+	want := map[string]string{"count": "long", "host": "string", "duration_ns": "duration"}
+	if len(got) != len(want) {
+		t.Fatalf("footer types = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("footer type[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+// TestParquetPrinter_NoTypesNoFooter verifies the footer key is omitted entirely
+// when no DQL types are known (value-inference path), rather than writing an
+// empty or misleading annotation.
+func TestParquetPrinter_NoTypesNoFooter(t *testing.T) {
+	var buf bytes.Buffer
+	p := &ParquetPrinter{writer: &buf} // no types
+	if err := p.PrintList([]map[string]interface{}{{"a": float64(1)}}); err != nil {
+		t.Fatalf("PrintList: %v", err)
+	}
+	f, err := parquet.OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("open parquet: %v", err)
+	}
+	if v, ok := f.Lookup(dqlTypesMetadataKey); ok {
+		t.Errorf("expected no footer key without DQL types, got %q", v)
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes `-o parquet` snapshots self-describing by persisting the DQL column types into the Parquet file footer, so a consumer (e.g. a snapshot server like minigrail) can recover the declared Grail type of every column.

### Why

The writer correctly maps a Grail `long` → `INT64`. But Grail's own JSON serialiser emits integer-valued columns (`long`, `duration`) as **quoted strings** for int64 precision. A consumer reproducing Grail's wire form off the Parquet file sees `INT64` and can't tell whether Grail would have serialised it as `200` or `"200"` — the declared type is the missing signal. Today the writer computes that type to build the schema, then discards it.

### What changed

- On `-o parquet`, write the full DQL type block into the footer as JSON under key-value metadata key **`dtctl.dql.types`** (`{"status.code":"long","content":"string"}`). The mapping is already in hand; this just records it.
- **Solves the null-vs-non-existent case:** the footer serialises *every declared column*, not only those that materialised as physical columns. Grail omits null-valued fields from JSON records, so a field null in every returned row never becomes a record key and has **no physical column** — yet the footer still reports it and its type. A reader thus recovers the complete declared schema, not just the columns that happened to carry a non-null value in the export window.
- No physical-type or row-value change: `INT64` stays `INT64`. Purely additive footer metadata; readers that ignore it are unaffected.

### Behavior

| Case | Physical column? | In footer? |
|---|---|---|
| `long` with values | ✅ INT64 | ✅ `"long"` |
| `string` | ✅ STRING | ✅ `"string"` |
| declared but null in every row | ❌ (Grail omits nulls → no record key) | ✅ `"<type>"` |
| no DQL types known (inference path) | — | ❌ (key omitted) |

### Context

This is the clean, self-describing complement to #384 (`--include-types` for json/yaml). It's the piece the minigrail#17 snapshot path actually needs: the snapshot exports with `-o parquet`, which #384 doesn't touch, so the types have to travel *in* the file rather than via a separate json probe (which couldn't see all-null columns anyway). Read it back with DuckDB's `parquet_kv_metadata()` or any footer reader.

### Tests

- `TestParquetPrinter_DQLTypesFooter` — footer round-trips; asserts an all-null declared column is **absent from the physical schema but present in the footer** with its type.
- `TestParquetPrinter_NoTypesNoFooter` — the key is omitted entirely on the inference path (no misleading empty annotation).

`go build ./...`, `gofmt`, and `go test ./pkg/output/ ./pkg/exec/` all pass.