### PR TITLE
feat(openpipeline): add openpipeline-matcher, openpipeline-dql-processor, and preview-processor resources

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -9,7 +9,8 @@ var execCmd = &cobra.Command{
 	Use:   "exec",
 	Short: "Execute queries, workflows, or functions",
 	Long: `Execute operations on the Dynatrace platform: run workflows, invoke
-serverless functions, evaluate SLOs, or chat with Davis CoPilot.
+serverless functions, evaluate SLOs, chat with Davis CoPilot, or preview
+OpenPipeline processor definitions against sample records.
 
 For DQL queries, use 'dtctl query' instead (exec dql is deprecated).
 
@@ -18,7 +19,8 @@ Available operations:
   function (fn, func)     Invoke an app function or run ad-hoc JavaScript
   analyzer (az)           Run a Davis AI analyzer
   slo                     Evaluate a service-level objective
-  copilot (cp, chat)      Chat with Davis CoPilot interactively`,
+  copilot (cp, chat)      Chat with Davis CoPilot interactively
+  preview-processor       Preview an OpenPipeline processor against sample records`,
 	Example: `  # Execute a workflow and wait for completion
   dtctl exec workflow <workflow-id>
 
@@ -32,7 +34,10 @@ Available operations:
   dtctl exec slo <slo-id>
 
   # Chat with Davis CoPilot
-  dtctl exec copilot "What happened in the last hour?"`,
+  dtctl exec copilot "What happened in the last hour?"
+
+  # Preview a processor definition against sample records
+  dtctl exec preview-processor -f processor.json`,
 	RunE: requireSubcommand,
 }
 
@@ -45,4 +50,5 @@ func init() {
 	execCmd.AddCommand(execAnalyzerCmd)
 	execCmd.AddCommand(execCopilotCmd)
 	execCmd.AddCommand(execSLOCmd)
+	execCmd.AddCommand(execPreviewProcessorCmd)
 }

--- a/cmd/exec_preview_processor.go
+++ b/cmd/exec_preview_processor.go
@@ -23,7 +23,13 @@ and returns the matched/modified result for each record.
 
 The file (use "-" for stdin; there is no positional argument) is the processor
 definition body itself — the same JSON shape a processor has inside a pipeline
-config, e.g. {"type":"dql","matcher":"true","dqlScript":"...","sampleData":"..."}.
+config. It must be a complete processor definition; the endpoint validates the
+full schema and rejects a partial body, e.g. a DQL processor needs at least:
+
+  {"type":"dql","id":"preview","description":"preview","enabled":true,
+   "matcher":"true","dqlScript":"fieldsAdd severity = \"INFO\"",
+   "sampleData":"{\"content\":\"hello\"}"}
+
 You do NOT wrap it in a request envelope: dtctl builds the request around it and
 adds the configuration scope from --config-id. The processor body is forwarded
 verbatim, so any of the endpoint's processor types are accepted.

--- a/cmd/exec_preview_processor.go
+++ b/cmd/exec_preview_processor.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/resources/previewprocessor"
+)
+
+// execPreviewProcessorCmd executes a processor definition against sample
+// records and returns the matched/modified results.
+var execPreviewProcessorCmd = &cobra.Command{
+	Use:   "preview-processor",
+	Args:  cobra.NoArgs,
+	Short: "Preview an OpenPipeline processor definition against sample records",
+	Long: `Preview an OpenPipeline processor definition against sample records.
+
+The command runs a single processor against the sample records embedded in it
+and returns the matched/modified result for each record.
+
+The file (use "-" for stdin; there is no positional argument) is the processor
+definition body itself — the same JSON shape a processor has inside a pipeline
+config, e.g. {"type":"dql","matcher":"true","dqlScript":"...","sampleData":"..."}.
+You do NOT wrap it in a request envelope: dtctl builds the request around it and
+adds the configuration scope from --config-id. The processor body is forwarded
+verbatim, so any of the endpoint's processor types are accepted.
+
+Special error handling:
+  408 - Request timed out; try reducing the number of sample records
+  429 - Too many concurrent preview requests; wait and retry
+
+Examples:
+  # Preview a processor definition from a file
+  dtctl exec preview-processor -f processor.json
+
+  # Read from stdin
+  cat processor.json | dtctl exec preview-processor -f -
+
+  # Scope to a specific configuration
+  dtctl exec preview-processor -f processor.json --config-id logs
+
+  # Get structured output
+  dtctl exec preview-processor -f processor.json -o json
+  dtctl exec preview-processor -f processor.json -o yaml`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		fileFlag, _ := cmd.Flags().GetString("file")
+		configIDFlag, _ := cmd.Flags().GetString("config-id")
+		if fileFlag == "" {
+			return fmt.Errorf("--file is required")
+		}
+
+		_, c, printer, err := Setup()
+		if err != nil {
+			return err
+		}
+
+		handler := previewprocessor.NewHandler(c)
+		results, err := handler.Preview(fileFlag, configIDFlag)
+		if err != nil {
+			return err
+		}
+
+		ap := enrichAgent(printer, "exec", "preview-processor")
+
+		// Agent mode, an explicit -o format, or a --jq filter: delegate to the
+		// printer (which honors json/yaml/table/wide/csv/toon and applies jq).
+		if ap != nil || cmd.Root().PersistentFlags().Lookup("output").Changed || jqFilter != "" {
+			return printer.PrintList(results)
+		}
+
+		// Default (no -o): indented JSON of the results array to stdout.
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	},
+}
+
+func init() {
+	execPreviewProcessorCmd.Flags().StringP("file", "f", "", `read the processor definition body from a file ("-" for stdin); required`)
+	execPreviewProcessorCmd.Flags().String("config-id", "", `configuration scope, e.g. "logs"`)
+}

--- a/cmd/exec_preview_processor_test.go
+++ b/cmd/exec_preview_processor_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
+)
+
+const previewProcessorPath = "/platform/openpipeline/v1/preview/processor"
+
+// setupExecPreviewTest wires a mock server for the preview endpoint and points
+// the command at a throwaway config, restoring mutated globals and flags on
+// cleanup.
+func setupExecPreviewTest(t *testing.T, response string) {
+	t.Helper()
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		previewProcessorPath: func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(response))
+		},
+	})
+	t.Cleanup(ms.Close)
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	t.Cleanup(cleanup)
+
+	restore := pinVerifyGlobals(t, configPath)
+	t.Cleanup(func() {
+		restore()
+		testutil.ResetCommandFlags(execPreviewProcessorCmd)
+	})
+	testutil.ResetCommandFlags(execPreviewProcessorCmd)
+}
+
+func writeProcessorFile(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "processor.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return path
+}
+
+func TestExecPreviewProcessorCmd_Success(t *testing.T) {
+	setupExecPreviewTest(t, `{"results":[{"matched":true,"record":{"content":"hi"}}]}`)
+
+	path := writeProcessorFile(t, `{"type":"dql","matcher":"true","dqlScript":"fieldsAdd x = 1"}`)
+	_ = execPreviewProcessorCmd.Flags().Set("file", path)
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = execPreviewProcessorCmd.RunE(execPreviewProcessorCmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("RunE() error = %v", runErr)
+	}
+	// Default output is an indented JSON array of results.
+	if !strings.Contains(out, `"matched": true`) {
+		t.Errorf("stdout missing matched result:\n%s", out)
+	}
+}
+
+func TestExecPreviewProcessorCmd_JSONOutput(t *testing.T) {
+	setupExecPreviewTest(t, `{"results":[{"matched":true,"record":{"content":"hi"}}]}`)
+
+	path := writeProcessorFile(t, `{"type":"dql","matcher":"true","dqlScript":"fieldsAdd x = 1"}`)
+	_ = execPreviewProcessorCmd.Flags().Set("file", path)
+
+	// An explicit -o json delegates to the printer's PrintList instead of the
+	// default indented-JSON path.
+	outputFormat = "json"
+	rootCmd.PersistentFlags().Lookup("output").Changed = true
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = execPreviewProcessorCmd.RunE(execPreviewProcessorCmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("RunE() error = %v", runErr)
+	}
+	if !strings.Contains(out, `"matched"`) {
+		t.Errorf("stdout missing matched field:\n%s", out)
+	}
+}
+
+func TestExecPreviewProcessorCmd_FileRequired(t *testing.T) {
+	setupExecPreviewTest(t, `{"results":[]}`)
+
+	err := execPreviewProcessorCmd.RunE(execPreviewProcessorCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "--file is required") {
+		t.Fatalf("RunE() error = %v, want --file required error", err)
+	}
+}
+
+func TestExecPreviewProcessorCmd_MissingFile(t *testing.T) {
+	setupExecPreviewTest(t, `{"results":[]}`)
+	_ = execPreviewProcessorCmd.Flags().Set("file", filepath.Join(t.TempDir(), "nope.json"))
+
+	err := execPreviewProcessorCmd.RunE(execPreviewProcessorCmd, nil)
+	if err == nil {
+		t.Fatal("RunE() error = nil, want error for missing file")
+	}
+}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -41,8 +41,11 @@ Examples:
   # Verify inline DQL query
   dtctl verify query "fetch logs | summarize count()"
 
-  # Verify with template variables
-  dtctl verify query -f query.dql --set env=prod --set timeframe=1h
+  # Verify an OpenPipeline matcher expression
+  dtctl verify openpipeline-matcher 'matchesValue(content, "error")'
+
+  # Verify an OpenPipeline DQL processor script
+  dtctl verify openpipeline-dql-processor 'fieldsAdd severity = "INFO"'
 
   # Verify and fail on warnings (strict mode for CI/CD)
   dtctl verify query -f query.dql --fail-on-warn
@@ -59,4 +62,6 @@ Use "dtctl verify <command> --help" for more information about a command.
 
 func init() {
 	rootCmd.AddCommand(verifyCmd)
+	verifyCmd.AddCommand(verifyOpenPipelineMatcherCmd)
+	verifyCmd.AddCommand(verifyOpenPipelineDQLProcessorCmd)
 }

