### PR TITLE
fix: read direct shares from the correct API response key

### DIFF
--- a/cmd/share.go
+++ b/cmd/share.go
@@ -107,7 +107,7 @@ Examples:
 
 		var existingShare *document.DirectShare
 		for _, s := range shares.Shares {
-			if s.Access == access {
+			if s.ExactAccess(access) {
 				existingShare = &s
 				break
 			}
@@ -227,7 +227,7 @@ Examples:
 			// Delete all shares (optionally filtered by access level)
 			deleted := 0
 			for _, share := range shares.Shares {
-				if access != "" && share.Access != access {
+				if access != "" && !share.ExactAccess(access) {
 					continue
 				}
 				if err := handler.DeleteDirectShare(share.ID); err != nil {
@@ -241,7 +241,7 @@ Examples:
 			recipientIDs := append(users, groups...)
 			removed := 0
 			for _, share := range shares.Shares {
-				if access != "" && share.Access != access {
+				if access != "" && !share.ExactAccess(access) {
 					continue
 				}
 				if err := handler.RemoveDirectShareRecipients(share.ID, recipientIDs); err != nil {

--- a/pkg/resources/document/document.go
+++ b/pkg/resources/document/document.go
@@ -103,9 +103,16 @@ func toSDKDocument(d *Document) *sdkdocument.Document {
 
 // DirectShare is the CLI read model for a direct share.
 type DirectShare struct {
-	ID         string `json:"id" table:"ID"`
-	DocumentID string `json:"documentId" table:"DOCUMENT_ID"`
-	Access     string `json:"access" table:"ACCESS"`
+	ID         string   `json:"id" table:"ID"`
+	DocumentID string   `json:"documentId" table:"DOCUMENT_ID"`
+	Access     []string `json:"access" table:"ACCESS"`
+}
+
+// ExactAccess reports whether the share grants exactly the given access level.
+// Delegates to the SDK DirectShare.ExactAccess method.
+func (s DirectShare) ExactAccess(level string) bool {
+	sdkShare := sdkdocument.DirectShare{Access: s.Access}
+	return sdkShare.ExactAccess(level)
 }
 
 // fromSDKDirectShare converts an SDK DirectShare to the CLI DirectShare.

--- a/sdk/api/document/document.go
+++ b/sdk/api/document/document.go
@@ -542,14 +542,35 @@ func extractIDFromResponse(body []byte) string {
 
 // DirectShare represents a direct share for a document
 type DirectShare struct {
-	ID         string `json:"id"`
-	DocumentID string `json:"documentId"`
-	Access     string `json:"access"`
+	ID         string   `json:"id"`
+	DocumentID string   `json:"documentId"`
+	Access     []string `json:"access"`
+}
+
+// ExactAccess reports whether the share grants exactly the given access level.
+func (s DirectShare) ExactAccess(level string) bool {
+	want := accessToLevels(level)
+	if len(s.Access) != len(want) {
+		return false
+	}
+	for _, w := range want {
+		found := false
+		for _, a := range s.Access {
+			if a == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // DirectShareList represents a list of direct shares
 type DirectShareList struct {
-	Shares      []DirectShare `json:"directShares"`
+	Shares      []DirectShare `json:"direct-shares"`
 	TotalCount  int           `json:"totalCount"`
 	NextPageKey string        `json:"nextPageKey,omitempty"`
 }

--- a/sdk/api/document/document_test.go
+++ b/sdk/api/document/document_test.go
@@ -235,6 +235,35 @@ func TestListEnvironmentShares(t *testing.T) {
 	}
 }
 
+func TestListDirectShares(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/direct-shares", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// The API returns the array under the kebab-case "direct-shares" key, and access as
+		// an array, both matching environment-shares.
+		_, _ = w.Write([]byte(`{"direct-shares":[{"id":"share-1","documentId":"doc-123","access":["read"]}],"totalCount":1}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.ListDirectShares(context.Background(), "doc-123")
+	if err != nil {
+		t.Fatalf("ListDirectShares() error: %v", err)
+	}
+	if len(result.Shares) != 1 {
+		t.Fatalf("got %d shares, want 1", len(result.Shares))
+	}
+	if result.Shares[0].ID != "share-1" {
+		t.Errorf("got share ID %q, want share-1", result.Shares[0].ID)
+	}
+	if !result.Shares[0].ExactAccess("read") {
+		t.Errorf("got access %v, want exactly read", result.Shares[0].Access)
+	}
+}
+
 func TestDeleteEnvironmentShare(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/platform/document/v1/environment-shares/share-1", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description

`DirectShareList` unmarshals the direct-shares response into a field tagged `json:"directShares"`, but the document API returns the shares under the key `direct-shares`. so the slice always decodes empty. the sibling `EnvironmentShareList` already uses the hyphenated `environment-shares`, this brings direct shares in line with the same convention

impact: `unshare --all` (and anything that lists direct shares) sees zero shares and silently revokes nothing, so the access stays in place - a quiet access leak

## Related Issues

Closes #371

## Testing

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)

added `TestListDirectShares` that feeds a raw `{"direct-shares":[...],"totalCount":1}` payload: on main it decodes 0 shares, with the tag fix it decodes the share correctly