### PR TITLE
fix: don't panic when .content.content is not an object

### DIFF
--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -460,6 +460,46 @@ func TestExtractDocumentContent(t *testing.T) {
 	}
 }
 
+func TestExtractDocumentContent_NonMapNestedContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		inner interface{}
+	}{
+		{"string", "# Welcome to the team"},
+		{"nil", nil},
+		{"slice", []interface{}{"a"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := map[string]interface{}{
+				"name": "Launchpad",
+				"content": map[string]interface{}{
+					"content": tt.inner,
+					"format":  "markdown",
+				},
+			}
+
+			contentData, name, _, warnings := extractDocumentContent(doc, "launchpad")
+
+			if name != "Launchpad" {
+				t.Errorf("name = %q, want %q", name, "Launchpad")
+			}
+			if len(warnings) != 0 {
+				t.Errorf("got %d warnings, want 0: %v", len(warnings), warnings)
+			}
+
+			var content map[string]interface{}
+			if err := json.Unmarshal(contentData, &content); err != nil {
+				t.Fatalf("contentData is not valid JSON: %v", err)
+			}
+			if content["format"] != "markdown" {
+				t.Errorf("format = %v, want markdown - a non-map .content.content must leave the outer content in place", content["format"])
+			}
+		})
+	}
+}
+
 func TestCountDocumentItems(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/apply/apply_document.go
+++ b/pkg/apply/apply_document.go
@@ -281,8 +281,10 @@ func extractDocumentContent(doc map[string]interface{}, docType string) ([]byte,
 		if isMap {
 			// Check for double-nested content (common mistake)
 			if innerContent, hasInner := contentMap["content"]; hasInner {
-				warnings = append(warnings, "detected double-nested content (.content.content) - using inner content")
-				contentMap = innerContent.(map[string]interface{})
+				if inner, ok := innerContent.(map[string]interface{}); ok {
+					warnings = append(warnings, "detected double-nested content (.content.content) - using inner content")
+					contentMap = inner
+				}
 			}
 
 			// Validate structure based on document type


### PR DESCRIPTION
## Description

`extractDocumentContent` in `pkg/apply` unwraps double-nested content with a bare type assertion, so a document whose body has its own `content` key crashes apply:

```
panic: interface conversion: interface {} is string, not map[string]interface {}
```

this is reachable through the round-trip the CLI itself produces. `MarshalYAML` renders the document body under a top-level `content` key (`sdk/api/document/document.go:1208`), so exporting a document whose body already has `content` and feeding it back gives `content.content` as a string

the assertion used to be safe: only dashboards and notebooks went through this path, and their bodies never carry a top-level `content` key. #390 generalized apply to documents of any type, which broke that invariant without adding the guard

two details worth noting - the panic happens before the safety check, so `safety-level: readonly` does not stop it, and under `--agent` the process prints a Go stack trace instead of the documented `{"ok":false,"error":{...}}` envelope

`cmd/create_documents.go` carries the same function with the comma-ok guard already in place, so this just brings apply in line - after the change the two are identical

## Related Issues

none - found while comparing the apply and create paths

## Testing

added `TestExtractDocumentContent_NonMapNestedContent` covering a string, nil and a slice as the inner value. It panics before the change and passes after, and asserts the outer content is kept rather than silently replaced

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