--- a/cmd/verify_openpipeline_dql_processor.go
+++ b/cmd/verify_openpipeline_dql_processor.go
@@ -46,6 +46,10 @@ Examples:
   dtctl verify openpipeline-dql-processor 'fieldsAdd x = 1' -o json
   dtctl verify openpipeline-dql-processor 'fieldsAdd x = 1' -o yaml`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !isSupportedVerifyOutputFormat(outputFormat) {
+			return fmt.Errorf("unsupported output format %q for verify openpipeline-dql-processor (supported: json, yaml, toon)", outputFormat)
+		}
+
 		fileFlag, _ := cmd.Flags().GetString("file")
 		configIDFlag, _ := cmd.Flags().GetString("config-id")
 

--- a/cmd/verify_openpipeline_dql_processor.go
+++ b/cmd/verify_openpipeline_dql_processor.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -99,16 +98,7 @@ Examples:
 				return err
 			}
 		} else {
-			if result.Valid {
-				fmt.Println("✓ Valid")
-			} else {
-				fmt.Println("✗ Invalid")
-			}
-			if result.Summary != "" {
-				for _, line := range strings.Split(result.Summary, "\n") {
-					fmt.Printf("  %s\n", line)
-				}
-			}
+			printVerifyResultHuman(result)
 		}
 
 		// A false verdict is a successful API call that must still exit non-zero

--- a/cmd/verify_openpipeline_dql_processor.go
+++ b/cmd/verify_openpipeline_dql_processor.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/dqlprocessorverify"
+)
+
+// verifyOpenPipelineDQLProcessorCmd validates a DQL processor script against
+// the OpenPipeline DQL processor verify endpoint.
+var verifyOpenPipelineDQLProcessorCmd = &cobra.Command{
+	Use:   "openpipeline-dql-processor [dql-script]",
+	Args:  cobra.MaximumNArgs(1),
+	Short: "Verify an OpenPipeline DQL processor script",
+	Long: `Verify an OpenPipeline DQL processor script without applying it.
+
+The command sends the script to the OpenPipeline DQL processor verify endpoint
+and reports whether it is valid. Diagnostics (errors, warnings) are printed
+with their source positions when available.
+
+The script can be provided as a positional argument or read from a file (use
+"-" for stdin). Exactly one of these must be supplied.
+
+Exit codes:
+  0 - Script is valid
+  1 - Script is invalid, or the command failed (auth, network, or server error)
+
+Examples:
+  # Verify inline DQL processor script
+  dtctl verify openpipeline-dql-processor 'fieldsAdd severity = "INFO"'
+
+  # Read script from a file
+  dtctl verify openpipeline-dql-processor -f processor.dql
+
+  # Read script from stdin
+  cat processor.dql | dtctl verify openpipeline-dql-processor -f -
+
+  # Verify scoped to a specific configuration
+  dtctl verify openpipeline-dql-processor 'fieldsAdd x = 1' --config-id logs
+
+  # Get structured output
+  dtctl verify openpipeline-dql-processor 'fieldsAdd x = 1' -o json
+  dtctl verify openpipeline-dql-processor 'fieldsAdd x = 1' -o yaml`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fileFlag, _ := cmd.Flags().GetString("file")
+		configIDFlag, _ := cmd.Flags().GetString("config-id")
+
+		// Exactly one of: positional arg or --file
+		hasArg := len(args) > 0
+		hasFile := fileFlag != ""
+		if hasArg && hasFile {
+			return fmt.Errorf("provide either a positional DQL script or --file, not both")
+		}
+		if !hasArg && !hasFile {
+			return fmt.Errorf("a DQL script or --file is required")
+		}
+
+		var script string
+		if hasFile {
+			content, err := readVerifyExpressionFromFile(fileFlag)
+			if err != nil {
+				return err
+			}
+			script = content
+		} else {
+			script = args[0]
+		}
+
+		_, c, printer, err := Setup()
+		if err != nil {
+			return err
+		}
+
+		handler := dqlprocessorverify.NewHandler(c)
+		result, err := handler.Verify(dqlprocessorverify.VerifyOptions{
+			Script:          script,
+			ConfigurationID: configIDFlag,
+		})
+		if err != nil {
+			return err
+		}
+
+		ap := enrichAgent(printer, "verify", "openpipeline-dql-processor")
+
+		// Agent mode, an explicit -o format, or a --jq filter: delegate to the
+		// printer (agent envelope carrying valid/notifications, or
+		// json/yaml/table/wide/csv/toon with jq applied). Otherwise emit the
+		// default human-readable summary.
+		if ap != nil || cmd.Root().PersistentFlags().Lookup("output").Changed || jqFilter != "" {
+			if err := printer.Print(result); err != nil {
+				return err
+			}
+		} else {
+			if result.Valid {
+				fmt.Println("✓ Valid")
+			} else {
+				fmt.Println("✗ Invalid")
+			}
+			if result.Summary != "" {
+				for _, line := range strings.Split(result.Summary, "\n") {
+					fmt.Printf("  %s\n", line)
+				}
+			}
+		}
+
+		// A false verdict is a successful API call that must still exit non-zero
+		// in every mode. silentExitError is intercepted in root.go before the
+		// agent error-envelope path, so the ok:true envelope printed above stands
+		// as the sole output and the process still exits with ExitError.
+		if !result.Valid {
+			return &silentExitError{code: client.ExitError}
+		}
+		return nil
+	},
+}
+
+func init() {
+	verifyOpenPipelineDQLProcessorCmd.Flags().StringP("file", "f", "", `read the DQL script from a file ("-" for stdin)`)
+	verifyOpenPipelineDQLProcessorCmd.Flags().String("config-id", "", `configuration scope, e.g. "logs"`)
+}

--- a/cmd/verify_openpipeline_dql_processor_test.go
+++ b/cmd/verify_openpipeline_dql_processor_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+)
+
+const dqlProcessorVerifyPath = "/platform/openpipeline/v1/dqlProcessor/verify"
+
+// setupVerifyDQLProcessorTest wires a mock server for the DQL processor verify
+// endpoint and points the command at a throwaway config, restoring mutated
+// globals and command flags on cleanup.
+func setupVerifyDQLProcessorTest(t *testing.T, response string) {
+	t.Helper()
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		dqlProcessorVerifyPath: func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(response))
+		},
+	})
+	t.Cleanup(ms.Close)
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	t.Cleanup(cleanup)
+
+	restore := pinVerifyGlobals(t, configPath)
+	t.Cleanup(func() {
+		restore()
+		testutil.ResetCommandFlags(verifyOpenPipelineDQLProcessorCmd)
+	})
+	testutil.ResetCommandFlags(verifyOpenPipelineDQLProcessorCmd)
+}
+
+func TestVerifyOpenPipelineDQLProcessorCmd_Valid(t *testing.T) {
+	setupVerifyDQLProcessorTest(t, `{"valid":true,"notifications":[]}`)
+
+	err := verifyOpenPipelineDQLProcessorCmd.RunE(verifyOpenPipelineDQLProcessorCmd, []string{`fieldsAdd severity = "INFO"`})
+	if err != nil {
+		t.Fatalf("RunE() error = %v, want nil for valid script", err)
+	}
+}
+
+func TestVerifyOpenPipelineDQLProcessorCmd_Invalid(t *testing.T) {
+	setupVerifyDQLProcessorTest(t, `{"valid":false,"notifications":[{"severity":"ERROR","message":"bad"}]}`)
+
+	err := verifyOpenPipelineDQLProcessorCmd.RunE(verifyOpenPipelineDQLProcessorCmd, []string{"parsee content"})
+	var silent *silentExitError
+	if !errors.As(err, &silent) {
+		t.Fatalf("RunE() error = %v, want *silentExitError", err)
+	}
+	if silent.code != client.ExitError {
+		t.Errorf("exit code = %d, want %d", silent.code, client.ExitError)
+	}
+}
+
+func TestVerifyOpenPipelineDQLProcessorCmd_FromFile(t *testing.T) {
+	setupVerifyDQLProcessorTest(t, `{"valid":true}`)
+
+	path := filepath.Join(t.TempDir(), "processor.dql")
+	if err := os.WriteFile(path, []byte(`fieldsAdd x = 1`), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	_ = verifyOpenPipelineDQLProcessorCmd.Flags().Set("file", path)
+
+	if err := verifyOpenPipelineDQLProcessorCmd.RunE(verifyOpenPipelineDQLProcessorCmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+}
+
+func TestVerifyOpenPipelineDQLProcessorCmd_JSONOutput(t *testing.T) {
+	setupVerifyDQLProcessorTest(t, `{"valid":true,"notifications":[]}`)
+
+	outputFormat = "json"
+	rootCmd.PersistentFlags().Lookup("output").Changed = true
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = verifyOpenPipelineDQLProcessorCmd.RunE(verifyOpenPipelineDQLProcessorCmd, []string{"fieldsAdd x = 1"})
+	})
+	if runErr != nil {
+		t.Fatalf("RunE() error = %v", runErr)
+	}
+	if !strings.Contains(out, `"valid": true`) {
+		t.Errorf("stdout missing JSON valid field:\n%s", out)
+	}
+}
+
+func TestVerifyOpenPipelineDQLProcessorCmd_ServerError(t *testing.T) {
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		dqlProcessorVerifyPath: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"message":"boom"}}`))
+		},
+	})
+	t.Cleanup(ms.Close)
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	t.Cleanup(cleanup)
+	restore := pinVerifyGlobals(t, configPath)
+	t.Cleanup(func() {
+		restore()
+		testutil.ResetCommandFlags(verifyOpenPipelineDQLProcessorCmd)
+	})
+	testutil.ResetCommandFlags(verifyOpenPipelineDQLProcessorCmd)
+
+	err := verifyOpenPipelineDQLProcessorCmd.RunE(verifyOpenPipelineDQLProcessorCmd, []string{"fieldsAdd x = 1"})
+	if err == nil {
+		t.Fatal("RunE() error = nil, want error for server 500")
+	}
+}
+
+func TestVerifyOpenPipelineDQLProcessorCmd_MissingFile(t *testing.T) {
+	setupVerifyDQLProcessorTest(t, `{"valid":true}`)
+	_ = verifyOpenPipelineDQLProcessorCmd.Flags().Set("file", filepath.Join(t.TempDir(), "nope.dql"))
+
+	err := verifyOpenPipelineDQLProcessorCmd.RunE(verifyOpenPipelineDQLProcessorCmd, nil)
+	if err == nil {
+		t.Fatal("RunE() error = nil, want error for missing --file")
+	}
+}
+
+func TestVerifyOpenPipelineDQLProcessorCmd_ArgAndFileConflict(t *testing.T) {
+	setupVerifyDQLProcessorTest(t, `{"valid":true}`)
+	_ = verifyOpenPipelineDQLProcessorCmd.Flags().Set("file", "processor.dql")
+
+	err := verifyOpenPipelineDQLProcessorCmd.RunE(verifyOpenPipelineDQLProcessorCmd, []string{"fieldsAdd x = 1"})
+	if err == nil {
+		t.Fatal("RunE() error = nil, want conflict error for arg + --file")
+	}
+}
+
+func TestVerifyOpenPipelineDQLProcessorCmd_NoInput(t *testing.T) {
+	setupVerifyDQLProcessorTest(t, `{"valid":true}`)
+
+	err := verifyOpenPipelineDQLProcessorCmd.RunE(verifyOpenPipelineDQLProcessorCmd, nil)
+	if err == nil {
+		t.Fatal("RunE() error = nil, want error for missing DQL script")
+	}
+}

