### PR TITLE
fix: paginate direct shares so unshare --all sees every page

### DIFF
--- a/sdk/api/document/document.go
+++ b/sdk/api/document/document.go
@@ -610,30 +610,61 @@ func (h *Handler) CreateDirectShare(ctx context.Context, req CreateDirectShareRe
 	return &result, nil
 }
 
-// ListDirectShares lists direct shares for a document
+// ListDirectShares lists direct shares for a document.
+// Paginates automatically using the Document API style (page-size sent on every request).
 func (h *Handler) ListDirectShares(ctx context.Context, documentID string) (*DirectShareList, error) {
-	req := h.client.HTTP().R().SetContext(ctx)
+	var allShares []DirectShare
+	var totalCount int
+	nextPageKey := ""
 
+	filterStr := ""
 	if documentID != "" {
-		req.SetQueryParam("filter", fmt.Sprintf("documentId=='%s'", escapeFilterValue(documentID)))
+		filterStr = fmt.Sprintf("documentId=='%s'", escapeFilterValue(documentID))
 	}
 
-	resp, err := req.Get("/platform/document/v1/direct-shares")
+	for {
+		var result DirectShareList
+		req := h.client.HTTP().R().SetContext(ctx)
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to list direct shares: %w", err)
+		filters := map[string]string{}
+		if filterStr != "" {
+			filters["filter"] = filterStr
+		}
+
+		req.SetQueryParamsFromValues(httpclient.PaginationParams{
+			Style:         httpclient.PaginationDocumentAPI,
+			PageKeyParam:  "page-key",
+			PageSizeParam: "page-size",
+			NextPageKey:   nextPageKey,
+			Filters:       filters,
+		}.QueryParams())
+
+		resp, err := req.Get("/platform/document/v1/direct-shares")
+		if err != nil {
+			return nil, fmt.Errorf("failed to list direct shares: %w", err)
+		}
+
+		if err := httpclient.CheckResponse(resp); err != nil {
+			return nil, fmt.Errorf("failed to list direct shares: %w", err)
+		}
+
+		if err := json.Unmarshal(resp.Body(), &result); err != nil {
+			return nil, fmt.Errorf("list direct shares: parse response: %w", err)
+		}
+
+		allShares = append(allShares, result.Shares...)
+		totalCount = result.TotalCount
+
+		if result.NextPageKey == "" {
+			break
+		}
+		nextPageKey = result.NextPageKey
 	}
 
-	if err := httpclient.CheckResponse(resp); err != nil {
-		return nil, fmt.Errorf("failed to list direct shares: %w", err)
-	}
-
-	var result DirectShareList
-	if err := json.Unmarshal(resp.Body(), &result); err != nil {
-		return nil, fmt.Errorf("list direct shares: parse response: %w", err)
-	}
-
-	return &result, nil
+	return &DirectShareList{
+		Shares:     allShares,
+		TotalCount: totalCount,
+	}, nil
 }
 
 // DeleteDirectShare deletes a direct share

--- a/sdk/api/document/document_test.go
+++ b/sdk/api/document/document_test.go
@@ -264,6 +264,44 @@ func TestListDirectShares(t *testing.T) {
 	}
 }
 
+func TestListDirectShares_Paginated(t *testing.T) {
+	callCount := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/direct-shares", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if f := r.URL.Query().Get("filter"); f != "documentId=='doc-123'" {
+			t.Errorf("filter = %q, want the document filter on every page", f)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page-key") {
+		case "":
+			_, _ = w.Write([]byte(`{"direct-shares":[{"id":"share-1","documentId":"doc-123","access":["read"]}],` +
+				`"totalCount":2,"nextPageKey":"page2token"}`))
+		case "page2token":
+			_, _ = w.Write([]byte(`{"direct-shares":[{"id":"share-2","documentId":"doc-123","access":["read"]}],` +
+				`"totalCount":2}`))
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, `{"error":{"message":"unknown page key"}}`)
+		}
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	result, err := h.ListDirectShares(context.Background(), "doc-123")
+	if err != nil {
+		t.Fatalf("ListDirectShares() error: %v", err)
+	}
+	if len(result.Shares) != 2 {
+		t.Errorf("got %d shares, want 2 - later pages are dropped", len(result.Shares))
+	}
+	if result.TotalCount != 2 {
+		t.Errorf("TotalCount = %d, want 2", result.TotalCount)
+	}
+	if callCount != 2 {
+		t.Errorf("API called %d times, want 2", callCount)
+	}
+}
+
 func TestDeleteEnvironmentShare(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/platform/document/v1/environment-shares/share-1", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description

`ListDirectShares` issues a single unpaginated GET, so on a document with more than one page of direct shares `dtctl unshare document --all` deletes the first page, reports success and leaves the rest in place:

```
OK Deleted 20 share(s) from document "doc-1"     # 25 shares existed, exit 0
```

for an operation whose whole point is revoking access, reporting success while access survives is the bad failure mode here

the endpoint is already modelled as paginated - `DirectShareList` declares `NextPageKey` and the response is parsed into it, the value is just never read. Every other list in this file paginates: `List` (:236), `ListEnvironmentShares` (:860), `ListSnapshots` (:1086)

`ListEnvironmentShares` is the closest analogue and it is worth noting that it paginates even though a document can hold at most one environment share (`CreateEnvironmentShare` returns `ErrShareConflict` on a second one), while direct shares - which have no such limit - do not

## Related Issues

none - found while working on the direct share list parsing

## Testing

added `TestListDirectShares_Paginated`, which serves two pages and asserts both are collected and that the filter is sent on every request. Before the change it reports `got 1 shares, want 2` and `API called 1 times, want 2`

follows the Document API pagination style documented in AGENTS.md, matching `ListEnvironmentShares`

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
