### PR TITLE
feat(sdk/document): support writing document labels on create and update

### DIFF
--- a/cmd/create_documents.go
+++ b/cmd/create_documents.go
@@ -25,12 +25,20 @@ The document type must be provided via --type or included as a "type" field in
 the payload. This command works for any document type: dashboard, notebook,
 launchpad, custom app documents, etc.
 
+Labels can be attached with repeatable --label flags, or carried in the payload
+under a "labels" array (as produced by 'dtctl get document -o json'). Because
+the create API cannot set labels directly, they are applied with a follow-up
+update immediately after creation.
+
 Examples:
   # Create a launchpad document from JSON
   dtctl create document -f launchpad.json --type launchpad
 
   # Create from a payload that already contains a "type" field
   dtctl create document -f my-app-config.yaml
+
+  # Create with classification labels
+  dtctl create document -f config.yaml --type my-app:config --label team-a --label env:prod
 
   # Create with template variables
   dtctl create document -f config.yaml --type my-app:config --set env=prod
@@ -149,6 +157,7 @@ func createDocumentRunE(docType string) func(cmd *cobra.Command, args []string) 
 		description, _ := cmd.Flags().GetString("description")
 		id, _ := cmd.Flags().GetString("id")
 		setFlags, _ := cmd.Flags().GetStringArray("set")
+		labels, _ := cmd.Flags().GetStringArray("label")
 
 		// Read the file
 		fileData, err := os.ReadFile(file)
@@ -183,6 +192,12 @@ func createDocumentRunE(docType string) func(cmd *cobra.Command, args []string) 
 
 		// Extract content, name, description using the same logic as apply
 		contentData, extractedName, extractedDesc, warnings := extractDocumentContent(doc, docType)