--- a/cmd/verify_openpipeline_matcher.go
+++ b/cmd/verify_openpipeline_matcher.go
@@ -51,6 +51,10 @@ Examples:
   dtctl verify openpipeline-matcher 'matchesValue(content, "error")' -o json
   dtctl verify openpipeline-matcher 'matchesValue(content, "error")' -o yaml`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !isSupportedVerifyOutputFormat(outputFormat) {
+			return fmt.Errorf("unsupported output format %q for verify openpipeline-matcher (supported: json, yaml, toon)", outputFormat)
+		}
+
 		fileFlag, _ := cmd.Flags().GetString("file")
 		contextFlag, _ := cmd.Flags().GetString("context")
 		configIDFlag, _ := cmd.Flags().GetString("config-id")

--- a/cmd/verify_openpipeline_matcher.go
+++ b/cmd/verify_openpipeline_matcher.go
@@ -106,16 +106,7 @@ Examples:
 				return err
 			}
 		} else {
-			if result.Valid {
-				fmt.Println("✓ Valid")
-			} else {
-				fmt.Println("✗ Invalid")
-			}
-			if result.Summary != "" {
-				for _, line := range strings.Split(result.Summary, "\n") {
-					fmt.Printf("  %s\n", line)
-				}
-			}
+			printVerifyResultHuman(result)
 		}
 
 		// A false verdict is a successful API call that must still exit non-zero
@@ -127,6 +118,30 @@ Examples:
 		}
 		return nil
 	},
+}
+
+// printVerifyResultHuman prints a verify verdict and its diagnostics in the same
+// human-readable style as "verify query": the verdict is written to stderr
+// (colored when stderr is a terminal) so redirecting the command's stdout keeps
+// the verdict visible. Shared by the matcher and DQL-processor verify commands,
+// whose VerifyResult is the same type.
+func printVerifyResultHuman(result *matcherverify.VerifyResult) {
+	useColor := isStderrTerminal()
+	switch {
+	case result.Valid && useColor:
+		fmt.Fprintf(os.Stderr, "%s✔%s Valid\n", colorGreen, colorReset)
+	case result.Valid:
+		fmt.Fprintln(os.Stderr, "✔ Valid")
+	case useColor:
+		fmt.Fprintf(os.Stderr, "%s✖%s Invalid\n", colorRed, colorReset)
+	default:
+		fmt.Fprintln(os.Stderr, "✖ Invalid")
+	}
+	if result.Summary != "" {
+		for _, line := range strings.Split(result.Summary, "\n") {
+			fmt.Fprintf(os.Stderr, "  %s\n", line)
+		}
+	}
 }
 
 // readVerifyExpressionFromFile reads a text expression from a file or stdin.

--- a/cmd/verify_openpipeline_matcher.go
+++ b/cmd/verify_openpipeline_matcher.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/matcherverify"
+)
+
+// verifyOpenPipelineMatcherCmd validates a DQL matcher expression against the
+// OpenPipeline matcher verify endpoint.
+var verifyOpenPipelineMatcherCmd = &cobra.Command{
+	Use:   "openpipeline-matcher [matcher-expression]",
+	Args:  cobra.MaximumNArgs(1),
+	Short: "Verify an OpenPipeline DQL matcher expression",
+	Long: `Verify an OpenPipeline DQL matcher expression without applying it.
+
+The command sends the matcher expression to the OpenPipeline matcher verify
+endpoint and reports whether it is valid. Diagnostics (errors, warnings) are
+printed with their source positions when available.
+
+The matcher can be provided as a positional argument or read from a file (use
+"-" for stdin). Exactly one of these must be supplied.
+
+Exit codes:
+  0 - Matcher is valid
+  1 - Matcher is invalid, or the command failed (auth, network, or server error)
+
+Examples:
+  # Verify inline matcher expression
+  dtctl verify openpipeline-matcher 'matchesValue(content, "error")'
+
+  # Read matcher from a file
+  dtctl verify openpipeline-matcher -f matcher.dql
+
+  # Read matcher from stdin
+  echo 'matchesValue(content, "error")' | dtctl verify openpipeline-matcher -f -
+
+  # Verify with a stage context
+  dtctl verify openpipeline-matcher 'matchesValue(content, "error")' --context ROUTING_RULE
+
+  # Verify scoped to a specific configuration
+  dtctl verify openpipeline-matcher 'matchesValue(content, "error")' --config-id logs
+
+  # Get structured output
+  dtctl verify openpipeline-matcher 'matchesValue(content, "error")' -o json
+  dtctl verify openpipeline-matcher 'matchesValue(content, "error")' -o yaml`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fileFlag, _ := cmd.Flags().GetString("file")
+		contextFlag, _ := cmd.Flags().GetString("context")
+		configIDFlag, _ := cmd.Flags().GetString("config-id")
+
+		// Exactly one of: positional arg or --file
+		hasArg := len(args) > 0
+		hasFile := fileFlag != ""
+		if hasArg && hasFile {
+			return fmt.Errorf("provide either a positional matcher expression or --file, not both")
+		}
+		if !hasArg && !hasFile {
+			return fmt.Errorf("a matcher expression or --file is required")
+		}
+
+		var query string
+		if hasFile {
+			content, err := readVerifyExpressionFromFile(fileFlag)
+			if err != nil {
+				return err
+			}
+			query = content
+		} else {
+			query = args[0]
+		}
+
+		_, c, printer, err := Setup()
+		if err != nil {
+			return err
+		}
+
+		handler := matcherverify.NewHandler(c)
+		result, err := handler.Verify(matcherverify.VerifyOptions{
+			Query:           query,
+			ConfigurationID: configIDFlag,
+			Context:         contextFlag,
+		})
+		if err != nil {
+			return err
+		}
+
+		ap := enrichAgent(printer, "verify", "openpipeline-matcher")
+
+		// Agent mode, an explicit -o format, or a --jq filter: delegate to the
+		// printer (agent envelope carrying valid/notifications, or
+		// json/yaml/table/wide/csv/toon with jq applied). Otherwise emit the
+		// default human-readable summary.
+		if ap != nil || cmd.Root().PersistentFlags().Lookup("output").Changed || jqFilter != "" {
+			if err := printer.Print(result); err != nil {
+				return err
+			}
+		} else {
+			if result.Valid {
+				fmt.Println("✓ Valid")
+			} else {
+				fmt.Println("✗ Invalid")
+			}
+			if result.Summary != "" {
+				for _, line := range strings.Split(result.Summary, "\n") {
+					fmt.Printf("  %s\n", line)
+				}
+			}
+		}
+
+		// A false verdict is a successful API call that must still exit non-zero
+		// in every mode. silentExitError is intercepted in root.go before the
+		// agent error-envelope path, so the ok:true envelope printed above stands
+		// as the sole output and the process still exits with ExitError.
+		if !result.Valid {
+			return &silentExitError{code: client.ExitError}
+		}
+		return nil
+	},
+}
+
+// readVerifyExpressionFromFile reads a text expression from a file or stdin.
+func readVerifyExpressionFromFile(path string) (string, error) {
+	var reader io.Reader
+	if path == "-" {
+		reader = os.Stdin
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return "", fmt.Errorf("open %q: %w", path, err)
+		}
+		defer func() { _ = f.Close() }()
+		reader = f
+	}
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return "", fmt.Errorf("read expression: %w", err)
+	}
+	return string(content), nil
+}
+
+func init() {
+	verifyOpenPipelineMatcherCmd.Flags().StringP("file", "f", "", `read the matcher from a file ("-" for stdin)`)
+	verifyOpenPipelineMatcherCmd.Flags().String("context", "", `stage context, e.g. "processing" or "ROUTING_RULE"`)
+	verifyOpenPipelineMatcherCmd.Flags().String("config-id", "", `configuration scope, e.g. "logs"`)
+}

--- a/cmd/verify_openpipeline_matcher_test.go
+++ b/cmd/verify_openpipeline_matcher_test.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+)
+
+const matcherVerifyPath = "/platform/openpipeline/v1/matcher/verify"
+
+// pinVerifyGlobals sets the process-global command state to a known baseline for
+// the openpipeline verify/preview command tests (which read package-level globals
+// and the root "output" persistent flag) and returns a function that restores the
+// previous values. Isolating these prevents state leaking between tests in the
+// shared cmd package from flipping the human-vs-structured output branch.
+func pinVerifyGlobals(t *testing.T, configPath string) (restore func()) {
+	t.Helper()
+	origCfg, origPlain, origJQ := cfgFile, plainMode, jqFilter
+	origAgent, origFormat := agentMode, outputFormat
+
+	outputFlag := rootCmd.PersistentFlags().Lookup("output")
+	origOutputChanged := false
+	if outputFlag != nil {
+		origOutputChanged = outputFlag.Changed
+	}
+
+	cfgFile = configPath
+	plainMode = true
+	jqFilter = ""
+	agentMode = false
+	outputFormat = "table"
+	if outputFlag != nil {
+		outputFlag.Changed = false
+	}
+
+	return func() {
+		cfgFile, plainMode, jqFilter = origCfg, origPlain, origJQ
+		agentMode, outputFormat = origAgent, origFormat
+		if outputFlag != nil {
+			outputFlag.Changed = origOutputChanged
+		}
+	}
+}
+
+// setupVerifyMatcherTest wires a mock server for the matcher verify endpoint and
+// points the command at a throwaway config. It restores the mutated globals and
+// command flags on cleanup. The handler returns the given raw JSON response.
+func setupVerifyMatcherTest(t *testing.T, response string) {
+	t.Helper()
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		matcherVerifyPath: func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(response))
+		},
+	})
+	t.Cleanup(ms.Close)
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	t.Cleanup(cleanup)
+
+	restore := pinVerifyGlobals(t, configPath)
+	t.Cleanup(func() {
+		restore()
+		testutil.ResetCommandFlags(verifyOpenPipelineMatcherCmd)
+	})
+	testutil.ResetCommandFlags(verifyOpenPipelineMatcherCmd)
+}
+
+func TestVerifyOpenPipelineMatcherCmd_Valid(t *testing.T) {
+	setupVerifyMatcherTest(t, `{"valid":true,"notifications":[]}`)
+
+	err := verifyOpenPipelineMatcherCmd.RunE(verifyOpenPipelineMatcherCmd, []string{`matchesValue(content, "error")`})
+	if err != nil {
+		t.Fatalf("RunE() error = %v, want nil for valid matcher", err)
+	}
+}
+
+func TestVerifyOpenPipelineMatcherCmd_Invalid(t *testing.T) {
+	setupVerifyMatcherTest(t, `{"valid":false,"notifications":[{"severity":"ERROR","message":"bad"}]}`)
+
+	err := verifyOpenPipelineMatcherCmd.RunE(verifyOpenPipelineMatcherCmd, []string{"!@#$"})
+	// An invalid verdict must exit non-zero via silentExitError.
+	var silent *silentExitError
+	if !errors.As(err, &silent) {
+		t.Fatalf("RunE() error = %v, want *silentExitError", err)
+	}
+	if silent.code != client.ExitError {
+		t.Errorf("exit code = %d, want %d", silent.code, client.ExitError)
+	}
+}
+
+func TestVerifyOpenPipelineMatcherCmd_JSONOutput(t *testing.T) {
+	setupVerifyMatcherTest(t, `{"valid":true,"notifications":[]}`)
+
+	// An explicit -o json routes through the printer instead of the human
+	// summary. Flip the global format and the root flag's Changed bit; both are
+	// restored by the setup helper's cleanup.
+	outputFormat = "json"
+	rootCmd.PersistentFlags().Lookup("output").Changed = true
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = verifyOpenPipelineMatcherCmd.RunE(verifyOpenPipelineMatcherCmd, []string{`matchesValue(content, "x")`})
+	})
+	if runErr != nil {
+		t.Fatalf("RunE() error = %v", runErr)
+	}
+	if !strings.Contains(out, `"valid": true`) {
+		t.Errorf("stdout missing JSON valid field:\n%s", out)
+	}
+}
+
+func TestVerifyOpenPipelineMatcherCmd_ServerError(t *testing.T) {
+	// Point the command at a config whose server always 500s.
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		matcherVerifyPath: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"message":"boom"}}`))
+		},
+	})
+	t.Cleanup(ms.Close)
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	t.Cleanup(cleanup)
+	restore := pinVerifyGlobals(t, configPath)
+	t.Cleanup(func() {
+		restore()
+		testutil.ResetCommandFlags(verifyOpenPipelineMatcherCmd)
+	})
+	testutil.ResetCommandFlags(verifyOpenPipelineMatcherCmd)
+
+	err := verifyOpenPipelineMatcherCmd.RunE(verifyOpenPipelineMatcherCmd, []string{"expr"})
+	if err == nil {
+		t.Fatal("RunE() error = nil, want error for server 500")
+	}
+}
+
+func TestVerifyOpenPipelineMatcherCmd_FromFile(t *testing.T) {
+	setupVerifyMatcherTest(t, `{"valid":true}`)
+
+	path := filepath.Join(t.TempDir(), "matcher.dql")
+	if err := os.WriteFile(path, []byte(`matchesValue(content, "error")`), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	_ = verifyOpenPipelineMatcherCmd.Flags().Set("file", path)
+
+	if err := verifyOpenPipelineMatcherCmd.RunE(verifyOpenPipelineMatcherCmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+}
+
+func TestVerifyOpenPipelineMatcherCmd_ArgAndFileConflict(t *testing.T) {
+	setupVerifyMatcherTest(t, `{"valid":true}`)
+	_ = verifyOpenPipelineMatcherCmd.Flags().Set("file", "matcher.dql")
+
+	err := verifyOpenPipelineMatcherCmd.RunE(verifyOpenPipelineMatcherCmd, []string{"expr"})
+	if err == nil {
+		t.Fatal("RunE() error = nil, want conflict error for arg + --file")
+	}
+}
+
+func TestVerifyOpenPipelineMatcherCmd_NoInput(t *testing.T) {
+	setupVerifyMatcherTest(t, `{"valid":true}`)
+
+	err := verifyOpenPipelineMatcherCmd.RunE(verifyOpenPipelineMatcherCmd, nil)
+	if err == nil {
+		t.Fatal("RunE() error = nil, want error for missing matcher expression")
+	}
+}
+
+func TestVerifyOpenPipelineMatcherCmd_MissingFile(t *testing.T) {
+	setupVerifyMatcherTest(t, `{"valid":true}`)
+	_ = verifyOpenPipelineMatcherCmd.Flags().Set("file", filepath.Join(t.TempDir(), "nope.dql"))
+
+	err := verifyOpenPipelineMatcherCmd.RunE(verifyOpenPipelineMatcherCmd, nil)
+	if err == nil {
+		t.Fatal("RunE() error = nil, want error for missing --file")
+	}
+}
+
+func TestReadVerifyExpressionFromFile(t *testing.T) {
+	t.Run("reads file content", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "expr.dql")
+		if err := os.WriteFile(path, []byte("some expression\n"), 0o600); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		got, err := readVerifyExpressionFromFile(path)
+		if err != nil {
+			t.Fatalf("readVerifyExpressionFromFile() error = %v", err)
+		}
+		if got != "some expression\n" {
+			t.Errorf("content = %q, want %q", got, "some expression\n")
+		}
+	})
+
+	t.Run("missing file is an error", func(t *testing.T) {
+		if _, err := readVerifyExpressionFromFile(filepath.Join(t.TempDir(), "missing")); err == nil {
+			t.Fatal("expected error for missing file, got nil")
+		}
+	})
+}

--- a/cmd/verify_openpipeline_matcher_test.go
+++ b/cmd/verify_openpipeline_matcher_test.go
@@ -116,6 +116,23 @@ func TestVerifyOpenPipelineMatcherCmd_JSONOutput(t *testing.T) {
 	}
 }
 
