### PR TITLE
fix(auth): fall back to file store on macOS keychain write denial (exit status 44)

### DIFF
--- a/sdk/session/token_manager.go
+++ b/sdk/session/token_manager.go
@@ -435,10 +435,10 @@ func (tm *TokenManager) saveToken(tokenName string, stored *StoredToken) error {
 			}
 		}
 		// Even the minimal (refresh-token-only) encoding could not be written.
-		// If that was a size limit, fall back to file storage, which can hold
-		// the full token (including the access token, so the fast path still
-		// works). Any other error (locked/corrupt keyring) is returned as-is.
-		if isKeyringTooLargeErr(lastErr) {
+		// Fall back to file storage for persistent write failures (size limit or
+		// write-access denied on macOS for unsigned binaries). Transient errors
+		// (locked/corrupt keyring) are returned as-is.
+		if isKeyringFallbackErr(lastErr) {
 			if fileErr := tm.deps.fileSetToken(keyringName, string(fullData)); fileErr == nil {
 				// Remove any stale keyring entry (and scope companion) so loadToken
 				// reads the full token — scope included — from the file next time.
@@ -461,15 +461,20 @@ func (tm *TokenManager) saveToken(tokenName string, stored *StoredToken) error {
 	return fmt.Errorf("OAuth tokens require a storage backend (keyring or file); set %s=file to use file-based storage", EnvTokenStorage)
 }
 
-// isKeyringTooLargeErr reports whether err is a keyring "data too large" error.
-// On macOS the go-keyring library surfaces errSecDataTooLarge (-25313) as
-// "data passed to Set was too big"; the security(1) CLI exits with code 161.
-func isKeyringTooLargeErr(err error) bool {
+// isKeyringFallbackErr reports whether a keyring write error should trigger the
+// file-storage fallback. Covers two persistent (non-transient) failure modes:
+//   - "too big" / "exit status 161": errSecDataTooLarge (-25313) — data exceeds
+//     the macOS Keychain per-item size limit
+//   - "exit status 44": errSecItemNotFound (-25300) — macOS rejects keychain
+//     writes from unsigned CGO_ENABLED=0 binaries (Ventura+)
+func isKeyringFallbackErr(err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := err.Error()
-	return strings.Contains(msg, "too big") || strings.Contains(msg, "exit status 161")
+	return strings.Contains(msg, "too big") ||
+		strings.Contains(msg, "exit status 44") ||
+		strings.Contains(msg, "exit status 161")
 }
 
 // keyringEncodings returns candidate serializations of stored for the keyring,

--- a/sdk/session/token_manager.go
+++ b/sdk/session/token_manager.go
@@ -465,8 +465,8 @@ func (tm *TokenManager) saveToken(tokenName string, stored *StoredToken) error {
 // file-storage fallback. Covers two persistent (non-transient) failure modes:
 //   - "too big" / "exit status 161": errSecDataTooLarge (-25313) — data exceeds
 //     the macOS Keychain per-item size limit
-//   - "exit status 44": errSecItemNotFound (-25300) — macOS rejects keychain
-//     writes from unsigned CGO_ENABLED=0 binaries (Ventura+)
+//   - "exit status 44": macOS rejects keychain writes from unsigned
+//     CGO_ENABLED=0 binaries (observed on Ventura+; exact OSStatus unverified)
 func isKeyringFallbackErr(err error) bool {
 	if err == nil {
 		return false

--- a/sdk/session/token_manager_save_test.go
+++ b/sdk/session/token_manager_save_test.go
@@ -190,9 +190,9 @@ func TestSaveToken_PreservesAccessTokenUnderSizeLimit(t *testing.T) {
 }
 
 // TestSaveToken_FallsBackToFileOnKeyringWriteDenied covers the macOS
-// "exit status 44" (errSecItemNotFound) case: unsigned CGO_ENABLED=0 binaries
-// on macOS Ventura+ cannot create new keychain items. All keyring encodings fail,
-// so saveToken must fall back to file storage instead of returning an error.
+// "exit status 44" case: unsigned CGO_ENABLED=0 binaries on macOS Ventura+
+// cannot create new keychain items. All keyring encodings fail, so saveToken
+// must fall back to file storage instead of returning an error.
 func TestSaveToken_FallsBackToFileOnKeyringWriteDenied(t *testing.T) {
 	t.Parallel()
 	stored := sampleStoredToken()

--- a/sdk/session/token_manager_save_test.go
+++ b/sdk/session/token_manager_save_test.go
@@ -35,7 +35,7 @@ func newTMWithSizedKeyring(t *testing.T, limitBytes int) (tm *TokenManager, keyr
 	}
 	tm.deps.setToken = func(_ *TokenStore, name, val string) error {
 		if limitBytes >= 0 && len(val) > limitBytes {
-			return fmt.Errorf("data passed to Set was too big") // matches isKeyringTooLargeErr
+			return fmt.Errorf("data passed to Set was too big") // matches isKeyringFallbackErr
 		}
 		keyring[name] = val
 		return nil
@@ -186,6 +186,41 @@ func TestSaveToken_PreservesAccessTokenUnderSizeLimit(t *testing.T) {
 				t.Errorf("expiry must be preserved alongside a cached access token")
 			}
 		})
+	}
+}
+
+// TestSaveToken_FallsBackToFileOnKeyringWriteDenied covers the macOS
+// "exit status 44" (errSecItemNotFound) case: unsigned CGO_ENABLED=0 binaries
+// on macOS Ventura+ cannot create new keychain items. All keyring encodings fail,
+// so saveToken must fall back to file storage instead of returning an error.
+func TestSaveToken_FallsBackToFileOnKeyringWriteDenied(t *testing.T) {
+	t.Parallel()
+	stored := sampleStoredToken()
+
+	tm, keyring, files := newTMWithSizedKeyring(t, -1) // -1 = unlimited size
+	// Override setToken to simulate macOS "exit status 44" on every write.
+	tm.deps.setToken = func(_ *TokenStore, _, _ string) error {
+		return fmt.Errorf("failed to store token in keyring: exit status 44")
+	}
+
+	if err := tm.saveToken("my-token", stored); err != nil {
+		t.Fatalf("saveToken() error = %v, want nil (file fallback)", err)
+	}
+
+	key := tm.getKeyringName("my-token")
+	if _, ok := keyring[key]; ok {
+		t.Errorf("keyring entry should be absent when write is denied")
+	}
+	raw, ok := files[key]
+	if !ok {
+		t.Fatalf("expected full token in file store, none found")
+	}
+	var got StoredToken
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.AccessToken != stored.AccessToken {
+		t.Errorf("file store access token = %q, want full access token", got.AccessToken)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #391

**Root cause**: The keyring fallback logic in `sdk/session/token_manager.go` only matched a subset of macOS Keychain write-denial error strings. When the system Keychain returns `exit status 44` (access denied / user interaction not allowed), the error was not recognized as a fallback trigger, causing the token save to fail outright instead of gracefully falling back to the file-based credential store.

**Fix**:
- Renamed `isKeyringTooLargeErr` → `isKeyringFallbackErr` to reflect the broader purpose of the function
- Added `"exit status 44"` to the list of recognized fallback-triggering error strings
- Added `TestSaveToken_FallsBackToFileOnKeyringWriteDenied` to cover the new case
- Updated a stale comment in the existing test

## Test plan

- [ ] `go test ./sdk/session/... -run TestSaveToken` passes, including the new `TestSaveToken_FallsBackToFileOnKeyringWriteDenied` test
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)