### PR TITLE
fix: strip the account token from a plugin's environment

### DIFF
--- a/cmd/plugin_dispatch.go
+++ b/cmd/plugin_dispatch.go
@@ -112,14 +112,15 @@ func builtinCommandNames() map[string]bool {
 	return names
 }
 
-// credentialEnvVars are the environment variables dtctl documents as token
+// credentialEnvVars are the environment variables dtctl itself names as token
 // carriers (docs/site/_docs/ai-agent-mode.md, `dtctl config init`'s
-// ${DT_API_TOKEN} scaffold). They are stripped from a plugin's environment:
-// plugins resolve credentials themselves through the sdk (the same config
-// file and keyring service), never through inherited env. Tokens placed in
-// user-chosen variables referenced via ${...} config expansion cannot be
-// recognized and are inherited like the rest of the environment.
-var credentialEnvVars = []string{"DTCTL_TOKEN", "DT_API_TOKEN"}
+// ${DT_API_TOKEN} scaffold, and `dtctl account login`/`account status` for the
+// account token). They are stripped from a plugin's environment: plugins
+// resolve credentials themselves through the sdk (the same config file and
+// keyring service), never through inherited env. Tokens placed in user-chosen
+// variables referenced via ${...} config expansion cannot be recognized and
+// are inherited like the rest of the environment.
+var credentialEnvVars = []string{"DTCTL_TOKEN", "DT_API_TOKEN", "DTCTL_ACCOUNT_TOKEN"}
 
 // pluginEnv builds the environment for a plugin exec from dtctl's own leading
 // flags: the inherited environment minus credentialEnvVars, plus the

--- a/cmd/plugin_dispatch_test.go
+++ b/cmd/plugin_dispatch_test.go
@@ -121,12 +121,13 @@ func TestPluginEnv(t *testing.T) {
 func TestPluginEnv_StripsCredentialEnvVars(t *testing.T) {
 	t.Setenv("DTCTL_TOKEN", "dt0s16.SECRET")
 	t.Setenv("DT_API_TOKEN", "dt0c01.SECRET")
+	t.Setenv("DTCTL_ACCOUNT_TOKEN", "dt0s16.SECRET")
 	t.Setenv("UNRELATED_VAR", "kept")
 
 	env := pluginEnv([]string{"--plain"})
 
 	joined := strings.Join(env, "\n")
-	for _, forbidden := range []string{"DTCTL_TOKEN=", "DT_API_TOKEN=", "SECRET"} {
+	for _, forbidden := range []string{"DTCTL_TOKEN=", "DT_API_TOKEN=", "DTCTL_ACCOUNT_TOKEN=", "SECRET"} {
 		if strings.Contains(joined, forbidden) {
 			t.Errorf("credential material leaked into plugin env (%s)", forbidden)
 		}

--- a/docs/dev/PLUGIN_CONVENTIONS.md
+++ b/docs/dev/PLUGIN_CONVENTIONS.md
@@ -35,8 +35,8 @@ dtctl sets these variables for the plugin process:
 | `DTCTL_CALLER_VERSION` | The dispatching dtctl's version, for compatibility decisions |
 
 **No tokens from dtctl.** dtctl never passes credentials via argv, and it
-strips its documented credential variables (`DTCTL_TOKEN`, `DT_API_TOKEN`)
-from the plugin's environment. The rest of the caller's environment is
+strips its documented credential variables (`DTCTL_TOKEN`, `DT_API_TOKEN`,
+`DTCTL_ACCOUNT_TOKEN`) from the plugin's environment. The rest of the caller's environment is
 inherited as-is — a token you placed in a custom variable (e.g. one referenced
 via `${MY_TOKEN}` in the config file) is not recognized as a credential and
 reaches the plugin like any other inherited variable. Plugins resolve


### PR DESCRIPTION
## Description

`pluginEnv` strips `DTCTL_TOKEN` and `DT_API_TOKEN` before handing the environment to a plugin, but not `DTCTL_ACCOUNT_TOKEN`, so the account token is inherited by every dispatched plugin

this looks like a missed update rather than a scope decision: plugin dispatch and `credentialEnvVars` landed in #359 on 2026-07-15, and `DTCTL_ACCOUNT_TOKEN` was introduced nine days later in #342 - the list could not have deliberately excluded a variable that did not exist yet, and it has not been touched since

it also crosses a privilege boundary that the docs say it should not. `dtctl plugin --help` promises "never tokens or other secrets" without qualification, and `docs/dev/PLUGIN_CONVENTIONS.md` says "No tokens from dtctl". The doc's carve-out is explicitly about user-chosen variables ("a token you placed in a custom variable"), which does not fit here - the name is hardcoded in dtctl and `cmd/root.go:1013` tells the user to set it: `account token required: set DTCTL_ACCOUNT_TOKEN or run 'dtctl account login'`

the effect is that a plugin which only needed environment-level access receives an account-level credential

## Related Issues

none - found while reading the plugin dispatch path

## Testing

extended the existing `TestPluginEnv_StripsCredentialEnvVars`, which fails before the change with `credential material leaked into plugin env (DTCTL_ACCOUNT_TOKEN=)` and passes after. Also updated the variable list in `PLUGIN_CONVENTIONS.md` so the doc keeps matching the code

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
