### PR TITLE
docs: add community Nix install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ curl -fsSL https://raw.githubusercontent.com/dynatrace-oss/dtctl/main/install.sh
 irm https://raw.githubusercontent.com/dynatrace-oss/dtctl/main/install.ps1 | iex
 ```
 
+```bash
+# Nix flake (community maintained, not part of this project)
+nix run github:srizzling/dtctl-nix -- version
+```
+
 Binary downloads, building from source, shell completion setup, and more in the **[Installation Guide](https://dynatrace-oss.github.io/dtctl/docs/installation/)**.
 
 ## Authenticate

--- a/docs/site/_docs/installation.md
+++ b/docs/site/_docs/installation.md
@@ -25,6 +25,34 @@ This downloads the latest release, extracts it to `~/.local/bin` (Linux) or `/us
 curl -fsSL https://raw.githubusercontent.com/dynatrace-oss/dtctl/main/install.sh | DTCTL_INSTALL_DIR=~/bin sh
 ```
 
+## Nix (community maintained)
+
+dtctl is not in nixpkgs, but a community flake packages the official release
+binaries and tracks new releases automatically.
+
+```bash
+nix run github:srizzling/dtctl-nix -- version
+```
+
+To add it to a flake, use the package or the overlay:
+
+```nix
+{
+  inputs.dtctl-nix.url = "github:srizzling/dtctl-nix";
+
+  # dtctl-nix.packages.${system}.dtctl
+  # or: nixpkgs.overlays = [ dtctl-nix.overlays.default ];  ->  pkgs.dtctl
+}
+```
+
+Shell completions are installed alongside the binary. Supported systems are
+`aarch64-darwin`, `aarch64-linux` and `x86_64-linux`; Intel macOS works through
+the overlay on a nixpkgs that still supports `x86_64-darwin`.
+
+This flake is maintained by the community and is not part of the dtctl project.
+Please report packaging issues to
+[srizzling/dtctl-nix](https://github.com/srizzling/dtctl-nix/issues).
+
 ## Windows (PowerShell)
 
 ```powershell
@@ -133,6 +161,9 @@ brew update && brew upgrade dtctl
 
 # Shell script (re-run)
 curl -fsSL https://raw.githubusercontent.com/dynatrace-oss/dtctl/main/install.sh | sh
+
+# Nix (community flake, from a flake that inputs it)
+nix flake update dtctl-nix
 
 # From source
 git pull && make build


### PR DESCRIPTION
## Description

Adds a Nix install method to the Installation guide and the README. dtctl isn't in nixpkgs, so this documents a community flake that packages the official release binaries — no change to dtctl itself, docs only.

The flake ([srizzling/dtctl-nix](https://github.com/srizzling/dtctl-nix)):

- installs upstream's prebuilt, signed binaries rather than rebuilding from source, so the Darwin code signature stays intact
- pins hashes read straight from each release's `checksums.txt`
- has a daily workflow that repins, builds on every supported system, and merges the bump — so a new dtctl release is available within a day without anyone touching it
- installs the bash/zsh/fish completions you already ship

It's explicitly labelled **community maintained**, states it isn't part of the dtctl project, and points packaging issues at its own tracker rather than this one.

In the README it's placed last in the install list and carries the same disclaimer inline, so it reads as clearly secondary to the officially supported methods. If you'd rather keep the README to first-party methods only, say the word and I'll drop that hunk — the Installation guide entry stands on its own.

One note on scope: supported systems are `aarch64-darwin`, `aarch64-linux`, `x86_64-linux`. Intel macOS is reachable via the overlay but isn't in the flake's outputs, because nixpkgs 26.11 dropped `x86_64-darwin` support.

Also adds the matching one-liner to the Updating section.

## Related Issues

None.

## Testing

Docs-only, so `make test` / `make lint` are unaffected. I verified the documented commands against dtctl 0.37.0:

- `nix run github:srizzling/dtctl-nix -- version` reports `dtctl version 0.37.0`
- the overlay and package outputs both resolve, and the completions land in the expected paths
- the flake builds on aarch64-darwin, aarch64-linux and x86_64-linux in CI

Happy to adjust the wording, placement, or level of detail — or to drop it entirely if you'd rather not point at community packaging from the docs.