### PR TITLE
chore(account): gate experimental account commands behind DTCTL_EXPERIMENTAL_ACCOUNT

### DIFF
--- a/cmd/account.go
+++ b/cmd/account.go
@@ -1,6 +1,30 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// accountExperimentalEnvVar gates the still-in-development platform "account"
+// command surface (account login/status/token). The command is only registered
+// on the root tree when this is set to a truthy value, so released builds hide
+// it entirely (an invocation yields the normal "unknown command" error). Remove
+// the gate — and this env var — once the account surface is GA.
+const accountExperimentalEnvVar = "DTCTL_EXPERIMENTAL_ACCOUNT"
+
+// accountExperimentalEnabled reports whether the experimental account command
+// surface should be registered. Any value other than empty/0/false/no/off
+// (case-insensitive) enables it.
+func accountExperimentalEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(accountExperimentalEnvVar))) {
+	case "", "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
 
 var accountCmd = &cobra.Command{
 	Use:   "account",
@@ -10,5 +34,13 @@ var accountCmd = &cobra.Command{
 }
 
 func init() {
+	// Account administration is still under development; keep it out of released
+	// builds unless explicitly opted in via DTCTL_EXPERIMENTAL_ACCOUNT. Skipping
+	// registration (rather than hiding) means end users get a plain "unknown
+	// command" and the feature's existence is not surfaced in help or the
+	// `dtctl commands` catalog. See docs — remove this gate when account is GA.
+	if !accountExperimentalEnabled() {
+		return
+	}
 	rootCmd.AddCommand(accountCmd)
 }

--- a/cmd/account_gate_test.go
+++ b/cmd/account_gate_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import "testing"
+
+// TestAccountExperimentalEnabled documents the truthiness matrix for the
+// DTCTL_EXPERIMENTAL_ACCOUNT gate that controls whether the in-development
+// account command surface is registered on the root tree.
+func TestAccountExperimentalEnabled(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"FALSE", false},
+		{"no", false},
+		{"off", false},
+		{" off ", false},
+		{"1", true},
+		{"true", true},
+		{"yes", true},
+		{"on", true},
+		{"enabled", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.val, func(t *testing.T) {
+			t.Setenv(accountExperimentalEnvVar, tc.val)
+			if got := accountExperimentalEnabled(); got != tc.want {
+				t.Fatalf("accountExperimentalEnabled() with %q = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAccountCommandNotRegisteredByDefault guards the release-safety invariant:
+// with the gate unset (the default under `go test`), the account command must
+// not be present on the command tree.
+func TestAccountCommandNotRegisteredByDefault(t *testing.T) {
+	if accountExperimentalEnabled() {
+		t.Skip("DTCTL_EXPERIMENTAL_ACCOUNT is set in this environment; gate is intentionally on")
+	}
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "account" {
+			t.Errorf("account command is registered but DTCTL_EXPERIMENTAL_ACCOUNT is unset")
+		}
+	}
+}


### PR DESCRIPTION
## Why

The `account` command surface is still under development and shouldn't ship enabled in a release. This gates it off by default so we can cut a release now, while keeping a single binary we can dogfood via an env var.

Chose a **runtime env-var gate** over a compile-time build tag: one build config (no goreleaser/release-please changes), the real release artifact is testable by setting the var, and it's a trivial revert at GA.

## What

Registration is gated on `DTCTL_EXPERIMENTAL_ACCOUNT` (truthy = any value except empty/`0`/`false`/`no`/`off`):

- `cmd/account.go` — `init()` skips `rootCmd.AddCommand(accountCmd)` unless enabled; adds `accountExperimentalEnabled()` helper + const.
- `cmd/account_gate_test.go` — truthiness matrix + invariant that the account command is absent by default.

> **Note:** an earlier revision of this PR also gated `ctx discover-account` and the login-time account-UUID auto-discovery. Both were removed from `main` in the meantime by #382 (the IAM access-info discovery was broken — 404 on every host), so after rebase this PR only needs to gate the `account` command tree. `account login` now requires an explicit `--account-uuid` / `DTCTL_ACCOUNT_UUID` / context value (upstream behavior), which is unaffected by this gate.

## Behavior

| | Gate off (default / release) | Gate on (`DTCTL_EXPERIMENTAL_ACCOUNT=1`) |
|---|---|---|
| `dtctl account` | `Error: unknown command "account"` | full `account login/status/token` tree |
| `--help` / `dtctl commands` | no mention of account | listed normally |

## At GA

Remove the `init()` guard, the env-var const/helper, and `cmd/account_gate_test.go`.

## Testing

- `go test ./cmd/...` passes; gofmt/vet clean.
- Verified both gate states on a built binary (table above).
- No user-facing docs reference `dtctl account`, so nothing dangles.