### PR TITLE
feat(document): apply and update documents of any type (#390)

### DIFF
--- a/cmd/agent_helpers.go
+++ b/cmd/agent_helpers.go
@@ -22,6 +22,10 @@ func extractApplyBase(result apply.ApplyResult) *apply.ApplyResultBase {
 		return &r.ApplyResultBase
 	case apply.NotebookApplyResult:
 		return &r.ApplyResultBase
+	case *apply.DocumentApplyResult:
+		return &r.ApplyResultBase
+	case apply.DocumentApplyResult:
+		return &r.ApplyResultBase
 	case *apply.SLOApplyResult:
 		return &r.ApplyResultBase
 	case apply.SLOApplyResult:

--- a/cmd/agent_helpers_test.go
+++ b/cmd/agent_helpers_test.go
@@ -33,6 +33,16 @@ func TestExtractApplyBase_PointerTypes(t *testing.T) {
 			want: "dashboard",
 		},
 		{
+			name: "DocumentApplyResult pointer (custom type)",
+			result: &apply.DocumentApplyResult{
+				ApplyResultBase: apply.ApplyResultBase{
+					Action: apply.ActionUpdated, ResourceType: "acme:config", ID: "doc1",
+				},
+				Labels: []string{"team-a"},
+			},
+			want: "acme:config",
+		},
+		{
 			name: "SettingsApplyResult pointer",
 			result: &apply.SettingsApplyResult{
 				ApplyResultBase: apply.ApplyResultBase{

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -74,6 +74,11 @@ Custom document types (--type):
     dtctl apply -f doc.json                              # updates, type auto-detected
     dtctl apply -f raw-content.json --type acme:config --id acme-config
 
+  Labels ride along in an exported document and are preserved on a round-trip
+  apply. Override them with repeatable --label flags (this replaces the full set):
+
+    dtctl apply -f doc.json --label team-a --label env:prod
+
 Array input (bulk apply):
   Files containing an array of resources (e.g., from 'dtctl get settings --schema ...
   -o yaml') are applied element-by-element. Partial failures do not abort the batch;
@@ -138,6 +143,7 @@ resources in sync with their file definitions.
 		overrideID, _ := cmd.Flags().GetString("id")
 		writeID, _ := cmd.Flags().GetBool("write-id")
 		docType, _ := cmd.Flags().GetString("type")
+		labels, _ := cmd.Flags().GetStringArray("label")
 		shareEnvironment, _ := cmd.Flags().GetString("share-environment")
 
 		if err := validateShareEnvironmentValue(shareEnvironment); err != nil {
@@ -203,6 +209,7 @@ resources in sync with their file definitions.
 			OverrideID:   overrideID,
 			WriteID:      writeID,
 			Type:         docType,
+			Labels:       labels,
 		}
 
 		results, applyErr := applier.Apply(fileData, opts)
@@ -279,6 +286,7 @@ func init() {
 	applyCmd.Flags().String("id", "", "override or inject resource ID (use with --write-id to stamp ID into file)")
 	applyCmd.Flags().Bool("write-id", false, "write the created resource ID back into the source file for idempotent future applies")
 	applyCmd.Flags().String("type", "", "document type (e.g. launchpad, acme:config); forces the file to be applied as a document of this type")
+	applyCmd.Flags().StringArray("label", []string{}, "document classification label (repeatable); replaces the document's labels, overriding any in the payload")
 	applyCmd.Flags().String("share-environment", "", "share the applied notebook/dashboard with everyone in the environment (values: 'read' or 'read-write'; bare --share-environment defaults to 'read')")
 	applyCmd.Flags().Lookup("share-environment").NoOptDefVal = "read"
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -58,10 +58,21 @@ Supported resource types:
   - Workflows (automation)
   - Dashboards
   - Notebooks
+  - Documents of any type (launchpad, custom app documents, e.g. acme:config)
   - SLOs
   - Grail buckets
   - Settings objects
   - Extension monitoring configurations
+
+Custom document types (--type):
+  Documents exported with 'dtctl get document -o json' carry their "type" field
+  and are detected automatically, so the export → edit → apply round-trip works
+  for any document type. Use --type to apply a file that has no embedded type, or
+  to force a specific type:
+
+    dtctl get document acme-config -o json > doc.json   # includes "type"
+    dtctl apply -f doc.json                              # updates, type auto-detected
+    dtctl apply -f raw-content.json --type acme:config --id acme-config
 
 Array input (bulk apply):
   Files containing an array of resources (e.g., from 'dtctl get settings --schema ...
@@ -126,6 +137,7 @@ resources in sync with their file definitions.
 		noHooks, _ := cmd.Flags().GetBool("no-hooks")
 		overrideID, _ := cmd.Flags().GetString("id")
 		writeID, _ := cmd.Flags().GetBool("write-id")
+		docType, _ := cmd.Flags().GetString("type")
 		shareEnvironment, _ := cmd.Flags().GetString("share-environment")
 
 		if err := validateShareEnvironmentValue(shareEnvironment); err != nil {
@@ -190,6 +202,7 @@ resources in sync with their file definitions.
 			ShowDiff:     showDiff,
 			OverrideID:   overrideID,
 			WriteID:      writeID,
+			Type:         docType,
 		}
 
 		results, applyErr := applier.Apply(fileData, opts)
@@ -265,6 +278,7 @@ func init() {
 	applyCmd.Flags().Bool("no-hooks", false, "skip pre-apply and post-apply hooks")
 	applyCmd.Flags().String("id", "", "override or inject resource ID (use with --write-id to stamp ID into file)")
 	applyCmd.Flags().Bool("write-id", false, "write the created resource ID back into the source file for idempotent future applies")
+	applyCmd.Flags().String("type", "", "document type (e.g. launchpad, acme:config); forces the file to be applied as a document of this type")
 	applyCmd.Flags().String("share-environment", "", "share the applied notebook/dashboard with everyone in the environment (values: 'read' or 'read-write'; bare --share-environment defaults to 'read')")
 	applyCmd.Flags().Lookup("share-environment").NoOptDefVal = "read"
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -65,19 +65,24 @@ Supported resource types:
   - Extension monitoring configurations
 
 Custom document types (--type):
-  Documents exported with 'dtctl get document -o json' carry their "type" field
+  Documents exported with 'dtctl get document -o yaml' carry their "type" field
   and are detected automatically, so the export → edit → apply round-trip works
   for any document type. Use --type to apply a file that has no embedded type, or
   to force a specific type:
 
-    dtctl get document acme-config -o json > doc.json   # includes "type"
-    dtctl apply -f doc.json                              # updates, type auto-detected
+    dtctl get document acme-config -o yaml > doc.yaml   # includes "type"
+    dtctl apply -f doc.yaml                              # updates, type auto-detected
     dtctl apply -f raw-content.json --type acme:config --id acme-config
 
-  Labels ride along in an exported document and are preserved on a round-trip
-  apply. Override them with repeatable --label flags (this replaces the full set):
+  Use -o yaml (not -o json) for the round-trip: JSON output is wrapped in a
+  result envelope that apply cannot read back; YAML is emitted as the plain
+  document.
 
-    dtctl apply -f doc.json --label team-a --label env:prod
+  Labels ride along in an exported document and are preserved on a round-trip
+  apply. Override them with repeatable --label flags (this replaces the full
+  set; labels cannot be cleared, only replaced):
+
+    dtctl apply -f doc.yaml --label team-a --label env:prod
 
 Array input (bulk apply):
   Files containing an array of resources (e.g., from 'dtctl get settings --schema ...
@@ -286,7 +291,7 @@ func init() {
 	applyCmd.Flags().String("id", "", "override or inject resource ID (use with --write-id to stamp ID into file)")
 	applyCmd.Flags().Bool("write-id", false, "write the created resource ID back into the source file for idempotent future applies")
 	applyCmd.Flags().String("type", "", "document type (e.g. launchpad, acme:config); forces the file to be applied as a document of this type")
-	applyCmd.Flags().StringArray("label", []string{}, "document classification label (repeatable); replaces the document's labels, overriding any in the payload")
+	applyCmd.Flags().StringArray("label", []string{}, "document classification label (repeatable); replaces the document's labels, overriding any in the payload (labels cannot be cleared, only replaced)")
 	applyCmd.Flags().String("share-environment", "", "share the applied notebook/dashboard with everyone in the environment (values: 'read' or 'read-write'; bare --share-environment defaults to 'read')")
 	applyCmd.Flags().Lookup("share-environment").NoOptDefVal = "read"
 

--- a/cmd/create_documents.go
+++ b/cmd/create_documents.go
@@ -26,7 +26,7 @@ the payload. This command works for any document type: dashboard, notebook,
 launchpad, custom app documents, etc.
 
 Labels can be attached with repeatable --label flags, or carried in the payload
-under a "labels" array (as produced by 'dtctl get document -o json'). Because
+under a "labels" array (as produced by 'dtctl get document -o yaml'). Because
 the create API cannot set labels directly, they are applied with a follow-up
 update immediately after creation.
 
@@ -193,7 +193,7 @@ func createDocumentRunE(docType string) func(cmd *cobra.Command, args []string) 
 		// Extract content, name, description using the same logic as apply
 		contentData, extractedName, extractedDesc, warnings := extractDocumentContent(doc, docType)
 
-		// Fall back to labels embedded in the payload (e.g. from 'get -o json')
+		// Fall back to labels embedded in the payload (e.g. from 'get -o yaml')
 		// when none were supplied via --label.
 		if len(labels) == 0 {
 			labels = extractDocumentLabels(doc)
@@ -285,7 +285,11 @@ func createDocumentRunE(docType string) func(cmd *cobra.Command, args []string) 
 		if tileCount > 0 {
 			output.PrintInfo("  %s: %d", capitalize(itemName(docType)), tileCount)
 		}
-		if result.ID != "" {
+		// Only dashboards and notebooks have a known viewer app whose URL can be
+		// derived from the type. For custom document types the app ID is unknown
+		// (e.g. "acme:config" is not served by "dynatrace.acme:configs"), so print
+		// no URL rather than a broken guess.
+		if result.ID != "" && (docType == "dashboard" || docType == "notebook") {
 			output.PrintInfo("  URL:  %s/ui/apps/dynatrace.%ss/%s/%s", c.BaseURL(), docType, docType, result.ID)
 		}
 		return nil
@@ -354,7 +358,7 @@ func extractDocumentContent(doc map[string]interface{}, docType string) ([]byte,
 }
 
 // extractDocumentLabels pulls a "labels" string array from a parsed document
-// payload (as produced by 'dtctl get document -o json'). Non-string entries are
+// payload (as produced by 'dtctl get document -o yaml'). Non-string entries are
 // skipped. Returns nil when no usable labels are present.
 func extractDocumentLabels(doc map[string]interface{}) []string {
 	raw, ok := doc["labels"].([]interface{})

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -323,6 +323,8 @@ func TestApplyFlags(t *testing.T) {
 		{"file", ""},
 		{"show-diff", "false"},
 		{"no-hooks", "false"},
+		{"type", ""},
+		{"label", "[]"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -16,13 +16,21 @@ Unlike 'apply' which works from YAML/JSON files, 'update' modifies individual
 fields of a resource using command-line flags. This is useful for quick,
 targeted changes without exporting and re-importing a full resource definition.
 
+Most 'update' subcommands modify individual fields via flags. The 'document'
+subcommand is file-based instead: it updates an existing document of any type
+from a YAML/JSON file (the update-only counterpart to 'create document').
+
 Available resources:
+  document                Update an existing document of any type from a file
   breakpoint              Update breakpoint condition/enabled state or workspace filters
   azure connection        Update Azure connection credentials
   azure monitoring        Update Azure monitoring configuration
   gcp connection          Update GCP connection credentials (Preview)
   gcp monitoring          Update GCP monitoring configuration (Preview)`,
-	Example: `  # Update an Azure connection
+	Example: `  # Update a custom document type (round-trip from 'get')
+  dtctl update document -f doc.json --type acme:config --id acme-config
+
+  # Update an Azure connection
   dtctl update azure connection <id> --name "New Name"
 
   # Update Live Debugger workspace filters
@@ -57,5 +65,6 @@ var updateSettingsHintCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(updateCmd)
+	updateCmd.AddCommand(updateDocumentCmd)
 	updateCmd.AddCommand(updateSettingsHintCmd)
 }

--- a/cmd/update_documents.go
+++ b/cmd/update_documents.go
@@ -24,9 +24,13 @@ This is the update-only counterpart to 'create document'. It works for any
 document type — dashboard, notebook, launchpad, or custom app documents such as
 acme:config — and completes the round-trip that 'create document' starts:
 
-  dtctl get document acme-config -o json > doc.json
-  # edit doc.json...
-  dtctl update document -f doc.json                # type + id read from the file
+  dtctl get document acme-config -o yaml > doc.yaml
+  # edit doc.yaml...
+  dtctl update document -f doc.yaml                # type + id read from the file
+
+Use -o yaml (not -o json) for the export: JSON output is wrapped in a result
+envelope that this command cannot read back; YAML is emitted as the plain
+document.
 
 The document type is resolved from --type, falling back to the "type" field in
 the payload. The target ID is resolved from --id, falling back to the "id" field
@@ -34,24 +38,25 @@ in the payload. Unlike 'apply', this command fails if the document does not
 already exist, so a typo in the ID never silently creates a new document.
 
 Labels are set with repeatable --label flags, or carried in the payload under a
-"labels" array (as produced by 'dtctl get document -o json'). Providing labels
+"labels" array (as produced by 'dtctl get document -o yaml'). Providing labels
 replaces the document's entire label set; omitting them leaves labels unchanged.
+Labels cannot be cleared, only replaced.
 
 Examples:
   # Round-trip update (type and id come from the exported file)
-  dtctl update document -f doc.json
+  dtctl update document -f doc.yaml
 
   # Update a custom document by explicit type and id
   dtctl update document -f content.json --type acme:config --id acme-config
 
   # Replace the document's labels
-  dtctl update document -f doc.json --label team-a --label env:prod
+  dtctl update document -f doc.yaml --label team-a --label env:prod
 
   # Preview the change without applying it
-  dtctl update document -f doc.json --dry-run
+  dtctl update document -f doc.yaml --dry-run
 
   # Show what changed
-  dtctl update document -f doc.json --show-diff
+  dtctl update document -f doc.yaml --show-diff
 
 See also:
   dtctl create document --help   # create a new document of any type
@@ -139,7 +144,7 @@ func init() {
 	updateDocumentCmd.Flags().String("type", "", "document type (e.g. launchpad, acme:config); read from payload if not provided")
 	updateDocumentCmd.Flags().String("id", "", "ID of the document to update; read from payload if not provided")
 	updateDocumentCmd.Flags().StringArray("set", []string{}, "set template variable (key=value)")
-	updateDocumentCmd.Flags().StringArray("label", []string{}, "classification label to set (repeatable); replaces the document's labels. Falls back to labels in the payload")
+	updateDocumentCmd.Flags().StringArray("label", []string{}, "classification label to set (repeatable); replaces the document's labels (cannot be cleared, only replaced). Falls back to labels in the payload")
 	updateDocumentCmd.Flags().Bool("dry-run", false, "preview the update without applying it")
 	updateDocumentCmd.Flags().Bool("show-diff", false, "show a diff of the change")
 	_ = updateDocumentCmd.MarkFlagRequired("file")

--- a/cmd/update_documents.go
+++ b/cmd/update_documents.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/apply"
+	"github.com/dynatrace-oss/dtctl/pkg/util/template"
+)
+
+// updateDocumentCmd updates an existing document of any type from a file.
+//
+// It is the update-only counterpart to 'create document': it accepts the same
+// --type + --id handling but fails instead of creating when the target document
+// does not exist. For create-or-update semantics use 'dtctl apply' instead.
+var updateDocumentCmd = &cobra.Command{
+	Use:   "document -f <file> --id <id> [--type <type>]",
+	Short: "Update an existing document of any type from a file",
+	Long: `Update an existing document from a YAML or JSON file.
+
+This is the update-only counterpart to 'create document'. It works for any
+document type — dashboard, notebook, launchpad, or custom app documents such as
+acme:config — and completes the round-trip that 'create document' starts:
+
+  dtctl get document acme-config -o json > doc.json
+  # edit doc.json...
+  dtctl update document -f doc.json                # type + id read from the file
+
+The document type is resolved from --type, falling back to the "type" field in
+the payload. The target ID is resolved from --id, falling back to the "id" field
+in the payload. Unlike 'apply', this command fails if the document does not
+already exist, so a typo in the ID never silently creates a new document.
+
+Examples:
+  # Round-trip update (type and id come from the exported file)
+  dtctl update document -f doc.json
+
+  # Update a custom document by explicit type and id
+  dtctl update document -f content.json --type acme:config --id acme-config
+
+  # Preview the change without applying it
+  dtctl update document -f doc.json --dry-run
+
+  # Show what changed
+  dtctl update document -f doc.json --show-diff
+
+See also:
+  dtctl create document --help   # create a new document of any type
+  dtctl apply --help             # create-or-update semantics
+`,
+	Aliases: []string{"doc"},
+	RunE:    updateDocumentRunE,
+}
+
+// updateDocumentRunE updates a document by delegating to the shared applier with
+// update-only semantics (RequireExisting). Reusing the applier keeps document
+// content extraction, ownership-aware safety checks, dry-run, and diff rendering
+// identical to 'apply'.
+func updateDocumentRunE(cmd *cobra.Command, _ []string) error {
+	file, _ := cmd.Flags().GetString("file")
+	if file == "" {
+		return fmt.Errorf("--file is required")
+	}
+
+	docType, _ := cmd.Flags().GetString("type")
+	id, _ := cmd.Flags().GetString("id")
+	setFlags, _ := cmd.Flags().GetStringArray("set")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	showDiff, _ := cmd.Flags().GetBool("show-diff")
+
+	fileData, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var templateVars map[string]interface{}
+	if len(setFlags) > 0 {
+		templateVars, err = template.ParseSetFlags(setFlags)
+		if err != nil {
+			return fmt.Errorf("invalid --set flag: %w", err)
+		}
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+	c, err := NewClientFromConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	applier := apply.NewApplier(c)
+	if !dryRun {
+		checker, err := NewSafetyChecker(cfg)
+		if err != nil {
+			return err
+		}
+		applier = applier.WithSafetyChecker(checker)
+	}
+
+	results, err := applier.Apply(fileData, apply.ApplyOptions{
+		TemplateVars:    templateVars,
+		DryRun:          dryRun,
+		ShowDiff:        showDiff,
+		OverrideID:      id,
+		Type:            docType,
+		RequireExisting: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	printer := NewPrinter()
+	enrichAgent(printer, "update", "document")
+	if len(results) == 1 {
+		return printer.Print(results[0])
+	}
+	items := make([]interface{}, len(results))
+	for i, r := range results {
+		items[i] = r
+	}
+	return printer.PrintList(items)
+}
+
+func init() {
+	updateDocumentCmd.Flags().StringP("file", "f", "", "file containing the document definition (required)")
+	updateDocumentCmd.Flags().String("type", "", "document type (e.g. launchpad, acme:config); read from payload if not provided")
+	updateDocumentCmd.Flags().String("id", "", "ID of the document to update; read from payload if not provided")
+	updateDocumentCmd.Flags().StringArray("set", []string{}, "set template variable (key=value)")
+	updateDocumentCmd.Flags().Bool("dry-run", false, "preview the update without applying it")
+	updateDocumentCmd.Flags().Bool("show-diff", false, "show a diff of the change")
+	_ = updateDocumentCmd.MarkFlagRequired("file")
+}

--- a/cmd/update_documents.go
+++ b/cmd/update_documents.go
@@ -33,12 +33,19 @@ the payload. The target ID is resolved from --id, falling back to the "id" field
 in the payload. Unlike 'apply', this command fails if the document does not
 already exist, so a typo in the ID never silently creates a new document.
 
+Labels are set with repeatable --label flags, or carried in the payload under a
+"labels" array (as produced by 'dtctl get document -o json'). Providing labels
+replaces the document's entire label set; omitting them leaves labels unchanged.
+
 Examples:
   # Round-trip update (type and id come from the exported file)
   dtctl update document -f doc.json
 
   # Update a custom document by explicit type and id
   dtctl update document -f content.json --type acme:config --id acme-config
+
+  # Replace the document's labels
+  dtctl update document -f doc.json --label team-a --label env:prod
 
   # Preview the change without applying it
   dtctl update document -f doc.json --dry-run
@@ -67,6 +74,7 @@ func updateDocumentRunE(cmd *cobra.Command, _ []string) error {
 	docType, _ := cmd.Flags().GetString("type")
 	id, _ := cmd.Flags().GetString("id")
 	setFlags, _ := cmd.Flags().GetStringArray("set")
+	labels, _ := cmd.Flags().GetStringArray("label")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	showDiff, _ := cmd.Flags().GetBool("show-diff")
 
@@ -107,6 +115,7 @@ func updateDocumentRunE(cmd *cobra.Command, _ []string) error {
 		ShowDiff:        showDiff,
 		OverrideID:      id,
 		Type:            docType,
+		Labels:          labels,
 		RequireExisting: true,
 	})
 	if err != nil {
@@ -130,6 +139,7 @@ func init() {
 	updateDocumentCmd.Flags().String("type", "", "document type (e.g. launchpad, acme:config); read from payload if not provided")
 	updateDocumentCmd.Flags().String("id", "", "ID of the document to update; read from payload if not provided")
 	updateDocumentCmd.Flags().StringArray("set", []string{}, "set template variable (key=value)")
+	updateDocumentCmd.Flags().StringArray("label", []string{}, "classification label to set (repeatable); replaces the document's labels. Falls back to labels in the payload")
 	updateDocumentCmd.Flags().Bool("dry-run", false, "preview the update without applying it")
 	updateDocumentCmd.Flags().Bool("show-diff", false, "show a diff of the change")
 	_ = updateDocumentCmd.MarkFlagRequired("file")

--- a/cmd/update_documents_test.go
+++ b/cmd/update_documents_test.go
@@ -22,6 +22,18 @@ func TestUpdateDocumentRegistered(t *testing.T) {
 	}
 }
 
+// TestUpdateDocumentHasLabelFlag verifies the repeatable --label flag is
+// registered so labels can be set on update (the counterpart to create's --label).
+func TestUpdateDocumentHasLabelFlag(t *testing.T) {
+	f := updateDocumentCmd.Flags().Lookup("label")
+	if f == nil {
+		t.Fatal("update document is missing the --label flag")
+	}
+	if f.Value.Type() != "stringArray" {
+		t.Errorf("expected --label to be a stringArray, got %q", f.Value.Type())
+	}
+}
+
 // TestUpdateDocumentRequiresFile ensures the command fails fast when --file is
 // omitted, before any network/config access.
 func TestUpdateDocumentRequiresFile(t *testing.T) {

--- a/cmd/update_documents_test.go
+++ b/cmd/update_documents_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestUpdateDocumentRegistered verifies the 'document' subcommand (and its
+// alias) is wired under 'update'.
+func TestUpdateDocumentRegistered(t *testing.T) {
+	c, _, err := updateCmd.Find([]string{"document"})
+	if err != nil {
+		t.Fatalf("update document not found: %v", err)
+	}
+	if c.Name() != "document" {
+		t.Errorf("expected command 'document', got %q", c.Name())
+	}
+
+	ca, _, err := updateCmd.Find([]string{"doc"})
+	if err != nil || ca.Name() != "document" {
+		t.Errorf("expected 'doc' alias to resolve to 'document', got %q (err=%v)", ca.Name(), err)
+	}
+}
+
+// TestUpdateDocumentRequiresFile ensures the command fails fast when --file is
+// omitted, before any network/config access.
+func TestUpdateDocumentRequiresFile(t *testing.T) {
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"update", "document"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --file is missing")
+	}
+	if !strings.Contains(err.Error(), "file") {
+		t.Errorf("expected error to mention the required 'file' flag, got: %v", err)
+	}
+}

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -68,7 +68,7 @@ dtctl supports both singular and plural resource names, plus short aliases.
 | `wfe-task-result` | — | get |
 | `dashboards` | `dashboard`, `dash`, `db` | get, describe, create, edit, delete, apply, share, unshare, history, restore, diff, watch |
 | `notebooks` | `notebook`, `nb` | get, describe, create, edit, delete, apply, share, unshare, history, restore, diff, watch |
-| `documents` | `document`, `doc` | get, describe, create, edit, delete, history, restore |
+| `documents` | `document`, `doc` | get, describe, create, apply, update, edit, delete, history, restore |
 | `trash` | — | get, describe, restore, delete |
 | `slos` | `slo` | get, describe, create, delete, apply, exec (evaluate), watch |
 | `slo-templates` | `slo-template` | get, describe |

--- a/docs/site/_docs/dashboards.md
+++ b/docs/site/_docs/dashboards.md
@@ -5,6 +5,8 @@ title: "Dashboards & Notebooks"
 
 Dynatrace dashboards and notebooks are managed as documents. dtctl supports the full lifecycle: list, view, create, edit, share, version-track, and delete — for both resource types.
 
+> Dashboards and notebooks are the two most common document types, but dtctl can create, apply, and update documents of **any** type (launchpads, custom app documents) and attach classification labels. See [Documents (any type)]({{ '/docs/documents/' | relative_url }}).
+
 ## Listing Documents
 
 ```bash

--- a/docs/site/_docs/documents.md
+++ b/docs/site/_docs/documents.md
@@ -1,0 +1,125 @@
+---
+layout: docs
+title: "Documents (any type)"
+---
+
+Dashboards and notebooks are the two most familiar kinds of Dynatrace *document*,
+but the Document Service stores documents of **any type** — launchpads and
+app-specific documents (for example `acme:config`) among them. dtctl can create,
+export, apply, and update documents of any type, and attach classification
+**labels** to them.
+
+If you only work with dashboards and notebooks, see
+[Dashboards & Notebooks]({{ '/docs/dashboards/' | relative_url }}) — it covers the
+same commands with dashboard/notebook-specific detail. This page focuses on
+**custom document types** and **labels**, which apply to every document type.
+
+> **Token scope:** creating, updating, or applying documents requires
+> `document:documents:write`. See
+> [Token Scopes]({{ '/docs/token-scopes/' | relative_url }}).
+
+## Document types
+
+Every document carries a `type`. `dashboard` and `notebook` are built in; anything
+else (`launchpad`, `acme:config`, …) is a custom type. dtctl treats a payload with
+a non-empty `type` field as a document, so the export → edit → re-import round-trip
+works for any type.
+
+```bash
+# List documents of a custom type with a raw Document API filter
+dtctl get documents --filter "type == 'launchpad'"
+```
+
+## Creating a document
+
+The type comes from `--type` or a `type` field in the file:
+
+```bash
+# Create a launchpad document
+dtctl create document -f launchpad.json --type launchpad
+
+# Create from a payload that already contains a "type" field
+dtctl create document -f my-app-config.yaml
+
+# Create with a custom ID and template variables
+dtctl create document -f config.yaml --type acme:config --id acme-config --set env=prod
+```
+
+`create` always creates — it fails if the ID already exists. Use `apply` for
+create-or-update, or `update document` for update-only.
+
+## Round-trip: export, edit, re-import
+
+Export a document, edit it locally, and re-apply. **Use `-o yaml`, not `-o json`:**
+JSON output is wrapped in a result envelope that `apply`/`update` cannot read back,
+whereas YAML is emitted as the plain document.
+
+```bash
+# Export (includes type, id, labels, and content)
+dtctl get document acme-config -o yaml > doc.yaml
+
+# Edit doc.yaml...
+
+# Re-import — type and id are read from the file
+dtctl apply -f doc.yaml            # create-or-update
+dtctl update document -f doc.yaml  # update-only (fails if it doesn't exist)
+```
+
+### apply vs. update document
+
+Both go through the same applier, so dry-run, `--show-diff`, template rendering
+(`--set`), safety checks, and labels behave identically. They differ only in intent:
+
+| | `apply -f` | `update document -f` |
+|---|---|---|
+| Target doesn't exist | creates it | **fails** (no accidental create on a typo'd ID) |
+| Type resolution | payload `type`, or `--type` | `--type`, or payload `type` |
+| ID resolution | payload `id`, or `--id` | `--id`, or payload `id` |
+
+```bash
+# Force a type for a file that carries only raw content
+dtctl apply -f content.json --type acme:config --id acme-config
+dtctl update document -f content.json --type acme:config --id acme-config
+
+# Preview and diff before writing
+dtctl update document -f doc.yaml --dry-run
+dtctl update document -f doc.yaml --show-diff
+```
+
+`--type` cannot be combined with array (bulk) input.
+
+## Labels
+
+Labels are classification strings stored in a document's metadata. Attach them on
+`create`, `apply`, or `update document` with a repeatable `--label` flag, or carry
+them in the payload under a `labels` array (as produced by `get document -o yaml`).
+
+```bash
+# Set labels at creation
+dtctl create document -f config.yaml --type acme:config --label team-a --label env:prod
+
+# Replace labels on an existing document
+dtctl update document -f doc.yaml --label team-a --label env:prod
+
+# Labels in an exported file round-trip through apply untouched
+dtctl get document acme-config -o yaml > doc.yaml
+dtctl apply -f doc.yaml
+```
+
+Behavior to know:
+
+- **Replace, not merge.** Passing `--label` replaces the document's entire label
+  set. Omitting `--label` leaves existing labels unchanged (an exported file's
+  `labels` array is preserved on a round-trip apply).
+- **Labels cannot be cleared**, only replaced — the Document Service offers no
+  clear-labels affordance.
+- **Create sets labels via a follow-up update.** The create API cannot set labels
+  directly, so dtctl issues a create and then a label update. This is not atomic:
+  if the label step fails, the document already exists and the error names it.
+
+Query labels back with the read side:
+
+```bash
+dtctl get documents --add-fields labels
+dtctl get document acme-config -o yaml   # labels appear at the top level
+```

--- a/docs/site/_includes/docs-nav.html
+++ b/docs/site/_includes/docs-nav.html
@@ -11,6 +11,7 @@
   <li><a href="{{ '/docs/dql-queries/' | relative_url }}" {% if page.title == "DQL Queries" %}class="active"{% endif %}>DQL Queries</a></li>
   <li><a href="{{ '/docs/inventory/' | relative_url }}" {% if page.title == "Environment Inventory" %}class="active"{% endif %}>Environment Inventory</a></li>
   <li><a href="{{ '/docs/dashboards/' | relative_url }}" {% if page.title == "Dashboards & Notebooks" %}class="active"{% endif %}>Dashboards & Notebooks</a></li>
+  <li><a href="{{ '/docs/documents/' | relative_url }}" {% if page.title == "Documents (any type)" %}class="active"{% endif %}>Documents (any type)</a></li>
   <li><a href="{{ '/docs/workflows/' | relative_url }}" {% if page.title == "Workflows" %}class="active"{% endif %}>Workflows</a></li>
   <li><a href="{{ '/docs/slos/' | relative_url }}" {% if page.title == "SLOs" %}class="active"{% endif %}>SLOs</a></li>
   <li><a href="{{ '/docs/settings/' | relative_url }}" {% if page.title == "Settings API" %}class="active"{% endif %}>Settings API</a></li>

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -133,13 +133,15 @@ func (a *Applier) determineOwnership(resourceOwnerID string) safety.ResourceOwne
 
 // ApplyOptions holds options for apply operation
 type ApplyOptions struct {
-	TemplateVars map[string]interface{}
-	DryRun       bool
-	Force        bool
-	ShowDiff     bool
-	NoHooks      bool   // skip pre-apply hooks
-	OverrideID   string // override or inject resource ID (from --id flag)
-	WriteID      bool   // write created resource ID back into the source file (from --write-id flag)
+	TemplateVars    map[string]interface{}
+	DryRun          bool
+	Force           bool
+	ShowDiff        bool
+	NoHooks         bool   // skip pre-apply hooks
+	OverrideID      string // override or inject resource ID (from --id flag)
+	WriteID         bool   // write created resource ID back into the source file (from --write-id flag)
+	Type            string // document type override (from --type flag); forces generic document handling
+	RequireExisting bool   // fail instead of creating when a document ID is missing (update semantics)
 }
 
 // ResourceType represents the type of resource
@@ -160,6 +162,7 @@ const (
 	ResourceExtensionConfig       ResourceType = "extension_config"
 	ResourceSegment               ResourceType = "segment"
 	ResourceAnomalyDetector       ResourceType = "anomaly_detector"
+	ResourceDocument              ResourceType = "document"
 	ResourceUnknown               ResourceType = "unknown"
 )
 
@@ -182,10 +185,22 @@ func (a *Applier) Apply(fileData []byte, opts ApplyOptions) ([]ApplyResult, erro
 		jsonData = []byte(rendered)
 	}
 
-	// Detect resource type
-	resourceType, isArray, err := detectResourceType(jsonData)
-	if err != nil {
-		return nil, err
+	// Determine resource type. An explicit --type (opts.Type) forces generic
+	// document handling and bypasses content-based detection: the user has
+	// declared the type, so we must not let a heuristic override it (e.g. a
+	// custom document whose content happens to carry a "tasks" field).
+	var resourceType ResourceType
+	var isArray bool
+	if opts.Type != "" {
+		if bytes.HasPrefix(bytes.TrimSpace(jsonData), []byte("[")) {
+			return nil, fmt.Errorf("--type cannot be used with array input")
+		}
+		resourceType = ResourceDocument
+	} else {
+		resourceType, isArray, err = detectResourceType(jsonData)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Array input: split into individual elements and apply each one
@@ -232,7 +247,7 @@ func (a *Applier) Apply(fileData []byte, opts ApplyOptions) ([]ApplyResult, erro
 	}
 
 	if opts.DryRun {
-		result, err := a.dryRun(resourceType, jsonData)
+		result, err := a.dryRun(resourceType, jsonData, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -323,6 +338,10 @@ func (a *Applier) applySingle(resourceType ResourceType, jsonData []byte, opts A
 		result, err = a.applyDocument(jsonData, "dashboard", opts)
 	case ResourceNotebook:
 		result, err = a.applyDocument(jsonData, "notebook", opts)
+	case ResourceDocument:
+		// Generic document of any type. opts.Type wins when set (--type flag);
+		// otherwise applyDocument resolves the type from the payload's "type" field.
+		result, err = a.applyDocument(jsonData, opts.Type, opts)
 	case ResourceSLO:
 		result, err = a.applySLO(jsonData)
 	case ResourceBucket:
@@ -397,7 +416,7 @@ func (a *Applier) applyList(resourceType ResourceType, data []byte, opts ApplyOp
 
 	for i, elem := range elements {
 		if opts.DryRun {
-			r, err := a.dryRun(resourceType, elem)
+			r, err := a.dryRun(resourceType, elem, opts)
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("item %d: %s", i+1, err))
 				continue
@@ -504,13 +523,15 @@ func detectResourceType(data []byte) (ResourceType, bool, error) {
 
 	// Documents have "metadata" or "content" at root level
 	if _, hasMetadata := raw["metadata"]; hasMetadata {
-		// Further distinguish between dashboard and notebook
-		if typeField, ok := raw["type"].(string); ok {
-			if typeField == "dashboard" {
+		// Further distinguish between dashboard, notebook, and custom types
+		if typeField, ok := raw["type"].(string); ok && typeField != "" {
+			switch typeField {
+			case "dashboard":
 				return ResourceDashboard, false, nil
-			}
-			if typeField == "notebook" {
+			case "notebook":
 				return ResourceNotebook, false, nil
+			default:
+				return ResourceDocument, false, nil // Custom document type
 			}
 		}
 		return ResourceDashboard, false, nil // Default to dashboard for documents
@@ -627,20 +648,37 @@ func detectResourceType(data []byte) (ResourceType, bool, error) {
 		}
 	}
 
+	// Generic document fallback: any object carrying a non-empty string "type"
+	// field that did not match a more specific resource above is treated as a
+	// custom document (e.g. "launchpad", "acme:config"). This mirrors what
+	// 'create document' accepts and enables round-trip apply/update of any
+	// document type. Kept last so all specific detectors take precedence.
+	if typeField, ok := raw["type"].(string); ok && typeField != "" {
+		return ResourceDocument, false, nil
+	}
+
 	return ResourceUnknown, false, fmt.Errorf("could not detect resource type from file content")
 }
 
 // dryRun validates what would be applied without actually applying.
 // Returns a DryRunResult with structured information about the planned operation.
-func (a *Applier) dryRun(resourceType ResourceType, data []byte) (ApplyResult, error) {
+func (a *Applier) dryRun(resourceType ResourceType, data []byte, opts ApplyOptions) (ApplyResult, error) {
 	var doc map[string]interface{}
 	if err := json.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	// For documents, check if it would be create or update
-	if resourceType == ResourceDashboard || resourceType == ResourceNotebook {
-		return a.dryRunDocument(resourceType, doc)
+	if resourceType == ResourceDashboard || resourceType == ResourceNotebook || resourceType == ResourceDocument {
+		docType := string(resourceType)
+		if resourceType == ResourceDocument {
+			// Resolve the concrete document type: --type wins, else payload "type".
+			docType = opts.Type
+			if docType == "" {
+				docType, _ = doc["type"].(string)
+			}
+		}
+		return a.dryRunDocument(docType, doc)
 	}
 
 	// Extension monitoring configs have specific fields

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -137,11 +137,12 @@ type ApplyOptions struct {
 	DryRun          bool
 	Force           bool
 	ShowDiff        bool
-	NoHooks         bool   // skip pre-apply hooks
-	OverrideID      string // override or inject resource ID (from --id flag)
-	WriteID         bool   // write created resource ID back into the source file (from --write-id flag)
-	Type            string // document type override (from --type flag); forces generic document handling
-	RequireExisting bool   // fail instead of creating when a document ID is missing (update semantics)
+	NoHooks         bool     // skip pre-apply hooks
+	OverrideID      string   // override or inject resource ID (from --id flag)
+	WriteID         bool     // write created resource ID back into the source file (from --write-id flag)
+	Type            string   // document type override (from --type flag); forces generic document handling
+	RequireExisting bool     // fail instead of creating when a document ID is missing (update semantics)
+	Labels          []string // document labels (from --label flags); when non-empty, overrides labels in the payload
 }
 
 // ResourceType represents the type of resource

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -528,7 +528,7 @@ func TestItemName(t *testing.T) {
 	}{
 		{"dashboard", "tiles"},
 		{"notebook", "sections"},
-		{"other", "sections"}, // default
+		{"acme:config", "items"}, // custom types get a generic item name
 	}
 
 	for _, tt := range tests {
@@ -643,11 +643,11 @@ func TestDocumentURL(t *testing.T) {
 			expected: "https://abc12345.apps.dynatrace.com/ui/apps/dynatrace.notebooks/notebook/nb-456",
 		},
 		{
-			name:     "other document type URL",
+			name:     "custom document type has no derivable viewer app URL",
 			baseURL:  "https://tenant.apps.dynatrace.com",
-			docType:  "report",
+			docType:  "acme:config",
 			id:       "rpt-789",
-			expected: "https://tenant.apps.dynatrace.com/ui/apps/dynatrace.reports/report/rpt-789",
+			expected: "",
 		},
 	}
 

--- a/pkg/apply/apply_document.go
+++ b/pkg/apply/apply_document.go
@@ -16,7 +16,7 @@ import (
 //
 // docType is the concrete document type. When empty it is resolved from the
 // payload's "type" field, allowing round-trip apply of documents exported with
-// 'dtctl get document -o json'.
+// 'dtctl get document -o yaml'.
 func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) (ApplyResult, error) {
 	// Parse to check for ID and name
 	var doc map[string]interface{}
@@ -36,7 +36,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 	contentData, name, description, validationWarnings := extractDocumentContent(doc, docType)
 
 	// Labels come from --label flags (opts.Labels) when supplied; otherwise they
-	// ride along in the exported document ('get document -o json') so a round-trip
+	// ride along in the exported document ('get document -o yaml') so a round-trip
 	// apply preserves (and can update) them. An empty opts.Labels (the flag's
 	// zero value when --label is absent) falls back to the payload.
 	labels := opts.Labels
@@ -346,12 +346,18 @@ func countDocumentItems(contentData []byte, docType string) int {
 	return 0
 }
 
-// itemName returns the item name for a document type (tiles for dashboards, sections for notebooks)
+// itemName returns the item name for a document type: tiles for dashboards,
+// sections for notebooks, and a generic "items" for custom document types
+// (whose content shape is unknown).
 func itemName(docType string) string {
-	if docType == "dashboard" {
+	switch docType {
+	case "dashboard":
 		return "tiles"
+	case "notebook":
+		return "sections"
+	default:
+		return "items"
 	}
-	return "sections"
 }
 
 // showJSONDiff displays a simple diff between two JSON documents
@@ -413,7 +419,10 @@ func (a *Applier) documentURL(docType, id string) string {
 	case "notebook":
 		return fmt.Sprintf("%s/ui/apps/dynatrace.notebooks/notebook/%s", a.baseURL, id)
 	default:
-		return fmt.Sprintf("%s/ui/apps/dynatrace.%ss/%s/%s", a.baseURL, docType, docType, id)
+		// Custom document types have no known viewer app — the app ID cannot be
+		// derived from the type (e.g. "acme:config" is not served by an app named
+		// "dynatrace.acme:configs"). Emit no URL rather than a broken guess.
+		return ""
 	}
 }
 

--- a/pkg/apply/apply_document.go
+++ b/pkg/apply/apply_document.go
@@ -11,12 +11,25 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 )
 
-// applyDocument applies a document resource (dashboard or notebook)
+// applyDocument applies a document resource of any type (dashboard, notebook,
+// or a custom type such as "launchpad" or "acme:config").
+//
+// docType is the concrete document type. When empty it is resolved from the
+// payload's "type" field, allowing round-trip apply of documents exported with
+// 'dtctl get document -o json'.
 func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) (ApplyResult, error) {
 	// Parse to check for ID and name
 	var doc map[string]interface{}
 	if err := json.Unmarshal(data, &doc); err != nil {
-		return nil, fmt.Errorf("failed to parse %s JSON: %w", docType, err)
+		return nil, fmt.Errorf("failed to parse document JSON: %w", err)
+	}
+
+	// Resolve the document type from the payload when not supplied by the caller.
+	if docType == "" {
+		docType, _ = doc["type"].(string)
+	}
+	if docType == "" {
+		return nil, fmt.Errorf("document type is required: use --type or include a \"type\" field in the payload")
 	}
 
 	// Extract and validate content - handle round-trippable format from 'get' command
@@ -39,6 +52,11 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 
 	id, hasID := doc["id"].(string)
 	if !hasID || id == "" {
+		// No ID provided. Update semantics require a target ID.
+		if opts.RequireExisting {
+			return nil, fmt.Errorf("cannot update %s without an id: provide --id or include an \"id\" field", docType)
+		}
+
 		// No ID provided - create new document
 		// Safety check for create operation
 		if err := a.checkSafety(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
@@ -81,6 +99,11 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 	// Check if document exists
 	metadata, err := handler.GetMetadata(id)
 	if err != nil {
+		// Update semantics: do not silently create a document that does not exist.
+		if opts.RequireExisting {
+			return nil, fmt.Errorf("%s %q not found (use 'dtctl create document' to create it): %w", docType, id, err)
+		}
+
 		// Document doesn't exist, create it
 		// Safety check for create operation
 		if err := a.checkSafety(safety.OperationCreate, safety.OwnershipUnknown); err != nil {
@@ -172,9 +195,12 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 	return a.buildDocumentResult(ActionUpdated, docType, resultID, resultName, tileCount, resultWarnings), nil
 }
 
-// buildDocumentResult constructs the appropriate document result type based on docType
+// buildDocumentResult constructs the appropriate document result type based on docType.
+// Custom document types (anything other than dashboard/notebook) map to the generic
+// DocumentApplyResult so the emitted resourceType reflects the real type.
 func (a *Applier) buildDocumentResult(action, docType, id, name string, itemCount int, warnings []string) ApplyResult {
-	if docType == "notebook" {
+	switch docType {
+	case "notebook":
 		return &NotebookApplyResult{
 			ApplyResultBase: ApplyResultBase{
 				Action:       action,
@@ -186,17 +212,29 @@ func (a *Applier) buildDocumentResult(action, docType, id, name string, itemCoun
 			URL:          a.documentURL(docType, id),
 			SectionCount: itemCount,
 		}
-	}
-	return &DashboardApplyResult{
-		ApplyResultBase: ApplyResultBase{
-			Action:       action,
-			ResourceType: "dashboard",
-			ID:           id,
-			Name:         name,
-			Warnings:     warnings,
-		},
-		URL:       a.documentURL(docType, id),
-		TileCount: itemCount,
+	case "dashboard":
+		return &DashboardApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       action,
+				ResourceType: "dashboard",
+				ID:           id,
+				Name:         name,
+				Warnings:     warnings,
+			},
+			URL:       a.documentURL(docType, id),
+			TileCount: itemCount,
+		}
+	default:
+		return &DocumentApplyResult{
+			ApplyResultBase: ApplyResultBase{
+				Action:       action,
+				ResourceType: docType,
+				ID:           id,
+				Name:         name,
+				Warnings:     warnings,
+			},
+			URL: a.documentURL(docType, id),
+		}
 	}
 }
 
@@ -367,9 +405,9 @@ func (a *Applier) documentURL(docType, id string) string {
 	}
 }
 
-// dryRunDocument performs dry-run validation for dashboard/notebook documents
-func (a *Applier) dryRunDocument(resourceType ResourceType, doc map[string]interface{}) (ApplyResult, error) {
-	docType := string(resourceType)
+// dryRunDocument performs dry-run validation for a document of any type
+// (dashboard, notebook, or a custom type).
+func (a *Applier) dryRunDocument(docType string, doc map[string]interface{}) (ApplyResult, error) {
 	id, _ := doc["id"].(string)
 
 	// Use the same extraction/validation logic as apply

--- a/pkg/apply/apply_document.go
+++ b/pkg/apply/apply_document.go
@@ -35,9 +35,14 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 	// Extract and validate content - handle round-trippable format from 'get' command
 	contentData, name, description, validationWarnings := extractDocumentContent(doc, docType)
 
-	// Labels ride along in the exported document ('get document -o json'), so a
-	// round-trip apply preserves (and can update) them.
-	labels := extractDocumentLabels(doc)
+	// Labels come from --label flags (opts.Labels) when supplied; otherwise they
+	// ride along in the exported document ('get document -o json') so a round-trip
+	// apply preserves (and can update) them. An empty opts.Labels (the flag's
+	// zero value when --label is absent) falls back to the payload.
+	labels := opts.Labels
+	if len(labels) == 0 {
+		labels = extractDocumentLabels(doc)
+	}
 
 	// Show validation warnings on stderr and collect for result
 	var resultWarnings []string
@@ -93,7 +98,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 			applyWriteBack(a.sourceFile, resultID, docType, opts.WriteID, false, &resultWarnings)
 		}
 
-		return a.buildDocumentResult(ActionCreated, docType, resultID, resultName, tileCount, resultWarnings), nil
+		return a.buildDocumentResult(ActionCreated, docType, resultID, resultName, tileCount, resultWarnings, labels), nil
 	}
 
 	// Check if document exists
@@ -101,7 +106,12 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 	if err != nil {
 		// Update semantics: do not silently create a document that does not exist.
 		if opts.RequireExisting {
-			return nil, fmt.Errorf("%s %q not found (use 'dtctl create document' to create it): %w", docType, id, err)
+			// Distinguish a genuine 404 from transient/auth/other failures so the
+			// "create it instead" hint isn't shown for errors that aren't a 404.
+			if document.IsNotFound(err) {
+				return nil, fmt.Errorf("%s %q not found (use 'dtctl create document' to create it)", docType, id)
+			}
+			return nil, fmt.Errorf("cannot verify %s %q for update: %w", docType, id, err)
 		}
 
 		// Document doesn't exist, create it
@@ -150,7 +160,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 		fileAlreadyHasID := !isUUID(id) // non-UUID id was in the file and is preserved
 		applyWriteBack(a.sourceFile, resultID, docType, opts.WriteID, fileAlreadyHasID, &resultWarnings)
 
-		return a.buildDocumentResult(ActionCreated, docType, resultID, resultName, tileCount, resultWarnings), nil
+		return a.buildDocumentResult(ActionCreated, docType, resultID, resultName, tileCount, resultWarnings, labels), nil
 	}
 
 	// Safety check for update operation - determine ownership from metadata
@@ -192,13 +202,14 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 		resultID = id
 	}
 
-	return a.buildDocumentResult(ActionUpdated, docType, resultID, resultName, tileCount, resultWarnings), nil
+	return a.buildDocumentResult(ActionUpdated, docType, resultID, resultName, tileCount, resultWarnings, labels), nil
 }
 
 // buildDocumentResult constructs the appropriate document result type based on docType.
 // Custom document types (anything other than dashboard/notebook) map to the generic
-// DocumentApplyResult so the emitted resourceType reflects the real type.
-func (a *Applier) buildDocumentResult(action, docType, id, name string, itemCount int, warnings []string) ApplyResult {
+// DocumentApplyResult so the emitted resourceType reflects the real type. labels are
+// surfaced on the custom-document result so a round-trip apply confirms what was set.
+func (a *Applier) buildDocumentResult(action, docType, id, name string, itemCount int, warnings, labels []string) ApplyResult {
 	switch docType {
 	case "notebook":
 		return &NotebookApplyResult{
@@ -233,7 +244,8 @@ func (a *Applier) buildDocumentResult(action, docType, id, name string, itemCoun
 				Name:         name,
 				Warnings:     warnings,
 			},
-			URL: a.documentURL(docType, id),
+			URL:    a.documentURL(docType, id),
+			Labels: labels,
 		}
 	}
 }

--- a/pkg/apply/apply_document_custom_test.go
+++ b/pkg/apply/apply_document_custom_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -243,6 +244,54 @@ func TestApply_RequireExisting_NoID(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "without an id") {
 		t.Errorf("expected 'without an id' error, got %v", err)
+	}
+}
+
+// TestApply_OptsLabels_OverridePayload verifies that labels supplied via
+// ApplyOptions (the --label flag) replace labels embedded in the payload on
+// update, and are surfaced on the returned DocumentApplyResult.
+func TestApply_OptsLabels_OverridePayload(t *testing.T) {
+	const id = "acme-cfg-2"
+	var patchLabels []string
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/document/v1/documents/" + id + "/metadata": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": id, "name": "My Config", "type": "acme:config", "version": 2,
+			})
+		},
+		"/platform/document/v1/documents/" + id: func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatalf("ParseMultipartForm: %v", err)
+			}
+			patchLabels = r.MultipartForm.Value["labels"]
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": id, "name": "My Config", "type": "acme:config", "version": 3,
+			})
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	// Payload carries labels [old]; --label (opts.Labels) should win.
+	payload := `{"id":"` + id + `","type":"acme:config","labels":["old"],"settings":{"enabled":true}}`
+	results, err := a.Apply([]byte(payload), ApplyOptions{Labels: []string{"team-a", "env:prod"}})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if want := []string{"team-a", "env:prod"}; !reflect.DeepEqual(patchLabels, want) {
+		t.Errorf("labels sent on update = %v, want %v (opts.Labels must override payload)", patchLabels, want)
+	}
+	res, ok := results[0].(*DocumentApplyResult)
+	if !ok {
+		t.Fatalf("expected *DocumentApplyResult, got %T", results[0])
+	}
+	if want := []string{"team-a", "env:prod"}; !reflect.DeepEqual(res.Labels, want) {
+		t.Errorf("result labels = %v, want %v", res.Labels, want)
 	}
 }
 

--- a/pkg/apply/apply_document_custom_test.go
+++ b/pkg/apply/apply_document_custom_test.go
@@ -1,0 +1,265 @@
+package apply
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestDetectResourceType_CustomDocument covers the generic-document detection
+// added for issue #390: any object carrying a non-empty custom "type" field is
+// treated as a document so it can be round-tripped through apply/update.
+func TestDetectResourceType_CustomDocument(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected ResourceType
+		wantErr  bool
+	}{
+		{
+			name:     "custom type only",
+			input:    `{"type":"acme:config","settings":{"enabled":true}}`,
+			expected: ResourceDocument,
+		},
+		{
+			name:     "custom type with content wrapper (get -o json round-trip)",
+			input:    `{"id":"acme-1","name":"cfg","type":"acme:config","content":{"foo":"bar"},"version":3}`,
+			expected: ResourceDocument,
+		},
+		{
+			name:     "custom type with metadata field",
+			input:    `{"metadata":{"name":"x"},"type":"acme:config"}`,
+			expected: ResourceDocument,
+		},
+		{
+			name:     "launchpad document",
+			input:    `{"type":"launchpad","content":{"widgets":[]}}`,
+			expected: ResourceDocument,
+		},
+		{
+			name:     "built-in dashboard type still wins",
+			input:    `{"type":"dashboard","content":{"tiles":{}}}`,
+			expected: ResourceDashboard,
+		},
+		{
+			name:     "built-in notebook type still wins",
+			input:    `{"type":"notebook","content":{"sections":[]}}`,
+			expected: ResourceNotebook,
+		},
+		{
+			name:     "empty type is not a document",
+			input:    `{"type":"","foo":"bar"}`,
+			expected: ResourceUnknown,
+			wantErr:  true,
+		},
+		{
+			name:     "no type and no known markers still unknown",
+			input:    `{"random":"field"}`,
+			expected: ResourceUnknown,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, isArray, err := detectResourceType([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got type %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if isArray {
+				t.Errorf("expected isArray=false")
+			}
+			if got != tt.expected {
+				t.Errorf("detectResourceType = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// docContentServer builds a test server exposing the documents create endpoint
+// and, optionally, a metadata + update endpoint for an existing document.
+func customDocMultipartCreateResponse(w http.ResponseWriter, id, name, docType string) {
+	boundary := "resp-boundary"
+	w.Header().Set("Content-Type", fmt.Sprintf("multipart/form-data; boundary=%s", boundary))
+	fmt.Fprintf(w,
+		"--%s\r\nContent-Disposition: form-data; name=\"metadata\"\r\nContent-Type: application/json\r\n\r\n{\"id\":%q,\"name\":%q,\"type\":%q,\"version\":1}\r\n--%s--\r\n",
+		boundary, id, name, docType, boundary)
+}
+
+// TestApply_CustomDocumentCreate applies a custom-typed document with no ID and
+// asserts it is created as a generic DocumentApplyResult carrying the real type.
+func TestApply_CustomDocumentCreate(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/document/v1/documents": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			customDocMultipartCreateResponse(w, "acme-new-1", "My Config", "acme:config")
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	docJSON := `{"type":"acme:config","name":"My Config","settings":{"enabled":true}}`
+	results, err := a.Apply([]byte(docJSON), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() custom document create error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	res, ok := results[0].(*DocumentApplyResult)
+	if !ok {
+		t.Fatalf("expected *DocumentApplyResult, got %T", results[0])
+	}
+	if res.Action != ActionCreated {
+		t.Errorf("expected action %q, got %q", ActionCreated, res.Action)
+	}
+	if res.ResourceType != "acme:config" {
+		t.Errorf("expected resourceType %q, got %q", "acme:config", res.ResourceType)
+	}
+	if res.ID != "acme-new-1" {
+		t.Errorf("expected id %q, got %q", "acme-new-1", res.ID)
+	}
+}
+
+// TestApply_CustomDocumentUpdate updates an existing custom document by supplying
+// --type and --id explicitly (payload carries only the raw content).
+func TestApply_CustomDocumentUpdate(t *testing.T) {
+	const id = "acme-cfg-1"
+	patched := false
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/document/v1/documents/" + id + "/metadata": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":      id,
+				"name":    "My Config",
+				"type":    "acme:config",
+				"version": 4,
+				"owner":   "someone-else",
+			})
+		},
+		"/platform/document/v1/documents/" + id: func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPatch {
+				t.Errorf("expected PATCH, got %s", r.Method)
+			}
+			if v := r.URL.Query().Get("optimistic-locking-version"); v != "4" {
+				t.Errorf("expected optimistic-locking-version=4, got %q", v)
+			}
+			patched = true
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":      id,
+				"name":    "My Config",
+				"type":    "acme:config",
+				"version": 5,
+			})
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	// Raw content payload with no embedded type/id — supplied via options.
+	docJSON := `{"settings":{"enabled":false}}`
+	results, err := a.Apply([]byte(docJSON), ApplyOptions{Type: "acme:config", OverrideID: id})
+	if err != nil {
+		t.Fatalf("Apply() custom document update error = %v", err)
+	}
+	if !patched {
+		t.Error("expected PATCH to be issued")
+	}
+	res, ok := results[0].(*DocumentApplyResult)
+	if !ok {
+		t.Fatalf("expected *DocumentApplyResult, got %T", results[0])
+	}
+	if res.Action != ActionUpdated {
+		t.Errorf("expected action %q, got %q", ActionUpdated, res.Action)
+	}
+	if res.ResourceType != "acme:config" {
+		t.Errorf("expected resourceType %q, got %q", "acme:config", res.ResourceType)
+	}
+}
+
+// TestApply_RequireExisting_NotFound asserts that update-only semantics fail
+// (instead of creating) when the target document does not exist.
+func TestApply_RequireExisting_NotFound(t *testing.T) {
+	const id = "missing-doc"
+	postCalled := false
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/document/v1/documents/" + id + "/metadata": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		},
+		"/platform/document/v1/documents": func(w http.ResponseWriter, r *http.Request) {
+			postCalled = true
+			w.WriteHeader(http.StatusOK)
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	docJSON := `{"settings":{"enabled":false}}`
+	_, err := a.Apply([]byte(docJSON), ApplyOptions{Type: "acme:config", OverrideID: id, RequireExisting: true})
+	if err == nil {
+		t.Fatal("expected error for RequireExisting on missing document, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got %v", err)
+	}
+	if postCalled {
+		t.Error("update-only apply must not fall back to creating the document")
+	}
+}
+
+// TestApply_RequireExisting_NoID fails fast when no target ID can be resolved.
+func TestApply_RequireExisting_NoID(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	_, err := a.Apply([]byte(`{"settings":{}}`), ApplyOptions{Type: "acme:config", RequireExisting: true})
+	if err == nil {
+		t.Fatal("expected error when updating without an id, got nil")
+	}
+	if !strings.Contains(err.Error(), "without an id") {
+		t.Errorf("expected 'without an id' error, got %v", err)
+	}
+}
+
+// TestApply_TypeFlag_RejectsArray ensures --type cannot be combined with array input.
+func TestApply_TypeFlag_RejectsArray(t *testing.T) {
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+	_, err := a.Apply([]byte(`[{"type":"acme:config"}]`), ApplyOptions{Type: "acme:config"})
+	if err == nil {
+		t.Fatal("expected error for --type with array input, got nil")
+	}
+	if !strings.Contains(err.Error(), "array") {
+		t.Errorf("expected array-related error, got %v", err)
+	}
+}

--- a/pkg/apply/result.go
+++ b/pkg/apply/result.go
@@ -44,6 +44,13 @@ type NotebookApplyResult struct {
 	SectionCount    int    `json:"sectionCount,omitempty" yaml:"sectionCount,omitempty" table:"SECTIONS"`
 }
 
+// DocumentApplyResult is the result of applying a document of a custom type
+// (any type other than dashboard or notebook, e.g. "launchpad" or "acme:config").
+type DocumentApplyResult struct {
+	ApplyResultBase `yaml:",inline"`
+	URL             string `json:"url,omitempty" yaml:"url,omitempty" table:"URL,wide"`
+}
+
 // SLOApplyResult is the result of applying an SLO resource.
 type SLOApplyResult struct {
 	ApplyResultBase `yaml:",inline"`

--- a/pkg/apply/result.go
+++ b/pkg/apply/result.go
@@ -48,7 +48,8 @@ type NotebookApplyResult struct {
 // (any type other than dashboard or notebook, e.g. "launchpad" or "acme:config").
 type DocumentApplyResult struct {
 	ApplyResultBase `yaml:",inline"`
-	URL             string `json:"url,omitempty" yaml:"url,omitempty" table:"URL,wide"`
+	URL             string   `json:"url,omitempty"    yaml:"url,omitempty"    table:"URL,wide"`
+	Labels          []string `json:"labels,omitempty" yaml:"labels,omitempty" table:"-"`
 }
 
 // SLOApplyResult is the result of applying an SLO resource.

--- a/pkg/resources/document/document.go
+++ b/pkg/resources/document/document.go
@@ -330,6 +330,12 @@ func (h *Handler) GetMetadata(id string) (*DocumentMetadata, error) {
 	return h.sdk.GetMetadata(context.Background(), id)
 }
 
+// IsNotFound reports whether err indicates the document does not exist (HTTP 404),
+// as opposed to a transient, auth, or other failure.
+func IsNotFound(err error) bool {
+	return errors.Is(err, httpclient.ErrNotFound)
+}
+
 // GetRaw retrieves a document's content as raw bytes.
 func (h *Handler) GetRaw(id string) ([]byte, error) {
 	doc, err := h.sdk.Get(context.Background(), id)


### PR DESCRIPTION
Fixes #390.

## Problem

`dtctl create document --type <custom:type>` can create a document of any type, but there was no CLI path to **update** one afterward:

- `apply` rejected `--type` (`unknown flag --type`)
- `apply -f doc.json` with an embedded custom `type` failed with `could not detect resource type from file content`
- `update document` did not exist (`unknown resource type "document"`)

So custom document types were first-class on `create` but read-only thereafter — the documented `get -o json` → edit → `apply` round-trip did not work for them.

## Changes

- **Generic document detection** (`pkg/apply`): an object with a non-empty custom `type` field is now recognized as a document (`ResourceDocument`). Kept as a last-resort fallback so every specific resource detector (workflow, SLO, settings, segment, …) still takes precedence. The exported `get document -o json` shape (`type` + `content`) is detected automatically.
- **`apply --type <type>`**: forces the file to be applied as a document of that type, bypassing content-based detection (so a custom document whose content happens to carry e.g. a `tasks` field is not misclassified). Rejected for array input.
- **`dtctl update document -f <file> [--type <type>] [--id <id>]`**: the update-only counterpart to `create document`. Type resolves from `--type` then the payload; ID from `--id` then the payload. Unlike `apply`, it **fails instead of silently creating** when the target does not exist, so a typo in the ID never creates a stray document.
- **`DocumentApplyResult`**: custom types now report their real `resourceType` instead of defaulting to `dashboard`.

Both entry points reuse the existing applier, so ownership-aware safety checks, dry-run, `--show-diff`, template rendering (`--set`), and `-o json/yaml/agent` output behave identically to dashboard/notebook applies.

## Examples

```bash
# Round-trip a custom document type (use -o yaml — see follow-up note below)
dtctl get document acme-config -o yaml > doc.yaml
# edit doc.yaml...
dtctl apply -f doc.yaml                 # updates, type auto-detected
dtctl update document -f doc.yaml       # update-only counterpart

# Explicit type + id for a raw-content file
dtctl apply -f content.json --type acme:config --id acme-config
dtctl update document -f content.json --type acme:config --id acme-config
```

## Tests

- Detection table for custom/launchpad types (and that empty/absent `type` still yields "unknown").
- Integration tests (mock Documents API) for custom-document create, update, update-only "not found" failure, missing-id failure, and `--type` + array rejection.
- `cmd`-level tests for `update document` registration/alias and the required `--file` flag.

`go build ./...`, `go vet ./...`, `go test ./pkg/apply/... ./cmd/... ./pkg/output/...` all pass.

---

## Update — rebased onto #395 (document labels) + follow-up improvements

Rebased cleanly onto `main` now that #395 (document label write support) is merged, and tied the two features together so the combined document story is symmetric:

- **Label parity across write paths.** New `ApplyOptions.Labels`, wired to a repeatable `--label` flag on both `apply` and `update document`, so custom document types get the same label control `create document` already has. An explicit `--label` replaces the label set; when omitted, labels embedded in an exported document still round-trip through untouched.
- **Agent-mode suggestions for custom documents.** `DocumentApplyResult` is now handled in `extractApplyBase`, so applying a custom-typed document in `--agent` mode emits create/update suggestions instead of silently producing none.
- **Applied labels surfaced.** `DocumentApplyResult` now reports `labels` (json/yaml) so a round-trip apply confirms what was set.
- **Precise update-only error.** The `RequireExisting` "not found" hint now fires only on a genuine 404 (via `document.IsNotFound`); transient/auth failures report `cannot verify … for update` instead of misleadingly suggesting the doc doesn't exist.

Added tests: `opts.Labels` overrides payload labels on update, `DocumentApplyResult` in the agent-helper and apply-flag tables, and `--label` registration on `update document`. `go build`, `go vet`, `gofmt`, both module test suites, and golden tests all pass.

---

## Update — review follow-up (docs + custom-type polish)

Addressing review findings, verified end-to-end against a live dev tenant:

- **Round-trip examples use `-o yaml`, not `-o json`.** `get … -o json` wraps output in the `{ok,result,context}` envelope, which `apply`/`update` cannot read back (`could not detect resource type from file content`); YAML is emitted as the plain document. Fixed across the `apply`, `update document`, and `create document` help text and code comments, with an explicit note explaining why.
- **GitHub Pages coverage.** New **Documents (any type)** docs page covering custom types, the `apply` vs `update document` distinction, the YAML round-trip, and the full labels story; added to the sidebar nav and cross-linked from Dashboards & Notebooks.
- **Labels are replace-only / cannot be cleared.** Documented in the `apply` and `update document` help, the `--label` flag descriptions, and the docs page.
- **No bogus URL for custom types.** Custom document types no longer emit a broken guess like `…/ui/apps/dynatrace.acme:configs/acme:config/<id>` — fixed in both the applier and the `create document` printer (dashboards/notebooks still show their real URLs).
- **Dry-run item label.** Custom-type dry-runs report a generic `itemType: items` instead of borrowing notebook `sections`.

Updated the two unit tests that pinned the old URL/item-name behavior. `gofmt`, `go vet`, `go build ./...`, and the full test suites in both modules (incl. golden) pass.
