### PR TITLE
fix: report CSV write errors instead of dropping them

### DIFF
--- a/pkg/output/csv.go
+++ b/pkg/output/csv.go
@@ -36,8 +36,16 @@ func (p *CSVPrinter) PrintList(obj interface{}) error {
 	}
 
 	writer := csv.NewWriter(p.writer)
-	defer writer.Flush()
+	if err := p.writeRecords(v, writer); err != nil {
+		return err
+	}
 
+	// csv.Writer buffers, so a failed write only surfaces here
+	writer.Flush()
+	return writer.Error()
+}
+
+func (p *CSVPrinter) writeRecords(v reflect.Value, writer *csv.Writer) error {
 	// Handle slice of maps (most common for DQL results)
 	if v.Index(0).Kind() == reflect.Map || (v.Index(0).Kind() == reflect.Interface && v.Index(0).Elem().Kind() == reflect.Map) {
 		return p.printMaps(v, writer)

--- a/pkg/output/csv_test.go
+++ b/pkg/output/csv_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
@@ -175,5 +176,24 @@ func TestCSVPrinter_PrintList_NonSlice(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "expected slice") {
 		t.Errorf("expected 'expected slice' error, got: %v", err)
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+
+func TestPrintList_ReportsWriteError(t *testing.T) {
+	// A single row fits in csv.Writer's buffer, so the failure can only
+	// surface on the final flush.
+	rows := []map[string]interface{}{{"host": "host-1", "status": "ERROR"}}
+
+	for _, format := range []string{"csv", "json", "jsonl", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			p := NewPrinterWithOpts(PrinterOptions{Format: format, Writer: failingWriter{}})
+			if err := p.PrintList(rows); err == nil {
+				t.Error("PrintList returned nil although every write failed")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

`CSVPrinter.PrintList` flushes in a deferred call and never looks at the error:

```go
writer := csv.NewWriter(p.writer)
defer writer.Flush()
```

`(*csv.Writer).Flush()` returns nothing, the error is only reachable through `writer.Error()`, and `printMaps`/`printStructs` return before the deferred flush runs. so `PrintList` returns nil no matter what happened

the buffer is 4KB, so for anything smaller than that nothing is written until the flush, which means the write error is not just unreported, it is the only place the failure exists at all

two ways this shows up:

- `dtctl query ... -o csv > out.csv` on a full filesystem leaves a truncated file and exits 0
- the spill path is worse: `WriteSpillFile` sees a nil error, so it chmods and renames the temp file into place and writes a sidecar manifest with the full row count. I reproduced this on a real full filesystem and got a committed spill of 8192 of 11030 bytes, 148 of 200 rows, with the last record cut mid-field

the other printers in this package already surface the error, csv was the odd one out

## Related Issues

none, found while reading the spill path

## Testing

added a table test over csv, json, jsonl and yaml that hands each printer a writer failing on every write and requires a non-nil error. before the change only the csv subtest fails, which is the point

- [x] Tests pass (`make test`)
- [x] Linting passes (`golangci-lint run ./pkg/output/...`)