### PR TITLE
fix: rewind multipart bodies before a retry

### DIFF
--- a/sdk/httpclient/client.go
+++ b/sdk/httpclient/client.go
@@ -134,6 +134,8 @@ func New(baseURL string, opts ...Option) (*Client, error) {
 		c.http.SetRetryWaitTime(1 * time.Second)
 		c.http.SetRetryMaxWaitTime(10 * time.Second)
 	}
+	// Multipart bodies are one-shot readers, so rewind them before a retry
+	c.http.SetRetryResetReaders(true)
 	c.http.AddRetryCondition(func(r *resty.Response, err error) bool {
 		retry := isRetryable(r, err)
 		if retry {

--- a/sdk/httpclient/client_test.go
+++ b/sdk/httpclient/client_test.go
@@ -1,6 +1,8 @@
 package httpclient
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -72,5 +74,54 @@ func TestClient_Retry(t *testing.T) {
 	}
 	if attempts != 3 {
 		t.Errorf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestClient_RetryResendsMultipartBody(t *testing.T) {
+	const content = `{"tiles":{"0":{"type":"markdown"}}}`
+
+	attempts := 0
+	received := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		file, _, err := r.FormFile("content")
+		if err != nil {
+			t.Errorf("FormFile: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
+		body, err := io.ReadAll(file)
+		if err != nil {
+			t.Errorf("ReadAll: %v", err)
+		}
+		received = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, WithToken("test-token"), WithRetry(3, 0, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := c.HTTP().R().
+		SetMultipartField("content", "content.json", "application/json", bytes.NewReader([]byte(content))).
+		Patch("/test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode())
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2", attempts)
+	}
+	if received != content {
+		t.Errorf("content = %q, want %q", received, content)
 	}
 }


### PR DESCRIPTION
## Description

the SDK client enables resty retries for every method, including POST and PATCH, and `isRetryable` fires on 429 and any 5xx. the document write paths hand resty a one-shot `bytes.Reader` as the multipart body:

- `sdk/api/document/document.go:336` (create)
- `sdk/api/document/document.go:383` (update)
- `sdk/api/document/document.go:405` (update with metadata)

resty only seeks multipart readers back to the start when `SetRetryResetReaders` is on, and we never turn it on. so the second attempt sends a zero-byte `content` part. the optimistic locking version is still valid, so the API accepts it and the document ends up with empty content while dtctl prints a success and exits 0

this reaches `dtctl create dashboard|notebook|launchpad`, `dtctl edit`, and `dtctl apply -f`. one 503 from a load balancer in front of the tenant is enough

the extension and lookup uploads are not affected, they build the body into a `bytes.Buffer` first, so they survive a retry already

## Related Issues

none, found while reading the retry path

## Testing

added `TestClient_RetryResendsMultipartBody`: the server answers 503 once, then parses the multipart part on the retry and compares it to what was sent. before the change the assertion fails with `content = ""`, after it the full payload arrives

- [x] Tests pass (`make test`)
- [ ] Linting passes (`make lint`)

on lint: `golangci-lint run` reports 21 govet findings on my machine, all in `pkg/output/*` and `pkg/watch/differ.go`, none in the files this PR touches. they look like they come from a newer linter than the one CI pins, since they are all the new `inline: Constant ... should be inlined` check