+
+		// Fall back to labels embedded in the payload (e.g. from 'get -o json')
+		// when none were supplied via --label.
+		if len(labels) == 0 {
+			labels = extractDocumentLabels(doc)
+		}
 
 		// Show validation warnings
 		for _, w := range warnings {
@@ -244,6 +259,7 @@ func createDocumentRunE(docType string) func(cmd *cobra.Command, args []string) 
 			Type:        docType,
 			Description: description,
 			Content:     contentData,
+			Labels:      labels,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create %s: %w", docType, err)
@@ -337,6 +353,23 @@ func extractDocumentContent(doc map[string]interface{}, docType string) ([]byte,
 	return contentData, name, description, warnings
 }
 
+// extractDocumentLabels pulls a "labels" string array from a parsed document
+// payload (as produced by 'dtctl get document -o json'). Non-string entries are
+// skipped. Returns nil when no usable labels are present.
+func extractDocumentLabels(doc map[string]interface{}) []string {
+	raw, ok := doc["labels"].([]interface{})
+	if !ok {
+		return nil
+	}
+	var labels []string
+	for _, v := range raw {
+		if s, ok := v.(string); ok && s != "" {
+			labels = append(labels, s)
+		}
+	}
+	return labels
+}
+
 // countDocumentItems counts tiles (for dashboards) or sections (for notebooks)
 func countDocumentItems(contentData []byte, docType string) int {
 	var content map[string]interface{}
@@ -388,6 +421,7 @@ func init() {
 	createDocumentCmd.Flags().String("description", "", "description for the document")
 	createDocumentCmd.Flags().String("id", "", "custom ID for the document (auto-generated if not provided)")
 	createDocumentCmd.Flags().StringArray("set", []string{}, "set template variable (key=value)")
+	createDocumentCmd.Flags().StringArray("label", []string{}, "classification label to attach (repeatable); falls back to labels in the payload")
 	_ = createDocumentCmd.MarkFlagRequired("file")
 
 	// Notebook flags

--- a/cmd/create_documents_labels_test.go
+++ b/cmd/create_documents_labels_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCreateDocumentLabelFlag(t *testing.T) {
+	if createDocumentCmd.Flags().Lookup("label") == nil {
+		t.Fatal("create document is missing the --label flag")
+	}
+}
+
+func TestExtractDocumentLabels_Cmd(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  map[string]interface{}
+		want []string
+	}{
+		{"absent", map[string]interface{}{}, nil},
+		{"strings", map[string]interface{}{"labels": []interface{}{"a", "b"}}, []string{"a", "b"}},
+		{"skips blanks and non-strings", map[string]interface{}{"labels": []interface{}{"a", "", 3, "b"}}, []string{"a", "b"}},
+		{"wrong type", map[string]interface{}{"labels": "a,b"}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractDocumentLabels(tt.doc); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractDocumentLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/apply/apply_document.go
+++ b/pkg/apply/apply_document.go
@@ -22,6 +22,10 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 	// Extract and validate content - handle round-trippable format from 'get' command
 	contentData, name, description, validationWarnings := extractDocumentContent(doc, docType)
 
+	// Labels ride along in the exported document ('get document -o json'), so a
+	// round-trip apply preserves (and can update) them.
+	labels := extractDocumentLabels(doc)
+
 	// Show validation warnings on stderr and collect for result
 	var resultWarnings []string
 	for _, w := range validationWarnings {
@@ -50,6 +54,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 			Type:        docType,
 			Description: description,
 			Content:     contentData,
+			Labels:      labels,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create %s: %w", docType, err)
@@ -100,6 +105,7 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 			Type:        docType,
 			Description: description,
 			Content:     contentData,
+			Labels:      labels,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create %s: %w", docType, err)
@@ -138,8 +144,14 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 		}
 	}
 
-	// Update the existing document (including metadata if name or description provided)
-	result, err := handler.UpdateWithMetadata(id, metadata.Version, contentData, "application/json", name, description)
+	// Update the existing document (including metadata/labels if provided).
+	result, err := handler.UpdateDocument(id, metadata.Version, document.UpdateRequest{
+		Content:     contentData,
+		ContentType: "application/json",
+		Name:        name,
+		Description: description,
+		Labels:      labels,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply %s: %w", docType, err)
 	}
@@ -186,6 +198,24 @@ func (a *Applier) buildDocumentResult(action, docType, id, name string, itemCoun
 		URL:       a.documentURL(docType, id),
 		TileCount: itemCount,
 	}
+}
+
+// extractDocumentLabels pulls a "labels" string array from a parsed document
+// payload (as produced by 'dtctl get document -o json'). Non-string entries are
+// skipped; nil is returned when no usable labels are present so the update path
+// treats it as "no change".
+func extractDocumentLabels(doc map[string]interface{}) []string {
+	raw, ok := doc["labels"].([]interface{})
+	if !ok {
+		return nil
+	}
+	var labels []string
+	for _, v := range raw {
+		if s, ok := v.(string); ok && s != "" {
+			labels = append(labels, s)
+		}
+	}
+	return labels
 }
 
 // extractDocumentContent extracts the content from a document, handling various input formats

--- a/pkg/apply/apply_document_labels_test.go
+++ b/pkg/apply/apply_document_labels_test.go
@@ -1,0 +1,85 @@
+package apply
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+// TestApply_DocumentUpdate_PreservesLabels verifies that labels embedded in an
+// exported document payload are sent through on a round-trip apply update.
+func TestApply_DocumentUpdate_PreservesLabels(t *testing.T) {
+	var patchLabels []string
+	patched := false
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/document/v1/documents/dash-1/metadata": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": "dash-1", "name": "Dash", "type": "dashboard", "version": 3,
+			})
+		},
+		"/platform/document/v1/documents/dash-1": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPatch {
+				t.Errorf("expected PATCH, got %s", r.Method)
+			}
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatalf("ParseMultipartForm: %v", err)
+			}
+			patchLabels = r.MultipartForm.Value["labels"]
+			patched = true
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": "dash-1", "name": "Dash", "type": "dashboard", "version": 4,
+				"labels": []string{"team-a", "env:prod"},
+			})
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	payload := `{"id":"dash-1","type":"dashboard","labels":["team-a","env:prod"],"content":{"tiles":{},"version":"1"}}`
+	results, err := a.Apply([]byte(payload), ApplyOptions{})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if !patched {
+		t.Fatal("expected PATCH to be issued")
+	}
+	if want := []string{"team-a", "env:prod"}; !reflect.DeepEqual(patchLabels, want) {
+		t.Errorf("labels sent on update = %v, want %v", patchLabels, want)
+	}
+	res, ok := results[0].(*DashboardApplyResult)
+	if !ok {
+		t.Fatalf("expected *DashboardApplyResult, got %T", results[0])
+	}
+	if res.Action != ActionUpdated {
+		t.Errorf("expected updated action, got %q", res.Action)
+	}
+}
+
+// TestExtractDocumentLabels covers label extraction from a parsed payload,
+// including non-string skipping and the absent-key case.
+func TestExtractDocumentLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  map[string]interface{}
+		want []string
+	}{
+		{"absent", map[string]interface{}{}, nil},
+		{"empty", map[string]interface{}{"labels": []interface{}{}}, nil},
+		{"strings", map[string]interface{}{"labels": []interface{}{"a", "b"}}, []string{"a", "b"}},
+		{"skips non-strings and blanks", map[string]interface{}{"labels": []interface{}{"a", 1, "", "b"}}, []string{"a", "b"}},
+		{"wrong type", map[string]interface{}{"labels": "a,b"}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractDocumentLabels(tt.doc); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractDocumentLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resources/document/document.go
+++ b/pkg/resources/document/document.go
@@ -251,6 +251,7 @@ type (
 	ShareInfo                     = sdkdocument.ShareInfo
 	UserContext                   = sdkdocument.UserContext
 	CreateRequest                 = sdkdocument.CreateRequest
+	UpdateRequest                 = sdkdocument.UpdateRequest
 	SsoEntity                     = sdkdocument.SsoEntity
 	CreateDirectShareRequest      = sdkdocument.CreateDirectShareRequest
 	CreateEnvironmentShareRequest = sdkdocument.CreateEnvironmentShareRequest
@@ -364,6 +365,17 @@ func (h *Handler) Update(id string, version int, content []byte, contentType str
 // UpdateWithMetadata updates a document's content and optionally its metadata (name, description).
 func (h *Handler) UpdateWithMetadata(id string, version int, content []byte, contentType string, name string, description string) (*Document, error) {
 	d, err := h.sdk.UpdateWithMetadata(context.Background(), id, version, content, contentType, name, description)
+	if err != nil {
+		return nil, err
+	}
+	return fromSDKDocument(d), nil
+}
+
+// UpdateDocument performs a partial update of a document (content, name,
+// description, and/or labels). It is the general form behind Update /
+// UpdateWithMetadata and the only write path that can set labels.
+func (h *Handler) UpdateDocument(id string, version int, req UpdateRequest) (*Document, error) {
+	d, err := h.sdk.UpdateDocument(context.Background(), id, version, req)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/api/document/document.go
+++ b/sdk/api/document/document.go
@@ -307,11 +307,26 @@ func (h *Handler) Delete(ctx context.Context, id string, version int) error {
 
 // CreateRequest contains the data needed to create a new document
 type CreateRequest struct {
-	ID          string // Optional - if not provided, system generates one
-	Name        string // Required
-	Type        string // Required - e.g., "dashboard", "notebook"
-	Description string // Optional
-	Content     []byte // Required - the document content
+	ID          string   // Optional - if not provided, system generates one
+	Name        string   // Required
+	Type        string   // Required - e.g., "dashboard", "notebook"
+	Description string   // Optional
+	Content     []byte   // Required - the document content
+	Labels      []string // Optional - classification labels stored in document metadata
+}
+
+// addLabelParts appends each label as its own "labels" multipart form field.
+// The Documents API models labels on write as a repeated form field — one part
+// per label, value taken verbatim — the symmetric counterpart to the JSON array
+// returned on read. Providing labels replaces the document's full label set;
+// omitting them (nil/empty slice) leaves existing labels untouched.
+//
+// SetMultipartField (rather than FormData.Add) is used so that a labels-only
+// update still switches the request into multipart mode.
+func addLabelParts(r *resty.Request, labels []string) {
+	for _, l := range labels {
+		r.SetMultipartField("labels", "", "", strings.NewReader(l))
+	}
 }
 
 // Create creates a new document
@@ -369,51 +384,72 @@ func (h *Handler) Create(ctx context.Context, req CreateRequest) (*Document, err
 		doc.Type = req.Type
 	}
 
+	// The create endpoint does not accept labels, so apply them with a follow-up
+	// update once the document (and its version) exist. This is not atomic: on
+	// failure the document is already created, so the error names it explicitly.
+	if len(req.Labels) > 0 {
+		labeled, err := h.UpdateDocument(ctx, doc.ID, doc.Version, UpdateRequest{Labels: req.Labels})
+		if err != nil {
+			return doc, fmt.Errorf("document %q created but setting labels failed: %w", doc.ID, err)
+		}
+		return labeled, nil
+	}
+
 	return doc, nil
 }
 
-// Update updates a document's content
-func (h *Handler) Update(ctx context.Context, id string, version int, content []byte, contentType string) (*Document, error) {
-	if contentType == "" {
-		contentType = "application/json"
-	}
-
-	resp, err := h.client.HTTP().R().SetContext(ctx).
-		SetQueryParam("optimistic-locking-version", fmt.Sprintf("%d", version)).
-		SetMultipartField("content", "content", contentType, bytes.NewReader(content)).
-		Patch(fmt.Sprintf("/platform/document/v1/documents/%s", id))
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to update document: %w", err)
-	}
-
-	if err := httpclient.CheckResponse(resp); err != nil {
-		return nil, fmt.Errorf("failed to update document %q: %w", id, err)
-	}
-
-	return parseUpdateResponse(resp, id, version+1, "")
+// UpdateRequest contains the (all optional) fields that can be changed on an
+// existing document via updateDocument. Any zero-valued field is omitted from
+// the request and the API leaves the corresponding attribute unchanged. A
+// non-empty Labels slice replaces the document's entire label set; an empty or
+// nil slice sends no labels, which the API also treats as "no change" (this
+// endpoint offers no way to clear labels).
+type UpdateRequest struct {
+	Content     []byte   // Document content; omitted when empty (content unchanged)
+	ContentType string   // Content-Type for Content; defaults to application/json
+	Name        string   // New name; omitted when empty
+	Description string   // New description; omitted when empty
+	Labels      []string // Replacement label set; omitted when empty
 }
 
-// UpdateWithMetadata updates a document's content and optionally its metadata (name, description)
+// Update updates a document's content.
+func (h *Handler) Update(ctx context.Context, id string, version int, content []byte, contentType string) (*Document, error) {
+	return h.UpdateDocument(ctx, id, version, UpdateRequest{Content: content, ContentType: contentType})
+}
+
+// UpdateWithMetadata updates a document's content and optionally its metadata (name, description).
 func (h *Handler) UpdateWithMetadata(ctx context.Context, id string, version int, content []byte, contentType string, name string, description string) (*Document, error) {
-	if contentType == "" {
-		contentType = "application/json"
-	}
+	return h.UpdateDocument(ctx, id, version, UpdateRequest{
+		Content:     content,
+		ContentType: contentType,
+		Name:        name,
+		Description: description,
+	})
+}
 
+// UpdateDocument performs a partial update of a document via the updateDocument
+// endpoint. It is the general form behind Update / UpdateWithMetadata and is the
+// only write path that can set labels (the create endpoint cannot).
+func (h *Handler) UpdateDocument(ctx context.Context, id string, version int, req UpdateRequest) (*Document, error) {
 	r := h.client.HTTP().R().SetContext(ctx).
-		SetQueryParam("optimistic-locking-version", fmt.Sprintf("%d", version)).
-		SetMultipartField("content", "content", contentType, bytes.NewReader(content))
+		SetQueryParam("optimistic-locking-version", fmt.Sprintf("%d", version))
 
-	// Add name and description if provided
-	if name != "" {
-		r.SetMultipartFormData(map[string]string{"name": name})
+	if len(req.Content) > 0 {
+		contentType := req.ContentType
+		if contentType == "" {
+			contentType = "application/json"
+		}
+		r.SetMultipartField("content", "content", contentType, bytes.NewReader(req.Content))
 	}
-	if description != "" {
-		r.SetMultipartFormData(map[string]string{"description": description})
+	if req.Name != "" {
+		r.SetMultipartFormData(map[string]string{"name": req.Name})
 	}
+	if req.Description != "" {
+		r.SetMultipartFormData(map[string]string{"description": req.Description})
+	}
+	addLabelParts(r, req.Labels)
 
 	resp, err := r.Patch(fmt.Sprintf("/platform/document/v1/documents/%s", id))
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to update document: %w", err)
 	}
@@ -422,7 +458,7 @@ func (h *Handler) UpdateWithMetadata(ctx context.Context, id string, version int
 		return nil, fmt.Errorf("failed to update document %q: %w", id, err)
 	}
 
-	return parseUpdateResponse(resp, id, version+1, name)
+	return parseUpdateResponse(resp, id, version+1, req.Name)
 }
 
 // parseUpdateResponse parses an update/create response that may be either
@@ -468,6 +504,7 @@ func metadataToDocument(m *DocumentMetadata) *Document {
 		IsPrivate:   m.IsPrivate,
 		Created:     m.ModificationInfo.CreatedTime,
 		Modified:    m.ModificationInfo.LastModifiedTime,
+		Labels:      m.Labels,
 	}
 }
 

--- a/sdk/api/document/document_labels_test.go
+++ b/sdk/api/document/document_labels_test.go
@@ -1,0 +1,215 @@
+package document
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// multipartLabels parses a multipart/form-data request and returns the values
+// of the repeated "labels" form field (the wire format the Documents API uses
+// for labels on write).
+func multipartLabels(t *testing.T, r *http.Request) []string {
+	t.Helper()
+	if err := r.ParseMultipartForm(1 << 20); err != nil {
+		t.Fatalf("ParseMultipartForm: %v", err)
+	}
+	return r.MultipartForm.Value["labels"]
+}
+
+func writeMetadata(w http.ResponseWriter, id string, version int, labels []string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(DocumentMetadata{
+		ID:      id,
+		Name:    "doc",
+		Type:    "acme:config",
+		Version: version,
+		Labels:  labels,
+	})
+}
+
+// TestUpdateDocument_SetsLabels asserts labels are sent as repeated verbatim
+// form fields and the returned document reflects them.
+func TestUpdateDocument_SetsLabels(t *testing.T) {
+	var gotLabels []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/documents/doc-1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if v := r.URL.Query().Get("optimistic-locking-version"); v != "4" {
+			t.Errorf("optimistic-locking-version = %q, want 4", v)
+		}
+		gotLabels = multipartLabels(t, r)
+		writeMetadata(w, "doc-1", 5, []string{"team-a", "env:prod"})
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	doc, err := h.UpdateDocument(context.Background(), "doc-1", 4, UpdateRequest{
+		Content: []byte(`{"k":"v"}`),
+		Labels:  []string{"team-a", "env:prod"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateDocument: %v", err)
+	}
+	if want := []string{"team-a", "env:prod"}; !reflect.DeepEqual(gotLabels, want) {
+		t.Errorf("wire labels = %v, want %v", gotLabels, want)
+	}
+	if !reflect.DeepEqual(doc.Labels, []string{"team-a", "env:prod"}) {
+		t.Errorf("returned labels = %v, want [team-a env:prod]", doc.Labels)
+	}
+}
+
+// TestUpdateDocument_LabelsOnly ensures a labels-only update still uses
+// multipart (no content/name) and carries the labels.
+func TestUpdateDocument_LabelsOnly(t *testing.T) {
+	var gotLabels []string
+	var contentType string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/documents/doc-2", func(w http.ResponseWriter, r *http.Request) {
+		contentType = r.Header.Get("Content-Type")
+		gotLabels = multipartLabels(t, r)
+		writeMetadata(w, "doc-2", 2, []string{"only"})
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.UpdateDocument(context.Background(), "doc-2", 1, UpdateRequest{Labels: []string{"only"}}); err != nil {
+		t.Fatalf("UpdateDocument: %v", err)
+	}
+	if !strings.HasPrefix(contentType, "multipart/") {
+		t.Errorf("Content-Type = %q, want multipart/form-data", contentType)
+	}
+	if want := []string{"only"}; !reflect.DeepEqual(gotLabels, want) {
+		t.Errorf("wire labels = %v, want %v", gotLabels, want)
+	}
+}
+
+// TestUpdateWithMetadata_NoLabels confirms the compatibility wrapper sends name
+// and description but no labels field.
+func TestUpdateWithMetadata_NoLabels(t *testing.T) {
+	var hasLabels bool
+	var gotName string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/documents/doc-3", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseMultipartForm(1 << 20)
+		_, hasLabels = r.MultipartForm.Value["labels"]
+		gotName = r.MultipartForm.Value["name"][0]
+		writeMetadata(w, "doc-3", 2, nil)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.UpdateWithMetadata(context.Background(), "doc-3", 1, []byte(`{}`), "application/json", "New Name", "desc"); err != nil {
+		t.Fatalf("UpdateWithMetadata: %v", err)
+	}
+	if hasLabels {
+		t.Error("UpdateWithMetadata must not send a labels field")
+	}
+	if gotName != "New Name" {
+		t.Errorf("name = %q, want New Name", gotName)
+	}
+}
+
+// TestCreate_WithLabels asserts create honors labels via a follow-up update:
+// the POST carries no labels, and a subsequent PATCH sets them.
+func TestCreate_WithLabels(t *testing.T) {
+	var postHadLabels bool
+	var patchLabels []string
+	patched := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/documents", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		_ = r.ParseMultipartForm(1 << 20)
+		_, postHadLabels = r.MultipartForm.Value["labels"]
+		writeMetadata(w, "new-1", 1, nil)
+	})
+	mux.HandleFunc("/platform/document/v1/documents/new-1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if v := r.URL.Query().Get("optimistic-locking-version"); v != "1" {
+			t.Errorf("follow-up locking version = %q, want 1", v)
+		}
+		patched = true
+		patchLabels = multipartLabels(t, r)
+		writeMetadata(w, "new-1", 2, []string{"a", "b"})
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	doc, err := h.Create(context.Background(), CreateRequest{
+		Name:    "doc",
+		Type:    "acme:config",
+		Content: []byte(`{"k":"v"}`),
+		Labels:  []string{"a", "b"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if postHadLabels {
+		t.Error("create POST must not carry labels (API rejects them there)")
+	}
+	if !patched {
+		t.Fatal("expected a follow-up PATCH to set labels")
+	}
+	if want := []string{"a", "b"}; !reflect.DeepEqual(patchLabels, want) {
+		t.Errorf("follow-up labels = %v, want %v", patchLabels, want)
+	}
+	if !reflect.DeepEqual(doc.Labels, []string{"a", "b"}) {
+		t.Errorf("returned labels = %v, want [a b]", doc.Labels)
+	}
+	if doc.Version != 2 {
+		t.Errorf("returned version = %d, want 2 (create + label update)", doc.Version)
+	}
+}
+
+// TestCreate_NoLabels_NoFollowup ensures no PATCH happens when no labels are set.
+func TestCreate_NoLabels_NoFollowup(t *testing.T) {
+	patched := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/documents", func(w http.ResponseWriter, r *http.Request) {
+		writeMetadata(w, "new-2", 1, nil)
+	})
+	mux.HandleFunc("/platform/document/v1/documents/new-2", func(w http.ResponseWriter, r *http.Request) {
+		patched = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.Create(context.Background(), CreateRequest{Name: "d", Type: "t", Content: []byte(`{}`)}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if patched {
+		t.Error("create without labels must not issue a follow-up PATCH")
+	}
+}
+
+// TestCreate_LabelFollowupFails surfaces a clear error naming the created
+// document when the follow-up label update fails.
+func TestCreate_LabelFollowupFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/documents", func(w http.ResponseWriter, r *http.Request) {
+		writeMetadata(w, "new-3", 1, nil)
+	})
+	mux.HandleFunc("/platform/document/v1/documents/new-3", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":400,"message":"bad label"}}`))
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	doc, err := h.Create(context.Background(), CreateRequest{
+		Name: "d", Type: "t", Content: []byte(`{}`), Labels: []string{"x"},
+	})
+	if err == nil {
+		t.Fatal("expected error when follow-up label update fails")
+	}
+	if doc == nil || doc.ID != "new-3" {
+		t.Errorf("expected the created document to be returned with its id, got %+v", doc)
+	}
+}


### PR DESCRIPTION
Fixes #389.

## Problem

The `sdk/api/document` package could **read** labels (`DocumentMetadata.Labels`, `DocumentFilters.AddFields: ["labels"]`) but had no way to **write** them: `CreateRequest` had no `Labels`, and the update methods carried only content/name/description. Labels were queryable but could never be populated.

## Wire format (verified against the live Document Service)

I fetched the Document Service `openapi.yaml` and probed a dev tenant to nail down the exact contract:

- The **create** endpoint (`POST /documents`) has **no `labels` field** — labels cannot be set at create time.
- The **update** endpoint (`PATCH /documents/{id}`, `updateDocument`) accepts labels as a **repeated `labels` multipart form field** — one part per label, value taken verbatim (JSON-array or comma-separated values are rejected / mis-parsed). Providing labels **replaces** the full set; omitting them is "no change" (there is no clear-labels affordance).

Confirmed end-to-end on a dev tenant: `--label a --label b` → `labels:["a","b"]`, and a `get -o json | edit | apply` round-trip preserves them.

## Changes

**SDK**
- Add `Labels []string` to `CreateRequest`. Since the create API can't set labels, `Create` applies them via a follow-up `updateDocument` once the document (and its version) exist. This isn't atomic — on follow-up failure the document already exists, so the returned error names it explicitly and the created doc is still returned.
- Add `UpdateRequest` + `Handler.UpdateDocument`, the general partial-update form that can set labels. `Update` and `UpdateWithMetadata` now delegate to it (behavior unchanged). Labels use `SetMultipartField` so a labels-only update still switches the request into multipart mode.
- Copy `Labels` through `metadataToDocument` so returned documents reflect the new labels.

**CLI (consumers, so the change is usable & testable)**
- `create document`: repeatable `--label`, with fallback to a `labels` array in the payload.
- `apply`: thread labels from the document payload through create and update, so a `get document -o json` → edit → `apply` round-trip preserves (and can change) labels on dashboards/notebooks.

## Design note for review

The issue asked to "add `Labels` to `CreateRequest`". The API doesn't support create-time labels, so I honor `CreateRequest.Labels` via a **follow-up update** rather than dropping it. If you'd prefer labels be update-only (no `CreateRequest.Labels`, no hidden second call), that's an easy trim — flagging since it's a genuine API-shape decision.

`update document --label` isn't added here because the `update document` command lands in #390 (separate PR); once both merge it gets label support for free via the shared applier.

## Tests

- SDK: repeated-field multipart encoding on update; labels-only update stays multipart; `UpdateWithMetadata` sends no labels; create issues a follow-up PATCH (and none when no labels); follow-up-failure error names the doc.
- apply: labels round-trip through an update (mock), plus `extractDocumentLabels` table.
- cmd: `--label` flag registration + label extraction.

`go build ./...` and `go vet ./...` pass in both modules; `sdk/api/document`, `pkg/apply`, `pkg/resources/document`, `cmd`, and golden suites all pass.