+func TestVerifyOpenPipelineMatcherCmd_UnsupportedOutputFormat(t *testing.T) {
+	setupVerifyMatcherTest(t, `{"valid":true,"notifications":[]}`)
+
+	// csv/wide are rejected for the verify family (same as "verify query"),
+	// so the command errors before making a request.
+	outputFormat = "csv"
+	rootCmd.PersistentFlags().Lookup("output").Changed = true
+
+	err := verifyOpenPipelineMatcherCmd.RunE(verifyOpenPipelineMatcherCmd, []string{`matchesValue(content, "x")`})
+	if err == nil {
+		t.Fatal("RunE() error = nil, want error for unsupported output format")
+	}
+	if !strings.Contains(err.Error(), "unsupported output format") {
+		t.Errorf("error = %q, want it to mention unsupported output format", err.Error())
+	}
+}
+
 func TestVerifyOpenPipelineMatcherCmd_ServerError(t *testing.T) {
 	// Point the command at a config whose server always 500s.
 	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2034,6 +2034,38 @@ dtctl get settings <object-id> --schema builtin:openpipeline.logs.pipelines
 
 **Note:** See the [Settings API](#settings-api) section below for full details on managing OpenPipeline configurations.
 
+### Verify & Preview Pipeline Components
+
+Before you apply a pipeline change, validate its individual components against the OpenPipeline engine and dry-run a processor against sample records — all read-only, no live config is touched. These use the same restricted DQL subset the engine enforces (matchers allow only `matchesPhrase`, `matchesValue`, `isNull`, `iAny`, …; DQL processor scripts are limited to processor commands like `parse`, `fields*`, `fieldsFlatten`), so they catch pipeline-context errors that a generic `dtctl verify query` misses.
+
+```bash
+# Verify a matching condition (inline, file, or stdin)
+dtctl verify openpipeline-matcher 'matchesValue(content, "error")'
+dtctl verify openpipeline-matcher -f matcher.dql
+echo 'matchesValue(content, "error")' | dtctl verify openpipeline-matcher -f -
+
+# Scope to a stage context or a configuration
+dtctl verify openpipeline-matcher 'matchesValue(content, "error")' --context ROUTING_RULE
+dtctl verify openpipeline-matcher 'matchesValue(content, "error")' --config-id logs
+
+# Verify a DQL processor script
+dtctl verify openpipeline-dql-processor 'parse content, "IPV4:ip"'
+dtctl verify openpipeline-dql-processor -f processor.dql --config-id logs
+
+# Preview a processor against its embedded sample records (-f required; pass the
+# processor body itself — dtctl builds the request envelope around it)
+dtctl exec preview-processor -f processor.json
+dtctl exec preview-processor -f processor.json --config-id logs
+cat processor.json | dtctl exec preview-processor -f -
+
+# Structured output on any of them (verify: json/yaml/toon; preview also table/csv)
+dtctl verify openpipeline-matcher 'matchesValue(content, "error")' -o json
+dtctl verify openpipeline-dql-processor 'parse content, "x"' -o yaml
+dtctl exec preview-processor -f processor.json -o yaml
+```
+
+The two `verify` commands **exit non-zero on an invalid verdict** in every output mode (including `-A`), so they drop straight into CI and agent pipelines without parsing JSON. Diagnostics (severity, message, source position) are surfaced in all formats. All three need only `openpipeline:configurations:read` — already in the read scope tier, so no new grants.
+
 ### Translate Classic Pipelines to OpenPipeline
 
 Migrating from Classic pipelines to OpenPipeline? `dtctl get classic-pipelines-translation` converts your tenant's Classic pipeline configuration for a scope into an OpenPipeline configuration pipeline (Settings shape). It is a read-only call that returns the translated pipeline verbatim — the reliable starting point you then review and apply via the Settings API.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2053,7 +2053,12 @@ dtctl verify openpipeline-dql-processor 'parse content, "IPV4:ip"'
 dtctl verify openpipeline-dql-processor -f processor.dql --config-id logs
 
 # Preview a processor against its embedded sample records (-f required; pass the
-# processor body itself — dtctl builds the request envelope around it)
+# processor body itself — dtctl builds the request envelope around it). The body
+# must be a complete processor definition; the endpoint validates the full schema
+# and rejects a partial body. A minimal DQL processor:
+#   {"type":"dql","id":"preview","description":"preview","enabled":true,
+#    "matcher":"true","dqlScript":"fieldsAdd severity = \"INFO\"",
+#    "sampleData":"{\"content\":\"hello\"}"}
 dtctl exec preview-processor -f processor.json
 dtctl exec preview-processor -f processor.json --config-id logs
 cat processor.json | dtctl exec preview-processor -f -

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -25,14 +25,14 @@ dtctl [verb] [resource-type] [resource-name] [flags]
 | `query` | Execute a DQL query |
 | `wait` | Poll a DQL query until a record-count condition is met (tests/CI) |
 | `inspect` | Inspect a spilled query-result file locally (rows, schema, stats) without re-querying Grail |
-| `exec` | Execute a workflow, function, analyzer, or CoPilot skill |
+| `exec` | Execute a workflow, function, analyzer, CoPilot skill, or OpenPipeline processor preview |
 | `history` | Show version history (snapshots) of a document |
 | `restore` | Restore a document to a previous version |
 | `diff` | Show differences between local and remote resources |
 | `enable` | Enable a cloud monitoring configuration (GCP/Azure) in one step |
 | `share` | Share a document with users or groups |
 | `unshare` | Remove sharing from a document |
-| `verify` | Verify DQL query syntax |
+| `verify` | Verify DQL query syntax and OpenPipeline matcher/DQL-processor components |
 | `alias` | Manage command aliases |
 | `ctx` | Quick context management |
 | `doctor` | Health check (config, context, token, connectivity, auth) |
@@ -185,6 +185,11 @@ dtctl query "..." --segments-file segments.yaml  # Segments with variables from 
 # Verify query syntax
 dtctl verify query "fetch logs | limit 10"
 dtctl verify query -f query.dql --canonical --fail-on-warn
+
+# Verify OpenPipeline components (restricted DQL subset; exits non-zero if invalid)
+dtctl verify openpipeline-matcher 'matchesValue(content, "error")'
+dtctl verify openpipeline-matcher -f matcher.dql --context ROUTING_RULE
+dtctl verify openpipeline-dql-processor 'parse content, "IPV4:ip"' --config-id logs
 ```
 
 ## Inspect Commands
@@ -276,6 +281,10 @@ dtctl exec copilot "What is DQL?" --stream
 dtctl exec copilot nl2dql "error logs from last hour"
 dtctl exec copilot dql2nl "fetch logs | filter status='ERROR'"
 dtctl exec copilot document-search "CPU analysis" --collections notebooks
+
+# OpenPipeline processor preview (dry-run against embedded sample records; -f required)
+dtctl exec preview-processor -f processor.json
+dtctl exec preview-processor -f processor.json --config-id logs
 ```
 
 ## Diff Command

--- a/pkg/auth/resource_scopes.go
+++ b/pkg/auth/resource_scopes.go
@@ -164,7 +164,7 @@ var localResources = map[string]bool{
 	"set-credentials": true, "migrate-tokens": true, "init": true,
 	"view": true, "current": true, "set": true,
 	// ctx aliases
-	"describe": true, "delete": true, "token": true,
+	"describe": true, "delete": true, "token": true, "discover-account": true,
 	// auth (local token storage / introspection)
 	"login": true, "logout": true, "refresh": true, "status": true, "whoami": true,
 	// alias management

--- a/pkg/auth/resource_scopes.go
+++ b/pkg/auth/resource_scopes.go
@@ -137,6 +137,12 @@ var ResourceScopes = map[string]AccessScopes{
 	// call that returns the translated pipeline document.
 	"classic-pipelines-translation": {Read: []string{"openpipeline:configurations:read"}},
 
+	// OpenPipeline verify and preview endpoints — all read-only; they validate
+	// or preview pipeline definitions without persisting any changes.
+	"openpipeline-matcher":       {Read: []string{"openpipeline:configurations:read"}},
+	"openpipeline-dql-processor": {Read: []string{"openpipeline:configurations:read"}},
+	"preview-processor":          {Read: []string{"openpipeline:configurations:read"}},
+
 	// Cloud monitoring (enable/create aws|azure|gcp) touches two APIs: the
 	// hyperscaler-authentication *connection* (Settings API,
 	// builtin:hyperscaler-authentication.connections.*) and the *monitoring
@@ -286,6 +292,9 @@ func (s *scopeSet) addReadTier(extended bool) {
 	s.addResource("notification", AccessRead)
 	s.add("hub:catalog:read")
 	s.addResource("classic-pipelines-translation", AccessRead)
+	s.addResource("openpipeline-matcher", AccessRead)
+	s.addResource("openpipeline-dql-processor", AccessRead)
+	s.addResource("preview-processor", AccessRead)
 }
 
 // addMineWrites adds the write/run scopes granted from readwrite-mine upward:
@@ -347,6 +356,9 @@ func (s *scopeSet) addUnrestricted() {
 	s.addResource("notification", AccessRead)
 	s.add("hub:catalog:read")
 	s.addResource("classic-pipelines-translation", AccessRead)
+	s.addResource("openpipeline-matcher", AccessRead)
+	s.addResource("openpipeline-dql-processor", AccessRead)
+	s.addResource("preview-processor", AccessRead)
 	// writes / destructive
 	s.addResource("dashboard", AccessWrite, AccessDelete)
 	s.add("document:environment-shares:write")

--- a/pkg/output/golden_test.go
+++ b/pkg/output/golden_test.go
@@ -18,17 +18,21 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/resources/azuremonitoringconfig"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/bucket"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/document"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/dqlprocessorverify"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/edgeconnect"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/extension"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/gcpconnection"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/gcpmonitoringconfig"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/hub"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/iam"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/matcherverify"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/platformtoken"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/previewprocessor"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/segment"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/settings"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/slo"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
+	sdkmatcherverify "github.com/dynatrace-oss/dtctl/sdk/api/matcherverify"
 )
 
 // -update flag: regenerate golden files
@@ -2710,4 +2714,129 @@ func TestGolden_GetPlatformTokens_Empty(t *testing.T) {
 		t.Fatalf("PrintList failed: %v", err)
 	}
 	assertGolden(t, "empty/platform-tokens", buf.String())
+}
+
+// ---------------------------------------------------------------------------
+// OpenPipeline verify and preview golden tests
+// ---------------------------------------------------------------------------
+
+func matcherVerifyResultFixtures() []matcherverify.VerifyResult {
+	return []matcherverify.VerifyResult{
+		*matcherverify.FromSDKVerifyResponse(&sdkmatcherverify.VerifyResponse{Valid: true}),
+		*matcherverify.FromSDKVerifyResponse(&sdkmatcherverify.VerifyResponse{
+			Valid: false,
+			Notifications: []sdkmatcherverify.MetadataNotification{
+				{
+					Severity: "ERROR",
+					Message:  "unexpected token",
+					SyntaxPosition: &sdkmatcherverify.SyntaxRange{
+						Start: sdkmatcherverify.SyntaxPosition{Line: 1, Column: 1, Index: 0},
+						End:   sdkmatcherverify.SyntaxPosition{Line: 1, Column: 6, Index: 5},
+					},
+				},
+				{Severity: "WARN", Message: "expression is deprecated"},
+			},
+		}),
+	}
+}
+
+func TestGolden_VerifyOpenpipelineMatcher(t *testing.T) {
+	fixtures := matcherVerifyResultFixtures()
+
+	formats := map[string]string{
+		"table": "table",
+		"json":  "json",
+		"yaml":  "yaml",
+	}
+
+	for name, format := range formats {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printer := NewPrinterWithWriter(format, &buf)
+			if err := printer.PrintList(fixtures); err != nil {
+				t.Fatalf("PrintList failed: %v", err)
+			}
+			assertGolden(t, "verify/openpipeline-matcher-"+name, buf.String())
+		})
+	}
+}
+
+func dqlProcessorVerifyResultFixtures() []dqlprocessorverify.VerifyResult {
+	return []dqlprocessorverify.VerifyResult{
+		*matcherverify.FromSDKVerifyResponse(&sdkmatcherverify.VerifyResponse{Valid: true}),
+		*matcherverify.FromSDKVerifyResponse(&sdkmatcherverify.VerifyResponse{
+			Valid: false,
+			Notifications: []sdkmatcherverify.MetadataNotification{
+				{
+					Severity: "ERROR",
+					Message:  "invalid field reference",
+					SyntaxPosition: &sdkmatcherverify.SyntaxRange{
+						Start: sdkmatcherverify.SyntaxPosition{Line: 2, Column: 5, Index: 0},
+						End:   sdkmatcherverify.SyntaxPosition{Line: 2, Column: 12, Index: 0},
+					},
+				},
+			},
+		}),
+	}
+}
+
+func TestGolden_VerifyOpenpipelineDQLProcessor(t *testing.T) {
+	fixtures := dqlProcessorVerifyResultFixtures()
+
+	formats := map[string]string{
+		"table": "table",
+		"json":  "json",
+		"yaml":  "yaml",
+	}
+
+	for name, format := range formats {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printer := NewPrinterWithWriter(format, &buf)
+			if err := printer.PrintList(fixtures); err != nil {
+				t.Fatalf("PrintList failed: %v", err)
+			}
+			assertGolden(t, "verify/openpipeline-dql-processor-"+name, buf.String())
+		})
+	}
+}
+
+func previewProcessorResultFixtures() []previewprocessor.PreviewResult {
+	return []previewprocessor.PreviewResult{
+		{
+			Matched: true,
+			Record: map[string]any{
+				"content":  "error occurred in service-a",
+				"severity": "ERROR",
+				"foo":      float64(1),
+			},
+		},
+		{
+			Matched: false,
+			Record: map[string]any{
+				"content": "info log from service-b",
+			},
+		},
+	}
+}
+
+func TestGolden_ExecPreviewProcessor(t *testing.T) {
+	fixtures := previewProcessorResultFixtures()
+
+	formats := map[string]string{
+		"table": "table",
+		"json":  "json",
+		"yaml":  "yaml",
+	}
+
+	for name, format := range formats {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printer := NewPrinterWithWriter(format, &buf)
+			if err := printer.PrintList(fixtures); err != nil {
+				t.Fatalf("PrintList failed: %v", err)
+			}
+			assertGolden(t, "exec/preview-processor-"+name, buf.String())
+		})
+	}
 }

--- a/pkg/output/testdata/golden/exec/preview-processor-json.golden
+++ b/pkg/output/testdata/golden/exec/preview-processor-json.golden
@@ -1,0 +1,16 @@
+[
+  {
+    "matched": true,
+    "record": {
+      "content": "error occurred in service-a",
+      "foo": 1,
+      "severity": "ERROR"
+    }
+  },
+  {
+    "matched": false,
+    "record": {
+      "content": "info log from service-b"
+    }
+  }
+]

--- a/pkg/output/testdata/golden/exec/preview-processor-table.golden
+++ b/pkg/output/testdata/golden/exec/preview-processor-table.golden
@@ -1,0 +1,3 @@
+MATCHED   RECORD      
+true      <3 items>   
+false     <1 items>   

--- a/pkg/output/testdata/golden/exec/preview-processor-yaml.golden
+++ b/pkg/output/testdata/golden/exec/preview-processor-yaml.golden
@@ -1,0 +1,8 @@
+- matched: true
+  record:
+    content: error occurred in service-a
+    foo: 1
+    severity: ERROR
+- matched: false
+  record:
+    content: info log from service-b

--- a/pkg/output/testdata/golden/verify/openpipeline-dql-processor-json.golden
+++ b/pkg/output/testdata/golden/verify/openpipeline-dql-processor-json.golden
@@ -1,0 +1,26 @@
+[
+  {
+    "valid": true
+  },
+  {
+    "valid": false,
+    "notifications": [
+      {
+        "severity": "ERROR",
+        "message": "invalid field reference",
+        "syntaxPosition": {
+          "start": {
+            "line": 2,
+            "column": 5,
+            "index": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 12,
+            "index": 0
+          }
+        }
+      }
+    ]
+  }
+]

--- a/pkg/output/testdata/golden/verify/openpipeline-dql-processor-table.golden
+++ b/pkg/output/testdata/golden/verify/openpipeline-dql-processor-table.golden
@@ -1,0 +1,3 @@
+VALID   NOTIFICATIONS                               
+true                                                
+false   ERROR (2:5-2:12): invalid field reference   

--- a/pkg/output/testdata/golden/verify/openpipeline-dql-processor-yaml.golden
+++ b/pkg/output/testdata/golden/verify/openpipeline-dql-processor-yaml.golden
@@ -1,0 +1,14 @@
+- valid: true
+- valid: false
+  notifications:
+    - severity: ERROR
+      message: invalid field reference
+      syntaxPosition:
+        start:
+          line: 2
+          column: 5
+          index: 0
+        end:
+          line: 2
+          column: 12
+          index: 0

--- a/pkg/output/testdata/golden/verify/openpipeline-matcher-json.golden
+++ b/pkg/output/testdata/golden/verify/openpipeline-matcher-json.golden
@@ -1,0 +1,30 @@
+[
+  {
+    "valid": true
+  },
+  {
+    "valid": false,
+    "notifications": [
+      {
+        "severity": "ERROR",
+        "message": "unexpected token",
+        "syntaxPosition": {
+          "start": {
+            "line": 1,
+            "column": 1,
+            "index": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 6,
+            "index": 5
+          }
+        }
+      },
+      {
+        "severity": "WARN",
+        "message": "expression is deprecated"
+      }
+    ]
+  }
+]

