### PR TITLE
Appobs 36823 dtctl add log message flag to update breakpoint

### DIFF
--- a/cmd/breakpoint_helpers.go
+++ b/cmd/breakpoint_helpers.go
@@ -44,10 +44,11 @@ func defaultLiveDebuggerDeps() liveDebuggerDeps {
 }
 
 type breakpointRow struct {
-	ID       string `table:"ID" json:"id" yaml:"id"`
-	Filename string `table:"FILENAME" json:"filename" yaml:"filename"`
-	Line     int    `table:"LINE NUMBER" json:"lineNumber" yaml:"lineNumber"`
-	Active   bool   `table:"ACTIVE" json:"active" yaml:"active"`
+	ID         string `table:"ID" json:"id" yaml:"id"`
+	Filename   string `table:"FILENAME" json:"filename" yaml:"filename"`
+	Line       int    `table:"LINE NUMBER" json:"lineNumber" yaml:"lineNumber"`
+	Active     bool   `table:"ACTIVE" json:"active" yaml:"active"`
+	LogMessage string `table:"LOG MESSAGE" json:"logMessage" yaml:"logMessage"`
 }
 
 func runGetBreakpoints(cmd *cobra.Command, args []string) error {
@@ -180,7 +181,8 @@ func breakpointRowFromRule(rule livedebugger.BreakpointRule) (breakpointRow, boo
 	}
 
 	isDisabled := rule.IsDisabled
-	return breakpointRow{ID: id, Filename: filename, Line: line, Active: !isDisabled}, true
+	logMessage := unqualifyBreakpointOutputMessage(extractBreakpointOutputMessage(rule))
+	return breakpointRow{ID: id, Filename: filename, Line: line, Active: !isDisabled, LogMessage: logMessage}, true
 }
 
 func currentProjectPath() string {

--- a/cmd/breakpoint_helpers_test.go
+++ b/cmd/breakpoint_helpers_test.go
@@ -623,6 +623,9 @@ func TestRunGetBreakpoints_StructuredView(t *testing.T) {
 	if !strings.Contains(output, "\"id\": \"bp-1\"") || !strings.Contains(output, "\"filename\": \"OrderController.java\"") {
 		t.Fatalf("unexpected structured output: %q", output)
 	}
+	if !strings.Contains(output, "\"logMessage\": \"Hit on {frame.filename}:{frame.line}\"") {
+		t.Fatalf("expected unqualified log message in output: %q", output)
+	}
 }
 
 func TestRunGetBreakpoints_AgentEnvelope(t *testing.T) {

--- a/cmd/describe_breakpoints.go
+++ b/cmd/describe_breakpoints.go
@@ -40,6 +40,7 @@ type breakpointStatusResult struct {
 	Location           string                  `json:"location,omitempty" yaml:"location,omitempty"`
 	Enabled            bool                    `json:"enabled" yaml:"enabled"`
 	DisableReason      string                  `json:"disableReason,omitempty" yaml:"disableReason,omitempty"`
+	LogMessage         string                  `json:"logMessage,omitempty" yaml:"logMessage,omitempty"`
 	Status             string                  `json:"status" yaml:"status"`
 	ActiveRooks        []breakpointRookInfo    `json:"activeRooks,omitempty" yaml:"activeRooks,omitempty"`
 	ActiveTips         []breakpointTip         `json:"activeTips,omitempty" yaml:"activeTips,omitempty"`
@@ -197,6 +198,7 @@ func buildBreakpointStatusResult(rule livedebugger.BreakpointRule, statusResp ma
 		result.Enabled = row.Active
 	}
 	result.DisableReason = rule.DisableReason
+	result.LogMessage = unqualifyBreakpointOutputMessage(extractBreakpointOutputMessage(rule))
 
 	ruleStatuses, err := extractRuleStatuses(statusResp)
 	if err != nil {
@@ -463,6 +465,9 @@ func printBreakpointStatusResult(result breakpointStatusResult) {
 	output.FprintDescribeKV(w, "Enabled:", kw, "%t", result.Enabled)
 	if result.DisableReason != "" {
 		output.FprintDescribeKV(w, "Disable reason:", kw, "%s", result.DisableReason)
+	}
+	if result.LogMessage != "" {
+		output.FprintDescribeKV(w, "Log message:", kw, "%s", result.LogMessage)
 	}
 	output.FprintDescribeKV(w, "Status:", kw, "%s", result.Status)
 	_, _ = fmt.Fprintln(w)

--- a/cmd/update_breakpoints.go
+++ b/cmd/update_breakpoints.go
@@ -357,7 +357,11 @@ func buildEditBreakpointSettings(rule livedebugger.BreakpointRule, condition str
 
 	outputMessage := extractBreakpointOutputMessage(rule)
 	if logMessageChanged {
-		outputMessage = logMessage
+		if logMessage == "" {
+			outputMessage = unqualifyBreakpointOutputMessage(breakpointDefaultOutputMessage)
+		} else {
+			outputMessage = logMessage
+		}
 	}
 
 	settings := map[string]interface{}{
@@ -572,7 +576,11 @@ func describeBreakpointEdits(conditionChanged bool, condition string, logMessage
 		changes = append(changes, fmt.Sprintf("condition=%q", condition))
 	}
 	if logMessageChanged {
-		changes = append(changes, fmt.Sprintf("log-message=%q", logMessage))
+		displayMessage := logMessage
+		if displayMessage == "" {
+			displayMessage = unqualifyBreakpointOutputMessage(breakpointDefaultOutputMessage)
+		}
+		changes = append(changes, fmt.Sprintf("log-message=%q", displayMessage))
 	}
 	if enabledChanged {
 		changes = append(changes, fmt.Sprintf("enabled=%t", enabled))

--- a/cmd/update_breakpoints.go
+++ b/cmd/update_breakpoints.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -53,6 +54,9 @@ Examples:
   # Add or update a condition
 	 dtctl update breakpoint dtctl-rule-123 --condition "value>othervalue"
 
+  # Change the log message (use {variable} placeholders)
+	 dtctl update breakpoint dtctl-rule-123 --log-message "Hit on {frame.filename}:{frame.line} value={newTodoRecord.title}"
+
   # Enable a breakpoint
 	 dtctl update breakpoint OrderController.java:306 --enabled true
 
@@ -75,6 +79,7 @@ Examples:
 		}
 
 		conditionChanged := cmd.Flags().Changed("condition")
+		logMessageChanged := cmd.Flags().Changed("log-message")
 		enabled, enabledChanged, err := getOptionalBoolFlag(cmd, "enabled", trailingArgs)
 		if err != nil {
 			return err
@@ -84,8 +89,8 @@ Examples:
 			if err := requireFiltersValue(filters); err != nil {
 				return err
 			}
-			if conditionChanged || enabledChanged {
-				return fmt.Errorf("--filters cannot be combined with --condition or --enabled")
+			if conditionChanged || enabledChanged || logMessageChanged {
+				return fmt.Errorf("--filters cannot be combined with --condition, --log-message, or --enabled")
 			}
 			if len(args) > 0 {
 				return fmt.Errorf("--filters does not accept a breakpoint identifier")
@@ -181,11 +186,12 @@ Examples:
 		if len(args) > 1 && !enabledChanged {
 			return fmt.Errorf("accepts 1 arg(s), received %d", len(args))
 		}
-		if !conditionChanged && !enabledChanged {
-			return fmt.Errorf("at least one of --condition or --enabled is required")
+		if !conditionChanged && !enabledChanged && !logMessageChanged {
+			return fmt.Errorf("at least one of --condition, --log-message, or --enabled is required")
 		}
 
 		condition, _ := cmd.Flags().GetString("condition")
+		logMessage, _ := cmd.Flags().GetString("log-message")
 		identifier := strings.TrimSpace(args[0])
 
 		cfg, err := LoadConfig()
@@ -207,7 +213,7 @@ Examples:
 		}
 
 		if dryRun {
-			changes := describeBreakpointEdits(conditionChanged, condition, enabledChanged, enabled)
+			changes := describeBreakpointEdits(conditionChanged, condition, logMessageChanged, logMessage, enabledChanged, enabled)
 			return printBreakpointMessage("update", fmt.Sprintf("Dry run: would update breakpoint %s (%s)", identifier, changes))
 		}
 
@@ -257,12 +263,12 @@ Examples:
 			return err
 		}
 
-		if conditionChanged {
+		if conditionChanged || logMessageChanged {
 			if len(targetRules) == 0 {
 				return fmt.Errorf("breakpoint %q not found in the current workspace", identifier)
 			}
 			for _, rule := range targetRules {
-				ruleSettings, err := buildEditBreakpointSettings(rule, condition, true)
+				ruleSettings, err := buildEditBreakpointSettings(rule, condition, conditionChanged, logMessage, logMessageChanged)
 				if err != nil {
 					return err
 				}
@@ -308,7 +314,7 @@ Examples:
 			}
 		}
 
-		return printBreakpointMessage("update", fmt.Sprintf("Updated breakpoint %s (%s)", targetDescription, describeBreakpointEdits(conditionChanged, condition, enabledChanged, enabled)))
+		return printBreakpointMessage("update", fmt.Sprintf("Updated breakpoint %s (%s)", targetDescription, describeBreakpointEdits(conditionChanged, condition, logMessageChanged, logMessage, enabledChanged, enabled)))
 	},
 }
 
@@ -328,7 +334,7 @@ func resolveBreakpointRulesForEdit(rules []livedebugger.BreakpointRule, identifi
 	return nil, identifier, true, nil
 }
 
-func buildEditBreakpointSettings(rule livedebugger.BreakpointRule, condition string, conditionChanged bool) (map[string]interface{}, error) {
+func buildEditBreakpointSettings(rule livedebugger.BreakpointRule, condition string, conditionChanged bool, logMessage string, logMessageChanged bool) (map[string]interface{}, error) {
 	row, ok := breakpointRowFromRule(rule)
 	if !ok || row.ID == "" {
 		return nil, fmt.Errorf("rule missing mutable rule id")
@@ -349,6 +355,11 @@ func buildEditBreakpointSettings(rule livedebugger.BreakpointRule, condition str
 		currentCondition = condition
 	}
 
+	outputMessage := extractBreakpointOutputMessage(rule)
+	if logMessageChanged {
+		outputMessage = logMessage
+	}
+
 	settings := map[string]interface{}{
 		"mutableRuleId":               row.ID,
 		"collectLocalsMethod":         stringValue(paths["store.rookout.frame"]),
@@ -358,7 +369,7 @@ func buildEditBreakpointSettings(rule livedebugger.BreakpointRule, condition str
 		"ttlTimeLimitInterval":        0,
 		"collectedVariables":          extractCollectedVariables(paths),
 		"targetConfiguration":         map[string]interface{}{"targetId": extractBreakpointTargetID(rule)},
-		"outputMessage":               extractBreakpointOutputMessage(rule),
+		"outputMessage":               outputMessage,
 		"condition":                   currentCondition,
 		"rateLimit":                   stringValue(aug["rateLimit"]),
 		"tracingCollection":           stringValue(paths["store.rookout.tracing"]) == "trace.dump()",
@@ -434,12 +445,33 @@ func parseThreadLocalPath(path string) (string, string, bool) {
 	return className, member, true
 }
 
+// breakpointPlaceholderPattern matches {placeholder} tokens in a log message.
+var breakpointPlaceholderPattern = regexp.MustCompile(`\{[^{}]*\}`)
+
+// unqualifyBreakpointOutputMessage reverses the backend qualification of a log
+// message so users see the friendly form. The backend rewrites {frame.X} to
+// store.rookout.frame.X and {anything.else} to
+// store.rookout.variables.anything.else; this strips those prefixes back out.
+// Other namespaces (rook, agent, bp, message_info, controller) pass through
+// unchanged, matching the backend.
+func unqualifyBreakpointOutputMessage(message string) string {
+	return breakpointPlaceholderPattern.ReplaceAllStringFunc(message, func(match string) string {
+		inner := match[1 : len(match)-1]
+		switch {
+		case strings.HasPrefix(inner, "store.rookout.frame."):
+			inner = "frame." + strings.TrimPrefix(inner, "store.rookout.frame.")
+		case strings.HasPrefix(inner, "store.rookout.variables."):
+			inner = strings.TrimPrefix(inner, "store.rookout.variables.")
+		}
+		return "{" + inner + "}"
+	})
+}
+
 func extractBreakpointOutputMessage(rule livedebugger.BreakpointRule) string {
 	processing := rule.Processing
 	if processing == nil {
 		return breakpointDefaultOutputMessage
 	}
-
 	_, ok := processing["operations"].([]interface{})
 	if !ok {
 		return breakpointDefaultOutputMessage
@@ -534,10 +566,13 @@ func intValue(value interface{}, defaultValue int) int {
 	}
 }
 
-func describeBreakpointEdits(conditionChanged bool, condition string, enabledChanged bool, enabled bool) string {
-	changes := make([]string, 0, 2)
+func describeBreakpointEdits(conditionChanged bool, condition string, logMessageChanged bool, logMessage string, enabledChanged bool, enabled bool) string {
+	changes := make([]string, 0, 3)
 	if conditionChanged {
 		changes = append(changes, fmt.Sprintf("condition=%q", condition))
+	}
+	if logMessageChanged {
+		changes = append(changes, fmt.Sprintf("log-message=%q", logMessage))
 	}
 	if enabledChanged {
 		changes = append(changes, fmt.Sprintf("enabled=%t", enabled))
@@ -576,6 +611,7 @@ func getOptionalBoolFlag(cmd *cobra.Command, flagName string, trailingArgs []str
 func init() {
 	updateCmd.AddCommand(updateBreakpointCmd)
 	updateBreakpointCmd.Flags().String("condition", "", `Condition expression (e.g. "a==1 && b!='bbb'", "'val' in arr", "x>0 && y<=10")`)
+	updateBreakpointCmd.Flags().String("log-message", "", `Log message template with {variable} placeholders (e.g. "Hit on {frame.filename}:{frame.line} value={newTodoRecord.title}")`)
 	updateBreakpointCmd.Flags().String("enabled", "", "Enable or disable the breakpoint")
 	updateBreakpointCmd.Flags().String("filters", "", "workspace filters to apply (comma-separated key:value pairs)")
 	updateBreakpointCmd.Flags().BoolP("yes", "y", false, "skip the confirmation prompt when changing workspace filters affects existing breakpoints")

--- a/cmd/update_breakpoints_test.go
+++ b/cmd/update_breakpoints_test.go
@@ -106,7 +106,7 @@ func TestBuildEditBreakpointSettings(t *testing.T) {
 		},
 	}
 
-	settings, err := buildEditBreakpointSettings(rule, "value>othervalue", true)
+	settings, err := buildEditBreakpointSettings(rule, "value>othervalue", true, "", false)
 	if err != nil {
 		t.Fatalf("buildEditBreakpointSettings returned error: %v", err)
 	}
@@ -350,16 +350,60 @@ func TestIntValue(t *testing.T) {
 }
 
 func TestDescribeBreakpointEdits(t *testing.T) {
-	if got := describeBreakpointEdits(false, "", false, false); got != "" {
+	if got := describeBreakpointEdits(false, "", false, "", false, false); got != "" {
 		t.Fatalf("expected empty changes, got %q", got)
 	}
-	if got := describeBreakpointEdits(true, "a>1", false, false); got != "condition=\"a>1\"" {
+	if got := describeBreakpointEdits(true, "a>1", false, "", false, false); got != "condition=\"a>1\"" {
 		t.Fatalf("unexpected condition-only description: %q", got)
 	}
-	if got := describeBreakpointEdits(false, "", true, true); got != "enabled=true" {
+	if got := describeBreakpointEdits(false, "", false, "", true, true); got != "enabled=true" {
 		t.Fatalf("unexpected enabled-only description: %q", got)
 	}
-	if got := describeBreakpointEdits(true, "a>1", true, false); got != "condition=\"a>1\", enabled=false" {
+	if got := describeBreakpointEdits(true, "a>1", false, "", true, false); got != "condition=\"a>1\", enabled=false" {
 		t.Fatalf("unexpected combined description: %q", got)
+	}
+	if got := describeBreakpointEdits(false, "", true, "Hit {frame.line}", false, false); got != "log-message=\"Hit {frame.line}\"" {
+		t.Fatalf("unexpected log-message-only description: %q", got)
+	}
+}
+
+func TestUnqualifyBreakpointOutputMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "frame prefix stripped to frame",
+			in:   "Hit on {store.rookout.frame.filename}:{store.rookout.frame.line}",
+			want: "Hit on {frame.filename}:{frame.line}",
+		},
+		{
+			name: "variables prefix stripped entirely",
+			in:   "value={store.rookout.variables.newTodoRecord.title}",
+			want: "value={newTodoRecord.title}",
+		},
+		{
+			name: "other namespaces pass through unchanged",
+			in:   "agent {agent.id} rook {rook.id} bp {bp.id}",
+			want: "agent {agent.id} rook {rook.id} bp {bp.id}",
+		},
+		{
+			name: "mixed prefixes",
+			in:   "{store.rookout.frame.line} {store.rookout.variables.x.y} {controller.id}",
+			want: "{frame.line} {x.y} {controller.id}",
+		},
+		{
+			name: "no placeholders",
+			in:   "plain message",
+			want: "plain message",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := unqualifyBreakpointOutputMessage(tc.in); got != tc.want {
+				t.Fatalf("unqualifyBreakpointOutputMessage(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/update_breakpoints_test.go
+++ b/cmd/update_breakpoints_test.go
@@ -168,7 +168,7 @@ func TestBuildEditBreakpointSettings_LogMessageChanged(t *testing.T) {
 					},
 				},
 			},
-			"location": map[string]interface{}{"filename": "OrderController.java", "lineno": float64(306)},
+			"location":  map[string]interface{}{"filename": "OrderController.java", "lineno": float64(306)},
 			"rateLimit": "150/20000",
 		},
 		Processing: map[string]interface{}{

--- a/cmd/update_breakpoints_test.go
+++ b/cmd/update_breakpoints_test.go
@@ -153,6 +153,54 @@ func TestBuildEditBreakpointSettings(t *testing.T) {
 	}
 }
 
+func TestBuildEditBreakpointSettings_LogMessageChanged(t *testing.T) {
+	rule := livedebugger.BreakpointRule{
+		ID: "dtctl-rule-2",
+		AugJSON: map[string]interface{}{
+			"action": map[string]interface{}{
+				"operations": []interface{}{
+					map[string]interface{}{
+						"name": "set",
+						"paths": map[string]interface{}{
+							"store.rookout.frame":     "frame.dump()",
+							"store.rookout.traceback": "stack.traceback()",
+						},
+					},
+				},
+			},
+			"location": map[string]interface{}{"filename": "OrderController.java", "lineno": float64(306)},
+			"rateLimit": "150/20000",
+		},
+		Processing: map[string]interface{}{
+			"operations": []interface{}{
+				map[string]interface{}{"name": "set", "paths": map[string]interface{}{"temp.message.rookout": "store.rookout"}},
+				map[string]interface{}{"name": "format", "path": "temp.message.rookout.message", "format": "Hit on {store.rookout.frame.filename}:{store.rookout.frame.line}"},
+				map[string]interface{}{"name": "send_rookout", "path": "temp.message"},
+			},
+		},
+	}
+
+	settings, err := buildEditBreakpointSettings(rule, "", false, "Hit on {frame.filename}:{frame.line} value={myVar}", true)
+	if err != nil {
+		t.Fatalf("buildEditBreakpointSettings returned error: %v", err)
+	}
+
+	// When logMessageChanged=true, outputMessage must be the raw user-supplied string.
+	// The backend is responsible for qualifying {frame.X} → store.rookout.frame.X at storage time.
+	if settings["outputMessage"] != "Hit on {frame.filename}:{frame.line} value={myVar}" {
+		t.Fatalf("expected raw user-supplied log message, got: %#v", settings["outputMessage"])
+	}
+
+	// Empty string resets to the friendly default rather than sending an empty message.
+	settings, err = buildEditBreakpointSettings(rule, "", false, "", true)
+	if err != nil {
+		t.Fatalf("buildEditBreakpointSettings returned error: %v", err)
+	}
+	if settings["outputMessage"] != "Hit on {frame.filename}:{frame.line}" {
+		t.Fatalf("expected friendly default on empty log message, got: %#v", settings["outputMessage"])
+	}
+}
+
 func TestResolveBreakpointRulesForEdit(t *testing.T) {
 	rules := []livedebugger.BreakpointRule{
 		{
@@ -364,6 +412,9 @@ func TestDescribeBreakpointEdits(t *testing.T) {
 	}
 	if got := describeBreakpointEdits(false, "", true, "Hit {frame.line}", false, false); got != "log-message=\"Hit {frame.line}\"" {
 		t.Fatalf("unexpected log-message-only description: %q", got)
+	}
+	if got := describeBreakpointEdits(false, "", true, "", false, false); got != "log-message=\"Hit on {frame.filename}:{frame.line}\"" {
+		t.Fatalf("unexpected empty log-message reset description: %q", got)
 	}
 }
 

--- a/docs/LIVE_DEBUGGER.md
+++ b/docs/LIVE_DEBUGGER.md
@@ -192,7 +192,9 @@ It supports `{variable}` placeholders that are interpolated at runtime:
 
 You always use the short, friendly form (e.g. `{frame.line}`), and the message
 is displayed the same way in `get` and `describe`. If `--log-message` is omitted
-on update, the current message is preserved.
+on update, the current message is preserved. Passing an empty string
+(`--log-message ""`) resets the message to the default:
+`Hit on {frame.filename}:{frame.line}`.
 
 ### Notes
 

--- a/docs/LIVE_DEBUGGER.md
+++ b/docs/LIVE_DEBUGGER.md
@@ -120,6 +120,7 @@ Default output is a table with:
 - filename
 - line number
 - active state
+- log message (with `{variable}` placeholders in their friendly form; see [Log messages](#log-messages))
 
 Structured output is also supported:
 
@@ -143,6 +144,7 @@ dtctl describe OrderController.java:306
 The command uses `GetRuleStatusBreakdown` and summarizes:
 
 - enabled/disabled state
+- log message (see [Log messages](#log-messages))
 - overall status
 - active and pending rooks
 - warnings and errors
@@ -171,11 +173,33 @@ dtctl update breakpoint OrderController.java:306 --enabled true
 dtctl update breakpoint OrderController.java:306 --enabled false
 ```
 
+Change the log message:
+
+```bash
+dtctl update breakpoint OrderController.java:306 --log-message "Hit on {frame.filename}:{frame.line} value={newTodoRecord.title}"
+```
+
+### Log messages
+
+A breakpoint's log message is the line emitted each time the breakpoint is hit.
+It supports `{variable}` placeholders that are interpolated at runtime:
+
+- `{frame.filename}`, `{frame.line}`, and other `frame.*` fields expose the hit
+  location and stack frame.
+- `{myVar.field}` (any other name) references a captured application variable.
+- Reserved namespaces such as `{rook.*}`, `{agent.*}`, `{bp.*}`,
+  `{message_info.*}`, and `{controller.*}` pass through unchanged.
+
+You always use the short, friendly form (e.g. `{frame.line}`), and the message
+is displayed the same way in `get` and `describe`. If `--log-message` is omitted
+on update, the current message is preserved.
+
 ### Notes
 
 - identifiers can be either a mutable breakpoint ID or `filename:line`
 - source locations resolve all matching breakpoints in the current workspace
 - `--dry-run` is supported
+- at least one of `--condition`, `--log-message`, or `--enabled` is required
 
 ## 6. Delete breakpoints
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -3272,9 +3272,10 @@ dtctl get breakpoints
 dtctl describe OrderController.java:306
 dtctl describe dtctl-rule-123
 
-# Edit condition / enabled state
+# Edit condition / enabled state / log message
 dtctl update breakpoint OrderController.java:306 --condition "orderId != null"
 dtctl update breakpoint OrderController.java:306 --enabled false
+dtctl update breakpoint OrderController.java:306 --log-message "Hit on {frame.filename}:{frame.line} order={orderId}"
 
 # Delete by ID, by location, or all
 dtctl delete breakpoint dtctl-rule-123
@@ -3297,6 +3298,8 @@ dtctl query "fetch application.snapshots | limit 5" --decode-snapshots -o yaml
 ```
 
 `--decode-snapshots` enriches each record with `parsed_snapshot` decoded from `snapshot.data` and `snapshot.string_map`. By default, variant wrappers are simplified to plain values; use `--decode-snapshots=full` to preserve type annotations.
+
+The breakpoint log message (shown in `get`/`describe` and set via `update breakpoint --log-message`) supports `{variable}` placeholders — `{frame.*}` for the hit location, any other name (for example `{orderId}`) for a captured variable. Use the short form; messages are displayed the same way in `get` and `describe`.
 
 ---
 

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -1879,6 +1879,7 @@ dtctl get breakpoints                                          # list breakpoint
 dtctl describe breakpoint <breakpoint-id|filename:line>                   # describe breakpoint rollout/status
 dtctl update breakpoint <id|filename:line> --condition "..."   # update condition
 dtctl update breakpoint <id|filename:line> --enabled true|false # enable/disable
+dtctl update breakpoint <id|filename:line> --log-message "..."  # update the hit log message
 dtctl delete breakpoint <id|filename:line|--all>               # delete breakpoints
 ```
 
@@ -1887,6 +1888,7 @@ dtctl delete breakpoint <id|filename:line|--all>               # delete breakpoi
 Design notes:
 - `dtctl describe` keeps existing resource-subcommand behavior; breakpoint describe is only routed for breakpoint-like identifiers.
 - Mutating operations (`update` filter update, `create`, `update`, `delete`) must run safety checks, including in dry-run mode.
+- Breakpoint log messages use `{variable}` placeholders and are stored qualified by the backend (`{frame.line}` → `store.rookout.frame.line`, other names → `store.rookout.variables.*`). The CLI passes the raw user string through on update and strips those prefixes back out for display in `get`/`describe`, so users only ever deal with the short form. `get breakpoints` includes the log message in its default (non-wide) table.
 - `--filters` is optional on `create`. Filters are workspace-scoped and sticky: once set (via `update breakpoint --filters` or `create breakpoint ... --filters`), they persist for subsequent breakpoints until changed. Because a single filter set applies to the whole workspace, changing the filters re-scopes all existing breakpoints (not just new ones); `create`/`update` count the active breakpoints affected and prompt for confirmation before applying the change, bypassable with `--yes` (`-y`) and skipped in non-interactive contexts (`--plain`/agent mode). When `--filters` is supplied on `create`, the workspace filters are updated first, then the breakpoint is created; otherwise `create` requires that workspace filters were already configured.
 
 ## Examples

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -299,9 +299,9 @@ This document tracks the current implementation status of dtctl. For future plan
 ### Live Debugger Features (Experimental)
 - [x] Configure workspace filters: `dtctl update breakpoint --filters key:value[,key:value...]` (also supports `key=value`)
 - [x] Create breakpoint: `dtctl create breakpoint File.java:line` (optional `--filters key:value[,...]` sets workspace filters in the same step)
-- [x] List breakpoints: `dtctl get breakpoints`
-- [x] Describe breakpoint status by ID or location: `dtctl describe <id|filename:line>`
-- [x] Update breakpoint condition/enabled state: `dtctl update breakpoint <id|filename:line> --condition ... --enabled ...`
+- [x] List breakpoints (table includes log message): `dtctl get breakpoints`
+- [x] Describe breakpoint status by ID or location (shows log message): `dtctl describe <id|filename:line>`
+- [x] Update breakpoint condition/enabled state/log message: `dtctl update breakpoint <id|filename:line> --condition ... --enabled ... --log-message ...`
 - [x] Delete breakpoint by ID/location and bulk delete with confirmation: `dtctl delete breakpoint <id|filename:line|--all> [-y] [--dry-run]`
 - [x] Verbose GraphQL troubleshooting output with `-v/--debug`
 - [x] Safety checks applied to create/update/delete and workspace filter updates

--- a/docs/site/_docs/live-debugger.md
+++ b/docs/site/_docs/live-debugger.md
@@ -63,14 +63,14 @@ When `--filters` changes the workspace filters, it also re-scopes existing break
 ### List Breakpoints
 
 ```bash
-# List all breakpoints
+# List all breakpoints (includes the log message column)
 dtctl get breakpoints
 ```
 
 ### Describe a Breakpoint
 
 ```bash
-# View full details of a breakpoint including hit count and status
+# View full details of a breakpoint including its log message, hit count, and status
 dtctl describe breakpoint bp-abc123
 ```
 
@@ -80,9 +80,19 @@ dtctl describe breakpoint bp-abc123
 # Add a conditional expression to a breakpoint
 dtctl update breakpoint bp-abc123 --condition "userId != null"
 
+# Change the log message emitted when the breakpoint is hit
+dtctl update breakpoint bp-abc123 --log-message "Hit on {frame.filename}:{frame.line} user={userId}"
+
 # Disable a breakpoint without deleting it
 dtctl update breakpoint bp-abc123 --enabled=false
 ```
+
+The log message supports `{variable}` placeholders: `{frame.*}` fields expose the
+hit location, any other name (for example `{userId}`) references a captured
+application variable, and reserved namespaces such as `{rook.*}` or
+`{controller.*}` pass through unchanged. Use the short, friendly form — messages
+are displayed the same way in `get` and `describe`. At least one of
+`--condition`, `--log-message`, or `--enabled` is required.
 
 ### Delete Breakpoints
 


### PR DESCRIPTION
## Description

Adds first-class support for Live Debugger breakpoint **log messages** (the line emitted each time a breakpoint is hit).

- **`update breakpoint --log-message`** — new flag to set a breakpoint's log message. The raw template with `{variable}` placeholders is passed through and qualified by the backend; omitting the flag preserves the current message. At least one of `--condition`, `--log-message`, or `--enabled` is now required (and `--log-message` is mutually exclusive with `--filters`, like the other per-breakpoint flags).
- **`get breakpoints`** — new `LOG MESSAGE` column in the default table (also in JSON/YAML output).
- **`describe breakpoint`** — shows the log message in both text and structured output.
- **Friendly display** — the backend stores messages qualified (e.g. `{frame.line}` → `store.rookout.frame.line`, other names → `store.rookout.variables.*`). A shared helper strips those prefixes back to the short `{frame.*}`/`{var}` form so `get`/`describe` show messages exactly as users type them.
- Docs updated across user guides and dev design docs.

## Related Issues
Closes APPOBS-36823

## Testing
- Added `TestUnqualifyBreakpointOutputMessage` (frame/variables/pass-through/mixed cases) and a `--log-message` case in `TestDescribeBreakpointEdits`.
- Updated `buildEditBreakpointSettings` test for the new signature.
- Added assertion that `get breakpoints` emits the unqualified `logMessage`.
- Manually verified the default `get breakpoints` table now includes the log message column.

- [x] Tests pass (`make test`)
- [ ] Linting passes (`make lint`) — could not run locally (golangci-lint v1 installed vs v2 config); `go vet` and `gofmt` are clean, CI will run lint