--- a/pkg/output/testdata/golden/verify/openpipeline-matcher-table.golden
+++ b/pkg/output/testdata/golden/verify/openpipeline-matcher-table.golden
@@ -1,0 +1,4 @@
+VALID   NOTIFICATIONS                       
+true                                        
+false   ERROR (1:1-1:6): unexpected token   
+        WARN: expression is deprecated      

--- a/pkg/output/testdata/golden/verify/openpipeline-matcher-yaml.golden
+++ b/pkg/output/testdata/golden/verify/openpipeline-matcher-yaml.golden
@@ -1,0 +1,16 @@
+- valid: true
+- valid: false
+  notifications:
+    - severity: ERROR
+      message: unexpected token
+      syntaxPosition:
+        start:
+          line: 1
+          column: 1
+          index: 0
+        end:
+          line: 1
+          column: 6
+          index: 5
+    - severity: WARN
+      message: expression is deprecated

--- a/pkg/resources/dqlprocessorverify/dqlprocessorverify.go
+++ b/pkg/resources/dqlprocessorverify/dqlprocessorverify.go
@@ -1,0 +1,46 @@
+// Package dqlprocessorverify is the CLI resource layer for the OpenPipeline DQL
+// processor verify endpoint. It delegates HTTP calls to the SDK and shapes the
+// response into a display-ready VerifyResult using the shared formatting logic
+// from the matcherverify package.
+package dqlprocessorverify
+
+import (
+	"context"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/matcherverify"
+	sdkdql "github.com/dynatrace-oss/dtctl/sdk/api/dqlprocessorverify"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+// VerifyOptions are the inputs for a single DQL processor verify request.
+type VerifyOptions struct {
+	Script          string
+	ConfigurationID string
+}
+
+// VerifyResult is a type alias for the shared matcherverify.VerifyResult, which
+// has the same table/JSON/YAML shape for both verify commands.
+type VerifyResult = matcherverify.VerifyResult
+
+// Handler verifies OpenPipeline DQL processor scripts.
+type Handler struct {
+	sdk *sdkdql.Handler
+}
+
+// NewHandler creates a new DQL processor verify handler.
+func NewHandler(c *client.Client) *Handler {
+	return &Handler{sdk: sdkdql.NewHandler(httpclient.Wrap(c.HTTP()))}
+}
+
+// Verify calls the verify endpoint and returns the display-ready result.
+func (h *Handler) Verify(opts VerifyOptions) (*VerifyResult, error) {
+	sdkResult, err := h.sdk.Verify(context.Background(), sdkdql.DQLProcessorVerifyRequest{
+		Script:          opts.Script,
+		ConfigurationID: opts.ConfigurationID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return matcherverify.FromSDKVerifyResponse(sdkResult), nil
+}

--- a/pkg/resources/dqlprocessorverify/dqlprocessorverify_test.go
+++ b/pkg/resources/dqlprocessorverify/dqlprocessorverify_test.go
@@ -1,6 +1,7 @@
 package dqlprocessorverify
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -24,9 +25,8 @@ func newTestHandler(t *testing.T, status int, body string, capture *[]byte) *Han
 			t.Errorf("method = %s, want POST", r.Method)
 		}
 		if capture != nil {
-			buf := make([]byte, r.ContentLength)
-			_, _ = r.Body.Read(buf)
-			*capture = buf
+			b, _ := io.ReadAll(r.Body)
+			*capture = b
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)

--- a/pkg/resources/dqlprocessorverify/dqlprocessorverify_test.go
+++ b/pkg/resources/dqlprocessorverify/dqlprocessorverify_test.go
@@ -1,0 +1,100 @@
+package dqlprocessorverify
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+)
+
+const verifyPath = "/platform/openpipeline/v1/dqlProcessor/verify"
+
+// newTestHandler wires a Handler to a mock server serving the given response body
+// at the DQL processor verify endpoint. It records the last request body when
+// capture is non-nil so callers can assert the forwarded options.
+func newTestHandler(t *testing.T, status int, body string, capture *[]byte) *Handler {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != verifyPath {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if capture != nil {
+			buf := make([]byte, r.ContentLength)
+			_, _ = r.Body.Read(buf)
+			*capture = buf
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	c, err := client.NewForTesting(srv.URL, "test-token")
+	if err != nil {
+		t.Fatalf("client.NewForTesting: %v", err)
+	}
+	return NewHandler(c)
+}
+
+func TestHandler_Verify_Valid(t *testing.T) {
+	var body []byte
+	h := newTestHandler(t, http.StatusOK, `{"valid":true,"notifications":[]}`, &body)
+
+	got, err := h.Verify(VerifyOptions{
+		Script:          `fieldsAdd severity = "INFO"`,
+		ConfigurationID: "logs",
+	})
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if !got.Valid {
+		t.Errorf("Valid = false, want true")
+	}
+	if len(got.Notifications) != 0 {
+		t.Errorf("Notifications = %v, want empty", got.Notifications)
+	}
+	// The options must be forwarded into the SDK request body.
+	if !strings.Contains(string(body), `"configurationId"`) {
+		t.Errorf("request body missing configurationId: %s", body)
+	}
+}
+
+func TestHandler_Verify_Invalid(t *testing.T) {
+	resp := `{
+		"valid": false,
+		"notifications": [{
+			"severity": "ERROR",
+			"message": "There's no command ` + "`parsee`" + `.",
+			"syntaxPosition": {
+				"start": {"line": 1, "column": 1, "index": 0},
+				"end":   {"line": 1, "column": 6, "index": 5}
+			}
+		}]
+	}`
+	h := newTestHandler(t, http.StatusOK, resp, nil)
+
+	got, err := h.Verify(VerifyOptions{Script: "parsee content"})
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if got.Valid {
+		t.Errorf("Valid = true, want false")
+	}
+	if len(got.Notifications) != 1 {
+		t.Fatalf("len(Notifications) = %d, want 1", len(got.Notifications))
+	}
+	if !strings.HasPrefix(got.Summary, "ERROR (1:1-1:6):") {
+		t.Errorf("Summary = %q, want ERROR position prefix", got.Summary)
+	}
+}
+
+func TestHandler_Verify_ServerError(t *testing.T) {
+	h := newTestHandler(t, http.StatusInternalServerError, `{"error":{"message":"boom"}}`, nil)
+	if _, err := h.Verify(VerifyOptions{Script: "fieldsAdd x = 1"}); err == nil {
+		t.Fatal("Verify() expected error for 500, got nil")
+	}
+}

--- a/pkg/resources/matcherverify/matcherverify.go
+++ b/pkg/resources/matcherverify/matcherverify.go
@@ -1,0 +1,127 @@
+// Package matcherverify is the CLI resource layer for the OpenPipeline matcher
+// verify endpoint. It delegates HTTP calls to the SDK and shapes the response
+// into a display-ready VerifyResult that carries structured notifications for
+// machine formats (json/yaml/agent) and a flattened text column for tables.
+package matcherverify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	sdkmatcher "github.com/dynatrace-oss/dtctl/sdk/api/matcherverify"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+// VerifyOptions are the inputs for a single matcher verify request.
+type VerifyOptions struct {
+	Query           string
+	ConfigurationID string
+	Context         string
+}
+
+// SyntaxPosition is a single line/column/index position in the source expression.
+type SyntaxPosition struct {
+	Line   int `json:"line" yaml:"line"`
+	Column int `json:"column" yaml:"column"`
+	Index  int `json:"index" yaml:"index"`
+}
+
+// SyntaxRange is a start/end source range.
+type SyntaxRange struct {
+	Start SyntaxPosition `json:"start" yaml:"start"`
+	End   SyntaxPosition `json:"end" yaml:"end"`
+}
+
+// Notification is a single diagnostic (severity, message, optional position),
+// preserved as structured data so json/yaml/agent output keeps the details.
+type Notification struct {
+	Severity       string       `json:"severity" yaml:"severity"`
+	Message        string       `json:"message" yaml:"message"`
+	SyntaxPosition *SyntaxRange `json:"syntaxPosition,omitempty" yaml:"syntaxPosition,omitempty"`
+}
+
+// VerifyResult is the CLI read-model for a verify response. Notifications is the
+// structured list surfaced in json/yaml/agent output; Summary is the same list
+// flattened to a human string, used only for the table NOTIFICATIONS column and
+// the default human-readable summary.
+type VerifyResult struct {
+	Valid         bool           `json:"valid" yaml:"valid" table:"VALID"`
+	Notifications []Notification `json:"notifications,omitempty" yaml:"notifications,omitempty" table:"-"`
+	Summary       string         `json:"-" yaml:"-" table:"NOTIFICATIONS"`
+}
+
+// Handler verifies OpenPipeline matcher expressions.
+type Handler struct {
+	sdk *sdkmatcher.Handler
+}
+
+// NewHandler creates a new matcher verify handler.
+func NewHandler(c *client.Client) *Handler {
+	return &Handler{sdk: sdkmatcher.NewHandler(httpclient.Wrap(c.HTTP()))}
+}
+
+// Verify calls the verify endpoint and returns the display-ready result.
+func (h *Handler) Verify(opts VerifyOptions) (*VerifyResult, error) {
+	sdkResult, err := h.sdk.Verify(context.Background(), sdkmatcher.MatcherVerifyRequest{
+		Query:           opts.Query,
+		ConfigurationID: opts.ConfigurationID,
+		Context:         opts.Context,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return FromSDKVerifyResponse(sdkResult), nil
+}
+
+// FromSDKVerifyResponse converts an SDK VerifyResponse into a CLI VerifyResult,
+// preserving structured notifications and computing the flattened Summary.
+// Exported so sibling packages can reuse the conversion without depending on the Handler.
+func FromSDKVerifyResponse(r *sdkmatcher.VerifyResponse) *VerifyResult {
+	notifications := make([]Notification, 0, len(r.Notifications))
+	for _, n := range r.Notifications {
+		note := Notification{Severity: n.Severity, Message: n.Message}
+		if n.SyntaxPosition != nil {
+			note.SyntaxPosition = &SyntaxRange{
+				Start: SyntaxPosition(n.SyntaxPosition.Start),
+				End:   SyntaxPosition(n.SyntaxPosition.End),
+			}
+		}
+		notifications = append(notifications, note)
+	}
+	return &VerifyResult{
+		Valid:         r.Valid,
+		Notifications: notifications,
+		Summary:       FormatNotifications(r.Notifications),
+	}
+}
+
+// FormatNotifications formats a slice of MetadataNotification entries into a
+// single human-readable string with one entry per line.
+// Format: "SEVERITY (line:col-line:col): message" (position omitted if absent).
+// Exported so sibling packages (dqlprocessorverify) can reuse the same display logic.
+func FormatNotifications(notifications []sdkmatcher.MetadataNotification) string {
+	if len(notifications) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(notifications))
+	for _, n := range notifications {
+		parts = append(parts, formatNotification(n))
+	}
+	return strings.Join(parts, "\n")
+}
+
+// formatNotification formats a single MetadataNotification as a human-readable string.
+func formatNotification(n sdkmatcher.MetadataNotification) string {
+	if n.SyntaxPosition != nil {
+		pos := n.SyntaxPosition
+		return fmt.Sprintf("%s (%d:%d-%d:%d): %s",
+			n.Severity,
+			pos.Start.Line, pos.Start.Column,
+			pos.End.Line, pos.End.Column,
+			n.Message,
+		)
+	}
+	return fmt.Sprintf("%s: %s", n.Severity, n.Message)
+}

--- a/pkg/resources/matcherverify/matcherverify_test.go
+++ b/pkg/resources/matcherverify/matcherverify_test.go
@@ -1,10 +1,118 @@
 package matcherverify
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/dynatrace-oss/dtctl/pkg/client"
 	sdkmatcher "github.com/dynatrace-oss/dtctl/sdk/api/matcherverify"
 )
+
+const verifyPath = "/platform/openpipeline/v1/matcher/verify"
+
+// newTestHandler wires a Handler to a mock server serving the given response body
+// at the matcher verify endpoint. It fails the test if the request method is not
+// POST, and records the last request body for assertions.
+func newTestHandler(t *testing.T, status int, body string, capture *[]byte) *Handler {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != verifyPath {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if capture != nil {
+			buf := make([]byte, r.ContentLength)
+			_, _ = r.Body.Read(buf)
+			*capture = buf
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	c, err := client.NewForTesting(srv.URL, "test-token")
+	if err != nil {
+		t.Fatalf("client.NewForTesting: %v", err)
+	}
+	return NewHandler(c)
+}
+
+func TestHandler_Verify_Valid(t *testing.T) {
+	var body []byte
+	h := newTestHandler(t, http.StatusOK, `{"valid":true,"notifications":[]}`, &body)
+
+	got, err := h.Verify(VerifyOptions{
+		Query:           `matchesValue(content, "error")`,
+		ConfigurationID: "logs",
+		Context:         "ROUTING_RULE",
+	})
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if !got.Valid {
+		t.Errorf("Valid = false, want true")
+	}
+	if len(got.Notifications) != 0 {
+		t.Errorf("Notifications = %v, want empty", got.Notifications)
+	}
+	if got.Summary != "" {
+		t.Errorf("Summary = %q, want empty", got.Summary)
+	}
+	// The options must be forwarded to the SDK request body.
+	if !containsAll(string(body), `"query"`, `"configurationId"`, `"context"`) {
+		t.Errorf("request body missing forwarded options: %s", body)
+	}
+}
+
+func TestHandler_Verify_Invalid(t *testing.T) {
+	resp := `{
+		"valid": false,
+		"notifications": [{
+			"severity": "ERROR",
+			"message": "unexpected token",
+			"syntaxPosition": {
+				"start": {"line": 1, "column": 1, "index": 0},
+				"end":   {"line": 1, "column": 6, "index": 5}
+			}
+		}]
+	}`
+	h := newTestHandler(t, http.StatusOK, resp, nil)
+
+	got, err := h.Verify(VerifyOptions{Query: "!@#$"})
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if got.Valid {
+		t.Errorf("Valid = true, want false")
+	}
+	if len(got.Notifications) != 1 {
+		t.Fatalf("len(Notifications) = %d, want 1", len(got.Notifications))
+	}
+	if got.Summary != "ERROR (1:1-1:6): unexpected token" {
+		t.Errorf("Summary = %q", got.Summary)
+	}
+}
+
+func TestHandler_Verify_ServerError(t *testing.T) {
+	h := newTestHandler(t, http.StatusInternalServerError, `{"error":{"message":"boom"}}`, nil)
+	if _, err := h.Verify(VerifyOptions{Query: "test"}); err == nil {
+		t.Fatal("Verify() expected error for 500, got nil")
+	}
+}
+
+// containsAll reports whether s contains every substring in subs.
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
 
 func TestFromSDKVerifyResponse(t *testing.T) {
 	sdkResp := &sdkmatcher.VerifyResponse{

--- a/pkg/resources/matcherverify/matcherverify_test.go
+++ b/pkg/resources/matcherverify/matcherverify_test.go
@@ -1,6 +1,7 @@
 package matcherverify
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,9 +26,8 @@ func newTestHandler(t *testing.T, status int, body string, capture *[]byte) *Han
 			t.Errorf("method = %s, want POST", r.Method)
 		}
 		if capture != nil {
-			buf := make([]byte, r.ContentLength)
-			_, _ = r.Body.Read(buf)
-			*capture = buf
+			b, _ := io.ReadAll(r.Body)
+			*capture = b
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)

--- a/pkg/resources/matcherverify/matcherverify_test.go
+++ b/pkg/resources/matcherverify/matcherverify_test.go
@@ -1,0 +1,112 @@
+package matcherverify
+
+import (
+	"testing"
+
+	sdkmatcher "github.com/dynatrace-oss/dtctl/sdk/api/matcherverify"
+)
+
+func TestFromSDKVerifyResponse(t *testing.T) {
+	sdkResp := &sdkmatcher.VerifyResponse{
+		Valid: false,
+		Notifications: []sdkmatcher.MetadataNotification{
+			{
+				Severity: "ERROR",
+				Message:  "There's no command `parsee`.",
+				SyntaxPosition: &sdkmatcher.SyntaxRange{
+					Start: sdkmatcher.SyntaxPosition{Line: 1, Column: 1, Index: 0},
+					End:   sdkmatcher.SyntaxPosition{Line: 1, Column: 6, Index: 5},
+				},
+			},
+			{Severity: "WARN", Message: "no position"},
+		},
+	}
+
+	got := FromSDKVerifyResponse(sdkResp)
+
+	if got.Valid {
+		t.Errorf("Valid = true, want false")
+	}
+	if len(got.Notifications) != 2 {
+		t.Fatalf("Notifications len = %d, want 2", len(got.Notifications))
+	}
+
+	// Structured notifications are preserved, including the position range.
+	first := got.Notifications[0]
+	if first.SyntaxPosition == nil {
+		t.Fatal("Notifications[0].SyntaxPosition = nil, want populated")
+	}
+	if first.SyntaxPosition.Start.Column != 1 || first.SyntaxPosition.End.Column != 6 {
+		t.Errorf("position = %+v, want start col 1 / end col 6", first.SyntaxPosition)
+	}
+	// A notification without a position keeps SyntaxPosition nil.
+	if got.Notifications[1].SyntaxPosition != nil {
+		t.Errorf("Notifications[1].SyntaxPosition = %+v, want nil", got.Notifications[1].SyntaxPosition)
+	}
+
+	// Summary flattens both notifications, one per line.
+	want := "ERROR (1:1-1:6): There's no command `parsee`.\nWARN: no position"
+	if got.Summary != want {
+		t.Errorf("Summary = %q, want %q", got.Summary, want)
+	}
+}
+
+func TestFromSDKVerifyResponse_Valid(t *testing.T) {
+	got := FromSDKVerifyResponse(&sdkmatcher.VerifyResponse{Valid: true})
+	if !got.Valid {
+		t.Errorf("Valid = false, want true")
+	}
+	if len(got.Notifications) != 0 {
+		t.Errorf("Notifications = %v, want empty", got.Notifications)
+	}
+	if got.Summary != "" {
+		t.Errorf("Summary = %q, want empty", got.Summary)
+	}
+}
+
+func TestFormatNotifications(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []sdkmatcher.MetadataNotification
+		want  string
+	}{
+		{
+			name:  "empty",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "without position",
+			input: []sdkmatcher.MetadataNotification{{Severity: "WARN", Message: "heads up"}},
+			want:  "WARN: heads up",
+		},
+		{
+			name: "with position",
+			input: []sdkmatcher.MetadataNotification{{
+				Severity: "ERROR",
+				Message:  "bad",
+				SyntaxPosition: &sdkmatcher.SyntaxRange{
+					Start: sdkmatcher.SyntaxPosition{Line: 2, Column: 3},
+					End:   sdkmatcher.SyntaxPosition{Line: 2, Column: 7},
+				},
+			}},
+			want: "ERROR (2:3-2:7): bad",
+		},
+		{
+			name: "multiple joined by newline",
+			input: []sdkmatcher.MetadataNotification{
+				{Severity: "INFO", Message: "one"},
+				{Severity: "INFO", Message: "two"},
+			},
+			want: "INFO: one\nINFO: two",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatNotifications(tt.input); got != tt.want {
+				t.Errorf("FormatNotifications() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resources/previewprocessor/previewprocessor.go
+++ b/pkg/resources/previewprocessor/previewprocessor.go
@@ -1,0 +1,122 @@
+// Package previewprocessor is the CLI resource layer for the OpenPipeline
+// preview processor endpoint. It delegates HTTP calls to the SDK and shapes
+// the response into display-ready PreviewResult entries with table tags.
+//
+// File reading (the --file flag) is handled here rather than in the SDK, in
+// line with the dtctl delegation contract.
+package previewprocessor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	sdkpreview "github.com/dynatrace-oss/dtctl/sdk/api/previewprocessor"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+// PreviewResult is the CLI read-model for a single preview result entry.
+type PreviewResult struct {
+	Matched bool           `json:"matched" yaml:"matched" table:"MATCHED"`
+	Record  map[string]any `json:"record,omitempty" yaml:"record,omitempty" table:"RECORD"`
+}
+
+// Handler previews OpenPipeline processor definitions against sample records.
+type Handler struct {
+	sdk *sdkpreview.Handler
+}
+
+// NewHandler creates a new preview processor handler.
+func NewHandler(c *client.Client) *Handler {
+	return &Handler{sdk: sdkpreview.NewHandler(httpclient.Wrap(c.HTTP()))}
+}
+
+// Preview reads a processor definition body from the given file path ("-" for
+// stdin), wraps it in the preview request envelope (adding configID when set),
+// sends it to the preview endpoint, and returns the display-ready results.
+//
+// The file is the processor body itself (e.g. {"type":"dql","dqlScript":...,
+// "sampleData":...}) — the same shape a processor has inside a pipeline config —
+// not the transport envelope. dtctl builds {"processor":<body>,"configId":...}
+// around it, so callers never hand-write the wrapper.
+func (h *Handler) Preview(filename, configID string) ([]PreviewResult, error) {
+	body, err := readFileOrStdin(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	envelope, err := buildEnvelope(body, configID)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResult, err := h.sdk.Preview(context.Background(), envelope)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]PreviewResult, len(sdkResult.Results))
+	for i, r := range sdkResult.Results {
+		results[i] = PreviewResult{
+			Matched: r.Matched,
+			Record:  r.Record,
+		}
+	}
+	return results, nil
+}
+
+// buildEnvelope wraps a processor body in the preview request envelope. The
+// processor bytes are embedded verbatim (the processor is a oneOf union dtctl
+// deliberately does not interpret); configID is added as the top-level
+// "configId" only when non-empty. It errors if the body is not a JSON object.
+func buildEnvelope(processor json.RawMessage, configID string) (json.RawMessage, error) {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(processor, &probe); err != nil {
+		return nil, fmt.Errorf("processor definition must be a JSON object: %w", err)
+	}
+
+	env := map[string]json.RawMessage{"processor": processor}
+	if configID != "" {
+		idBytes, err := json.Marshal(configID)
+		if err != nil {
+			return nil, err
+		}
+		env["configId"] = idBytes
+	}
+
+	out, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("build preview request: %w", err)
+	}
+	return out, nil
+}
+
+// readFileOrStdin reads a file (or stdin when filename is "-") and returns the
+// content as json.RawMessage after a basic JSON validity check.
+func readFileOrStdin(filename string) (json.RawMessage, error) {
+	var reader io.Reader
+	if filename == "-" {
+		reader = os.Stdin
+	} else {
+		f, err := os.Open(filename)
+		if err != nil {
+			return nil, fmt.Errorf("open %q: %w", filename, err)
+		}
+		defer func() { _ = f.Close() }()
+		reader = f
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read processor definition: %w", err)
+	}
+
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("processor definition is not valid JSON")
+	}
+
+	return json.RawMessage(data), nil
+}

--- a/pkg/resources/previewprocessor/previewprocessor_test.go
+++ b/pkg/resources/previewprocessor/previewprocessor_test.go
@@ -1,0 +1,136 @@
+package previewprocessor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildEnvelope(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		configID   string
+		wantConfig string // expected value of configId ("" = key must be absent)
+		wantErr    bool
+	}{
+		{
+			name:       "wraps processor body without configId when flag empty",
+			body:       `{"type":"dql","dqlScript":"fieldsAdd foo = 1"}`,
+			configID:   "",
+			wantConfig: "",
+		},
+		{
+			name:       "wraps processor body and adds configId from flag",
+			body:       `{"type":"dql","dqlScript":"fieldsAdd foo = 1"}`,
+			configID:   "logs",
+			wantConfig: "logs",
+		},
+		{
+			name:     "non-object processor body is an error",
+			body:     `["not","an","object"]`,
+			configID: "logs",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid JSON body is an error",
+			body:     `{not json`,
+			configID: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := buildEnvelope(json.RawMessage(tt.body), tt.configID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var env map[string]json.RawMessage
+			if err := json.Unmarshal(out, &env); err != nil {
+				t.Fatalf("envelope is not valid JSON: %v", err)
+			}
+
+			// The processor body must be embedded verbatim under "processor".
+			gotProcessor, ok := env["processor"]
+			if !ok {
+				t.Fatalf("envelope missing \"processor\" key")
+			}
+			if !jsonEqual(t, gotProcessor, json.RawMessage(tt.body)) {
+				t.Errorf("processor body altered:\n got: %s\nwant: %s", gotProcessor, tt.body)
+			}
+
+			// configId present iff the flag was set.
+			rawID, hasID := env["configId"]
+			if tt.wantConfig == "" {
+				if hasID {
+					t.Errorf("configId present but flag was empty: %s", rawID)
+				}
+				return
+			}
+			var id string
+			if err := json.Unmarshal(rawID, &id); err != nil {
+				t.Fatalf("configId is not a JSON string: %v", err)
+			}
+			if id != tt.wantConfig {
+				t.Errorf("configId = %q, want %q", id, tt.wantConfig)
+			}
+		})
+	}
+}
+
+func TestReadFileOrStdin(t *testing.T) {
+	t.Run("reads a valid JSON file", func(t *testing.T) {
+		body := `{"type":"dql","dqlScript":"fieldsAdd foo = 1"}`
+		path := filepath.Join(t.TempDir(), "processor.json")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		got, err := readFileOrStdin(path)
+		if err != nil {
+			t.Fatalf("readFileOrStdin() error = %v", err)
+		}
+		if !jsonEqual(t, got, json.RawMessage(body)) {
+			t.Errorf("content = %s, want %s", got, body)
+		}
+	})
+
+	t.Run("missing file is an error", func(t *testing.T) {
+		if _, err := readFileOrStdin(filepath.Join(t.TempDir(), "nope.json")); err == nil {
+			t.Fatal("expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("invalid JSON is an error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bad.json")
+		if err := os.WriteFile(path, []byte(`{not json`), 0o600); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		if _, err := readFileOrStdin(path); err == nil {
+			t.Fatal("expected error for invalid JSON, got nil")
+		}
+	})
+}
+
+// jsonEqual reports whether two raw JSON documents are semantically equal.
+func jsonEqual(t *testing.T, a, b json.RawMessage) bool {
+	t.Helper()
+	var av, bv any
+	if err := json.Unmarshal(a, &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b, &bv); err != nil {
+		return false
+	}
+	ab, _ := json.Marshal(av)
+	bb, _ := json.Marshal(bv)
+	return string(ab) == string(bb)
+}

--- a/pkg/resources/previewprocessor/previewprocessor_test.go
+++ b/pkg/resources/previewprocessor/previewprocessor_test.go
@@ -2,10 +2,111 @@ package previewprocessor
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
 )
+
+const previewPath = "/platform/openpipeline/v1/preview/processor"
+
+// newTestHandler wires a Handler to a mock server serving the given response body
+// at the preview endpoint. When capture is non-nil the request body is recorded.
+func newTestHandler(t *testing.T, status int, body string, capture *[]byte) *Handler {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != previewPath {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if capture != nil {
+			b, _ := io.ReadAll(r.Body)
+			*capture = b
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	c, err := client.NewForTesting(srv.URL, "test-token")
+	if err != nil {
+		t.Fatalf("client.NewForTesting: %v", err)
+	}
+	return NewHandler(c)
+}
+
+// writeProcessorFile writes a processor body to a temp file and returns its path.
+func writeProcessorFile(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "processor.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return path
+}
+
+func TestHandler_Preview(t *testing.T) {
+	resp := `{"results":[
+		{"matched":true,"record":{"content":"hello","severity":"INFO"}},
+		{"matched":false}
+	]}`
+	var reqBody []byte
+	h := newTestHandler(t, http.StatusOK, resp, &reqBody)
+
+	path := writeProcessorFile(t, `{"type":"dql","matcher":"true","dqlScript":"fieldsAdd severity = \"INFO\""}`)
+	results, err := h.Preview(path, "logs")
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if !results[0].Matched {
+		t.Errorf("results[0].Matched = false, want true")
+	}
+	if results[0].Record["severity"] != "INFO" {
+		t.Errorf("results[0].Record[severity] = %v, want INFO", results[0].Record["severity"])
+	}
+	if results[1].Matched {
+		t.Errorf("results[1].Matched = true, want false")
+	}
+	// The handler must wrap the processor body in an envelope and add configId.
+	if !strings.Contains(string(reqBody), `"processor"`) || !strings.Contains(string(reqBody), `"configId":"logs"`) {
+		t.Errorf("request body missing envelope/configId: %s", reqBody)
+	}
+}
+
+func TestHandler_Preview_FileError(t *testing.T) {
+	h := newTestHandler(t, http.StatusOK, `{"results":[]}`, nil)
+	if _, err := h.Preview(filepath.Join(t.TempDir(), "missing.json"), ""); err == nil {
+		t.Fatal("Preview() expected error for missing file, got nil")
+	}
+}
+
+func TestHandler_Preview_InvalidBody(t *testing.T) {
+	h := newTestHandler(t, http.StatusOK, `{"results":[]}`, nil)
+	// A non-object body is valid JSON but fails the envelope object check before
+	// any HTTP call is made.
+	path := writeProcessorFile(t, `["not","an","object"]`)
+	if _, err := h.Preview(path, ""); err == nil {
+		t.Fatal("Preview() expected error for non-object body, got nil")
+	}
+}
+
+func TestHandler_Preview_ServerError(t *testing.T) {
+	h := newTestHandler(t, http.StatusInternalServerError, `{"error":{"message":"boom"}}`, nil)
+	path := writeProcessorFile(t, `{"type":"dql"}`)
+	if _, err := h.Preview(path, ""); err == nil {
+		t.Fatal("Preview() expected error for 500, got nil")
+	}
+}
 
 func TestBuildEnvelope(t *testing.T) {
 	tests := []struct {

--- a/sdk/api/dqlprocessorverify/dqlprocessorverify.go
+++ b/sdk/api/dqlprocessorverify/dqlprocessorverify.go
@@ -1,0 +1,56 @@
+// Package dqlprocessorverify is a thin, read-only SDK client for the
+// OpenPipeline DQL processor verify endpoint, which validates a DQL processor
+// script against an optional configuration scope.
+//
+// The response types are shared with the sibling matcherverify package
+// (VerifyResponse, MetadataNotification, SyntaxRange, SyntaxPosition).
+package dqlprocessorverify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dynatrace-oss/dtctl/sdk/api/matcherverify"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+const basePath = "/platform/openpipeline/v1/dqlProcessor/verify"
+
+// Handler calls the DQL processor verify endpoint.
+type Handler struct {
+	client *httpclient.Client
+}
+
+// NewHandler creates a new DQL processor verify handler.
+func NewHandler(c *httpclient.Client) *Handler {
+	return &Handler{client: c}
+}
+
+// DQLProcessorVerifyRequest is the request body for the DQL processor verify endpoint.
+type DQLProcessorVerifyRequest struct {
+	Script          string   `json:"script"`
+	ConfigurationID string   `json:"configurationId,omitempty"`
+	ProtectedFields []string `json:"protectedFields,omitempty"`
+}
+
+// Verify sends a DQL processor verify request and returns the parsed response.
+func (h *Handler) Verify(ctx context.Context, req DQLProcessorVerifyRequest) (*matcherverify.VerifyResponse, error) {
+	resp, err := h.client.HTTP().R().SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetBody(req).
+		Post(basePath)
+	if err != nil {
+		return nil, fmt.Errorf("verify dql processor: %w", err)
+	}
+	if err := httpclient.CheckResponse(resp); err != nil {
+		return nil, fmt.Errorf("verify dql processor: %w", err)
+	}
+
+	var result matcherverify.VerifyResponse
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, fmt.Errorf("verify dql processor: parse response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/sdk/api/dqlprocessorverify/dqlprocessorverify.go
+++ b/sdk/api/dqlprocessorverify/dqlprocessorverify.go
@@ -29,9 +29,8 @@ func NewHandler(c *httpclient.Client) *Handler {
 
 // DQLProcessorVerifyRequest is the request body for the DQL processor verify endpoint.
 type DQLProcessorVerifyRequest struct {
-	Script          string   `json:"script"`
-	ConfigurationID string   `json:"configurationId,omitempty"`
-	ProtectedFields []string `json:"protectedFields,omitempty"`
+	Script          string `json:"script"`
+	ConfigurationID string `json:"configurationId,omitempty"`
 }
 
 // Verify sends a DQL processor verify request and returns the parsed response.

--- a/sdk/api/dqlprocessorverify/dqlprocessorverify_test.go
+++ b/sdk/api/dqlprocessorverify/dqlprocessorverify_test.go
@@ -1,0 +1,153 @@
+package dqlprocessorverify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *httpclient.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c, err := httpclient.New(srv.URL, httpclient.WithToken("dt0c01.test"))
+	if err != nil {
+		t.Fatalf("httpclient.New: %v", err)
+	}
+	return c
+}
+
+// keysOf returns the top-level keys of a decoded JSON object, for diagnostics.
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func TestVerify_Valid(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req DQLProcessorVerifyRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.Script != "fieldsAdd foo = 1" {
+			t.Errorf("script = %q, want %q", req.Script, "fieldsAdd foo = 1")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"valid":true,"notifications":[]}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.Verify(context.Background(), DQLProcessorVerifyRequest{
+		Script: "fieldsAdd foo = 1",
+	})
+	if err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+	if !result.Valid {
+		t.Errorf("Valid = false, want true")
+	}
+}
+
+func TestVerify_Invalid(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"valid": false,
+			"notifications": [{
+				"severity": "ERROR",
+				"message": "syntax error near '!'",
+				"syntaxPosition": {
+					"start": {"line": 1, "column": 1, "index": 0},
+					"end":   {"line": 1, "column": 1, "index": 0}
+				}
+			}]
+		}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.Verify(context.Background(), DQLProcessorVerifyRequest{Script: "!invalid"})
+	if err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+	if result.Valid {
+		t.Errorf("Valid = true, want false")
+	}
+	if len(result.Notifications) != 1 {
+		t.Fatalf("len(Notifications) = %d, want 1", len(result.Notifications))
+	}
+}
+
+func TestVerify_WithConfigID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Pin the exact wire key: the DQL processor verify endpoint uses
+		// "configurationId", NOT "configId" (the preview endpoint's field).
+		// Decoding into the request struct alone would not catch a wrong json
+		// tag, since the client marshals with the same struct.
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(body, &raw); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if _, ok := raw["configurationId"]; !ok {
+			t.Errorf("request body missing \"configurationId\" key; got %v", keysOf(raw))
+		}
+		if _, ok := raw["configId"]; ok {
+			t.Error("request body must not use \"configId\" for the DQL processor endpoint")
+		}
+
+		var req DQLProcessorVerifyRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.ConfigurationID != "logs" {
+			t.Errorf("configurationId = %q, want %q", req.ConfigurationID, "logs")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"valid":true}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.Verify(context.Background(), DQLProcessorVerifyRequest{
+		Script:          "fieldsAdd x = 1",
+		ConfigurationID: "logs",
+	})
+	if err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+}
+
+func TestVerify_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"internal error"}}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.Verify(context.Background(), DQLProcessorVerifyRequest{Script: "test"}); err == nil {
+		t.Fatal("Verify() expected error for 500")
+	}
+}

--- a/sdk/api/matcherverify/matcherverify.go
+++ b/sdk/api/matcherverify/matcherverify.go
@@ -1,0 +1,84 @@
+// Package matcherverify is a thin, read-only SDK client for the OpenPipeline
+// matcher verify endpoint, which validates a DQL matcher expression against an
+// optional configuration scope and stage context.
+//
+// The shared verify response types (VerifyResponse, MetadataNotification,
+// SyntaxPosition, SyntaxRange) are defined here and re-used by the sibling
+// dqlprocessorverify package, which covers the DQL processor verify endpoint.
+package matcherverify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+const basePath = "/platform/openpipeline/v1/matcher/verify"
+
+// Handler calls the matcher verify endpoint.
+type Handler struct {
+	client *httpclient.Client
+}
+
+// NewHandler creates a new matcher verify handler.
+func NewHandler(c *httpclient.Client) *Handler {
+	return &Handler{client: c}
+}
+
+// MatcherVerifyRequest is the request body for the matcher verify endpoint.
+type MatcherVerifyRequest struct {
+	Query            string   `json:"query"`
+	ConfigurationID  string   `json:"configurationId,omitempty"`
+	Context          string   `json:"context,omitempty"`
+	RestrictedFields []string `json:"restrictedFields,omitempty"`
+}
+
+// SyntaxPosition describes a single position (line/column/index) in a source expression.
+type SyntaxPosition struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+	Index  int `json:"index"`
+}
+
+// SyntaxRange describes a source range with start and end positions.
+type SyntaxRange struct {
+	Start SyntaxPosition `json:"start"`
+	End   SyntaxPosition `json:"end"`
+}
+
+// MetadataNotification is a single diagnostic notification returned by a verify endpoint.
+type MetadataNotification struct {
+	Severity       string       `json:"severity"`
+	Message        string       `json:"message"`
+	SyntaxPosition *SyntaxRange `json:"syntaxPosition,omitempty"`
+}
+
+// VerifyResponse is the response body returned by both the matcher verify and
+// DQL processor verify endpoints.
+type VerifyResponse struct {
+	Valid         bool                   `json:"valid"`
+	Notifications []MetadataNotification `json:"notifications,omitempty"`
+}
+
+// Verify sends a matcher verify request and returns the parsed response.
+func (h *Handler) Verify(ctx context.Context, req MatcherVerifyRequest) (*VerifyResponse, error) {
+	resp, err := h.client.HTTP().R().SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetBody(req).
+		Post(basePath)
+	if err != nil {
+		return nil, fmt.Errorf("verify matcher: %w", err)
+	}
+	if err := httpclient.CheckResponse(resp); err != nil {
+		return nil, fmt.Errorf("verify matcher: %w", err)
+	}
+
+	var result VerifyResponse
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, fmt.Errorf("verify matcher: parse response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/sdk/api/matcherverify/matcherverify.go
+++ b/sdk/api/matcherverify/matcherverify.go
@@ -29,10 +29,9 @@ func NewHandler(c *httpclient.Client) *Handler {
 
 // MatcherVerifyRequest is the request body for the matcher verify endpoint.
 type MatcherVerifyRequest struct {
-	Query            string   `json:"query"`
-	ConfigurationID  string   `json:"configurationId,omitempty"`
-	Context          string   `json:"context,omitempty"`
-	RestrictedFields []string `json:"restrictedFields,omitempty"`
+	Query           string `json:"query"`
+	ConfigurationID string `json:"configurationId,omitempty"`
+	Context         string `json:"context,omitempty"`
 }
 
 // SyntaxPosition describes a single position (line/column/index) in a source expression.

--- a/sdk/api/matcherverify/matcherverify_test.go
+++ b/sdk/api/matcherverify/matcherverify_test.go
@@ -1,0 +1,167 @@
+package matcherverify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *httpclient.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c, err := httpclient.New(srv.URL, httpclient.WithToken("dt0c01.test"))
+	if err != nil {
+		t.Fatalf("httpclient.New: %v", err)
+	}
+	return c
+}
+
+// keysOf returns the top-level keys of a decoded JSON object, for diagnostics.
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func TestVerify_Valid(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req MatcherVerifyRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.Query != "matchesValue(content, \"error\")" {
+			t.Errorf("query = %q, want %q", req.Query, "matchesValue(content, \"error\")")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"valid":true,"notifications":[]}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.Verify(context.Background(), MatcherVerifyRequest{
+		Query: "matchesValue(content, \"error\")",
+	})
+	if err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+	if !result.Valid {
+		t.Errorf("Valid = false, want true")
+	}
+}
+
+func TestVerify_Invalid(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"valid": false,
+			"notifications": [{
+				"severity": "ERROR",
+				"message": "unexpected token",
+				"syntaxPosition": {
+					"start": {"line": 1, "column": 1, "index": 0},
+					"end":   {"line": 1, "column": 6, "index": 5}
+				}
+			}]
+		}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.Verify(context.Background(), MatcherVerifyRequest{Query: "!@#$"})
+	if err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+	if result.Valid {
+		t.Errorf("Valid = true, want false")
+	}
+	if len(result.Notifications) != 1 {
+		t.Fatalf("len(Notifications) = %d, want 1", len(result.Notifications))
+	}
+	n := result.Notifications[0]
+	if n.Severity != "ERROR" {
+		t.Errorf("severity = %q, want ERROR", n.Severity)
+	}
+	if n.SyntaxPosition == nil {
+		t.Fatal("SyntaxPosition is nil, want non-nil")
+	}
+	if n.SyntaxPosition.Start.Line != 1 {
+		t.Errorf("start.line = %d, want 1", n.SyntaxPosition.Start.Line)
+	}
+}
+
+func TestVerify_WithConfigAndContext(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Pin the exact wire key: the matcher endpoint uses "configurationId",
+		// NOT "configId" (which is the preview endpoint's field). Decoding into
+		// the request struct alone would not catch a wrong json tag, since the
+		// client marshals with the same struct — so assert the raw key here.
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(body, &raw); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if _, ok := raw["configurationId"]; !ok {
+			t.Errorf("request body missing \"configurationId\" key; got %v", keysOf(raw))
+		}
+		if _, ok := raw["configId"]; ok {
+			t.Error("request body must not use \"configId\" for the matcher endpoint")
+		}
+
+		var req MatcherVerifyRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.ConfigurationID != "logs" {
+			t.Errorf("configurationId = %q, want %q", req.ConfigurationID, "logs")
+		}
+		if req.Context != "ROUTING_RULE" {
+			t.Errorf("context = %q, want %q", req.Context, "ROUTING_RULE")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"valid":true}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.Verify(context.Background(), MatcherVerifyRequest{
+		Query:           "matchesValue(content, \"test\")",
+		ConfigurationID: "logs",
+		Context:         "ROUTING_RULE",
+	})
+	if err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+}
+
+func TestVerify_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"internal error"}}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.Verify(context.Background(), MatcherVerifyRequest{Query: "test"}); err == nil {
+		t.Fatal("Verify() expected error for 500")
+	}
+}

--- a/sdk/api/previewprocessor/previewprocessor.go
+++ b/sdk/api/previewprocessor/previewprocessor.go
@@ -1,0 +1,78 @@
+// Package previewprocessor is a thin SDK client for the OpenPipeline preview
+// processor endpoint, which executes a processor definition against sample
+// records and returns the matched/modified results.
+//
+// The request body is a oneOf union envelope (processor definition + sample
+// records) that the SDK accepts and forwards verbatim as a [json.RawMessage]
+// without interpreting or validating its structure.
+//
+// Error codes 408 (request timeout) and 429 (too many concurrent requests) are
+// caught and surfaced with clear, distinct messages.
+package previewprocessor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+const basePath = "/platform/openpipeline/v1/preview/processor"
+
+// Handler calls the preview processor endpoint.
+type Handler struct {
+	client *httpclient.Client
+}
+
+// NewHandler creates a new preview processor handler.
+func NewHandler(c *httpclient.Client) *Handler {
+	return &Handler{client: c}
+}
+
+// PreviewProcessorResultEntry is a single result entry from the preview endpoint.
+type PreviewProcessorResultEntry struct {
+	Matched bool           `json:"matched"`
+	Record  map[string]any `json:"record,omitempty"`
+}
+
+// PreviewProcessorResult is the full response from the preview endpoint.
+type PreviewProcessorResult struct {
+	Results []PreviewProcessorResultEntry `json:"results"`
+}
+
+// Preview sends a processor preview request and returns the parsed results.
+// The envelope parameter is the raw JSON request body (a oneOf union of
+// processor definition + sample records) forwarded verbatim to the API.
+func (h *Handler) Preview(ctx context.Context, envelope json.RawMessage) (*PreviewProcessorResult, error) {
+	resp, err := h.client.HTTP().R().SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetBody([]byte(envelope)).
+		Post(basePath)
+	if err != nil {
+		return nil, fmt.Errorf("preview processor: %w", err)
+	}
+
+	// Handle these error codes explicitly before the generic checker so we can
+	// return a distinct, actionable message for each.
+	switch resp.StatusCode() {
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("preview processor: endpoint not found (the preview processor endpoint is not available in this environment)")
+	case http.StatusRequestTimeout:
+		return nil, fmt.Errorf("preview processor: request timed out — the sample data may be too large or the processor too complex; try reducing the number of sample records")
+	case http.StatusTooManyRequests:
+		return nil, fmt.Errorf("preview processor: too many concurrent preview requests — wait a moment and retry")
+	}
+
+	if err := httpclient.CheckResponse(resp); err != nil {
+		return nil, fmt.Errorf("preview processor: %w", err)
+	}
+
+	var result PreviewProcessorResult
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, fmt.Errorf("preview processor: parse response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/sdk/api/previewprocessor/previewprocessor_test.go
+++ b/sdk/api/previewprocessor/previewprocessor_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
@@ -85,7 +86,7 @@ func TestPreview_NotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("Preview() expected error for 404")
 	}
-	if msg := err.Error(); !containsStr(msg, "not found") {
+	if msg := err.Error(); !strings.Contains(msg, "not found") {
 		t.Errorf("expected not-found message, got: %v", err)
 	}
 }
@@ -101,7 +102,7 @@ func TestPreview_Timeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("Preview() expected error for 408")
 	}
-	if msg := err.Error(); !containsStr(msg, "timed out") {
+	if msg := err.Error(); !strings.Contains(msg, "timed out") {
 		t.Errorf("expected timeout message, got: %v", err)
 	}
 }
@@ -117,7 +118,7 @@ func TestPreview_TooManyRequests(t *testing.T) {
 	if err == nil {
 		t.Fatal("Preview() expected error for 429")
 	}
-	if msg := err.Error(); !containsStr(msg, "concurrent") {
+	if msg := err.Error(); !strings.Contains(msg, "concurrent") {
 		t.Errorf("expected concurrency message, got: %v", err)
 	}
 }
@@ -133,16 +134,4 @@ func TestPreview_ServerError(t *testing.T) {
 	if _, err := h.Preview(context.Background(), sampleEnvelope); err == nil {
 		t.Fatal("Preview() expected error for 500")
 	}
-}
-
-func containsStr(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr ||
-		func() bool {
-			for i := 0; i+len(substr) <= len(s); i++ {
-				if s[i:i+len(substr)] == substr {
-					return true
-				}
-			}
-			return false
-		}())
 }

--- a/sdk/api/previewprocessor/previewprocessor_test.go
+++ b/sdk/api/previewprocessor/previewprocessor_test.go
@@ -1,0 +1,148 @@
+package previewprocessor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *httpclient.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c, err := httpclient.New(srv.URL, httpclient.WithToken("dt0c01.test"))
+	if err != nil {
+		t.Fatalf("httpclient.New: %v", err)
+	}
+	return c
+}
+
+// sampleEnvelope mirrors the real request shape: a processor definition (with
+// its sample data embedded under sampleData) wrapped with the config scope.
+var sampleEnvelope = json.RawMessage(`{
+	"processor": {"type": "dql", "matcher": "true", "dqlScript": "fieldsAdd foo = 1", "sampleData": "{\"content\":\"hello\"}"},
+	"configId": "logs"
+}`)
+
+func TestPreview_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		// The SDK must forward the envelope verbatim (it is a oneOf union the
+		// SDK deliberately does not interpret) so that fields built upstream —
+		// e.g. the top-level "configId" — reach the wire unchanged.
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if !bytes.Equal(body, sampleEnvelope) {
+			t.Errorf("request body not forwarded verbatim:\n got: %s\nwant: %s", body, sampleEnvelope)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"results": [
+				{"matched": true, "record": {"content": "hello", "foo": 1}},
+				{"matched": false, "record": {"content": "world"}}
+			]
+		}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.Preview(context.Background(), sampleEnvelope)
+	if err != nil {
+		t.Fatalf("Preview() error: %v", err)
+	}
+	if len(result.Results) != 2 {
+		t.Fatalf("len(Results) = %d, want 2", len(result.Results))
+	}
+	if !result.Results[0].Matched {
+		t.Errorf("Results[0].Matched = false, want true")
+	}
+	if result.Results[1].Matched {
+		t.Errorf("Results[1].Matched = true, want false")
+	}
+}
+
+func TestPreview_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.Preview(context.Background(), sampleEnvelope)
+	if err == nil {
+		t.Fatal("Preview() expected error for 404")
+	}
+	if msg := err.Error(); !containsStr(msg, "not found") {
+		t.Errorf("expected not-found message, got: %v", err)
+	}
+}
+
+func TestPreview_Timeout(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusRequestTimeout)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.Preview(context.Background(), sampleEnvelope)
+	if err == nil {
+		t.Fatal("Preview() expected error for 408")
+	}
+	if msg := err.Error(); !containsStr(msg, "timed out") {
+		t.Errorf("expected timeout message, got: %v", err)
+	}
+}
+
+func TestPreview_TooManyRequests(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	_, err := h.Preview(context.Background(), sampleEnvelope)
+	if err == nil {
+		t.Fatal("Preview() expected error for 429")
+	}
+	if msg := err.Error(); !containsStr(msg, "concurrent") {
+		t.Errorf("expected concurrency message, got: %v", err)
+	}
+}
+
+func TestPreview_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(basePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"internal error"}}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.Preview(context.Background(), sampleEnvelope); err == nil {
+		t.Fatal("Preview() expected error for 500")
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr ||
+		func() bool {
+			for i := 0; i+len(substr) <= len(s); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}())
+}


### PR DESCRIPTION
## OpenPipeline verify & preview resources

Adds three stateless OpenPipeline resources — two under `verify` and one under `exec` — to validate and dry-run pipeline configuration components **before** applying them to a live config.

### Why

An OpenPipeline **matcher** holds a *matching condition* that filters ingested data and reduces the scope of records a processor acts on; a **DQL processor** then transforms those records. Both use a restricted DQL subset scoped to the pipeline engine — matchers allow only a limited feature set (`matchesPhrase`, `matchesValue`, `isNull`, `iAny`, …), and processor scripts are limited to the processor-specific commands (`parse`, `fields*`, `fieldsFlatten`). A generic `verify query` check doesn't enforce those constraints, so it misses errors that only surface in a pipeline context. These resources call the endpoints the engine itself uses, and let you preview a transformation against sample records without touching a live config.

### What's introduced

| Command | Endpoint | Docs |
|---------|----------|------|
| `verify openpipeline-matcher` — validate a matching condition (DQL matcher) | `POST /platform/openpipeline/v1/matcher/verify` | [Matcher API — verify](https://docs.dynatrace.com/docs/platform/openpipeline/reference/openpipeline-api/matcher-api/post-verify) |
| `verify openpipeline-dql-processor` — validate a DQL processor script | `POST /platform/openpipeline/v1/dqlProcessor/verify` | [DQL Processor API — verify](https://docs.dynatrace.com/docs/platform/openpipeline/reference/openpipeline-api/dql-processor-api/post-verify) |
| `exec preview-processor` — run a processor against its embedded sample records | `POST /platform/openpipeline/v1/preview/processor` | [Preview API — processor](https://docs.dynatrace.com/docs/platform/openpipeline/reference/openpipeline-api/preview-api/post-processor) |

The two `verify` resources exit non-zero on an invalid verdict (in every output mode, including `-A`) so they drop straight into CI and skill pipelines without JSON parsing. Diagnostics (severity, message, source position) are surfaced in all formats. `preview-processor` takes just the processor **body**, and dtctl builds the request envelope around it, sourcing the config scope from `--config-id`.

All three are read-only (`openpipeline:configurations:read`, already in the read tier — no new scopes to grant) and need no safety checker.

### Command structure

```
dtctl verify openpipeline-matcher <dql-query> [flags]
dtctl verify openpipeline-matcher --file <path> [flags]
  -f, --file <path>          Read the matcher from a file ("-" for stdin)
      --context <stage>      Stage context, e.g. "processing" or "ROUTING_RULE"
      --config-id <id>       Configuration scope

dtctl verify openpipeline-dql-processor <script> [flags]
dtctl verify openpipeline-dql-processor --file <path> [flags]
  -f, --file <path>          Read the DQL script from a file ("-" for stdin)
      --config-id <id>       Configuration scope

dtctl exec preview-processor --file <path> [flags]
  -f, --file <path>          Read the processor definition body (JSON) from a
                             file ("-" for stdin). Required — no inline arg.
                             dtctl wraps it in the request envelope.
      --config-id <id>       Configuration scope, e.g. "logs"
```

Input rules:
- `openpipeline-matcher` / `openpipeline-dql-processor`: positional arg **or** `-f` — exactly one required (clear error if both or neither are given).
- `preview-processor`: `-f` is required; the processor body is structured JSON, so there is no positional arg.

### Usage

```bash
# Verify a matching condition (inline, file, or stdin)
dtctl verify openpipeline-matcher 'matchesValue(content, "error")'
dtctl verify openpipeline-matcher -f matcher.dql
echo 'invalid matcher !!!' | dtctl verify openpipeline-matcher -f -   # exits 1

# Scope / stage context
dtctl verify openpipeline-matcher 'matchesValue(content, "error")' --context ROUTING_RULE
dtctl verify openpipeline-matcher 'matchesValue(content, "error")' --config-id logs

# Verify a DQL processor script
dtctl verify openpipeline-dql-processor 'parse content, "IPV4:ip"'
dtctl verify openpipeline-dql-processor -f processor.dql --config-id logs

# Preview a processor against its sample records (-f required)
dtctl exec preview-processor -f processor.json
dtctl exec preview-processor -f processor.json --config-id logs
cat processor.json | dtctl exec preview-processor -f -

# Structured output on any of them
dtctl verify openpipeline-matcher 'matchesValue(content, "error")' -o json
dtctl exec preview-processor -f processor.json -o yaml
dtctl verify openpipeline-dql-processor 'parse content, "x"' -A
```

### Related

- **Part of #56** — delivers the *"validate matchers and DQL in OpenPipeline"* piece of that request. The create/read-of-configurations part is handled via the Settings API (see the OpenPipeline section in QUICK_START), so this does not fully close #56.
- **Implements the API design from #75** (OpenPipeline verifier & preview endpoint definitions).
