### PR TITLE
feat: embeddable service engine (cmd.Run, pkg/engine) and experimental dtctl serve http

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,10 @@ pkg/
   ├── plugin/    # kubectl-style exec plugin resolution/discovery (docs/dev/PLUGIN_CONVENTIONS.md)
   ├── resources/ # Resource handlers — thin CLI wrappers that delegate to sdk/api/
   ├── output/    # Formatters (table, JSON, YAML, charts, agent envelope, color control)
-  └── exec/      # DQL query execution
+  ├── exec/      # DQL query execution
+  ├── vfs/       # Virtual-filesystem seam: user-supplied file paths resolve against the host disk (CLI) or per-request virtual files (engine)
+  ├── engine/    # Embeddable service engine: one dtctl command line per request — multi-tenant session, virtual files, CLI-identical output
+  └── serve/     # `dtctl serve` — reference HTTP wrapper over pkg/engine (wired in main, outside the invocation lock)
 sdk/            # Separate Go module (github.com/dynatrace-oss/dtctl/sdk)
   ├── session/     # The session layer (docs/dev/CONFIG_CONTRACT.md): config model + load/save, credential stores, OAuth flow/refresh + cross-process lock, client-from-context with parameterized User-Agent, safety semantics
   ├── api/         # Typed API wrappers (one package per Dynatrace API surface)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ kubectl-inspired CLI for Dynatrace (dashboards, workflows, SLOs, etc). Go + Cobr
 
 ```text
 cmd/          # Cobra commands (get, describe, create, delete, apply, exec, ctx, doctor, commands, plugin)
+              # plus the embedding entrypoint: run.go (cmd.Run + per-invocation isolation),
+              # session.go, capabilities.go, stdio.go, blocked.go (docs/dev/SERVICE_ENGINE_DESIGN.md)
 pkg/
   ├── client/    # Shim over sdk/session's client; keeps CLI-only extras (typed errors, pagination, OTel injection) and pins the dtctl/<version> User-Agent
   ├── config/    # Shim over sdk/session — the config model/keyring implementation lives in the sdk
@@ -25,7 +27,7 @@ pkg/
   ├── exec/      # DQL query execution
   ├── vfs/       # Virtual-filesystem seam: user-supplied file paths resolve against the host disk (CLI) or per-request virtual files (engine)
   ├── engine/    # Embeddable service engine: one dtctl command line per request — multi-tenant session, virtual files, CLI-identical output
-  └── serve/     # `dtctl serve` — reference HTTP wrapper over pkg/engine (wired in main, outside the invocation lock)
+  └── serve/     # `dtctl serve <protocol>` — reference servers over pkg/engine, one subcommand per protocol (`serve http` today; wired in main, outside the invocation lock)
 sdk/            # Separate Go module (github.com/dynatrace-oss/dtctl/sdk)
   ├── session/     # The session layer (docs/dev/CONFIG_CONTRACT.md): config model + load/save, credential stores, OAuth flow/refresh + cross-process lock, client-from-context with parameterized User-Agent, safety semantics
   ├── api/         # Typed API wrappers (one package per Dynatrace API surface)
@@ -83,8 +85,8 @@ When adding a new AI agent to the skills system, update **all** of the following
 ## Adding a Resource
 
 1. **SDK layer** (`sdk/api/<name>/`): Create typed API wrapper with CRUD functions using `httpclient.Client`. No file I/O, no display logic.
-2. **CLI layer** (`pkg/resources/<name>/`): Create resource handler that delegates to SDK. Handle file reading, display fields, name resolution here.
-3. **Commands**: Add to `cmd/get.go`, `cmd/describe.go`, etc.
+2. **CLI layer** (`pkg/resources/<name>/`): Create resource handler that delegates to SDK. Handle file reading, display fields, name resolution here. Read user-supplied paths through `pkg/vfs`, never `os` directly (see [Embedding Invariants](#-critical-embedding-invariants-)).
+3. **Commands**: Add to `cmd/get.go`, `cmd/describe.go`, etc. Mutating verbs need a safety check; `-f`/`--file` flags go through `vfs`; no `os.Exit`, no ungated subprocess.
 4. Register in resolver
 5. Add tests: `sdk/api/<name>/*_test.go` (SDK unit tests) + `test/e2e/<name>_test.go` (E2E)
 
@@ -113,6 +115,8 @@ func (h *Handler) List(opts ListOptions) ([]Resource, error)
 | Add EXEC | `cmd/exec.go`, `pkg/exec/<type>.go` | See `pkg/exec/workflow.go` polling |
 | Add DQL template | `pkg/exec/dql.go`, `pkg/util/template/` | Use `text/template`, `--set` flag |
 | Fix output | `pkg/output/<format>.go` | Test: `dtctl get <resource> -o <format>` |
+| Read a user file | `pkg/vfs/` | `vfs.ReadFile` / `vfs.ReadFileOrStdin` — never `os.ReadFile` |
+| Add a serve protocol | `pkg/serve/<proto>.go` | Copy `pkg/serve/http.go`; register in `NewCommand()` |
 
 **Tests**: `make test` or `go test ./...` • E2E: `test/e2e/` • Integration: `test/integration/`
 
@@ -199,6 +203,74 @@ if !dryRun {
 
 **Examples**: [cmd/edit.go](cmd/edit.go), [cmd/create.go](cmd/create.go), [cmd/apply.go](cmd/apply.go)
 
+## 🚨 **CRITICAL: Embedding Invariants** 🚨
+
+dtctl runs as a one-shot CLI **and** as an in-process library, one invocation per
+service request (`cmd.Run` → `pkg/engine` → `dtctl serve http`). Same command
+tree, same code paths, same bytes on stdout — the only difference is where the
+invocation's credentials, files, and streams come from.
+
+Every rule below has a guard test, because every one of them was violated at
+least once — including twice inside the PR that introduced the model. Full
+rationale: [docs/dev/SERVICE_ENGINE_DESIGN.md](docs/dev/SERVICE_ENGINE_DESIGN.md).
+
+### 1. User-supplied file paths go through `pkg/vfs` — never `os` directly
+
+```go
+content, err := os.ReadFile(pathFromFlag)        // ❌ reads the SERVER's disk
+content, err := vfs.ReadFile(pathFromFlag)       // ✅
+content, err := vfs.ReadFileOrStdin(pathFromFlag) // ✅ when "-" means stdin
+```
+
+The test is **whose file is it**: a path the *user named* (`-f`, `--file`,
+`--data-file`, a query file, an `apply --write-id` writeback) is request state
+and must go through the seam. A path *dtctl chose* (editor temp file, config
+file, spill buffer) is host state and stays on `os`.
+
+Never open `/dev/stdin` as a path — the seam swaps the `os.Stdin` *variable*, so
+a path slips past it and doesn't exist on Windows. Use `os.Stdin` or
+`vfs.ReadFileOrStdin`.
+
+*Guard*: `go test ./cmd/ -run TestUserFilePathsGoThroughVFS`
+
+### 2. No subprocess without a capability gate
+
+Spawning (`exec.Command`, `syscall.Exec`) belongs in one of the five gateway
+files, each gated on a `cmd.Capabilities` field. Embedded callers grant nothing,
+so those paths become structurally unreachable rather than merely discouraged.
+
+*Guard*: `go test ./cmd/ -run TestSubprocessSpawnsConfinedToGateways`
+
+### 3. No `os.Exit` in command bodies
+
+An in-process caller dies with it. Return an error — `*silentExitError` for a
+specific exit code with no extra message.
+
+*Guard*: `go test ./cmd/ -run TestNoOsExitOutsideExecute`
+
+### 4. Credentials come from `LoadConfig()`, never from the process
+
+A `Session` transparently swaps in a synthetic single-context config. Reaching
+for `os.Getenv("DTCTL_TOKEN")`, the keyring, or a config path directly would
+hand one tenant's request the host's credentials — a session has scrubbed all of
+them precisely so that cannot happen.
+
+### 5. Output stays byte-identical to the CLI
+
+Print via `pkg/output`, `fmt.Print*`, or cobra — all resolve `os.Stdout`/
+`os.Stderr` dynamically, so the stream seam catches them. Don't cache a writer
+across invocations; don't make output depend on the host environment.
+
+*Guard*: `go test ./pkg/engine/ -run TestEngineOutputEqualsCLI` (builds the real
+binary and diffs CLI vs. engine stdout/stderr/exit code)
+
+### 6. New top-level command? Decide if it belongs in a service
+
+Add it to `unsupportedCommands` in `pkg/engine/policy.go` **with a reason** if it
+manages host-local state (config, keyring, shell, installed tools, an
+interactive session) or would nest the service in itself. The reason is
+user-facing — it appears in the `unsupported_in_service` error's suggestions.
+
 ## Privacy
 
 Never put customer names, employee names, usernames, or specific Dynatrace environment identifiers into the codebase, GitHub issues, PRs, release notes, or commits.
@@ -216,6 +288,12 @@ Never put customer names, employee names, usernames, or specific Dynatrace envir
 
 ❌ **Don't** skip safety checks on mutating commands  
 ✅ **Do** add safety checks to ALL create/edit/apply/delete/update commands
+
+❌ **Don't** read a user-supplied path with `os.ReadFile` / `os.Open`  
+✅ **Do** use `vfs.ReadFile` / `vfs.ReadFileOrStdin` (see Embedding Invariants)
+
+❌ **Don't** call `exec.Command` or `os.Exit` from a command body  
+✅ **Do** go through a capability gateway, and return errors instead of exiting
 
 ❌ **Don't** send `page-size` together with `next-page-key`/`page-key` on paginated requests  
 ❌ **Don't** drop filter/search params on subsequent pages — page tokens do NOT always preserve them  
@@ -386,6 +464,7 @@ if r.URL.Query().Get("nextPageKey") != "" {
 - **Design**: [docs/dev/API_DESIGN.md](docs/dev/API_DESIGN.md)
 - **Architecture**: [docs/dev/ARCHITECTURE.md](docs/dev/ARCHITECTURE.md)
 - **Status**: [docs/dev/IMPLEMENTATION_STATUS.md](docs/dev/IMPLEMENTATION_STATUS.md)
+- **Embedding/service model**: [docs/dev/SERVICE_ENGINE_DESIGN.md](docs/dev/SERVICE_ENGINE_DESIGN.md)
 - **Future Work**: [docs/dev/FUTURE_FEATURES.md](docs/dev/FUTURE_FEATURES.md)
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ pkg/
   ├── exec/      # DQL query execution
   ├── vfs/       # Virtual-filesystem seam: user-supplied file paths resolve against the host disk (CLI) or per-request virtual files (engine)
   ├── engine/    # Embeddable service engine: one dtctl command line per request — multi-tenant session, virtual files, CLI-identical output
-  └── serve/     # `dtctl serve <protocol>` — reference servers over pkg/engine, one subcommand per protocol (`serve http` today; wired in main, outside the invocation lock)
+  └── serve/     # `dtctl serve <protocol>` — reference servers over pkg/engine, one subcommand per protocol (`serve http` today; wired in main, outside the invocation lock). Experimental: registered only when DTCTL_EXPERIMENTAL_SERVE is set
 sdk/            # Separate Go module (github.com/dynatrace-oss/dtctl/sdk)
   ├── session/     # The session layer (docs/dev/CONFIG_CONTRACT.md): config model + load/save, credential stores, OAuth flow/refresh + cross-process lock, client-from-context with parameterized User-Agent, safety semantics
   ├── api/         # Typed API wrappers (one package per Dynatrace API surface)
@@ -223,9 +223,14 @@ content, err := vfs.ReadFileOrStdin(pathFromFlag) // ✅ when "-" means stdin
 ```
 
 The test is **whose file is it**: a path the *user named* (`-f`, `--file`,
-`--data-file`, a query file, an `apply --write-id` writeback) is request state
-and must go through the seam. A path *dtctl chose* (editor temp file, config
-file, spill buffer) is host state and stays on `os`.
+`--data-file`, a query file, a file to `diff`, an `apply --write-id` writeback)
+is request state and must go through the seam. A path *dtctl chose* (editor temp
+file, config file, spill buffer) is host state and stays on `os` — but only when
+a blocked command or an ungranted capability keeps a request from reaching it.
+
+**The rule follows the path, not the package.** `cmd/` reading through the seam
+and then handing the path to a `pkg/` helper that calls `os.ReadFile` is the
+same hole one frame deeper. The guard scans `cmd/` *and* `pkg/`.
 
 Never open `/dev/stdin` as a path — the seam swaps the `os.Stdin` *variable*, so
 a path slips past it and doesn't exist on Windows. Use `os.Stdin` or
@@ -233,11 +238,14 @@ a path slips past it and doesn't exist on Windows. Use `os.Stdin` or
 
 *Guard*: `go test ./cmd/ -run TestUserFilePathsGoThroughVFS`
 
-### 2. No subprocess without a capability gate
+### 2. No subprocess — and no host disk — without a capability gate
 
 Spawning (`exec.Command`, `syscall.Exec`) belongs in one of the five gateway
-files, each gated on a `cmd.Capabilities` field. Embedded callers grant nothing,
-so those paths become structurally unreachable rather than merely discouraged.
+files, each gated on a `cmd.Capabilities` field. Host-disk features outside the
+vfs seam are gated the same way: result spilling needs `HostDiskSpill`, because a
+spilled file outlives the request on the server and its path means nothing to the
+caller. Embedded callers grant nothing, so those paths become structurally
+unreachable rather than merely discouraged.
 
 *Guard*: `go test ./cmd/ -run TestSubprocessSpawnsConfinedToGateways`
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Token-based authentication and multi-environment configuration are covered in th
 - **Multi-environment**: Switch between dev/staging/prod with a single command; safety levels prevent accidental changes
 - **Watch mode**: Real-time monitoring with `--watch` for all resources
 - **DQL passthrough**: Execute queries directly, with template variables and file-based input
-- **Embeddable**: `dtctl serve http` (or `pkg/engine` in Go) runs the same command surface in-process for services and Workflow actions — multi-tenant per request, no host config, output byte-identical to the CLI
+- **Embeddable**: `dtctl serve http` (experimental, opt in with `DTCTL_EXPERIMENTAL_SERVE=1`) or `pkg/engine` in Go runs the same command surface in-process for services and Workflow actions — multi-tenant per request, no host config, output byte-identical to the CLI
 - **[NO_COLOR](https://no-color.org/) support**: Respects `NO_COLOR`, `FORCE_COLOR=1`, and auto-detects TTY
 
 ## Supported Resources
@@ -125,7 +125,7 @@ These skills provide the domain context (e.g., how to write DQL queries, which m
 
 ## Running as a Service
 
-`dtctl serve http` exposes the CLI over HTTP for AI agents and automation: one request executes one dtctl command line for one tenant (`POST /v1/execute`) and returns the exact output the CLI would have printed. Each request brings its own environment URL and token, file arguments resolve against per-request virtual files, and host-only commands are unavailable. Go callers can embed `pkg/engine` directly instead. It is a reference implementation with no authentication of its own — see [Server Mode](https://dynatrace-oss.github.io/dtctl/docs/serve/) before exposing it beyond localhost.
+`dtctl serve http` exposes the CLI over HTTP for AI agents and automation. It is **experimental**: set `DTCTL_EXPERIMENTAL_SERVE=1` to enable the command, and expect the contract to change. One request executes one dtctl command line for one tenant (`POST /v1/execute`) and returns the exact output the CLI would have printed. Each request brings its own environment URL and token, file arguments resolve against per-request virtual files, and host-only commands are unavailable. Go callers can embed `pkg/engine` directly instead. It is a reference implementation with no authentication of its own — see [Server Mode](https://dynatrace-oss.github.io/dtctl/docs/serve/) before exposing it beyond localhost.
 
 ## Observability
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Token-based authentication and multi-environment configuration are covered in th
 - **Multi-environment**: Switch between dev/staging/prod with a single command; safety levels prevent accidental changes
 - **Watch mode**: Real-time monitoring with `--watch` for all resources
 - **DQL passthrough**: Execute queries directly, with template variables and file-based input
+- **Embeddable**: `dtctl serve http` (or `pkg/engine` in Go) runs the same command surface in-process for services and Workflow actions — multi-tenant per request, no host config, output byte-identical to the CLI
 - **[NO_COLOR](https://no-color.org/) support**: Respects `NO_COLOR`, `FORCE_COLOR=1`, and auto-detects TTY
 
 ## Supported Resources
@@ -122,6 +123,10 @@ npx skills add dynatrace/dynatrace-for-ai
 
 These skills provide the domain context (e.g., how to write DQL queries, which metrics to use for service health, how to navigate distributed traces) while dtctl provides the operational tool to act on it. Together they give AI agents everything they need to work with Dynatrace effectively.
 
+## Running as a Service
+
+`dtctl serve http` exposes the CLI over HTTP for AI agents and automation: one request executes one dtctl command line for one tenant (`POST /v1/execute`) and returns the exact output the CLI would have printed. Each request brings its own environment URL and token, file arguments resolve against per-request virtual files, and host-only commands are unavailable. Go callers can embed `pkg/engine` directly instead. It is a reference implementation with no authentication of its own — see [Server Mode](https://dynatrace-oss.github.io/dtctl/docs/serve/) before exposing it beyond localhost.
+
 ## Observability
 
 dtctl supports W3C Trace Context propagation and OTLP span export via the OpenTelemetry SDK. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) for full details on distributed tracing, environment variables, and CI/CD pipeline integration.
@@ -137,6 +142,7 @@ Full documentation is available at **[dynatrace-oss.github.io/dtctl](https://dyn
 - [Output Formats](https://dynatrace-oss.github.io/dtctl/docs/output-formats/): Table, JSON, YAML, CSV, charts
 - [AI Agent Mode](https://dynatrace-oss.github.io/dtctl/docs/ai-agent-mode/): Structured envelope, auto-detection, agent skill
 - [Token Scopes](https://dynatrace-oss.github.io/dtctl/docs/token-scopes/): Required API token scopes per safety level
+- [Server Mode](https://dynatrace-oss.github.io/dtctl/docs/serve/): Running dtctl as a server, the execute API, and embedding `pkg/engine`
 
 Resource-specific guides: [DQL Queries](https://dynatrace-oss.github.io/dtctl/docs/dql-queries/) · [Workflows](https://dynatrace-oss.github.io/dtctl/docs/workflows/) · [Dashboards](https://dynatrace-oss.github.io/dtctl/docs/dashboards/) · [SLOs](https://dynatrace-oss.github.io/dtctl/docs/slos/) · [Settings](https://dynatrace-oss.github.io/dtctl/docs/settings/) · [Extensions](https://dynatrace-oss.github.io/dtctl/docs/extensions/) · [Analyzers](https://dynatrace-oss.github.io/dtctl/docs/analyzers/) · [CoPilot](https://dynatrace-oss.github.io/dtctl/docs/copilot/) · [and more...](https://dynatrace-oss.github.io/dtctl/docs/quick-start/)
 

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"strings"
-
 	"github.com/spf13/cobra"
 )
 
@@ -15,15 +12,9 @@ import (
 const accountExperimentalEnvVar = "DTCTL_EXPERIMENTAL_ACCOUNT"
 
 // accountExperimentalEnabled reports whether the experimental account command
-// surface should be registered. Any value other than empty/0/false/no/off
-// (case-insensitive) enables it.
+// surface should be registered.
 func accountExperimentalEnabled() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(accountExperimentalEnvVar))) {
-	case "", "0", "false", "no", "off":
-		return false
-	default:
-		return true
-	}
+	return ExperimentalEnabled(accountExperimentalEnvVar)
 }
 
 var accountCmd = &cobra.Command{

--- a/cmd/alias_resolve.go
+++ b/cmd/alias_resolve.go
@@ -26,7 +26,7 @@ func resolveAlias(args []string, cfg *config.Config) ([]string, bool, error) {
 
 	// Aliases from an auto-discovered local .dtctl.yaml are untrusted and never
 	// honored — they can run arbitrary commands. The warning is emitted once in
-	// execute() via cfg.IgnoredExecKeys(); here we simply decline to expand.
+	// executeArgs() via cfg.IgnoredExecKeys(); here we simply decline to expand.
 	if cfg.IsLocal() {
 		return nil, false, nil
 	}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -194,6 +194,12 @@ resources in sync with their file definitions.
 
 		// Configure pre-apply and post-apply hooks
 		if !noHooks {
+			// Capability gate: hooks execute arbitrary configured commands.
+			// Fail loudly when the config requests one the host forbids —
+			// silently skipping a validation hook would be worse.
+			if !caps.ApplyHooks && (cfg.GetPreApplyHook() != "" || cfg.GetPostApplyHook() != "") {
+				return &CapabilityError{Feature: "apply hooks"}
+			}
 			if hookCmd := cfg.GetPreApplyHook(); hookCmd != "" {
 				applier = applier.WithPreApplyHook(hookCmd).WithSourceFile(file)
 			}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -185,6 +185,10 @@ resources in sync with their file definitions.
 		// Create applier with safety checker (safety checks happen inside applier
 		// with proper ownership determination for updates)
 		applier := apply.NewApplier(c)
+		// The source file is the --write-id writeback target (and hook
+		// context) — it must be set regardless of whether hooks are
+		// configured, or the id never lands back in the file.
+		applier = applier.WithSourceFile(file)
 		if !dryRun {
 			checker, err := NewSafetyChecker(cfg)
 			if err != nil {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/document"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // applyCmd represents the apply command
@@ -156,7 +157,7 @@ resources in sync with their file definitions.
 		}
 
 		// Read the file
-		fileData, err := os.ReadFile(file)
+		fileData, err := vfs.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
 		}

--- a/cmd/apply_extension_configs.go
+++ b/cmd/apply_extension_configs.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // applyExtensionConfigCmd creates or updates a monitoring configuration for an extension
@@ -56,7 +56,7 @@ Examples:
 		}
 
 		// Read the file
-		fileData, err := os.ReadFile(file)
+		fileData, err := vfs.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
 		}

--- a/cmd/blocked.go
+++ b/cmd/blocked.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// UnsupportedCommandError is returned when an invocation names a top-level
+// command that the embedding caller has removed from the surface via
+// RunOptions.BlockedCommands — commands that only make sense on a host CLI
+// (config, ctx, auth, ...) and are meaningless or unsafe inside a service.
+// It is a surface error like ProfileError, distinct from safety (permission)
+// and capability (process-ability) errors; agent mode renders it with the
+// stable code "unsupported_in_service" (see errorToDetail).
+type UnsupportedCommandError struct {
+	// Command is the space-joined command path relative to root (e.g. "config view").
+	Command string
+	// Reason says why the command is out of scope for this environment.
+	Reason string
+}
+
+// Headline is the one-line statement of the block, shared by the
+// human-readable Error() string and the structured agent-mode ErrorDetail so
+// the two never drift.
+func (e *UnsupportedCommandError) Headline() string {
+	return fmt.Sprintf("command %q is not supported in this environment", e.Command)
+}
+
+// Suggestions are the remediation hints, shared with the agent-mode ErrorDetail.
+func (e *UnsupportedCommandError) Suggestions() []string {
+	return []string{
+		e.Reason,
+		"run 'dtctl commands' to see the available command set",
+	}
+}
+
+func (e *UnsupportedCommandError) Error() string {
+	return e.Headline() + "\n\n" +
+		"  " + e.Reason + ". Run 'dtctl commands' to see what is available here,\n" +
+		"  or run this command with a local dtctl installation."
+}
+
+// runBlocked holds the active invocation's blocked-command set (top-level
+// command name → reason). Guarded by runMu like the rest of the per-invocation
+// state; nil means the full surface (the CLI default).
+var runBlocked map[string]string
+
+// applyBlockedCommands masks every subtree whose top-level command name is in
+// blocked, using the same mechanics as the profile mask (applyProfile): Hidden
+// removes the command from --help, the `dtctl commands` catalog, and shell
+// completion in one shot, and runnable nodes are wrapped with a guard that
+// returns an UnsupportedCommandError. Arg validation and flag parsing are
+// neutralized so the guard is the only observable outcome — a blocked
+// command's arg/flag shape must not leak through generic Cobra errors.
+//
+// The restriction composes with profiles: both masks apply per run and the
+// pristine-tree restore (restorePristineTree) undoes them before the next.
+func applyBlockedCommands(root *cobra.Command, blocked map[string]string) {
+	if len(blocked) == 0 {
+		return
+	}
+	for _, top := range root.Commands() {
+		reason, ok := blocked[top.Name()]
+		if !ok {
+			continue
+		}
+		walkCommands(top, func(cmd *cobra.Command) {
+			cmd.Hidden = true
+			// Unlike the profile mask, guard even non-runnable parents: a
+			// blocked bare parent (e.g. `config`) would otherwise print its
+			// help with exit 0, leaking the subtree and reporting success.
+			cmd.Args = cobra.ArbitraryArgs
+			cmd.DisableFlagParsing = true
+			cmd.RunE = unsupportedRunE(commandPathRelative(cmd, root), reason)
+			cmd.Run = nil
+		})
+	}
+}
+
+// unsupportedRunE returns a RunE that reports the command as unsupported in
+// this environment. Masking wraps RunE (rather than removing the command) so
+// the caller gets a specific, signposted error instead of a generic "unknown
+// command".
+func unsupportedRunE(path, reason string) func(*cobra.Command, []string) error {
+	return func(*cobra.Command, []string) error {
+		return &UnsupportedCommandError{Command: path, Reason: reason}
+	}
+}

--- a/cmd/blocked_test.go
+++ b/cmd/blocked_test.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+)
+
+// TestRunBlockedCommand_Guard: a blocked top-level command must fail with the
+// signposted "not supported" message carrying the caller's reason — not run,
+// and not degrade to a generic unknown-command error.
+func TestRunBlockedCommand_Guard(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"config"}, RunOptions{
+		BlockedCommands: map[string]string{"config": "it manages host state"},
+		Stdout:          &stdout,
+		Stderr:          &stderr,
+	})
+	require.Equal(t, client.ExitUsageError, code)
+	require.Contains(t, stderr.String(), `command "config" is not supported in this environment`)
+	require.Contains(t, stderr.String(), "it manages host state",
+		"the caller's reason must reach the user")
+}
+
+// TestRunBlockedCommand_Subtree: blocking a top-level command blocks its whole
+// subtree, and the error names the full command path.
+func TestRunBlockedCommand_Subtree(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	var stderr bytes.Buffer
+	code := Run([]string{"config", "view"}, RunOptions{
+		BlockedCommands: map[string]string{"config": "host config"},
+		Stderr:          &stderr,
+	})
+	require.NotZero(t, code)
+	require.Contains(t, stderr.String(), `command "config view" is not supported`)
+}
+
+// TestRunBlockedCommand_ArgAndFlagShapeDoesNotLeak: the guard must win over
+// Cobra's arg validation and flag parsing — a wrong arg count or unknown flag
+// on a blocked command still yields the block, not a shape error.
+func TestRunBlockedCommand_ArgAndFlagShapeDoesNotLeak(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	var stderr bytes.Buffer
+	code := Run([]string{"config", "--bogus-flag", "too", "many", "args"}, RunOptions{
+		BlockedCommands: map[string]string{"config": "host state"},
+		Stderr:          &stderr,
+	})
+	require.NotZero(t, code)
+	require.Contains(t, stderr.String(), "is not supported in this environment")
+	require.NotContains(t, stderr.String(), "unknown flag")
+}
+
+// TestRunBlockedCommand_AgentEnvelope: with --agent the block renders as a
+// structured envelope on stdout with the stable code. The flag never reaches
+// Cobra parsing (the mask disables it), so this exercises the raw-argv
+// fallback in executeArgs.
+func TestRunBlockedCommand_AgentEnvelope(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	var stdout bytes.Buffer
+	code := Run([]string{"config", "--agent"}, RunOptions{
+		BlockedCommands: map[string]string{"config": "it manages host state"},
+		Stdout:          &stdout,
+	})
+	require.Equal(t, client.ExitUsageError, code)
+	require.Contains(t, stdout.String(), `"code":"unsupported_in_service"`)
+	require.Contains(t, stdout.String(), `"ok":false`)
+}
+
+// TestRunBlockedCommand_HiddenFromCatalog: a blocked command disappears from
+// the `dtctl commands` catalog — an agent bootstrapping from the catalog must
+// not be steered toward commands it cannot run.
+func TestRunBlockedCommand_HiddenFromCatalog(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	var withBlock bytes.Buffer
+	code := Run([]string{"commands"}, RunOptions{
+		BlockedCommands: map[string]string{"doctor": "host diagnostics"},
+		Stdout:          &withBlock,
+	})
+	require.Zero(t, code)
+	require.NotContains(t, withBlock.String(), "doctor")
+	require.Contains(t, withBlock.String(), "get", "unblocked commands stay listed")
+
+	// The next unrestricted run sees the full surface again (pristine restore).
+	var without bytes.Buffer
+	code = Run([]string{"commands"}, RunOptions{Stdout: &without})
+	require.Zero(t, code)
+	require.Contains(t, without.String(), "doctor")
+}
+
+// TestRunBlockedCommand_NextRunUnaffected: the mask is strictly per-invocation
+// — the same command runs normally when the next caller doesn't block it.
+func TestRunBlockedCommand_NextRunUnaffected(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	var stderr bytes.Buffer
+	code := Run([]string{"config"}, RunOptions{
+		BlockedCommands: map[string]string{"config": "host state"},
+		Stderr:          &stderr,
+	})
+	require.NotZero(t, code)
+
+	var stdout bytes.Buffer
+	code = Run([]string{"config", "--help"}, RunOptions{Stdout: &stdout})
+	require.Zero(t, code, "config must work again without the block")
+	require.True(t, strings.Contains(stdout.String(), "config"),
+		"help for the unblocked command must render")
+}

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -8,7 +8,7 @@ import "fmt"
 // these, so an embedding caller — the service engine, `dtctl serve`, tests —
 // can make those paths structurally unreachable instead of relying on
 // configuration. The CLI binary grants everything; embedded callers grant
-// nothing (see the dtctl-as-a-service design, work item E3).
+// nothing (see docs/dev/SERVICE_ENGINE_DESIGN.md).
 type Capabilities struct {
 	// PluginDispatch allows unknown commands to exec dtctl-* binaries from
 	// PATH (full process replacement on Unix).

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -3,12 +3,13 @@ package cmd
 import "fmt"
 
 // Capabilities enumerates the process-level abilities the host grants the
-// command tree. Every path that would spawn a subprocess (or hand the process
-// over entirely, as Unix plugin dispatch does via exec) is gated on one of
-// these, so an embedding caller — the service engine, `dtctl serve`, tests —
-// can make those paths structurally unreachable instead of relying on
-// configuration. The CLI binary grants everything; embedded callers grant
-// nothing (see docs/dev/SERVICE_ENGINE_DESIGN.md).
+// command tree: spawning a subprocess (or handing the process over entirely, as
+// Unix plugin dispatch does via exec), and reaching for the host's disk outside
+// the vfs seam. Every such path is gated on one of these, so an embedding
+// caller — the service engine, `dtctl serve`, tests — can make it structurally
+// unreachable instead of relying on configuration. The CLI binary grants
+// everything; embedded callers grant nothing (see
+// docs/dev/SERVICE_ENGINE_DESIGN.md).
 type Capabilities struct {
 	// PluginDispatch allows unknown commands to exec dtctl-* binaries from
 	// PATH (full process replacement on Unix).
@@ -21,6 +22,11 @@ type Capabilities struct {
 	Editor bool
 	// BrowserOpen allows `open` to spawn the OS URL handler.
 	BrowserOpen bool
+	// HostDiskSpill allows large results to spill to a file on the host disk
+	// (`--spill`, `--spill-to`, and the automatic spill in agent mode). The
+	// spilled file and the path returned to the caller are both host state, so
+	// an embedded invocation returns its rows inline instead.
+	HostDiskSpill bool
 }
 
 // AllCapabilities is the CLI default: everything granted.
@@ -31,6 +37,7 @@ func AllCapabilities() Capabilities {
 		ApplyHooks:     true,
 		Editor:         true,
 		BrowserOpen:    true,
+		HostDiskSpill:  true,
 	}
 }
 

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -1,0 +1,60 @@
+package cmd
+
+import "fmt"
+
+// Capabilities enumerates the process-level abilities the host grants the
+// command tree. Every path that would spawn a subprocess (or hand the process
+// over entirely, as Unix plugin dispatch does via exec) is gated on one of
+// these, so an embedding caller — the service engine, `dtctl serve`, tests —
+// can make those paths structurally unreachable instead of relying on
+// configuration. The CLI binary grants everything; embedded callers grant
+// nothing (see the dtctl-as-a-service design, work item E3).
+type Capabilities struct {
+	// PluginDispatch allows unknown commands to exec dtctl-* binaries from
+	// PATH (full process replacement on Unix).
+	PluginDispatch bool
+	// ShellAliases allows shell-form aliases ("!...") to run via sh -c.
+	ShellAliases bool
+	// ApplyHooks allows configured pre-/post-apply hook commands to run.
+	ApplyHooks bool
+	// Editor allows `edit` commands to spawn $EDITOR.
+	Editor bool
+	// BrowserOpen allows `open` to spawn the OS URL handler.
+	BrowserOpen bool
+}
+
+// AllCapabilities is the CLI default: everything granted.
+func AllCapabilities() Capabilities {
+	return Capabilities{
+		PluginDispatch: true,
+		ShellAliases:   true,
+		ApplyHooks:     true,
+		Editor:         true,
+		BrowserOpen:    true,
+	}
+}
+
+// caps holds the granted set for this process. Defaults to the full CLI set;
+// embedded callers override via SetCapabilities before executing commands.
+// (Folded into the per-execution Runtime by the E1 refactor.)
+var caps = AllCapabilities()
+
+// SetCapabilities replaces the granted capability set. It returns the
+// previous set so tests can restore it.
+func SetCapabilities(c Capabilities) Capabilities {
+	prev := caps
+	caps = c
+	return prev
+}
+
+// CapabilityError reports a feature that is not granted in this environment.
+// In agent mode it renders as a structured envelope with code
+// "capability_disabled".
+type CapabilityError struct {
+	// Feature is the human-readable name of the blocked ability.
+	Feature string
+}
+
+func (e *CapabilityError) Error() string {
+	return fmt.Sprintf("%s is not available in this environment", e.Feature)
+}

--- a/cmd/capabilities_test.go
+++ b/cmd/capabilities_test.go
@@ -62,7 +62,7 @@ func TestErrorToDetailCapabilityError(t *testing.T) {
 func TestSubprocessSpawnsConfinedToGateways(t *testing.T) {
 	// file → the capability that gates its spawn(s).
 	gateways := map[string]string{
-		"alias_resolve.go":        "ShellAliases (gated at the execute() call site in root.go)",
+		"alias_resolve.go":        "ShellAliases (gated at the executeArgs() call site in root.go)",
 		"edit.go":                 "Editor (gated in launchEditor)",
 		"exec_forward_unix.go":    "PluginDispatch (only called from tryPluginDispatch)",
 		"exec_forward_windows.go": "PluginDispatch (only called from tryPluginDispatch)",

--- a/cmd/capabilities_test.go
+++ b/cmd/capabilities_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetCapabilitiesRoundTrip(t *testing.T) {
+	prev := SetCapabilities(Capabilities{})
+	require.Equal(t, AllCapabilities(), prev, "CLI default must grant every capability")
+	require.Equal(t, Capabilities{}, caps)
+
+	restored := SetCapabilities(prev)
+	require.Equal(t, Capabilities{}, restored, "SetCapabilities must return the value it replaced")
+	require.Equal(t, AllCapabilities(), caps)
+}
+
+func TestLaunchEditorCapabilityDisabled(t *testing.T) {
+	prev := SetCapabilities(Capabilities{})
+	t.Cleanup(func() { SetCapabilities(prev) })
+
+	err := launchEditor("vim", filepath.Join(t.TempDir(), "x.yaml"))
+	var capErr *CapabilityError
+	require.ErrorAs(t, err, &capErr)
+	require.Contains(t, capErr.Error(), "interactive editing")
+	require.Contains(t, capErr.Error(), "not available in this environment")
+}
+
+func TestPluginDispatchCapabilityDisabled(t *testing.T) {
+	prev := SetCapabilities(Capabilities{})
+	t.Cleanup(func() { SetCapabilities(prev) })
+
+	// With the capability off the gate must reject before any PATH lookup,
+	// so even a name that would resolve to a plugin falls through to the
+	// normal unknown-command error path.
+	code, handled := tryPluginDispatch([]string{"definitely-not-a-builtin"})
+	require.False(t, handled, "dispatch must decline when PluginDispatch is off")
+	require.Zero(t, code)
+}
+
+func TestErrorToDetailCapabilityError(t *testing.T) {
+	err := &CapabilityError{Feature: "apply hooks"}
+	detail := errorToDetail(err)
+	require.Equal(t, "capability_disabled", detail.Code)
+	require.Equal(t, err.Error(), detail.Message)
+
+	// Wrapped errors must still map (errors.As semantics).
+	detail = errorToDetail(errors.Join(errors.New("outer"), err))
+	require.Equal(t, "capability_disabled", detail.Code)
+}
+
+// TestSubprocessSpawnsConfinedToGateways is the E3 guard: every subprocess
+// spawn in cmd/ must live in one of the known capability-gated gateway files.
+// A spawn appearing anywhere else is a new escape hatch that bypasses the
+// Capabilities model and must either move behind an existing gateway or get
+// its own capability + gate before landing.
+func TestSubprocessSpawnsConfinedToGateways(t *testing.T) {
+	// file → the capability that gates its spawn(s).
+	gateways := map[string]string{
+		"alias_resolve.go":        "ShellAliases (gated at the execute() call site in root.go)",
+		"edit.go":                 "Editor (gated in launchEditor)",
+		"exec_forward_unix.go":    "PluginDispatch (only called from tryPluginDispatch)",
+		"exec_forward_windows.go": "PluginDispatch (only called from tryPluginDispatch)",
+		"open_intent.go":          "BrowserOpen (gated in openBrowser)",
+	}
+
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Clean(name))
+		require.NoError(t, err)
+
+		spawns := strings.Count(string(src), "exec.Command(") +
+			strings.Count(string(src), "syscall.Exec(") +
+			strings.Count(string(src), "exec.CommandContext(")
+		if spawns == 0 {
+			continue
+		}
+		require.Contains(t, gateways, name,
+			"%s spawns a subprocess outside the capability gateways — gate it behind cmd.Capabilities", name)
+	}
+}

--- a/cmd/check_scopes.go
+++ b/cmd/check_scopes.go
@@ -50,7 +50,13 @@ func (e *ScopeError) Error() string {
 // silentExitError carries a process exit code without producing any output.
 // Used by the explicit --check-scopes path, which prints its own verdict and
 // then needs to set a non-zero exit code without root.go printing a second error.
-type silentExitError struct{ code int }
+type silentExitError struct {
+	code int
+	// reason is recorded as the root span's status message for non-zero
+	// codes; it is never printed to the user (the command already produced
+	// its output — the code is part of its contract, not an error).
+	reason string
+}
 
 func (e *silentExitError) Error() string { return "" }
 
@@ -124,7 +130,7 @@ func scopePreflight(c *cobra.Command, _ []string) (skip bool, err error) {
 		}
 		printScopeVerdict(result)
 		if result.Status == scopeStatusInsufficient {
-			return true, &silentExitError{code: client.ExitPermissionError}
+			return true, &silentExitError{code: client.ExitPermissionError, reason: "insufficient scope"}
 		}
 		return true, nil
 	}

--- a/cmd/create_anomalydetector.go
+++ b/cmd/create_anomalydetector.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // createAnomalyDetectorCmd creates an anomaly detector from a file
@@ -45,7 +45,7 @@ Examples:
 		setFlags, _ := cmd.Flags().GetStringArray("set")
 
 		// Read the file
-		fileData, err := os.ReadFile(file)
+		fileData, err := vfs.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
 		}

--- a/cmd/create_buckets.go
+++ b/cmd/create_buckets.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/resources/bucket"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // createBucketCmd creates a Grail bucket
@@ -44,7 +44,7 @@ Examples:
 
 		if file != "" {
 			// Read from file
-			fileData, err := os.ReadFile(file)
+			fileData, err := vfs.ReadFile(file)
 			if err != nil {
 				return fmt.Errorf("failed to read file: %w", err)
 			}

--- a/cmd/create_documents.go
+++ b/cmd/create_documents.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -13,6 +12,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // createDocumentCmd creates a document of any type from a file
@@ -55,7 +55,7 @@ Examples:
 		if docType == "" {
 			file, _ := cmd.Flags().GetString("file")
 			if file != "" {
-				fileData, err := os.ReadFile(file)
+				fileData, err := vfs.ReadFile(file)
 				if err == nil {
 					jsonData, err := format.ValidateAndConvert(fileData)
 					if err == nil {
@@ -160,7 +160,7 @@ func createDocumentRunE(docType string) func(cmd *cobra.Command, args []string) 
 		labels, _ := cmd.Flags().GetStringArray("label")
 
 		// Read the file
-		fileData, err := os.ReadFile(file)
+		fileData, err := vfs.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
 		}

--- a/cmd/create_edgeconnects.go
+++ b/cmd/create_edgeconnects.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -12,6 +11,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/resources/edgeconnect"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // createEdgeConnectCmd creates an EdgeConnect
@@ -40,7 +40,7 @@ Examples:
 
 		if file != "" {
 			// Read from file
-			fileData, err := os.ReadFile(file)
+			fileData, err := vfs.ReadFile(file)
 			if err != nil {
 				return fmt.Errorf("failed to read file: %w", err)
 			}

--- a/cmd/create_extensions.go
+++ b/cmd/create_extensions.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -10,6 +9,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/extension"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // createExtensionCmd installs an extension — either a custom zip upload or a Hub extension.
@@ -67,7 +67,7 @@ Examples:
 
 func runUploadExtension(file string) error {
 	// Read the zip file
-	zipData, err := os.ReadFile(file)
+	zipData, err := vfs.ReadFile(file)
 	if err != nil {
 		return fmt.Errorf("failed to read file %q: %w", file, err)
 	}

--- a/cmd/create_lookups.go
+++ b/cmd/create_lookups.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/lookup"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // createLookupCmd creates a lookup table
@@ -66,7 +66,7 @@ Examples:
 		}
 
 		// Read file
-		fileData, err := os.ReadFile(file)
+		fileData, err := vfs.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
 		}

--- a/cmd/create_segments.go
+++ b/cmd/create_segments.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/resources/segment"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // createSegmentCmd creates a Grail filter segment
@@ -38,7 +38,7 @@ Examples:
 		}
 
 		// Read from file
-		fileData, err := os.ReadFile(file)
+		fileData, err := vfs.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
 		}

--- a/cmd/create_settings.go
+++ b/cmd/create_settings.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // createSettingsCmd creates a settings object from a file
@@ -52,7 +52,7 @@ Examples:
 		}
 
 		// Read the file
-		fileData, err := os.ReadFile(file)
+		fileData, err := vfs.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
 		}

--- a/cmd/create_slos.go
+++ b/cmd/create_slos.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // createSLOCmd creates an SLO from a file
@@ -38,7 +38,7 @@ Examples:
 		setFlags, _ := cmd.Flags().GetStringArray("set")
 
 		// Read the file
-		fileData, err := os.ReadFile(file)
+		fileData, err := vfs.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
 		}

--- a/cmd/create_workflows.go
+++ b/cmd/create_workflows.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
 )
@@ -39,7 +39,7 @@ Examples:
 		setFlags, _ := cmd.Flags().GetStringArray("set")
 
 		// Read the file
-		fileData, err := os.ReadFile(file)
+		fileData, err := vfs.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
 		}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/resources/document"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 var diffCmd = &cobra.Command{
@@ -213,7 +213,7 @@ func handleTwoRemoteResources(differ *diff.Differ, resourceType, id1, id2 string
 }
 
 func parseYAMLFile(path string) (interface{}, error) {
-	data, err := os.ReadFile(path)
+	data, err := vfs.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -138,12 +138,11 @@ func runDiff(cmd *cobra.Command, args []string) error {
 		fmt.Print(result.Patch)
 	}
 
-	exitCode := ExitCodeNoDiff
 	if result.HasChanges {
-		exitCode = ExitCodeHasDiff
+		// diff(1) semantics: exit 1 signals "differences found" without an
+		// error message — the patch itself is the output.
+		return &silentExitError{code: ExitCodeHasDiff, reason: "differences found"}
 	}
-
-	os.Exit(exitCode)
 	return nil
 }
 

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -1,8 +1,42 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/spf13/cobra"
 )
+
+// launchEditor opens path in the user's editor, resolving $EDITOR, then the
+// config preference, then vim. It is the single subprocess gateway for every
+// edit command and enforces the Editor capability, so embedded callers (which
+// grant no capabilities) can never spawn an editor.
+func launchEditor(preferredEditor, path string) error {
+	if !caps.Editor {
+		return &CapabilityError{Feature: "interactive editing (edit)"}
+	}
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = preferredEditor
+	}
+	if editor == "" {
+		editor = "vim"
+	}
+	parts := strings.Fields(editor)
+	if len(parts) == 0 {
+		return fmt.Errorf("no editor configured")
+	}
+	editorCmd := exec.Command(parts[0], append(parts[1:], path)...)
+	editorCmd.Stdin = os.Stdin
+	editorCmd.Stdout = os.Stdout
+	editorCmd.Stderr = os.Stderr
+	if err := editorCmd.Run(); err != nil {
+		return fmt.Errorf("editor failed: %w", err)
+	}
+	return nil
+}
 
 // editCmd represents the edit command
 var editCmd = &cobra.Command{

--- a/cmd/edit_anomalydetector.go
+++ b/cmd/edit_anomalydetector.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -77,24 +75,9 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		// Get the editor
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = cfg.Preferences.Editor
-		}
-		if editor == "" {
-			editor = "vim"
-		}
-
-		// Open the editor
-		parts := strings.Fields(editor)
-		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
-
-		if err := editorCmd.Run(); err != nil {
-			return fmt.Errorf("editor failed: %w", err)
+		// Open the editor (single gateway; enforces the Editor capability)
+		if err := launchEditor(cfg.Preferences.Editor, tmpfile.Name()); err != nil {
+			return err
 		}
 
 		// Read the edited file

--- a/cmd/edit_aws.go
+++ b/cmd/edit_aws.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -108,25 +106,9 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = cfg.Preferences.Editor
-		}
-		if editor == "" {
-			editor = "vim"
-		}
-
-		parts := strings.Fields(editor)
-		if len(parts) == 0 {
-			return fmt.Errorf("no editor configured")
-		}
-		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
-
-		if err := editorCmd.Run(); err != nil {
-			return fmt.Errorf("editor failed: %w", err)
+		// Open the editor (single gateway; enforces the Editor capability)
+		if err := launchEditor(cfg.Preferences.Editor, tmpfile.Name()); err != nil {
+			return err
 		}
 
 		editedData, err := os.ReadFile(tmpfile.Name())

--- a/cmd/edit_azure.go
+++ b/cmd/edit_azure.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -108,25 +106,9 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = cfg.Preferences.Editor
-		}
-		if editor == "" {
-			editor = "vim"
-		}
-
-		parts := strings.Fields(editor)
-		if len(parts) == 0 {
-			return fmt.Errorf("no editor configured")
-		}
-		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
-
-		if err := editorCmd.Run(); err != nil {
-			return fmt.Errorf("editor failed: %w", err)
+		// Open the editor (single gateway; enforces the Editor capability)
+		if err := launchEditor(cfg.Preferences.Editor, tmpfile.Name()); err != nil {
+			return err
 		}
 
 		editedData, err := os.ReadFile(tmpfile.Name())

--- a/cmd/edit_documents.go
+++ b/cmd/edit_documents.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -121,24 +119,9 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		// Get the editor
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = cfg.Preferences.Editor
-		}
-		if editor == "" {
-			editor = "vim"
-		}
-
-		// Open the editor
-		parts := strings.Fields(editor)
-		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
-
-		if err := editorCmd.Run(); err != nil {
-			return fmt.Errorf("editor failed: %w", err)
+		// Open the editor (single gateway; enforces the Editor capability)
+		if err := launchEditor(cfg.Preferences.Editor, tmpfile.Name()); err != nil {
+			return err
 		}
 
 		// Read the edited file
@@ -285,24 +268,9 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		// Get the editor
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = cfg.Preferences.Editor
-		}
-		if editor == "" {
-			editor = "vim"
-		}
-
-		// Open the editor
-		parts := strings.Fields(editor)
-		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
-
-		if err := editorCmd.Run(); err != nil {
-			return fmt.Errorf("editor failed: %w", err)
+		// Open the editor (single gateway; enforces the Editor capability)
+		if err := launchEditor(cfg.Preferences.Editor, tmpfile.Name()); err != nil {
+			return err
 		}
 
 		// Read the edited file
@@ -450,24 +418,9 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		// Get the editor
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = cfg.Preferences.Editor
-		}
-		if editor == "" {
-			editor = "vim"
-		}
-
-		// Open the editor
-		parts := strings.Fields(editor)
-		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
-
-		if err := editorCmd.Run(); err != nil {
-			return fmt.Errorf("editor failed: %w", err)
+		// Open the editor (single gateway; enforces the Editor capability)
+		if err := launchEditor(cfg.Preferences.Editor, tmpfile.Name()); err != nil {
+			return err
 		}
 
 		// Read the edited file

--- a/cmd/edit_gcp.go
+++ b/cmd/edit_gcp.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -108,25 +106,9 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = cfg.Preferences.Editor
-		}
-		if editor == "" {
-			editor = "vim"
-		}
-
-		parts := strings.Fields(editor)
-		if len(parts) == 0 {
-			return fmt.Errorf("no editor configured")
-		}
-		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
-
-		if err := editorCmd.Run(); err != nil {
-			return fmt.Errorf("editor failed: %w", err)
+		// Open the editor (single gateway; enforces the Editor capability)
+		if err := launchEditor(cfg.Preferences.Editor, tmpfile.Name()); err != nil {
+			return err
 		}
 
 		editedData, err := os.ReadFile(tmpfile.Name())

--- a/cmd/edit_segments.go
+++ b/cmd/edit_segments.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -109,24 +107,9 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		// Get the editor
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = cfg.Preferences.Editor
-		}
-		if editor == "" {
-			editor = "vim"
-		}
-
-		// Open the editor
-		parts := strings.Fields(editor)
-		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
-
-		if err := editorCmd.Run(); err != nil {
-			return fmt.Errorf("editor failed: %w", err)
+		// Open the editor (single gateway; enforces the Editor capability)
+		if err := launchEditor(cfg.Preferences.Editor, tmpfile.Name()); err != nil {
+			return err
 		}
 
 		// Read the edited file

--- a/cmd/edit_settings.go
+++ b/cmd/edit_settings.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -102,24 +100,9 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		// Get the editor
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = cfg.Preferences.Editor
-		}
-		if editor == "" {
-			editor = "vim"
-		}
-
-		// Open the editor
-		parts := strings.Fields(editor)
-		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
-
-		if err := editorCmd.Run(); err != nil {
-			return fmt.Errorf("editor failed: %w", err)
+		// Open the editor (single gateway; enforces the Editor capability)
+		if err := launchEditor(cfg.Preferences.Editor, tmpfile.Name()); err != nil {
+			return err
 		}
 
 		// Read the edited file

--- a/cmd/edit_workflows.go
+++ b/cmd/edit_workflows.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -118,24 +116,9 @@ Examples:
 			return fmt.Errorf("failed to close temp file: %w", err)
 		}
 
-		// Get the editor
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = cfg.Preferences.Editor
-		}
-		if editor == "" {
-			editor = "vim"
-		}
-
-		// Open the editor
-		parts := strings.Fields(editor)
-		editorCmd := exec.Command(parts[0], append(parts[1:], tmpfile.Name())...)
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
-
-		if err := editorCmd.Run(); err != nil {
-			return fmt.Errorf("editor failed: %w", err)
+		// Open the editor (single gateway; enforces the Editor capability)
+		if err := launchEditor(cfg.Preferences.Editor, tmpfile.Name()); err != nil {
+			return err
 		}
 
 		// Read the edited file

--- a/cmd/exec_copilot.go
+++ b/cmd/exec_copilot.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/copilot"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // execCopilotCmd executes a Davis CoPilot query
@@ -48,7 +48,7 @@ Examples:
 		inputFile, _ := cmd.Flags().GetString("file")
 
 		if inputFile != "" {
-			content, err := os.ReadFile(inputFile)
+			content, err := vfs.ReadFile(inputFile)
 			if err != nil {
 				return fmt.Errorf("failed to read file: %w", err)
 			}
@@ -132,7 +132,7 @@ Examples:
 		inputFile, _ := cmd.Flags().GetString("file")
 
 		if inputFile != "" {
-			content, err := os.ReadFile(inputFile)
+			content, err := vfs.ReadFile(inputFile)
 			if err != nil {
 				return fmt.Errorf("failed to read file: %w", err)
 			}
@@ -189,7 +189,7 @@ Examples:
 		inputFile, _ := cmd.Flags().GetString("file")
 
 		if inputFile != "" {
-			content, err := os.ReadFile(inputFile)
+			content, err := vfs.ReadFile(inputFile)
 			if err != nil {
 				return fmt.Errorf("failed to read file: %w", err)
 			}

--- a/cmd/experimental.go
+++ b/cmd/experimental.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+)
+
+// ExperimentalEnabled reports whether the experimental feature gated by the
+// given environment variable is switched on. Any value other than
+// empty/0/false/no/off (case-insensitive) enables it.
+//
+// Experimental surfaces are gated by *skipping registration*, not by hiding the
+// command: an end user of a released build gets a plain "unknown command", and
+// the feature's existence is not advertised in help or the `dtctl commands`
+// catalog. It is exported so surfaces that live outside this package can share
+// one definition of "enabled" — `dtctl serve` (pkg/serve, wired in main) is the
+// case that needs it.
+func ExperimentalEnabled(envVar string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(envVar))) {
+	case "", "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}

--- a/cmd/find_intents.go
+++ b/cmd/find_intents.go
@@ -3,12 +3,12 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/appengine"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 var (
@@ -66,13 +66,9 @@ Examples:
 		var data map[string]interface{}
 
 		if findIntentsDataFile != "" {
-			// Read from file
-			var content []byte
-			if findIntentsDataFile == "-" {
-				content, err = os.ReadFile("/dev/stdin")
-			} else {
-				content, err = os.ReadFile(findIntentsDataFile)
-			}
+			// Read from file, or stdin for "-" — both through the vfs seam, so
+			// an embedded invocation reads the request's files and stdin.
+			content, err := vfs.ReadFileOrStdin(findIntentsDataFile)
 			if err != nil {
 				return fmt.Errorf("failed to read data file: %w", err)
 			}

--- a/cmd/inventory.go
+++ b/cmd/inventory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/segment"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 	"github.com/dynatrace-oss/dtctl/sdk/inventory"
 )
 
@@ -141,7 +142,7 @@ Examples:
 // loadDefinitionsFile reads one capability-definitions file. File I/O stays in
 // the CLI layer — the SDK parses bytes (ParseDefinitions) and never sees paths.
 func loadDefinitionsFile(path string) (*inventory.Definitions, error) {
-	data, err := os.ReadFile(path)
+	data, err := vfs.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read definitions %s: %w", path, err)
 	}

--- a/cmd/open_intent.go
+++ b/cmd/open_intent.go
@@ -122,6 +122,10 @@ Examples:
 
 // openBrowser opens a URL in the default browser
 func openBrowser(url string) error {
+	if !caps.BrowserOpen {
+		return &CapabilityError{Feature: "opening a browser (open)"}
+	}
+
 	var cmd *exec.Cmd
 
 	switch runtime.GOOS {

--- a/cmd/open_intent.go
+++ b/cmd/open_intent.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/appengine"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 var (
@@ -73,13 +73,9 @@ Examples:
 		var data map[string]interface{}
 
 		if openIntentDataFile != "" {
-			// Read from file
-			var content []byte
-			if openIntentDataFile == "-" {
-				content, err = os.ReadFile("/dev/stdin")
-			} else {
-				content, err = os.ReadFile(openIntentDataFile)
-			}
+			// Read from file, or stdin for "-" — both through the vfs seam, so
+			// an embedded invocation reads the request's files and stdin.
+			content, err := vfs.ReadFileOrStdin(openIntentDataFile)
 			if err != nil {
 				return fmt.Errorf("failed to read data file: %w", err)
 			}

--- a/cmd/plugin_dispatch.go
+++ b/cmd/plugin_dispatch.go
@@ -25,6 +25,12 @@ import (
 // successful dispatch never returns (process replacement); the code path
 // returning here means Windows, or an exec failure.
 func tryPluginDispatch(args []string) (int, bool) {
+	// Capability gate: on Unix, dispatch REPLACES this process (syscall.Exec).
+	// Embedded callers must never reach it; falling through yields the normal
+	// unknown-command error with suggestions instead.
+	if !caps.PluginDispatch {
+		return 0, false
+	}
 	words, rest := splitPluginArgs(args)
 	if len(words) == 0 || isBuiltinCommandName(words[0]) {
 		return 0, false

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -158,6 +158,13 @@ func extractContextOverride(args []string) string {
 // for the full command tree, and a non-nil error only when a referenced profile
 // name does not exist.
 func resolveActiveProfile(args []string) (*config.Profile, error) {
+	// Session-backed invocations resolve against the synthetic config: no
+	// user-defined profiles and no context binding, but DTCTL_PROFILE (set per
+	// request via RunOptions.Env) still selects a built-in preset.
+	if runSession != nil {
+		return runSession.syntheticConfig().ResolveProfile()
+	}
+
 	var (
 		cfg *config.Config
 		err error

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -51,7 +51,7 @@ func (e *ProfileError) Error() string {
 //
 // A nil profile is the full command tree (no-op), preserving today's behavior.
 // The filter runs once, after the whole command tree is registered and before
-// Cobra dispatches — see execute() in root.go.
+// Cobra dispatches — see executeArgs() in root.go.
 func applyProfile(root *cobra.Command, p *config.Profile) {
 	if p == nil {
 		return

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/resolver"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // isTerminal checks if the given file is a terminal
@@ -210,7 +211,7 @@ Examples:
 				}
 				query = string(content)
 			} else {
-				content, err := os.ReadFile(queryFile)
+				content, err := vfs.ReadFile(queryFile)
 				if err != nil {
 					return fmt.Errorf("failed to read query file: %w", err)
 				}
@@ -575,7 +576,7 @@ func parseSegmentFlags(segmentIDs []string) ([]exec.FilterSegmentRef, error) {
 
 // parseSegmentsFile reads a YAML file containing an array of FilterSegmentRef entries.
 func parseSegmentsFile(path string) ([]exec.FilterSegmentRef, error) {
-	data, err := os.ReadFile(path)
+	data, err := vfs.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read segments file: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,6 +124,10 @@ func execute() int {
 		}
 
 		if isShell {
+			if !caps.ShellAliases {
+				output.PrintHumanError("%s", &CapabilityError{Feature: "shell aliases"})
+				return 1
+			}
 			if err := execShellAlias(expanded[0]); err != nil {
 				return 1
 			}
@@ -550,6 +554,16 @@ func errorToDetail(err error) *output.ErrorDetail {
 			Code:        "profile_blocked",
 			Message:     profileErr.Headline(),
 			Suggestions: profileErr.Suggestions(),
+		}
+	}
+
+	// CapabilityError — a host-restricted ability (subprocess spawn: plugins,
+	// aliases, hooks, editor, browser) was requested but not granted.
+	var capErr *CapabilityError
+	if errors.As(err, &capErr) {
+		return &output.ErrorDetail{
+			Code:    "capability_disabled",
+			Message: capErr.Error(),
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,6 +93,15 @@ func Execute() {
 	os.Exit(Run(os.Args[1:], RunOptions{}))
 }
 
+// AddCommand registers an additional top-level command on the dtctl root.
+// It exists for commands that live outside this package because they import
+// packages that themselves import cmd — registering from here would be an
+// import cycle. `dtctl serve` (pkg/serve, wired in main) is the canonical
+// case. Call before the first Execute/Run.
+func AddCommand(c *cobra.Command) {
+	rootCmd.AddCommand(c)
+}
+
 // executeArgs runs one invocation of the given command line (program name
 // excluded) and returns an exit code. Callers go through Run, which provides
 // serialization and the pristine-tree guarantee.
@@ -166,6 +175,14 @@ func executeArgs(argv []string) int {
 	applyProfile(rootCmd, prof)
 	// --- End command profile filter ---
 
+	// --- Blocked-command filter (embedded callers) ---
+	// Mask commands the embedding caller declared unsupported in its
+	// environment (RunOptions.BlockedCommands) — e.g. the service engine
+	// removes host-oriented commands like config/ctx/auth. Applied after the
+	// profile filter so both masks compose; a nil set is the full surface.
+	applyBlockedCommands(rootCmd, runBlocked)
+	// --- End blocked-command filter ---
+
 	// Initialise OpenTelemetry tracing. Done after alias resolution so that
 	// the span name reflects the actual command (not a pre-alias invocation).
 	// The root span covers the entire invocation; shutdown flushes buffered
@@ -238,7 +255,22 @@ func executeArgs(argv []string) int {
 		rootSpan.SetStatus(codes.Error, err.Error())
 		rootSpan.RecordError(err)
 
-		if agentMode || plainMode {
+		// Masked commands (profile mask, blocked-command filter) disable flag
+		// parsing so the guard is the only observable outcome — which also
+		// means --agent/--plain never reached the flag vars. Honor them from
+		// the raw argv so a machine caller still gets the structured envelope.
+		structuredError := agentMode || plainMode
+		if !structuredError {
+			var maskedProfile *ProfileError
+			var maskedUnsupported *UnsupportedCommandError
+			if errors.As(err, &maskedProfile) || errors.As(err, &maskedUnsupported) {
+				structuredError = hasRawFlag(spanArgs, "--agent") ||
+					hasShortFlagLetter(spanArgs, 'A') ||
+					hasRawFlag(spanArgs, "--plain")
+			}
+		}
+
+		if structuredError {
 			detail := errorToDetail(err)
 			detail.Suggestions = append(detail.Suggestions, allHints...)
 			// Agent/plain mode: error envelopes go to stdout (not stderr) because
@@ -568,6 +600,17 @@ func errorToDetail(err error) *output.ErrorDetail {
 		}
 	}
 
+	// UnsupportedCommandError — command removed from the surface by the
+	// embedding caller (e.g. host-oriented commands inside the service engine).
+	var unsupportedErr *UnsupportedCommandError
+	if errors.As(err, &unsupportedErr) {
+		return &output.ErrorDetail{
+			Code:        "unsupported_in_service",
+			Message:     unsupportedErr.Headline(),
+			Suggestions: unsupportedErr.Suggestions(),
+		}
+	}
+
 	// CapabilityError — a host-restricted ability (subprocess spawn: plugins,
 	// aliases, hooks, editor, browser) was requested but not granted.
 	var capErr *CapabilityError
@@ -774,6 +817,11 @@ func exitCodeForError(err error) int {
 
 	var profileErr *ProfileError
 	if errors.As(err, &profileErr) {
+		return client.ExitUsageError
+	}
+
+	var unsupportedErr *UnsupportedCommandError
+	if errors.As(err, &unsupportedErr) {
 		return client.ExitUsageError
 	}
 
@@ -1293,8 +1341,12 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 // initConfig reads in config file and ENV variables if set
 func initConfig() {
-	// Auto-detect AI agent environment and enable agent mode
-	if !agentMode && !noAgent {
+	// Auto-detect AI agent environment and enable agent mode. Session-backed
+	// invocations skip auto-detection entirely: whether the *host process*
+	// runs under an AI agent says nothing about the request, and host env
+	// must not shape a tenant's output. Service callers opt in per request,
+	// explicitly, with --agent on the command line.
+	if !agentMode && !noAgent && runSession == nil {
 		if info := aidetect.Detect(); info.Detected {
 			// Only auto-enable if user hasn't explicitly chosen a non-JSON
 			// output format. An explicit `-o json` is compatible — the agent

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,8 +112,11 @@ func executeArgs(argv []string) int {
 	// Resolving aliases first ensures the span name reflects the real command,
 	// not the pre-expansion alias. Load config quietly; if it fails, skip alias
 	// resolution (the real command will produce the proper error later).
+	// Session-backed invocations skip aliases entirely: they are a host-config
+	// convenience, and a tenant request must not expand through the host's
+	// alias table.
 	spanArgs := argv
-	if cfg, err := config.Load(); err == nil {
+	if cfg, err := config.Load(); err == nil && runSession == nil {
 		// Security: warn when an auto-discovered local .dtctl.yaml carries
 		// code-execution keys (aliases / apply hooks) that are ignored. This
 		// makes adoption of an untrusted per-project config visible instead of
@@ -944,6 +947,13 @@ func GetAgentMode() bool {
 // written, so a scripted `DTCTL_CONTEXT=x dtctl ...` cannot repoint other
 // processes on the machine.
 func LoadConfig() (*config.Config, error) {
+	// A session-backed invocation (embedded callers, see Session) is pinned to
+	// its own environment + token: the config file and context overrides do
+	// not apply.
+	if runSession != nil {
+		return runSession.syntheticConfig(), nil
+	}
+
 	var cfg *config.Config
 	var err error
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -174,14 +174,19 @@ func execute() int {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		// silentExitError carries an exit code only (e.g. --check-scopes already
-		// printed its verdict); set the status and return without re-printing.
+		// silentExitError carries an exit code only (e.g. --check-scopes printed
+		// its verdict, diff found differences, wait timed out); set the status
+		// and return without re-printing.
 		var silent *silentExitError
 		if errors.As(err, &silent) {
 			if silent.code == 0 {
 				rootSpan.SetStatus(codes.Ok, "")
 			} else {
-				rootSpan.SetStatus(codes.Error, "insufficient scope")
+				reason := silent.reason
+				if reason == "" {
+					reason = "silent non-zero exit"
+				}
+				rootSpan.SetStatus(codes.Error, reason)
 			}
 			return silent.code
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,14 +47,15 @@ var (
 	noAgent      bool // --no-agent flag: opt out of auto-detected agent mode
 
 	// tracingRootCtx holds the context carrying the root OTel span for this
-	// invocation. Set by execute() and read by NewClientFromConfig to inject
+	// invocation. Set by executeArgs() and read by NewClientFromConfig to inject
 	// W3C trace context headers on outgoing Dynatrace API requests.
 	//
 	// This is a package-level variable (rather than a function parameter) because
 	// NewClientFromConfig is referenced as a function value in breakpoint_helpers.go
 	// and changing its signature would cascade across 100+ call sites. The global is
-	// acceptable here because dtctl is a single-invocation CLI: execute() sets it
-	// once before any client is created, and the process exits shortly after.
+	// acceptable here because invocations are serialized (see Run): executeArgs()
+	// sets it before any client is created, and no other invocation can run
+	// concurrently in the same process.
 	tracingRootCtx context.Context
 )
 
@@ -83,15 +84,19 @@ func validateGlobalFlags() error {
 	return nil
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
+// Execute runs the CLI process: one invocation from os.Args, then exit.
+// Embedders use Run instead, which returns the exit code without terminating
+// the process. Routing through Run (rather than executeArgs directly) keeps a
+// single execution path, and ensures deferred functions (e.g. tracing
+// shutdown/flush) run before os.Exit, which os.Exit would otherwise bypass.
 func Execute() {
-	os.Exit(execute())
+	os.Exit(Run(os.Args[1:], RunOptions{}))
 }
 
-// execute runs the CLI and returns an exit code. Separating it from Execute
-// ensures that deferred functions (e.g. tracing shutdown/flush) run before
-// os.Exit is called, which os.Exit would otherwise bypass.
-func execute() int {
+// executeArgs runs one invocation of the given command line (program name
+// excluded) and returns an exit code. Callers go through Run, which provides
+// serialization and the pristine-tree guarantee.
+func executeArgs(argv []string) int {
 	// Setup enhanced error handling after all subcommands are registered
 	setupErrorHandlers(rootCmd)
 
@@ -99,11 +104,15 @@ func execute() int {
 	// agent-mode auto-preflight). Must run after all subcommands are registered.
 	installScopePreflight(rootCmd)
 
+	// Cobra falls back to os.Args when no args were set — always pin the
+	// requested argv so embedded invocations never see the host's arguments.
+	rootCmd.SetArgs(argv)
+
 	// --- Alias resolution (before Cobra parses args AND before tracing init) ---
 	// Resolving aliases first ensures the span name reflects the real command,
 	// not the pre-expansion alias. Load config quietly; if it fails, skip alias
 	// resolution (the real command will produce the proper error later).
-	spanArgs := os.Args[1:]
+	spanArgs := argv
 	if cfg, err := config.Load(); err == nil {
 		// Security: warn when an auto-discovered local .dtctl.yaml carries
 		// code-execution keys (aliases / apply hooks) that are ignored. This
@@ -116,8 +125,7 @@ func execute() int {
 				cfg.LocalConfigPath())
 		}
 
-		// os.Args[0] is the binary name; work with os.Args[1:]
-		expanded, isShell, err := resolveAlias(os.Args[1:], cfg)
+		expanded, isShell, err := resolveAlias(argv, cfg)
 		if err != nil {
 			output.PrintHumanError("%s", err)
 			return 1

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,16 +7,30 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 )
 
 // RunOptions configures a single embedded invocation. The zero value is the
-// CLI default: every capability granted.
+// CLI default: every capability granted, config and credentials resolved from
+// the host (config file, env, keyring), host environment untouched.
 type RunOptions struct {
 	// Capabilities restricts process-level abilities (subprocess spawns) for
 	// this invocation. nil grants everything (the CLI default); embedded
 	// callers typically pass &Capabilities{} to grant nothing.
 	Capabilities *Capabilities
+
+	// Session, when non-nil, pins the invocation to one environment + token
+	// and detaches it from the host's config file, contexts, keyring, and
+	// credential env vars. See Session.
+	Session *Session
+
+	// Env sets environment variables for the duration of the invocation
+	// (restored afterwards), e.g. DTCTL_PROFILE to select a command profile
+	// per request. Applied after session scrubbing, so an explicit entry wins.
+	// The mutation is process-wide while the invocation runs — see
+	// applyRunEnvironment.
+	Env map[string]string
 }
 
 // runMu serializes invocations. The command tree is package state (277
@@ -45,6 +59,15 @@ func Run(argv []string, opts RunOptions) int {
 	}
 	prev := SetCapabilities(granted)
 	defer SetCapabilities(prev)
+
+	cleanup, err := applyRunEnvironment(opts)
+	if err != nil {
+		// A malformed RunOptions is an embedding-caller bug, not a command
+		// error — report it on stderr with a usage exit code.
+		output.PrintHumanError("%s", err)
+		return client.ExitUsageError
+	}
+	defer cleanup()
 
 	restorePristineTree()
 	return executeArgs(argv)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
+	"os"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -38,6 +41,15 @@ type RunOptions struct {
 	// writes the host filesystem (the CLI default); embedded callers pass a
 	// vfs.MapFS built from the request's virtual files. See pkg/vfs.
 	FS vfs.FS
+
+	// Stdout and Stderr receive the invocation's output; Stdin feeds commands
+	// that read it ("-" file arguments, piped input). nil means the process
+	// streams (the CLI default). The redirection captures every output path —
+	// fmt.Print*, the output package, cobra help, error envelopes — as the
+	// exact byte stream the CLI would print. See redirectStdio.
+	Stdout io.Writer
+	Stderr io.Writer
+	Stdin  io.Reader
 }
 
 // runMu serializes invocations. The command tree is package state (277
@@ -70,14 +82,32 @@ func Run(argv []string, opts RunOptions) int {
 	cleanup, err := applyRunEnvironment(opts)
 	if err != nil {
 		// A malformed RunOptions is an embedding-caller bug, not a command
-		// error — report it on stderr with a usage exit code.
-		output.PrintHumanError("%s", err)
+		// error — report it on the caller's stderr with a usage exit code.
+		reportOptionsError(opts, err)
 		return client.ExitUsageError
 	}
 	defer cleanup()
 
+	restoreStdio, err := redirectStdio(opts.Stdout, opts.Stderr, opts.Stdin)
+	if err != nil {
+		reportOptionsError(opts, err)
+		return client.ExitUsageError
+	}
+	defer restoreStdio()
+
 	restorePristineTree()
 	return executeArgs(argv)
+}
+
+// reportOptionsError surfaces a RunOptions problem on the invocation's stderr
+// (falling back to the process stderr), without going through the redirected
+// stream machinery that may itself be the thing that failed.
+func reportOptionsError(opts RunOptions, err error) {
+	w := io.Writer(os.Stderr)
+	if opts.Stderr != nil {
+		w = opts.Stderr
+	}
+	fmt.Fprintf(w, "Error: %v\n", err)
 }
 
 // pristineCommandState is the subset of cobra.Command that dtctl mutates

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+)
+
+// RunOptions configures a single embedded invocation. The zero value is the
+// CLI default: every capability granted.
+type RunOptions struct {
+	// Capabilities restricts process-level abilities (subprocess spawns) for
+	// this invocation. nil grants everything (the CLI default); embedded
+	// callers typically pass &Capabilities{} to grant nothing.
+	Capabilities *Capabilities
+}
+
+// runMu serializes invocations. The command tree is package state (277
+// command values wired by init), so two interleaved executions would share
+// flag values and tree mutations. In-process callers therefore queue;
+// parallelism comes from running more instances — the model the WASI spike
+// validated at 20-47ms per-instance overhead (spike/SPIKE_RESULTS.md) — or
+// more processes. See the dtctl-as-a-service design, work item E1.
+var runMu sync.Mutex
+
+// Run executes one dtctl invocation in-process and returns its exit code.
+// argv is the command line without the program name (os.Args[1:] shape).
+//
+// Run is the embedding seam for the service engine and for `dtctl serve`:
+// unlike Execute it never terminates the process, and every invocation starts
+// from a pristine command tree — flag values reset to declared defaults, and
+// per-run tree mutations (command-profile masks, scope-preflight wraps)
+// undone. Concurrent calls are safe and execute one at a time.
+func Run(argv []string, opts RunOptions) int {
+	runMu.Lock()
+	defer runMu.Unlock()
+
+	granted := AllCapabilities()
+	if opts.Capabilities != nil {
+		granted = *opts.Capabilities
+	}
+	prev := SetCapabilities(granted)
+	defer SetCapabilities(prev)
+
+	restorePristineTree()
+	return executeArgs(argv)
+}
+
+// pristineCommandState is the subset of cobra.Command that dtctl mutates
+// between construction and execution. applyProfile overwrites RunE/Run/Args/
+// Hidden/DisableFlagParsing to mask commands, and installScopePreflight wraps
+// RunE; restoring these fields returns a command to its as-registered state.
+type pristineCommandState struct {
+	runE               func(*cobra.Command, []string) error
+	run                func(*cobra.Command, []string)
+	args               cobra.PositionalArgs
+	hidden             bool
+	disableFlagParsing bool
+}
+
+var (
+	pristineOnce sync.Once
+	pristineTree map[*cobra.Command]pristineCommandState
+)
+
+func capturePristineState(c *cobra.Command) pristineCommandState {
+	return pristineCommandState{
+		runE:               c.RunE,
+		run:                c.Run,
+		args:               c.Args,
+		hidden:             c.Hidden,
+		disableFlagParsing: c.DisableFlagParsing,
+	}
+}
+
+// restorePristineTree returns the whole command tree to its as-registered
+// state: the snapshot taken on first use (after all init() wiring, before any
+// execution) is written back over every command, and all flag values return
+// to their declared defaults. Each execution then applies its own per-run
+// mutations (scope-preflight wraps, profile masks) from a clean slate, so
+// nothing from one invocation — a --context override, a profile mask, an
+// output format — can leak into the next.
+func restorePristineTree() {
+	pristineOnce.Do(func() {
+		pristineTree = make(map[*cobra.Command]pristineCommandState)
+		walkCommands(rootCmd, func(c *cobra.Command) {
+			pristineTree[c] = capturePristineState(c)
+		})
+	})
+	walkCommands(rootCmd, func(c *cobra.Command) {
+		state, ok := pristineTree[c]
+		if !ok {
+			// A command registered after the first run (not a pattern dtctl
+			// uses, but harmless): its current state becomes its pristine one.
+			state = capturePristineState(c)
+			pristineTree[c] = state
+		}
+		c.RunE = state.runE
+		c.Run = state.run
+		c.Args = state.args
+		c.Hidden = state.hidden
+		c.DisableFlagParsing = state.disableFlagParsing
+		// No command sets IO writers at registration time, so pristine means
+		// nil: cobra then resolves os.Stdout/os.Stderr dynamically at print
+		// time. A caller-bound writer (tests do this) must not outlive its
+		// invocation.
+		c.SetOut(nil)
+		c.SetErr(nil)
+		c.SetIn(nil)
+		resetFlagSet(c.Flags())
+		resetFlagSet(c.PersistentFlags())
+	})
+	// Color decisions are cached per process but depend on per-run inputs
+	// (--plain, NO_COLOR, TTY-ness of the current stdout).
+	output.ResetColorCache()
+}
+
+// resetFlagSet returns every flag in fs to its declared default. Mirrors
+// testutil.ResetCommandFlags (cmd/testutil/helpers.go), which stays separate
+// so test helpers don't have to reach into the cmd package.
+func resetFlagSet(fs *pflag.FlagSet) {
+	fs.VisitAll(func(flag *pflag.Flag) {
+		flag.Changed = false
+		if sv, ok := flag.Value.(pflag.SliceValue); ok {
+			// SliceValue.Set appends rather than replaces; use Replace to
+			// restore the declared default. StringArray stores DefValue as
+			// JSON; other slice types fall back to nil (empty) if the format
+			// doesn't parse.
+			var defaults []string
+			if flag.DefValue != "[]" {
+				_ = json.Unmarshal([]byte(flag.DefValue), &defaults)
+			}
+			_ = sv.Replace(defaults)
+		} else {
+			_ = flag.Value.Set(flag.DefValue)
+		}
+	})
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,9 +64,9 @@ type RunOptions struct {
 // runMu serializes invocations. The command tree is package state (277
 // command values wired by init), so two interleaved executions would share
 // flag values and tree mutations. In-process callers therefore queue;
-// parallelism comes from running more instances — the model the WASI spike
-// validated at 20-47ms per-instance overhead (spike/SPIKE_RESULTS.md) — or
-// more processes. See the dtctl-as-a-service design, work item E1.
+// parallelism comes from running more instances — the model a WASI spike
+// measured at 20-47ms per-instance overhead — or more processes.
+// See docs/dev/SERVICE_ENGINE_DESIGN.md ("Serialization").
 var runMu sync.Mutex
 
 // runActive is true while an invocation executes (between runMu acquisition

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // RunOptions configures a single embedded invocation. The zero value is the
@@ -31,6 +32,12 @@ type RunOptions struct {
 	// The mutation is process-wide while the invocation runs — see
 	// applyRunEnvironment.
 	Env map[string]string
+
+	// FS resolves user-supplied file paths (-f and friends) for this
+	// invocation, including writebacks like `apply --write-id`. nil reads and
+	// writes the host filesystem (the CLI default); embedded callers pass a
+	// vfs.MapFS built from the request's virtual files. See pkg/vfs.
+	FS vfs.FS
 }
 
 // runMu serializes invocations. The command tree is package state (277

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -50,6 +51,14 @@ type RunOptions struct {
 	Stdout io.Writer
 	Stderr io.Writer
 	Stdin  io.Reader
+
+	// BlockedCommands removes top-level commands (with their whole subtree)
+	// from this invocation's surface: hidden from help, the `dtctl commands`
+	// catalog, and completion, and guarded so dispatch returns an
+	// UnsupportedCommandError (agent-mode code "unsupported_in_service").
+	// Keyed by top-level command name; the value is the human-readable reason.
+	// nil is the full surface (the CLI default). See applyBlockedCommands.
+	BlockedCommands map[string]string
 }
 
 // runMu serializes invocations. The command tree is package state (277
@@ -59,6 +68,20 @@ type RunOptions struct {
 // validated at 20-47ms per-instance overhead (spike/SPIKE_RESULTS.md) — or
 // more processes. See the dtctl-as-a-service design, work item E1.
 var runMu sync.Mutex
+
+// runActive is true while an invocation executes (between runMu acquisition
+// and release).
+var runActive atomic.Bool
+
+// RunActive reports whether a Run invocation is currently executing. Long-
+// running commands that themselves embed Run — `dtctl serve` accepting
+// requests — use it to refuse execution from inside another invocation:
+// blocking in a RunE would hold the invocation lock for the server's whole
+// lifetime and deadlock every request (main dispatches serve outside Run for
+// exactly this reason).
+func RunActive() bool {
+	return runActive.Load()
+}
 
 // Run executes one dtctl invocation in-process and returns its exit code.
 // argv is the command line without the program name (os.Args[1:] shape).
@@ -71,6 +94,8 @@ var runMu sync.Mutex
 func Run(argv []string, opts RunOptions) int {
 	runMu.Lock()
 	defer runMu.Unlock()
+	runActive.Store(true)
+	defer runActive.Store(false)
 
 	granted := AllCapabilities()
 	if opts.Capabilities != nil {
@@ -78,6 +103,9 @@ func Run(argv []string, opts RunOptions) int {
 	}
 	prev := SetCapabilities(granted)
 	defer SetCapabilities(prev)
+
+	runBlocked = opts.BlockedCommands
+	defer func() { runBlocked = nil }()
 
 	cleanup, err := applyRunEnvironment(opts)
 	if err != nil {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,229 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// captureRun invokes Run and returns its exit code plus everything written to
+// stdout. Stdout is swapped process-wide, so callers must not run in parallel
+// with other stdout-writing tests (cmd tests never do).
+func captureRun(t *testing.T, argv []string, opts RunOptions) (int, string) {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	code := Run(argv, opts)
+
+	_ = w.Close()
+	os.Stdout = orig
+	return code, <-done
+}
+
+// isolatedConfig points DTCTL_CONFIG at a minimal config file in a temp dir so
+// Run tests neither read nor write the developer's real config, and disables
+// agent auto-detection so output shape is stable under CI agents.
+func isolatedConfig(t *testing.T, content string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	t.Setenv("DTCTL_CONFIG", path)
+	t.Setenv("DTCTL_PROFILE", "")
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+}
+
+// TestRunFlagStateDoesNotLeakBetweenInvocations is the E1 isolation guard: a
+// flag set in one invocation (here the root persistent -o) must not change the
+// behavior of the next. `commands` is used because it renders purely from the
+// command tree — no config or network.
+func TestRunFlagStateDoesNotLeakBetweenInvocations(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	code, first := captureRun(t, []string{"commands"}, RunOptions{})
+	require.Zero(t, code)
+	require.Contains(t, first, "tool: dtctl", "default output is TOON")
+
+	code, jsonOut := captureRun(t, []string{"commands", "-o", "json"}, RunOptions{})
+	require.Zero(t, code)
+	require.True(t, strings.HasPrefix(strings.TrimSpace(jsonOut), "{"),
+		"-o json must produce JSON")
+
+	code, again := captureRun(t, []string{"commands"}, RunOptions{})
+	require.Zero(t, code)
+	require.Equal(t, first, again,
+		"a later invocation must not inherit the earlier -o json")
+}
+
+// TestRunProfileMaskDoesNotLeakBetweenInvocations: applyProfile destructively
+// masks commands (Hidden, RunE overwritten). A profiled invocation must leave
+// no trace on the next unprofiled one.
+func TestRunProfileMaskDoesNotLeakBetweenInvocations(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	t.Setenv("DTCTL_PROFILE", "query")
+	code, masked := captureRun(t, []string{"get", "--help"}, RunOptions{})
+	require.Zero(t, code)
+	require.NotContains(t, availableCommandsSection(t, masked), "workflows",
+		"profile 'query' must hide get workflows from help")
+	require.Contains(t, availableCommandsSection(t, masked), "analyzers",
+		"profile 'query' allows get analyzers")
+
+	t.Setenv("DTCTL_PROFILE", "")
+	code, full := captureRun(t, []string{"get", "--help"}, RunOptions{})
+	require.Zero(t, code)
+	require.Contains(t, availableCommandsSection(t, full), "workflows",
+		"after a profiled run, the full tree must be restored")
+
+	// The mask must also be functionally undone, not just cosmetically:
+	// invoking a previously-masked command must reach its real RunE (which
+	// fails on missing context config, not with a profile block).
+	code, out := captureRun(t, []string{"get", "workflows", "--plain"}, RunOptions{})
+	require.NotZero(t, code)
+	require.NotContains(t, out, "not available",
+		"previously-masked command must not still be profile-blocked")
+}
+
+// availableCommandsSection extracts the subcommand listing from cobra help
+// output. The static Long text of `get` mentions resource names as prose, so
+// mask assertions must scope to the actual command list.
+func availableCommandsSection(t *testing.T, help string) string {
+	t.Helper()
+	_, after, found := strings.Cut(help, "Available Commands:")
+	require.True(t, found, "help output must contain an Available Commands section:\n%s", help)
+	section, _, _ := strings.Cut(after, "Flags:")
+	return section
+}
+
+// TestRunRestoresCapabilities: Run must restore the process capability set it
+// found, whatever it granted for the invocation.
+func TestRunRestoresCapabilities(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	before := caps
+	_, _ = captureRun(t, []string{"commands"}, RunOptions{Capabilities: &Capabilities{}})
+	require.Equal(t, before, caps, "Run must restore the prior capability set")
+}
+
+// TestRunSerializesConcurrentInvocations: concurrent Run calls must queue, so
+// each complete output appears intact (never interleaved). Run with -race this
+// also proves the tree state handoff between invocations is race-free.
+func TestRunSerializesConcurrentInvocations(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	const workers = 4
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	var wg sync.WaitGroup
+	codes := make([]int, workers)
+	for i := range codes {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			codes[i] = Run([]string{"commands"}, RunOptions{})
+		}(i)
+	}
+	wg.Wait()
+
+	_ = w.Close()
+	os.Stdout = orig
+	out := <-done
+
+	for i, code := range codes {
+		require.Zero(t, code, "worker %d", i)
+	}
+	require.Equal(t, workers, strings.Count(out, "tool: dtctl"),
+		"each serialized invocation must emit one complete catalog")
+}
+
+// TestRunUsesArgvNotOsArgs: embedded invocations must never fall back to the
+// host process's os.Args (cobra's default when no args are set).
+func TestRunUsesArgvNotOsArgs(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	origArgs := os.Args
+	os.Args = []string{"dtctl", "get", "workflows"} // would need network if used
+	defer func() { os.Args = origArgs }()
+
+	code, out := captureRun(t, []string{"commands"}, RunOptions{})
+	require.Zero(t, code)
+	require.Contains(t, out, "tool: dtctl")
+}
+
+// TestRunExitCodeForUnknownCommand: error paths must come back as exit codes,
+// never a process exit (the E2 contract holds through Run).
+func TestRunExitCodeForUnknownCommand(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	code, _ := captureRun(t, []string{"no-such-command-xyz", "--plain"},
+		RunOptions{Capabilities: &Capabilities{}})
+	require.NotZero(t, code)
+}
+
+// TestRunScopePreflightNotStacked: installScopePreflight wraps every RunE per
+// invocation; without the pristine-tree restore the wrappers would stack one
+// deeper on every Run. Assert repeated runs stay well-formed and identical.
+func TestRunScopePreflightNotStacked(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+
+	var outputs []string
+	for i := 0; i < 3; i++ {
+		code, out := captureRun(t, []string{"commands"}, RunOptions{})
+		require.Zero(t, code, "run %d", i)
+		outputs = append(outputs, out)
+	}
+	require.Equal(t, outputs[0], outputs[1])
+	require.Equal(t, outputs[1], outputs[2])
+}
+
+// BenchmarkRun measures the per-invocation overhead of the pristine-tree
+// restore plus a full offline command dispatch.
+func BenchmarkRun(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("contexts: []\n"), 0o600); err != nil {
+		b.Fatal(err)
+	}
+	b.Setenv("DTCTL_CONFIG", path)
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer devNull.Close()
+	orig := os.Stdout
+	os.Stdout = devNull
+	defer func() { os.Stdout = orig }()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if code := Run([]string{"commands"}, RunOptions{}); code != 0 {
+			b.Fatalf("exit code %d", code)
+		}
+	}
+}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -45,8 +45,16 @@ func isolatedConfig(t *testing.T, content string) {
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 	t.Setenv("DTCTL_CONFIG", path)
 	t.Setenv("DTCTL_PROFILE", "")
-	t.Setenv("CLAUDECODE", "")
-	t.Setenv("CLAUDE_CODE", "")
+	// Suppress agent-mode auto-detection: the test machine may itself run
+	// under an AI agent (any of sdk/agentmode's known env vars), which would
+	// silently flip output to envelopes. Empty means "not set" to Detect.
+	for _, v := range []string{
+		"CLAUDECODE", "CLAUDE_CODE", "AI_AGENT", "CODEX", "CURSOR_AGENT",
+		"COPILOT_CLI", "GITHUB_COPILOT", "AGENT_CONTEXT_OUT", "KIRO_SESSION_ID",
+		"OPENCODE",
+	} {
+		t.Setenv(v, "")
+	}
 }
 
 // TestRunFlagStateDoesNotLeakBetweenInvocations is the E1 isolation guard: a

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -12,11 +12,12 @@ import (
 // callers. When set on RunOptions, the invocation runs against exactly this
 // environment and token: the host's config file, contexts, keyring, and
 // credential env vars are all out of the picture, which is what a multi-tenant
-// service needs — every request brings its own tenant (design work item E4).
+// service needs — every request brings its own tenant
+// (docs/dev/SERVICE_ENGINE_DESIGN.md).
 //
 // A session replaces credential *resolution*, not command *policy*: blocking
 // commands that make no sense service-side (config, ctx, login) is the
-// engine's job (work item E8), on top of this seam.
+// engine's job, on top of this seam.
 type Session struct {
 	// EnvironmentURL is the Dynatrace environment to run against
 	// (e.g. https://abc12345.apps.dynatrace.com). Required.

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -92,10 +92,13 @@ var runSession *Session
 // invocation, so host-level credentials and config selection cannot leak into
 // a tenant's request. DTCTL_TOKEN/DT_API_TOKEN/DTCTL_ACCOUNT_TOKEN mirror
 // credentialEnvVars (plugin_dispatch.go); DTCTL_CONFIG/DTCTL_CONTEXT would
-// repoint config discovery, which a session fully replaces.
+// repoint config discovery, which a session fully replaces; DTCTL_PROFILE and
+// DTCTL_OUTPUT would let the host's preferences shape the request's command
+// surface and output format (per-request values are set explicitly via
+// RunOptions.Env, which applies after this scrub).
 var sessionScrubbedEnvVars = []string{
 	"DTCTL_TOKEN", "DT_API_TOKEN", "DTCTL_ACCOUNT_TOKEN",
-	"DTCTL_CONFIG", "DTCTL_CONTEXT",
+	"DTCTL_CONFIG", "DTCTL_CONTEXT", "DTCTL_PROFILE", "DTCTL_OUTPUT",
 }
 
 // applyRunEnvironment installs the invocation's session and environment

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+)
+
+// Session is a per-invocation target + credential override for embedded
+// callers. When set on RunOptions, the invocation runs against exactly this
+// environment and token: the host's config file, contexts, keyring, and
+// credential env vars are all out of the picture, which is what a multi-tenant
+// service needs — every request brings its own tenant (design work item E4).
+//
+// A session replaces credential *resolution*, not command *policy*: blocking
+// commands that make no sense service-side (config, ctx, login) is the
+// engine's job (work item E8), on top of this seam.
+type Session struct {
+	// EnvironmentURL is the Dynatrace environment to run against
+	// (e.g. https://abc12345.apps.dynatrace.com). Required.
+	EnvironmentURL string
+	// Token authenticates every API call of this invocation. Required.
+	Token string
+	// SafetyLevel bounds mutating operations for this invocation
+	// (readonly | readwrite-mine | readwrite-all | dangerously-unrestricted).
+	// Empty selects the dtctl default (readwrite-all).
+	SafetyLevel config.SafetyLevel
+}
+
+// sessionContextName names the synthesized context and token. It appears in
+// safety-check messages ("Context 'session' does not allow ...").
+const sessionContextName = "session"
+
+func (s *Session) validate() error {
+	if s.EnvironmentURL == "" {
+		return fmt.Errorf("session: EnvironmentURL is required")
+	}
+	if s.Token == "" {
+		return fmt.Errorf("session: Token is required")
+	}
+	if s.SafetyLevel != "" {
+		valid := false
+		for _, l := range config.ValidSafetyLevels() {
+			if s.SafetyLevel == l {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return fmt.Errorf("session: invalid safety level %q", s.SafetyLevel)
+		}
+	}
+	return nil
+}
+
+// syntheticConfig materializes the session as a single-context in-memory
+// config, so everything downstream of LoadConfig (client construction, token
+// resolution, safety checks) works unchanged. The token is inline in the
+// Tokens list — resolution never touches a keyring or credential store.
+func (s *Session) syntheticConfig() *config.Config {
+	level := s.SafetyLevel
+	if level == "" {
+		level = config.DefaultSafetyLevel
+	}
+	return &config.Config{
+		APIVersion:     config.CurrentAPIVersion,
+		Kind:           "Config",
+		CurrentContext: sessionContextName,
+		Contexts: []config.NamedContext{{
+			Name: sessionContextName,
+			Context: config.Context{
+				Environment: s.EnvironmentURL,
+				TokenRef:    sessionContextName,
+				SafetyLevel: level,
+			},
+		}},
+		Tokens: []config.NamedToken{{
+			Name:  sessionContextName,
+			Token: s.Token,
+		}},
+	}
+}
+
+// runSession holds the active invocation's session override. Guarded by runMu
+// like the rest of the per-invocation state; nil means normal CLI behavior
+// (config file + context resolution).
+var runSession *Session
+
+// sessionScrubbedEnvVars are unset for the duration of a session-backed
+// invocation, so host-level credentials and config selection cannot leak into
+// a tenant's request. DTCTL_TOKEN/DT_API_TOKEN/DTCTL_ACCOUNT_TOKEN mirror
+// credentialEnvVars (plugin_dispatch.go); DTCTL_CONFIG/DTCTL_CONTEXT would
+// repoint config discovery, which a session fully replaces.
+var sessionScrubbedEnvVars = []string{
+	"DTCTL_TOKEN", "DT_API_TOKEN", "DTCTL_ACCOUNT_TOKEN",
+	"DTCTL_CONFIG", "DTCTL_CONTEXT",
+}
+
+// applyRunEnvironment installs the invocation's session and environment
+// variables and returns a cleanup restoring the previous process state. The
+// env mutations are process-wide, which is safe because invocations are
+// serialized (runMu) — but a host application reading the same variables
+// concurrently from other goroutines will observe them; hosts that care
+// should not share the process with unrelated env consumers.
+//
+// Order matters: session scrubbing first, then opts.Env, so an embedding
+// caller can explicitly re-grant a variable the scrub removed.
+func applyRunEnvironment(opts RunOptions) (cleanup func(), err error) {
+	if opts.Session != nil {
+		if err := opts.Session.validate(); err != nil {
+			return nil, err
+		}
+	}
+
+	var saved []envSnapshot
+	set := func(key, value string) {
+		saved = append(saved, snapshotEnv(key))
+		_ = os.Setenv(key, value)
+	}
+	unset := func(key string) {
+		saved = append(saved, snapshotEnv(key))
+		_ = os.Unsetenv(key)
+	}
+
+	if opts.Session != nil {
+		for _, key := range sessionScrubbedEnvVars {
+			unset(key)
+		}
+		// The synthetic config carries the token inline; keep resolution away
+		// from the host OS keyring entirely (deterministic, and a service must
+		// never read or populate host credential stores on a tenant's behalf).
+		set(config.EnvDisableKeyring, "1")
+	}
+	for key, value := range opts.Env {
+		set(key, value)
+	}
+
+	runSession = opts.Session
+	return func() {
+		runSession = nil
+		// Restore in reverse so an opts.Env entry that overrode a scrub
+		// unwinds through the scrub back to the original host value.
+		for i := len(saved) - 1; i >= 0; i-- {
+			saved[i].restore()
+		}
+	}, nil
+}
+
+type envSnapshot struct {
+	key     string
+	value   string
+	present bool
+}
+
+func snapshotEnv(key string) envSnapshot {
+	value, present := os.LookupEnv(key)
+	return envSnapshot{key: key, value: value, present: present}
+}
+
+func (e envSnapshot) restore() {
+	if e.present {
+		_ = os.Setenv(e.key, e.value)
+	} else {
+		_ = os.Unsetenv(e.key)
+	}
+}

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // Session is a per-invocation target + credential override for embedded
@@ -137,7 +138,9 @@ func applyRunEnvironment(opts RunOptions) (cleanup func(), err error) {
 	}
 
 	runSession = opts.Session
+	prevFS := vfs.SetActive(opts.FS)
 	return func() {
+		vfs.SetActive(prevFS)
 		runSession = nil
 		// Restore in reverse so an opts.Env entry that overrode a scrub
 		// unwinds through the scrub back to the original host value.

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -90,16 +90,23 @@ func (s *Session) syntheticConfig() *config.Config {
 var runSession *Session
 
 // sessionScrubbedEnvVars are unset for the duration of a session-backed
-// invocation, so host-level credentials and config selection cannot leak into
-// a tenant's request. DTCTL_TOKEN/DT_API_TOKEN/DTCTL_ACCOUNT_TOKEN mirror
+// invocation, so host-level credentials and preferences cannot leak into a
+// tenant's request. DTCTL_TOKEN/DT_API_TOKEN/DTCTL_ACCOUNT_TOKEN mirror
 // credentialEnvVars (plugin_dispatch.go); DTCTL_CONFIG/DTCTL_CONTEXT would
 // repoint config discovery, which a session fully replaces; DTCTL_PROFILE and
 // DTCTL_OUTPUT would let the host's preferences shape the request's command
 // surface and output format (per-request values are set explicitly via
 // RunOptions.Env, which applies after this scrub).
+//
+// The rest are here because a request's *output bytes* must not depend on the
+// host's environment: FORCE_COLOR would inject ANSI escapes into every
+// response, NO_COLOR is scrubbed alongside it so colour resolves from the
+// invocation alone, and DTCTL_SPILL/DTCTL_SPILL_DIR would re-enable spilling
+// (or redirect it) behind the HostDiskSpill capability's back.
 var sessionScrubbedEnvVars = []string{
 	"DTCTL_TOKEN", "DT_API_TOKEN", "DTCTL_ACCOUNT_TOKEN",
 	"DTCTL_CONFIG", "DTCTL_CONTEXT", "DTCTL_PROFILE", "DTCTL_OUTPUT",
+	"FORCE_COLOR", "NO_COLOR", "DTCTL_SPILL", "DTCTL_SPILL_DIR",
 }
 
 // applyRunEnvironment installs the invocation's session and environment

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 func TestApplyRunEnvironment_ScrubAndRestore(t *testing.T) {
@@ -189,6 +190,39 @@ func TestRunWithSession_ProfileViaEnv(t *testing.T) {
 		"per-request profile must mask the command surface")
 
 	require.Equal(t, "host-profile-value", os.Getenv("DTCTL_PROFILE"))
+}
+
+// TestRunWithSession_VirtualFile is the E6 core assertion: -f resolves
+// against the request's virtual filesystem, so a file that exists nowhere on
+// the host still applies — exactly the service scenario ("dtctl apply -f
+// x.yaml" where x.yaml lives in a LangChain-style virtual file system).
+func TestRunWithSession_VirtualFile(t *testing.T) {
+	env := newSessionMockEnv(t)
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+
+	virtual := vfs.NewMapFS(map[string][]byte{
+		"bucket.yaml": []byte("bucketName: virtual_bucket\ntable: logs\nretentionDays: 35\n"),
+	})
+
+	code, _ := captureRun(t,
+		[]string{"create", "bucket", "-f", "bucket.yaml", "--plain"},
+		RunOptions{
+			Session: &Session{EnvironmentURL: env.URL, Token: "tenant-token"},
+			FS:      virtual,
+		})
+	require.Zero(t, code, "create from a virtual file must succeed")
+
+	env.mu.Lock()
+	mutations := env.mutations
+	env.mu.Unlock()
+	require.Equal(t, 1, mutations)
+
+	// Without the FS the same invocation must fail: the file is virtual only.
+	code, _ = captureRun(t,
+		[]string{"create", "bucket", "-f", "bucket.yaml", "--plain"},
+		RunOptions{Session: &Session{EnvironmentURL: env.URL, Token: "tenant-token"}})
+	require.NotZero(t, code, "the virtual file must not exist on the host")
 }
 
 // TestRunWithSession_HostAliasesIgnored: aliases are host-config convenience;

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -1,0 +1,213 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+)
+
+func TestApplyRunEnvironment_ScrubAndRestore(t *testing.T) {
+	t.Setenv("DTCTL_TOKEN", "host-secret")
+	t.Setenv("DTCTL_CONFIG", "/host/config.yaml")
+	t.Setenv("DTCTL_PROFILE", "host-profile")
+	os.Unsetenv("DTCTL_DISABLE_KEYRING")
+
+	cleanup, err := applyRunEnvironment(RunOptions{
+		Session: &Session{EnvironmentURL: "https://x.example.invalid", Token: "t"},
+		Env:     map[string]string{"DTCTL_PROFILE": "query"},
+	})
+	require.NoError(t, err)
+
+	// Scrubbed for the invocation; explicit Env applied on top.
+	_, present := os.LookupEnv("DTCTL_TOKEN")
+	require.False(t, present, "session run must scrub host credential env")
+	_, present = os.LookupEnv("DTCTL_CONFIG")
+	require.False(t, present, "session run must scrub host config selection")
+	require.Equal(t, "query", os.Getenv("DTCTL_PROFILE"))
+	require.Equal(t, "1", os.Getenv(config.EnvDisableKeyring))
+	require.NotNil(t, runSession)
+
+	cleanup()
+
+	require.Equal(t, "host-secret", os.Getenv("DTCTL_TOKEN"))
+	require.Equal(t, "/host/config.yaml", os.Getenv("DTCTL_CONFIG"))
+	require.Equal(t, "host-profile", os.Getenv("DTCTL_PROFILE"))
+	_, present = os.LookupEnv(config.EnvDisableKeyring)
+	require.False(t, present, "cleanup must restore prior unset-ness")
+	require.Nil(t, runSession)
+}
+
+func TestRunWithSession_ValidationErrors(t *testing.T) {
+	for name, s := range map[string]*Session{
+		"missing url":      {Token: "t"},
+		"missing token":    {EnvironmentURL: "https://x.example.invalid"},
+		"bad safety level": {EnvironmentURL: "https://x.example.invalid", Token: "t", SafetyLevel: "nope"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			code := Run([]string{"get", "buckets"}, RunOptions{Session: s})
+			require.NotZero(t, code)
+		})
+	}
+}
+
+func TestSessionSyntheticConfig(t *testing.T) {
+	s := &Session{EnvironmentURL: "https://x.example.invalid", Token: "tok"}
+	cfg := s.syntheticConfig()
+
+	ctx, err := cfg.CurrentContextObj()
+	require.NoError(t, err)
+	require.Equal(t, "https://x.example.invalid", ctx.Environment)
+	require.Equal(t, config.DefaultSafetyLevel, ctx.SafetyLevel,
+		"empty safety level must select the dtctl default")
+
+	token, err := cfg.GetToken(ctx.TokenRef)
+	require.NoError(t, err)
+	require.Equal(t, "tok", token)
+}
+
+// sessionMockEnv is a fake Dynatrace environment that records the
+// Authorization header and whether any mutating request arrived.
+type sessionMockEnv struct {
+	*httptest.Server
+	mu        sync.Mutex
+	authSeen  []string
+	mutations int
+}
+
+func newSessionMockEnv(t *testing.T) *sessionMockEnv {
+	t.Helper()
+	m := &sessionMockEnv{}
+	m.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.authSeen = append(m.authSeen, r.Header.Get("Authorization"))
+		if r.Method != http.MethodGet {
+			m.mutations++
+		}
+		m.mu.Unlock()
+
+		switch {
+		case r.URL.Path == "/platform/storage/management/v1/bucket-definitions" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"buckets":[{"bucketName":"session_bucket","table":"logs","status":"active","retentionDays":35,"version":1,"updatable":true}]}`))
+		case r.URL.Path == "/platform/storage/management/v1/bucket-definitions" && r.Method == http.MethodPost:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"bucketName":"new_bucket","table":"logs","status":"creating","retentionDays":35,"version":1}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":404,"message":"not found"}}`))
+		}
+	}))
+	t.Cleanup(m.Server.Close)
+	return m
+}
+
+// TestRunWithSession_TargetsInjectedEnvironment is the E4 core assertion: a
+// session-backed invocation runs against exactly the injected environment and
+// token, ignoring host credential env vars and host config entirely.
+func TestRunWithSession_TargetsInjectedEnvironment(t *testing.T) {
+	env := newSessionMockEnv(t)
+
+	// Hostile host state: none of this may reach the request.
+	t.Setenv("DTCTL_TOKEN", "host-secret")
+	t.Setenv("DTCTL_CONFIG", "/nonexistent/host/config.yaml")
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+
+	code, out := captureRun(t, []string{"get", "buckets", "--plain"}, RunOptions{
+		Session: &Session{EnvironmentURL: env.URL, Token: "tenant-token"},
+	})
+	require.Zero(t, code)
+	require.Contains(t, out, "session_bucket")
+
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	require.NotEmpty(t, env.authSeen)
+	for _, auth := range env.authSeen {
+		require.Contains(t, auth, "tenant-token", "request must carry the session token")
+		require.NotContains(t, auth, "host-secret", "host credential env must never leak into a session request")
+	}
+}
+
+// TestRunWithSession_ReadOnlyBlocksMutation: the per-session safety level must
+// stop a mutating command before any request is sent.
+func TestRunWithSession_ReadOnlyBlocksMutation(t *testing.T) {
+	env := newSessionMockEnv(t)
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+
+	code, _ := captureRun(t,
+		[]string{"create", "bucket", "--name", "b", "--table", "logs", "--retention", "35", "--plain"},
+		RunOptions{Session: &Session{
+			EnvironmentURL: env.URL,
+			Token:          "tenant-token",
+			SafetyLevel:    config.SafetyLevelReadOnly,
+		}})
+	require.NotZero(t, code, "readonly session must refuse a create")
+
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	require.Zero(t, env.mutations, "no mutating request may reach the environment")
+}
+
+// TestRunWithSession_WriteAllowedByDefault: the default safety level permits
+// mutations, so the same create goes through.
+func TestRunWithSession_WriteAllowedByDefault(t *testing.T) {
+	env := newSessionMockEnv(t)
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+
+	code, _ := captureRun(t,
+		[]string{"create", "bucket", "--name", "b", "--table", "logs", "--retention", "35", "--plain"},
+		RunOptions{Session: &Session{EnvironmentURL: env.URL, Token: "tenant-token"}})
+	require.Zero(t, code)
+
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	require.Equal(t, 1, env.mutations)
+}
+
+// TestRunWithSession_ProfileViaEnv: RunOptions.Env selects a built-in command
+// profile per request, and the host's DTCTL_PROFILE is restored afterwards.
+func TestRunWithSession_ProfileViaEnv(t *testing.T) {
+	t.Setenv("DTCTL_PROFILE", "host-profile-value")
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+
+	code, out := captureRun(t, []string{"get", "--help"}, RunOptions{
+		Session: &Session{EnvironmentURL: "https://x.example.invalid", Token: "t"},
+		Env:     map[string]string{"DTCTL_PROFILE": "query"},
+	})
+	require.Zero(t, code)
+	require.NotContains(t, availableCommandsSection(t, out), "workflows",
+		"per-request profile must mask the command surface")
+
+	require.Equal(t, "host-profile-value", os.Getenv("DTCTL_PROFILE"))
+}
+
+// TestRunWithSession_HostAliasesIgnored: aliases are host-config convenience;
+// a tenant request must not expand through them even if the host config
+// defines one.
+func TestRunWithSession_HostAliasesIgnored(t *testing.T) {
+	env := newSessionMockEnv(t)
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+
+	// Without a session this config would expand `bkts` to `get buckets`.
+	isolatedConfig(t, "aliases:\n  bkts: get buckets\ncontexts: []\n")
+
+	code, _ := captureRun(t, []string{"bkts"}, RunOptions{
+		Session: &Session{EnvironmentURL: env.URL, Token: "t"},
+	})
+	require.NotZero(t, code, "alias must not expand for a session-backed invocation")
+
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	require.Empty(t, env.authSeen, "no request may be sent for an unexpanded alias")
+}

--- a/cmd/silent_exit_test.go
+++ b/cmd/silent_exit_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace-oss/dtctl/cmd/testutil"
+)
+
+// TestNoOsExitOutsideExecute is the E2 guard: command bodies must return a
+// *silentExitError (or a regular error) instead of calling os.Exit, so the
+// command tree stays embeddable — an in-process caller (engine, serve) must
+// never have its process terminated by a command. Only Execute() in root.go
+// may translate the code into os.Exit.
+func TestNoOsExitOutsideExecute(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Clean(name))
+		require.NoError(t, err)
+
+		count := strings.Count(string(src), "os.Exit(")
+		if name == "root.go" {
+			require.Equal(t, 1, count,
+				"root.go must contain exactly one os.Exit (in Execute); found %d", count)
+			continue
+		}
+		require.Zero(t, count,
+			"%s calls os.Exit — return a *silentExitError instead (see silentExitError doc)", name)
+	}
+}
+
+func TestDiffExitCodeViaSilentError(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.yaml")
+	b := filepath.Join(dir, "b.yaml")
+	require.NoError(t, os.WriteFile(a, []byte("name: one\nvalue: 1\n"), 0o600))
+	require.NoError(t, os.WriteFile(b, []byte("name: one\nvalue: 2\n"), 0o600))
+
+	t.Cleanup(func() { testutil.ResetCommandFlags(diffCmd) })
+
+	// Differences found: diff(1) semantics — silent exit code 1, no message.
+	rootCmd.SetArgs([]string{"diff", "-f", a, "-f", b})
+	err := rootCmd.Execute()
+	var silent *silentExitError
+	require.ErrorAs(t, err, &silent, "diff with changes must return *silentExitError")
+	require.Equal(t, ExitCodeHasDiff, silent.code)
+	require.Empty(t, silent.Error(), "silent exit errors must not print")
+
+	// Identical inputs: success, no error.
+	testutil.ResetCommandFlags(diffCmd)
+	rootCmd.SetArgs([]string{"diff", "-f", a, "-f", a})
+	require.NoError(t, rootCmd.Execute())
+}
+
+func TestExitCodeForErrorMapsSilentExit(t *testing.T) {
+	err := &silentExitError{code: 42, reason: "test"}
+	require.Equal(t, 42, exitCodeForError(err))
+	// Wrapped silent errors must still be found.
+	wrapped := errors.Join(err)
+	require.Equal(t, 42, exitCodeForError(wrapped))
+}

--- a/cmd/spill.go
+++ b/cmd/spill.go
@@ -14,6 +14,21 @@ import (
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
 )
 
+// spillExplicitlyRequested reports whether the command line asked for a spill,
+// as opposed to leaving it to the mode default. --spill-format and
+// --spill-threshold only shape a spill that happens anyway, so they do not
+// count — they are inert here exactly as they are under --spill=never.
+func spillExplicitlyRequested(cmd *cobra.Command) bool {
+	if to, _ := cmd.Flags().GetString("spill-to"); to != "" {
+		return true
+	}
+	if !cmd.Flags().Changed("spill") {
+		return false
+	}
+	val, _ := cmd.Flags().GetString("spill")
+	return normalizeMode(val) != string(exec.SpillNever)
+}
+
 // resolveSpillOptions resolves the effective result-spill settings using the
 // precedence flag → env → context-config → global-config → built-in default
 // (D15), and enforces the fixed flag-conflict rules (D25). It emits a warning
@@ -24,6 +39,21 @@ func resolveSpillOptions(cmd *cobra.Command, cfg *config.Config) (exec.SpillOpti
 	var base config.SpillConfig
 	if cfg != nil {
 		base = cfg.EffectiveSpillConfig()
+	}
+
+	// Spilling writes results to the host's disk and hands the caller a path to
+	// read later, so it needs the HostDiskSpill capability. An embedded
+	// invocation has no host disk of its own: the file would land on the
+	// *server's* disk (durable, and visible to later requests) while the path in
+	// the response would be unreadable by the caller. Ungranted, spilling is off
+	// — silently when it would only have been automatic, loudly when the command
+	// line asked for it, since silently inlining a result the caller asked to
+	// spill would misreport what happened.
+	if !caps.HostDiskSpill {
+		if spillExplicitlyRequested(cmd) {
+			return exec.SpillOptions{}, &CapabilityError{Feature: "result spilling to disk"}
+		}
+		return exec.SpillOptions{Mode: exec.SpillNever}, nil
 	}
 
 	spillChanged := cmd.Flags().Changed("spill")

--- a/cmd/spill_test.go
+++ b/cmd/spill_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -183,5 +184,83 @@ func TestSpillWritesParquet(t *testing.T) {
 		if got := spillWritesParquet(c.opts); got != c.want {
 			t.Errorf("%s: spillWritesParquet = %v, want %v", c.name, got, c.want)
 		}
+	}
+}
+
+// TestResolveSpillOptions_WithoutHostDiskCapability: spilling writes a file to
+// the host disk and returns a path to read it back, so an embedded invocation
+// (which grants no capabilities) must not spill. The automatic case degrades
+// silently to "never" — the caller gets its rows inline, which is what it can
+// actually use — while an explicit request fails, because silently inlining a
+// result the command line asked to spill would misreport what happened.
+func TestResolveSpillOptions_WithoutHostDiskCapability(t *testing.T) {
+	origAgent := agentMode
+	origCaps := SetCapabilities(Capabilities{}) // grant nothing, as embedders do
+	defer func() {
+		agentMode = origAgent
+		SetCapabilities(origCaps)
+	}()
+
+	// Agent mode would default to auto; without the capability it is never.
+	agentMode = true
+	got, err := resolveSpillOptions(newSpillTestCmd(), emptyConfig())
+	if err != nil {
+		t.Fatalf("automatic spill must degrade quietly, got error: %v", err)
+	}
+	if got.Mode != exec.SpillNever {
+		t.Errorf("mode = %q, want never", got.Mode)
+	}
+	if got.ToPath != "" || got.Dir != "" {
+		t.Errorf("no host path may be resolved: ToPath=%q Dir=%q", got.ToPath, got.Dir)
+	}
+
+	// An explicit --spill-to is a capability error, not a silent no-op.
+	c := newSpillTestCmd()
+	if err := c.Flags().Set("spill-to", "/tmp/tenant-chosen.jsonl"); err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolveSpillOptions(c, emptyConfig())
+	var capErr *CapabilityError
+	if !errors.As(err, &capErr) {
+		t.Fatalf("--spill-to without the capability = %v, want *CapabilityError", err)
+	}
+
+	// So is an explicit --spill=always.
+	c = newSpillTestCmd()
+	if err := c.Flags().Set("spill", "always"); err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolveSpillOptions(c, emptyConfig())
+	if !errors.As(err, &capErr) {
+		t.Fatalf("--spill=always without the capability = %v, want *CapabilityError", err)
+	}
+
+	// An explicit --spill=never asks for nothing, so it is not an error.
+	c = newSpillTestCmd()
+	if err := c.Flags().Set("spill", "never"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveSpillOptions(c, emptyConfig()); err != nil {
+		t.Fatalf("--spill=never without the capability = %v, want no error", err)
+	}
+}
+
+// TestResolveSpillOptions_CLIKeepsSpilling guards the other direction: the CLI
+// grants HostDiskSpill, so none of the above changes local behaviour.
+func TestResolveSpillOptions_CLIKeepsSpilling(t *testing.T) {
+	origAgent := agentMode
+	origCaps := SetCapabilities(AllCapabilities())
+	defer func() {
+		agentMode = origAgent
+		SetCapabilities(origCaps)
+	}()
+
+	agentMode = true
+	got, err := resolveSpillOptions(newSpillTestCmd(), emptyConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Mode != exec.SpillAuto {
+		t.Errorf("CLI agent-mode spill = %q, want auto", got.Mode)
 	}
 }

--- a/cmd/stdio.go
+++ b/cmd/stdio.go
@@ -11,7 +11,8 @@ import (
 // os.Stdin (rather than threading writers through every command) catches
 // every output path at once — fmt.Print*, the output package, cobra help,
 // error envelopes — which is exactly the CLI-identical byte stream the
-// service contract wants (design work item E7). Safe because invocations are
+// service contract wants (docs/dev/SERVICE_ENGINE_DESIGN.md). Safe because
+// invocations are
 // serialized (runMu) and the pristine-tree restore clears any cobra-bound
 // writers.
 //

--- a/cmd/stdio.go
+++ b/cmd/stdio.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"sync"
+)
+
+// redirectStdio routes the process standard streams to the invocation's
+// writers/reader for the duration of a Run. Swapping os.Stdout/os.Stderr/
+// os.Stdin (rather than threading writers through every command) catches
+// every output path at once — fmt.Print*, the output package, cobra help,
+// error envelopes — which is exactly the CLI-identical byte stream the
+// service contract wants (design work item E7). Safe because invocations are
+// serialized (runMu) and the pristine-tree restore clears any cobra-bound
+// writers.
+//
+// The returned cleanup restores the process streams and blocks until all
+// piped output has been drained into the destination writers.
+func redirectStdio(stdout, stderr io.Writer, stdin io.Reader) (cleanup func(), err error) {
+	if stdout == nil && stderr == nil && stdin == nil {
+		return func() {}, nil
+	}
+
+	var (
+		restores []func()
+		drain    sync.WaitGroup
+	)
+	fail := func(err error) (func(), error) {
+		for i := len(restores) - 1; i >= 0; i-- {
+			restores[i]()
+		}
+		return nil, err
+	}
+
+	pipeOut := func(target **os.File, dest io.Writer) error {
+		r, w, err := os.Pipe()
+		if err != nil {
+			return err
+		}
+		orig := *target
+		*target = w
+		drain.Add(1)
+		go func() {
+			defer drain.Done()
+			_, _ = io.Copy(dest, r)
+			_ = r.Close()
+		}()
+		restores = append(restores, func() {
+			*target = orig
+			// Closing the write end delivers EOF to the drain goroutine.
+			_ = w.Close()
+		})
+		return nil
+	}
+
+	if stdout != nil {
+		if err := pipeOut(&os.Stdout, stdout); err != nil {
+			return fail(err)
+		}
+	}
+	if stderr != nil {
+		if err := pipeOut(&os.Stderr, stderr); err != nil {
+			return fail(err)
+		}
+	}
+	if stdin != nil {
+		r, w, err := os.Pipe()
+		if err != nil {
+			return fail(err)
+		}
+		orig := os.Stdin
+		os.Stdin = r
+		go func() {
+			// Feed the request stdin; close on EOF so "-" readers terminate.
+			// If the command never reads, cleanup's r.Close() unblocks the
+			// copy with a write-on-closed-pipe error and the goroutine exits.
+			_, _ = io.Copy(w, stdin)
+			_ = w.Close()
+		}()
+		restores = append(restores, func() {
+			os.Stdin = orig
+			_ = r.Close()
+		})
+	}
+
+	return func() {
+		for i := len(restores) - 1; i >= 0; i-- {
+			restores[i]()
+		}
+		drain.Wait()
+	}, nil
+}

--- a/cmd/stdio_test.go
+++ b/cmd/stdio_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunRedirectedStdout: with RunOptions.Stdout set, the invocation's
+// complete output lands in the caller's writer and the process streams are
+// restored afterwards.
+func TestRunRedirectedStdout(t *testing.T) {
+	isolatedConfig(t, "contexts: []\n")
+	origOut, origErr := os.Stdout, os.Stderr
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"commands"}, RunOptions{Stdout: &stdout, Stderr: &stderr})
+	require.Zero(t, code)
+	require.Contains(t, stdout.String(), "tool: dtctl")
+	require.Same(t, origOut, os.Stdout, "process stdout must be restored")
+	require.Same(t, origErr, os.Stderr, "process stderr must be restored")
+}
+
+// TestRedirectStdioLargeOutput: writes far beyond the OS pipe buffer (64KB on
+// Linux) must be drained concurrently — no deadlock — and arrive complete and
+// in order after cleanup.
+func TestRedirectStdioLargeOutput(t *testing.T) {
+	var stdout bytes.Buffer
+	cleanup, err := redirectStdio(&stdout, nil, nil)
+	require.NoError(t, err)
+
+	const chunk = "0123456789abcdef"
+	const chunks = 1 << 16 // 1 MiB total
+	for i := 0; i < chunks; i++ {
+		_, err := os.Stdout.WriteString(chunk)
+		require.NoError(t, err)
+	}
+	cleanup()
+
+	require.Equal(t, len(chunk)*chunks, stdout.Len(),
+		"every byte must be drained before cleanup returns")
+	require.True(t, strings.HasSuffix(stdout.String(), chunk))
+}
+
+// TestRunRedirectedStreamsSeparated: stdout carries the structured result,
+// stderr the human messages — the separation must survive redirection.
+func TestRunRedirectedStreamsSeparated(t *testing.T) {
+	env := newSessionMockEnv(t)
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+
+	var stdout, stderr bytes.Buffer
+	code := Run(
+		[]string{"create", "bucket", "--name", "b", "--table", "logs", "--retention", "35", "--plain"},
+		RunOptions{
+			Session: &Session{EnvironmentURL: env.URL, Token: "t"},
+			Stdout:  &stdout,
+			Stderr:  &stderr,
+		})
+	require.Zero(t, code)
+	require.Contains(t, stderr.String(), "created",
+		"human success message goes to stderr")
+	require.NotContains(t, stdout.String(), "created",
+		"stdout must not carry the human message")
+}
+
+// TestRedirectStdioStdin: the mechanism-level check that os.Stdin serves the
+// caller's reader during the redirection window and is restored after.
+func TestRedirectStdioStdin(t *testing.T) {
+	orig := os.Stdin
+	cleanup, err := redirectStdio(nil, nil, strings.NewReader("from-the-request"))
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(os.Stdin)
+	require.NoError(t, err)
+	require.Equal(t, "from-the-request", string(data),
+		"os.Stdin must serve the request reader until EOF")
+
+	cleanup()
+	require.Same(t, orig, os.Stdin, "process stdin must be restored")
+}
+
+// TestRedirectStdioUnreadStdin: a command that never touches stdin must not
+// wedge the cleanup path.
+func TestRedirectStdioUnreadStdin(t *testing.T) {
+	cleanup, err := redirectStdio(nil, nil, strings.NewReader(strings.Repeat("x", 1<<20)))
+	require.NoError(t, err)
+	cleanup() // must return promptly with the feeder goroutine unblocked
+}

--- a/cmd/update_documents.go
+++ b/cmd/update_documents.go
@@ -2,12 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/apply"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // updateDocumentCmd updates an existing document of any type from a file.
@@ -83,7 +83,7 @@ func updateDocumentRunE(cmd *cobra.Command, _ []string) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	showDiff, _ := cmd.Flags().GetBool("show-diff")
 
-	fileData, err := os.ReadFile(file)
+	fileData, err := vfs.ReadFile(file)
 	if err != nil {
 		return fmt.Errorf("failed to read file: %w", err)
 	}

--- a/cmd/verify_analyzer.go
+++ b/cmd/verify_analyzer.go
@@ -73,7 +73,7 @@ Examples:
 		// (getAnalyzerValidateExitCode always returns non-zero when err != nil).
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			os.Exit(exitCode)
+			return &silentExitError{code: exitCode, reason: err.Error()}
 		}
 
 		switch outputFmt {
@@ -87,7 +87,8 @@ Examples:
 		}
 
 		if exitCode != 0 {
-			os.Exit(exitCode)
+			// Verdict already printed; the code encodes the failure class.
+			return &silentExitError{code: exitCode, reason: "analyzer validation failed"}
 		}
 		return nil
 	},

--- a/cmd/verify_openpipeline_dql_processor.go
+++ b/cmd/verify_openpipeline_dql_processor.go
@@ -106,7 +106,7 @@ Examples:
 		// agent error-envelope path, so the ok:true envelope printed above stands
 		// as the sole output and the process still exits with ExitError.
 		if !result.Valid {
-			return &silentExitError{code: client.ExitError}
+			return &silentExitError{code: client.ExitError, reason: "verification failed"}
 		}
 		return nil
 	},

--- a/cmd/verify_openpipeline_matcher.go
+++ b/cmd/verify_openpipeline_matcher.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -10,6 +9,7 @@ import (
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/matcherverify"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // verifyOpenPipelineMatcherCmd validates a DQL matcher expression against the
@@ -144,22 +144,13 @@ func printVerifyResultHuman(result *matcherverify.VerifyResult) {
 	}
 }
 
-// readVerifyExpressionFromFile reads a text expression from a file or stdin.
+// readVerifyExpressionFromFile reads a text expression from a user-supplied
+// path ("-" for stdin) through the vfs seam, so an embedded invocation reads
+// the request's virtual files rather than the host disk.
 func readVerifyExpressionFromFile(path string) (string, error) {
-	var reader io.Reader
-	if path == "-" {
-		reader = os.Stdin
-	} else {
-		f, err := os.Open(path)
-		if err != nil {
-			return "", fmt.Errorf("open %q: %w", path, err)
-		}
-		defer func() { _ = f.Close() }()
-		reader = f
-	}
-	content, err := io.ReadAll(reader)
+	content, err := vfs.ReadFileOrStdin(path)
 	if err != nil {
-		return "", fmt.Errorf("read expression: %w", err)
+		return "", fmt.Errorf("read expression from %q: %w", path, err)
 	}
 	return string(content), nil
 }

--- a/cmd/verify_openpipeline_matcher.go
+++ b/cmd/verify_openpipeline_matcher.go
@@ -114,7 +114,7 @@ Examples:
 		// agent error-envelope path, so the ok:true envelope printed above stands
 		// as the sole output and the process still exits with ExitError.
 		if !result.Valid {
-			return &silentExitError{code: client.ExitError}
+			return &silentExitError{code: client.ExitError, reason: "verification failed"}
 		}
 		return nil
 	},

--- a/cmd/verify_query.go
+++ b/cmd/verify_query.go
@@ -192,9 +192,10 @@ Examples:
 
 		// Handle errors (network, auth, API)
 		if err != nil {
-			// Exit with appropriate code
+			// Exit with the mapped code; nothing further is printed (the
+			// verify contract encodes the failure class in the exit code).
 			if exitCode != 0 {
-				os.Exit(exitCode)
+				return &silentExitError{code: exitCode, reason: err.Error()}
 			}
 			return err
 		}
@@ -226,9 +227,9 @@ Examples:
 			}
 		}
 
-		// Exit with appropriate code if non-zero
+		// Non-zero code without an error: the verdict was already printed.
 		if exitCode != 0 {
-			os.Exit(exitCode)
+			return &silentExitError{code: exitCode, reason: "query verification failed"}
 		}
 
 		return nil

--- a/cmd/verify_query.go
+++ b/cmd/verify_query.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // verifyQueryCmd represents the verify query subcommand
@@ -135,7 +136,7 @@ Examples:
 				}
 				query = string(content)
 			} else {
-				content, err := os.ReadFile(queryFile)
+				content, err := vfs.ReadFile(queryFile)
 				if err != nil {
 					return fmt.Errorf("failed to read query file: %w", err)
 				}

--- a/cmd/vfs_guard_test.go
+++ b/cmd/vfs_guard_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,34 +10,71 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// hostFileAccessAllowlist records every file in cmd/ that is permitted to touch
-// the host filesystem directly, with the reason it is not request state. A file
-// not listed here must read and write user-supplied paths through pkg/vfs.
+// hostFileAccessRoots are the trees the guard scans, relative to this package's
+// directory. cmd/ holds the flag plumbing and pkg/ the code it delegates to —
+// a user-named path is just as request-bound one call deeper, which is exactly
+// how `dtctl diff -f a.yaml -f b.yaml` (pkg/diff) and `dtctl inspect <file>`
+// (pkg/inspect) escaped the seam while a cmd/-only scan stayed green.
+//
+// sdk/ is deliberately out of scope: it is a separate module with no notion of
+// a dtctl invocation, and sdk/session owns the config file and credential
+// stores by contract (see docs/dev/CONFIG_CONTRACT.md).
+var hostFileAccessRoots = []string{"..", "../pkg"}
+
+// hostFileAccessAllowlist records every file permitted to touch the host
+// filesystem directly, keyed by slash-separated path from the repository root,
+// with the reason it is not request state. A file not listed here must read and
+// write user-supplied paths through pkg/vfs.
 //
 // The distinction is *whose* file it is:
 //
 //   - a path the user named on the command line (-f, --file, --data-file, a
-//     query file) is request state — under an embedded invocation it exists
-//     only in the request's virtual filesystem, so it must go through vfs
+//     query file, a file to diff) is request state — under an embedded
+//     invocation it exists only in the request's virtual filesystem, so it must
+//     go through vfs
 //   - a path dtctl chose itself (an editor round-trip temp file, the config
 //     file, a spill buffer) is host state and belongs on the host disk
+//
+// Host state is only defensible when an embedded invocation cannot reach it, so
+// each entry below names what keeps it unreachable: a blocked command, an
+// ungranted capability, or both.
 var hostFileAccessAllowlist = map[string]string{
 	// The config file is host state by definition, and the whole `config`
 	// command tree is unavailable in a service (engine policy).
-	"config.go": "reads/writes the local dtctl config file — host state, and `config` is blocked in a service",
+	"cmd/config.go": "reads/writes the local dtctl config file — host state, and `config` is blocked in a service",
 
 	// Editor round-trip files are dtctl's own scratch space: written to the
 	// host, opened in the host's editor, read back. `edit` requires the Editor
 	// capability and is blocked in a service, so this never runs embedded.
-	"edit.go":                 "editor round-trip temp file (Editor capability, blocked in a service)",
-	"edit_anomalydetector.go": "editor round-trip temp file (Editor capability, blocked in a service)",
-	"edit_aws.go":             "editor round-trip temp file (Editor capability, blocked in a service)",
-	"edit_azure.go":           "editor round-trip temp file (Editor capability, blocked in a service)",
-	"edit_documents.go":       "editor round-trip temp file (Editor capability, blocked in a service)",
-	"edit_gcp.go":             "editor round-trip temp file (Editor capability, blocked in a service)",
-	"edit_segments.go":        "editor round-trip temp file (Editor capability, blocked in a service)",
-	"edit_settings.go":        "editor round-trip temp file (Editor capability, blocked in a service)",
-	"edit_workflows.go":       "editor round-trip temp file (Editor capability, blocked in a service)",
+	"cmd/edit_anomalydetector.go": "editor round-trip temp file (Editor capability, blocked in a service)",
+	"cmd/edit_aws.go":             "editor round-trip temp file (Editor capability, blocked in a service)",
+	"cmd/edit_azure.go":           "editor round-trip temp file (Editor capability, blocked in a service)",
+	"cmd/edit_documents.go":       "editor round-trip temp file (Editor capability, blocked in a service)",
+	"cmd/edit_gcp.go":             "editor round-trip temp file (Editor capability, blocked in a service)",
+	"cmd/edit_segments.go":        "editor round-trip temp file (Editor capability, blocked in a service)",
+	"cmd/edit_settings.go":        "editor round-trip temp file (Editor capability, blocked in a service)",
+	"cmd/edit_workflows.go":       "editor round-trip temp file (Editor capability, blocked in a service)",
+
+	// Test-only helper: golden files are repository state, read and written by
+	// the test suite, never by a command.
+	"cmd/testutil/golden.go": "golden-file helper for tests — repository state, not reachable from a command",
+
+	// Spill machinery writes results to, and lists them from, a host directory
+	// dtctl chooses. It requires the HostDiskSpill capability, which embedded
+	// callers do not grant: a spilled file would outlive the request on the
+	// server's disk and the path returned would be unreadable by the caller.
+	"pkg/output/spill.go":      "writes/prunes dtctl's own spill directory (HostDiskSpill capability, never granted embedded)",
+	"pkg/output/spill_list.go": "enumerates dtctl's own spill directory (HostDiskSpill capability, never granted embedded)",
+	"pkg/inspect/reader.go":    "streams a spilled result file from the host disk; `inspect` is blocked in a service and nothing spills there",
+
+	// Plugin discovery stats candidate executables on PATH; skills installation
+	// writes files into locally installed AI assistants' directories. Both are
+	// host state, gated by the PluginDispatch capability and the `skills` block.
+	"pkg/plugin/plugin.go":    "stats plugin executables on the host PATH (PluginDispatch capability, never granted embedded)",
+	"pkg/skills/installer.go": "installs skill files for locally installed assistants — host state, and `skills` is blocked in a service",
+
+	// The seam itself: osFS is what "the host filesystem" means.
+	"pkg/vfs/vfs.go": "the vfs seam's own host-filesystem implementation",
 }
 
 // hostFileAccessCalls are the direct host-filesystem entry points that bypass
@@ -56,37 +94,82 @@ var hostFileAccessCalls = []string{
 
 // TestUserFilePathsGoThroughVFS is the E6 guard: user-supplied file paths must
 // resolve through pkg/vfs, never through os directly. A service request's
-// files exist only in the request — a direct os.ReadFile in a command silently
-// reads the *server's* disk instead, which is both a broken feature and a path
-// traversal into host state.
+// files exist only in the request — a direct os.ReadFile in a command (or in
+// the package it delegates to) silently reads the *server's* disk instead,
+// which is both a broken feature and a path traversal into host state.
 //
 // Adding a file to hostFileAccessAllowlist is a deliberate act: it asserts the
-// path is dtctl's own scratch/host state, not something the user named.
+// path is dtctl's own scratch/host state, not something the user named, and
+// names what keeps an embedded invocation from reaching it.
 func TestUserFilePathsGoThroughVFS(t *testing.T) {
-	entries, err := os.ReadDir(".")
-	require.NoError(t, err)
-
-	for _, e := range entries {
-		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		src, err := os.ReadFile(filepath.Clean(name))
-		require.NoError(t, err)
-		text := string(src)
-
-		for _, call := range hostFileAccessCalls {
-			if !strings.Contains(text, call) {
-				continue
+	scanned := 0
+	for _, root := range hostFileAccessRoots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
 			}
-			reason, allowed := hostFileAccessAllowlist[name]
-			require.True(t, allowed,
-				"%s calls %s directly — user-supplied paths must go through pkg/vfs "+
-					"(vfs.ReadFile / vfs.WriteFile / vfs.ReadFileOrStdin) so embedded "+
-					"invocations resolve them against the request's virtual files. If this "+
-					"path is dtctl's own scratch or host state, add %s to "+
-					"hostFileAccessAllowlist with the reason.", name, call, name)
-			require.NotEmpty(t, reason)
-		}
+			if d.IsDir() {
+				// ".." is the repository root: descend into cmd/ (this package
+				// and its helpers) but not into its sibling trees, which the
+				// roots list covers explicitly or excludes by design.
+				if root == ".." && path != ".." && filepath.Base(path) != "cmd" {
+					return filepath.SkipDir
+				}
+				if skipDir(filepath.Base(path)) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			name := d.Name()
+			if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				return nil
+			}
+			scanned++
+
+			src, readErr := os.ReadFile(filepath.Clean(path))
+			require.NoError(t, readErr)
+			text := string(src)
+
+			rel := repoRelative(path)
+			for _, call := range hostFileAccessCalls {
+				if !strings.Contains(text, call) {
+					continue
+				}
+				reason, allowed := hostFileAccessAllowlist[rel]
+				require.True(t, allowed,
+					"%s calls %s directly — user-supplied paths must go through pkg/vfs "+
+						"(vfs.ReadFile / vfs.WriteFile / vfs.ReadFileOrStdin) so embedded "+
+						"invocations resolve them against the request's virtual files. If this "+
+						"path is dtctl's own scratch or host state, add %s to "+
+						"hostFileAccessAllowlist with the reason it cannot be reached from an "+
+						"embedded invocation.", rel, call, rel)
+				require.NotEmpty(t, reason)
+			}
+			return nil
+		})
+		require.NoError(t, err)
 	}
+	// A scan that silently walks nothing would pass forever.
+	require.Greater(t, scanned, 100, "guard scanned suspiciously few files")
+}
+
+// skipDir excludes trees that hold no invocation code: generated protobuf
+// bindings, test fixtures, and vendored or hidden directories.
+func skipDir(name string) bool {
+	switch name {
+	case "proto", "testdata", "vendor", "node_modules":
+		return true
+	}
+	return strings.HasPrefix(name, ".")
+}
+
+// repoRelative turns a walk path (relative to cmd/) into a slash-separated
+// path from the repository root, so allowlist keys read the way a contributor
+// would write them.
+func repoRelative(path string) string {
+	clean := filepath.ToSlash(filepath.Clean(path))
+	if trimmed, ok := strings.CutPrefix(clean, "../"); ok {
+		return trimmed
+	}
+	return "cmd/" + clean
 }

--- a/cmd/vfs_guard_test.go
+++ b/cmd/vfs_guard_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// hostFileAccessAllowlist records every file in cmd/ that is permitted to touch
+// the host filesystem directly, with the reason it is not request state. A file
+// not listed here must read and write user-supplied paths through pkg/vfs.
+//
+// The distinction is *whose* file it is:
+//
+//   - a path the user named on the command line (-f, --file, --data-file, a
+//     query file) is request state — under an embedded invocation it exists
+//     only in the request's virtual filesystem, so it must go through vfs
+//   - a path dtctl chose itself (an editor round-trip temp file, the config
+//     file, a spill buffer) is host state and belongs on the host disk
+var hostFileAccessAllowlist = map[string]string{
+	// The config file is host state by definition, and the whole `config`
+	// command tree is unavailable in a service (engine policy).
+	"config.go": "reads/writes the local dtctl config file — host state, and `config` is blocked in a service",
+
+	// Editor round-trip files are dtctl's own scratch space: written to the
+	// host, opened in the host's editor, read back. `edit` requires the Editor
+	// capability and is blocked in a service, so this never runs embedded.
+	"edit.go":                 "editor round-trip temp file (Editor capability, blocked in a service)",
+	"edit_anomalydetector.go": "editor round-trip temp file (Editor capability, blocked in a service)",
+	"edit_aws.go":             "editor round-trip temp file (Editor capability, blocked in a service)",
+	"edit_azure.go":           "editor round-trip temp file (Editor capability, blocked in a service)",
+	"edit_documents.go":       "editor round-trip temp file (Editor capability, blocked in a service)",
+	"edit_gcp.go":             "editor round-trip temp file (Editor capability, blocked in a service)",
+	"edit_segments.go":        "editor round-trip temp file (Editor capability, blocked in a service)",
+	"edit_settings.go":        "editor round-trip temp file (Editor capability, blocked in a service)",
+	"edit_workflows.go":       "editor round-trip temp file (Editor capability, blocked in a service)",
+}
+
+// hostFileAccessCalls are the direct host-filesystem entry points that bypass
+// the vfs seam. os.Stdin/os.Stdout/os.Stderr are deliberately absent: the
+// stream seam swaps those variables per invocation (see stdio.go), so using
+// them is correct. Opening "/dev/stdin" as a *path* is not — that reaches the
+// process's real fd 0, past the redirection, and does not exist on Windows.
+var hostFileAccessCalls = []string{
+	"os.ReadFile(",
+	"os.WriteFile(",
+	"os.Open(",
+	"os.OpenFile(",
+	"os.Create(",
+	"os.ReadDir(",
+	`"/dev/stdin"`,
+}
+
+// TestUserFilePathsGoThroughVFS is the E6 guard: user-supplied file paths must
+// resolve through pkg/vfs, never through os directly. A service request's
+// files exist only in the request — a direct os.ReadFile in a command silently
+// reads the *server's* disk instead, which is both a broken feature and a path
+// traversal into host state.
+//
+// Adding a file to hostFileAccessAllowlist is a deliberate act: it asserts the
+// path is dtctl's own scratch/host state, not something the user named.
+func TestUserFilePathsGoThroughVFS(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Clean(name))
+		require.NoError(t, err)
+		text := string(src)
+
+		for _, call := range hostFileAccessCalls {
+			if !strings.Contains(text, call) {
+				continue
+			}
+			reason, allowed := hostFileAccessAllowlist[name]
+			require.True(t, allowed,
+				"%s calls %s directly — user-supplied paths must go through pkg/vfs "+
+					"(vfs.ReadFile / vfs.WriteFile / vfs.ReadFileOrStdin) so embedded "+
+					"invocations resolve them against the request's virtual files. If this "+
+					"path is dtctl's own scratch or host state, add %s to "+
+					"hostFileAccessAllowlist with the reason.", name, call, name)
+			require.NotEmpty(t, reason)
+		}
+	}
+}

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 	"github.com/dynatrace-oss/dtctl/pkg/wait"
 )
 
@@ -102,7 +103,7 @@ Examples:
 				}
 				query = string(content)
 			} else {
-				content, err := os.ReadFile(queryFile)
+				content, err := vfs.ReadFile(queryFile)
 				if err != nil {
 					return fmt.Errorf("failed to read query file: %w", err)
 				}

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -218,15 +218,16 @@ Examples:
 			}
 		}
 
-		// Set exit code based on result
+		// Exit code encodes the failure mode (documented contract: 1 timeout,
+		// 2 max attempts, 3 other); the result output was already printed.
 		if !result.Success {
 			switch result.FailureReason {
 			case "timeout":
-				os.Exit(1)
+				return &silentExitError{code: 1, reason: "wait: timeout"}
 			case "max attempts exceeded":
-				os.Exit(2)
+				return &silentExitError{code: 2, reason: "wait: max attempts exceeded"}
 			default:
-				os.Exit(3)
+				return &silentExitError{code: 3, reason: "wait: condition not met"}
 			}
 		}
 

--- a/docs/dev/ALIAS_DESIGN.md
+++ b/docs/dev/ALIAS_DESIGN.md
@@ -446,6 +446,14 @@ func execShellAlias(shellCmd string) error {
 }
 ```
 
+`execShellAlias` is gated on `Capabilities.ShellAliases`: the CLI grants it,
+embedded and service invocations do not, so a `!` alias there fails with a
+capability error instead of running `sh -c`. Session-backed invocations skip
+alias resolution entirely — aliases are a host-config convenience, and a
+tenant's request must not expand through the host's alias table — and `alias`
+is one of the top-level commands removed from the service surface
+([SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md)).
+
 ### Integration into Execute()
 
 ```go

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -143,6 +143,26 @@ dtctl get workflows --watch --watch-only
 - Advanced options available via flags
 - Comprehensive help at every level
 
+### 10. Embeddable by Construction
+**The CLI is the API.** A service embeds the same command surface rather than a
+parallel one, so there is nothing to drift: `pkg/engine` takes a command line
+exactly as a user would type it and returns the bytes the CLI would have
+printed.
+
+- **No second surface** — anything typeable is callable, and output is
+  byte-identical (enforced by a CLI-vs-engine equality test, not by review)
+- **The invocation carries its world** — credentials, files, streams, and
+  environment arrive per request; nothing about the host process leaks into one,
+  and nothing about one request survives into the next
+- **Host abilities are opt-in** — subprocesses, editors, browsers, and the host
+  disk are granted explicitly by the CLI and withheld from embedded callers, so
+  they are structurally unreachable rather than merely discouraged
+- **Practical consequence for contributors** — user-supplied file paths go
+  through `pkg/vfs`, subprocess spawns go through a capability gateway, and
+  command bodies return errors instead of calling `os.Exit`
+
+See [SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md).
+
 ## Command Structure
 
 ### Core Verbs
@@ -165,6 +185,7 @@ ctx         - Quick context management (list, switch, describe, set, delete)
 doctor      - Health check (config, context, token, connectivity, auth)
 diff        - Show differences between local and remote resources
 commands    - Machine-readable command catalog for AI agents (JSON/YAML, --brief, howto)
+serve       - Run dtctl as a server, one subcommand per protocol (serve http)
 
 # (not implemented yet)
 # patch       - Update specific fields of a resource
@@ -2288,5 +2309,6 @@ Exit code: 4
 - Resource diffing and change previews
 - Integration with CI/CD pipelines
 - ~~Plugin system for custom commands~~ — shipped 2026-07-12: kubectl-style exec plugins (`dtctl-<name>` on PATH; see [PLUGIN_CONVENTIONS.md](PLUGIN_CONVENTIONS.md))
+- ~~Run dtctl as a service~~ — shipped: `cmd.Run` + `pkg/engine` + `dtctl serve http` (see [SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md))
 - Shell integration (kubectl-like autocompletion)
 - Resource usage analytics and cost estimation

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -186,6 +186,7 @@ doctor      - Health check (config, context, token, connectivity, auth)
 diff        - Show differences between local and remote resources
 commands    - Machine-readable command catalog for AI agents (JSON/YAML, --brief, howto)
 serve       - Run dtctl as a server, one subcommand per protocol (serve http)
+              (experimental: registered only with DTCTL_EXPERIMENTAL_SERVE)
 
 # (not implemented yet)
 # patch       - Update specific fields of a resource

--- a/docs/dev/ARCHITECTURE.md
+++ b/docs/dev/ARCHITECTURE.md
@@ -438,7 +438,12 @@ dtctl/
 │   ├── config.go               # Config command
 │   ├── auth.go                 # Auth command
 │   ├── completion.go           # Shell completion
-│   └── version.go              # Version command
+│   ├── version.go              # Version command
+│   ├── run.go                  # cmd.Run: in-process entrypoint + per-invocation isolation
+│   ├── capabilities.go         # Capability gate for subprocess spawns
+│   ├── session.go              # Per-invocation tenant (synthetic config)
+│   ├── stdio.go                # Per-invocation stream redirection
+│   └── blocked.go              # Per-invocation command-surface mask
 │
 ├── pkg/
 │   ├── api/                    # Generated API clients
@@ -498,6 +503,18 @@ dtctl/
 │   │   ├── slo.go              # SLO evaluator
 │   │   ├── function.go         # Function executor
 │   │   └── intent.go           # Intent URL generator
+│   │
+│   ├── vfs/                    # File-access seam for user-supplied paths
+│   │   ├── vfs.go              # FS interface + host filesystem default
+│   │   └── mapfs.go            # In-memory FS built from a request's files
+│   │
+│   ├── engine/                 # Embeddable service engine
+│   │   ├── engine.go           # Execute(ctx, Request) — one command line per request
+│   │   └── policy.go           # Commands unsupported in a service
+│   │
+│   ├── serve/                  # `dtctl serve <protocol>` reference servers
+│   │   ├── serve.go            # Protocol parent command + standalone dispatch
+│   │   └── http.go             # `serve http` — POST /v1/execute, GET /healthz
 │   │
 │   └── util/                   # Utilities
 │       ├── editor.go           # Interactive editor
@@ -898,6 +915,45 @@ func isRetryable(r *resty.Response, err error) bool {
 
 ---
 
+### 5. Invocation Model Pattern
+
+dtctl is both a one-shot process and an in-process library called once per
+service request. `cmd.Run(argv, RunOptions)` is the single entrypoint for both;
+`Execute()` (the CLI's `main`) delegates to it.
+
+```go
+res, err := cmd.Run(argv, cmd.RunOptions{
+    Capabilities:    cmd.Capabilities{},        // no subprocesses
+    Session:         &cmd.Session{...},         // this request's tenant
+    FS:              vfs.NewMapFS(files),       // this request's files
+    Stdout:          &stdout,                   // this request's streams
+    BlockedCommands: engine.UnsupportedCommands(),
+})
+```
+
+Each invocation is bracketed by setup/restore of process-wide state:
+
+1. **Pristine command tree** — a one-time snapshot of every command's
+   as-registered state (`RunE`, `Run`, `Args`, `Hidden`, `DisableFlagParsing`)
+   is restored, and all flag values reset to declared defaults, so per-run
+   mutations (profile masks, scope-preflight wraps) and stale flag values cannot
+   leak into the next invocation.
+2. **Capabilities** applied, then restored.
+3. **Session** installed behind `LoadConfig()` as a synthetic single-context
+   config, with host credential/config environment variables scrubbed.
+4. **Filesystem** installed for user-supplied paths (`pkg/vfs`).
+5. **Streams** redirected (`os.Stdout`/`os.Stderr`/`os.Stdin` swapped), then
+   drained and restored.
+
+Because all five touch package or process state, invocations **serialize** on a
+package mutex — the command tree is 277 command values wired by `init()`.
+Parallelism comes from more instances or processes, not more goroutines. This is
+the constraint that makes the rest safe; see
+[SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md) for the full rationale and
+the invariants contributors must preserve.
+
+---
+
 ## Performance Considerations
 
 ### 1. Parallel Operations
@@ -1007,12 +1063,13 @@ httpClient.SetTLSClientConfig(&tls.Config{
 
 ### Phase 2 Additions:
 1. **Plugin System**: ✅ shipped 2026-07-12 as the kubectl-style exec convention — `dtctl foo` execs `dtctl-foo` from PATH; Go plugins rejected (see [PLUGIN_CONVENTIONS.md](PLUGIN_CONVENTIONS.md))
-2. **Interactive Mode**: TUI using bubbletea/lipgloss
-3. **Local Development Mode**: Mock server for testing
-4. **Credential Providers**: Integration with HashiCorp Vault, AWS Secrets Manager
-5. **Advanced Caching**: Persistent cache with TTL and invalidation
-6. **Metrics**: Built-in metrics collection for usage analytics
-7. **Auto-update**: Automatic version checking and updates
+2. **Embeddable engine / service mode**: ✅ shipped as `cmd.Run` + `pkg/engine` + `dtctl serve http` — the CLI surface runs in-process, multi-tenant, one invocation per request (see [SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md))
+3. **Interactive Mode**: TUI using bubbletea/lipgloss
+4. **Local Development Mode**: Mock server for testing
+5. **Credential Providers**: Integration with HashiCorp Vault, AWS Secrets Manager
+6. **Advanced Caching**: Persistent cache with TTL and invalidation
+7. **Metrics**: Built-in metrics collection for usage analytics
+8. **Auto-update**: Automatic version checking and updates
 
 ---
 

--- a/docs/dev/COMMAND_PROFILES_DESIGN.md
+++ b/docs/dev/COMMAND_PROFILES_DESIGN.md
@@ -333,6 +333,21 @@ rather than `RemoveCommand`.
 - The **always-available** set is merged into the allowlist, so those commands
   survive regardless of how narrow the profile is.
 
+### A second mask on the same mechanics: `BlockedCommands`
+
+Embedded callers apply a second, orthogonal mask built from `Hidden` + a `RunE`
+guard exactly as above: `RunOptions.BlockedCommands` (`applyBlockedCommands`,
+`cmd/blocked.go`). The two answer different questions — a profile answers "which
+commands exist for this caller" and blocks with `profile_blocked`, while
+`BlockedCommands` answers "which commands make sense in this environment at all"
+and blocks with `unsupported_in_service`. They **compose**: both masks apply to a
+run, and the per-invocation tree restore undoes both before the next one.
+
+One deliberate difference: the blocked mask also guards **non-runnable parents**
+(and neutralizes their arg/flag parsing), so a masked bare `config` cannot answer
+with its own help text and exit 0. The profile mask guards only runnable nodes.
+See [SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md).
+
 ### Config schema changes
 
 `pkg/config/config.go`:

--- a/docs/dev/CONFIG_CONTRACT.md
+++ b/docs/dev/CONFIG_CONTRACT.md
@@ -103,6 +103,15 @@ string. Management commands that rewrite the file must load with
 | `DTCTL_DISABLE_KEYRING` | Disable the OS keyring (any non-empty value). |
 | `DTCTL_TOKEN_STORAGE` | `file` forces the file-based OAuth store. |
 
+**Sanctioned bypass: `cmd.Session`.** An embedded invocation can carry its own
+environment and token, and then none of this contract applies to it: no config
+file is read (a synthetic in-memory single-context config stands in), no keyring
+is touched, and `DTCTL_TOKEN`, `DT_API_TOKEN`, `DTCTL_ACCOUNT_TOKEN`,
+`DTCTL_CONFIG`, `DTCTL_CONTEXT`, `DTCTL_PROFILE`, and `DTCTL_OUTPUT` are unset
+for the duration of the invocation so the host's identity and preferences cannot
+shape a tenant's request. See
+[SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md).
+
 ## Golden fixtures
 
 | Fixture | Asserts |

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # dtctl Implementation Status
 
-Last Updated: March 2026
+Last Updated: August 2026
 
 ## Overview
 
@@ -29,6 +29,12 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] Machine-readable command catalog (`dtctl commands`) for AI agent bootstrap
 - [x] [NO_COLOR](https://no-color.org/) standard: color disabled when piped, `NO_COLOR` env var, `FORCE_COLOR=1` override
 - [x] Consistent help text: all parent verb commands have `Long` descriptions and Cobra `Example` fields
+- [x] **Embeddable invocation** (`cmd.Run` + `RunOptions`): in-process entrypoint that never terminates the process, restores a pristine command tree per invocation, and serializes invocations (the command tree is package state). See [SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md)
+- [x] Per-invocation tenant (`cmd.Session`): one environment URL + token + safety level via a synthetic in-memory config; host config file, contexts, keyring, and credential env vars detached
+- [x] Capability gate (`cmd.Capabilities`): every subprocess spawn (plugins, shell aliases, apply hooks, editors, browser opens) is opt-in; embedded callers grant nothing
+- [x] Virtual filesystem seam (`pkg/vfs`): user-supplied file paths resolve against the host disk (CLI) or per-request virtual files (embedded), including `apply --write-id` writebacks
+- [x] Per-invocation streams: stdout/stderr/stdin redirect to caller-supplied writers, byte-identical to CLI output (enforced by a CLI-vs-engine equality test)
+- [x] Environment surface mask (`RunOptions.BlockedCommands`): host-only commands removed per invocation, with the stable agent error code `unsupported_in_service`
 
 ### Verbs Implemented
 - [x] `get` - List/retrieve resources
@@ -53,6 +59,7 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] `commands` - Machine-readable command catalog (JSON/YAML, `--brief`, resource filter, `howto` subcommand)
 - [x] `skills` - AI agent skill file management (install, uninstall, status for Claude, Codex, Copilot, Cursor, Kiro, Junie, OpenCode, OpenClaw; cross-client via `--cross-client`)
 - [x] `plugin` - kubectl-style exec plugins: unknown commands dispatch to `dtctl-<name>` binaries on PATH (`plugin list`, catalog integration; see [PLUGIN_CONVENTIONS.md](PLUGIN_CONVENTIONS.md))
+- [x] `serve` - Run dtctl as a server instead of a one-shot CLI, one subcommand per protocol: `serve http` (`POST /v1/execute`, `GET /healthz`, `--addr` default `127.0.0.1:7211`). Reference implementation over `pkg/engine`; see [SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md)
 
 ### Resources
 

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -59,7 +59,7 @@ This document tracks the current implementation status of dtctl. For future plan
 - [x] `commands` - Machine-readable command catalog (JSON/YAML, `--brief`, resource filter, `howto` subcommand)
 - [x] `skills` - AI agent skill file management (install, uninstall, status for Claude, Codex, Copilot, Cursor, Kiro, Junie, OpenCode, OpenClaw; cross-client via `--cross-client`)
 - [x] `plugin` - kubectl-style exec plugins: unknown commands dispatch to `dtctl-<name>` binaries on PATH (`plugin list`, catalog integration; see [PLUGIN_CONVENTIONS.md](PLUGIN_CONVENTIONS.md))
-- [x] `serve` - Run dtctl as a server instead of a one-shot CLI, one subcommand per protocol: `serve http` (`POST /v1/execute`, `GET /healthz`, `--addr` default `127.0.0.1:7211`). Reference implementation over `pkg/engine`; see [SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md)
+- [x] `serve` (experimental, gated behind `DTCTL_EXPERIMENTAL_SERVE`) - Run dtctl as a server instead of a one-shot CLI, one subcommand per protocol: `serve http` (`POST /v1/execute`, `GET /healthz`, `--addr` default `127.0.0.1:7211`). Reference implementation over `pkg/engine`; see [SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md)
 
 ### Resources
 

--- a/docs/dev/PLUGIN_CONVENTIONS.md
+++ b/docs/dev/PLUGIN_CONVENTIONS.md
@@ -21,6 +21,13 @@ installer, no registry, no RPC — deliberately.
 - Leading dtctl flags (`dtctl --context prod foo`) are consumed by dtctl and
   reflected into the environment contract below — they are not passed to the
   plugin.
+- **Dispatch is a gated host ability.** It runs only when
+  `Capabilities.PluginDispatch` is granted: the CLI binary grants it, embedded
+  and service invocations do not. Without the grant there is no `PATH` lookup at
+  all — an unknown command falls through to the normal suggestion-enhanced
+  unknown-command error. `plugin` itself is one of the top-level commands
+  removed from the service surface
+  ([SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md)).
 
 ## Environment contract
 

--- a/docs/dev/PRE_APPLY_HOOK_DESIGN.md
+++ b/docs/dev/PRE_APPLY_HOOK_DESIGN.md
@@ -459,6 +459,7 @@ type ApplyOptions struct {
 | **`--no-hooks`** | Skips hook entirely |
 | **`--dry-run`** | Hook still runs (validation is useful even in preview) |
 | **`--agent` mode** | Structured error with `code: "hook_rejected"` |
+| **Host forbids hooks** | When `cmd.Capabilities.ApplyHooks` is not granted (embedded/service callers) and a hook is configured, apply fails before touching the resource — `code: "capability_disabled"` in agent mode. It fails rather than skipping silently, because a validation hook that quietly does not run is worse than a refused apply. |
 
 ---
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -61,6 +61,18 @@ Command alias system design:
 
 ---
 
+### [SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md)
+dtctl as an in-process library a service calls once per request:
+- **The Seams** - Per-invocation command tree, capabilities, session, environment, files, streams
+- **Serialization** - Why invocations hold a package mutex, and what that rules out
+- **Surface Reduction** - The independent safety / profile / environment / capability axes
+- **Rules for Contributors** - `pkg/vfs` for user file paths, capability gates, no `os.Exit`
+- **`dtctl serve`** - The reference HTTP server and how to add a protocol
+
+**Use this for**: Changing anything in `cmd/`, adding a command, or reading a user-supplied file.
+
+---
+
 ### [../LIVE_DEBUGGER.md](../LIVE_DEBUGGER.md)
 User-facing Live Debugger workflow documentation:
 - **Workspace Filters** - Target runtimes with `dtctl update breakpoint --filters`
@@ -82,7 +94,7 @@ User-facing Live Debugger workflow documentation:
 **Adding a new resource?** Follow this pattern:
 1. Define in [API_DESIGN.md](API_DESIGN.md) - Resource Types section
 2. Implement in `pkg/resources/<resource>/`
-3. Add commands in `cmd/`
+3. Add commands in `cmd/` - read user-supplied file paths through `pkg/vfs` (not `os.ReadFile`), gate every subprocess spawn on `cmd.Capabilities`, and return errors instead of calling `os.Exit` (see [SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md))
 4. Update [IMPLEMENTATION_STATUS.md](IMPLEMENTATION_STATUS.md)
 5. Add tests in `test/`
 

--- a/docs/dev/SERVICE_ENGINE_DESIGN.md
+++ b/docs/dev/SERVICE_ENGINE_DESIGN.md
@@ -1,0 +1,243 @@
+# dtctl as a Service — Engine Design
+
+**Status:** Implemented
+**Created:** 2026-08-13
+**Audience:** anyone changing `cmd/`, adding a command, or reading a user-supplied file.
+
+> **Implementation:** `cmd/run.go` (`Run`, `RunOptions`, tree isolation, serialization),
+> `cmd/capabilities.go` (subprocess gate), `cmd/session.go` (per-request tenant),
+> `cmd/stdio.go` (stream redirection), `cmd/blocked.go` (surface mask),
+> `pkg/vfs/` (file seam), `pkg/engine/` (the embedding surface),
+> `pkg/serve/` (`dtctl serve http`, reference server).
+
+## Overview
+
+dtctl runs as a one-shot CLI *and* as an in-process library that a service can
+call once per request. The same command tree, the same code paths, the same
+bytes on stdout — the only difference is where the invocation's credentials,
+files, and streams come from.
+
+The motivating use cases are AI agents and automation that already know how to
+drive dtctl on a terminal: a Dynatrace Workflow action, an agent gateway, an
+MCP server. Rather than growing a second, parallel API surface that drifts from
+the CLI, an embedding host hands over **a command line** and gets back **what
+the CLI would have printed**.
+
+```go
+res, err := engine.Execute(ctx, engine.Request{
+    Command:        `apply -f workflow.yaml --write-id --agent`,
+    EnvironmentURL: "https://abc12345.apps.dynatrace.com",
+    Token:          tenantToken,
+    Files:          map[string][]byte{"workflow.yaml": src},
+})
+// res.Stdout is byte-identical to local CLI output;
+// res.Files["workflow.yaml"] now carries the stamped id.
+```
+
+## Goals
+
+1. **The CLI is the API.** No second command surface, no second output format.
+   Anything a user can type, a service can send.
+2. **Byte-identical output.** An agent moving between local CLI and service must
+   not be able to tell the difference. Enforced by a test, not by review.
+3. **Multi-tenant per invocation.** Each request carries its own environment and
+   token. Nothing about the host process's identity leaks into a request, and
+   nothing about one request survives into the next.
+4. **Host abilities are opt-in.** Subprocesses, editors, browsers, the host disk
+   — all off by default for embedded callers, granted explicitly by the CLI.
+5. **No new trust in the host.** A service must not be able to make dtctl read
+   the server's disk, credentials, or environment on a tenant's behalf.
+
+## Non-Goals
+
+- **A security sandbox.** The engine is a *correctness* boundary inside one
+  process, not an isolation boundary. It does not contain a hostile *command*
+  string; it prevents an honest one from reaching host state. Untrusted callers
+  belong behind a process or WASM boundary.
+- **Per-request preemption.** A run that has started cannot be killed
+  mid-flight; in-process Go code cannot be preempted safely.
+- **Intra-process parallelism.** See "Serialization" below. Scale with more
+  instances or processes.
+- **Authentication.** `pkg/serve` has none of its own. A deployment puts its own
+  authn/TLS/rate limiting in front, or embeds `pkg/engine` directly.
+
+## The five seams
+
+Each seam replaces one thing a CLI process normally takes from its environment.
+All are per-invocation and restored afterwards.
+
+| Seam | `RunOptions` field | Default (CLI) | Embedded |
+|---|---|---|---|
+| Command tree | — | pristine per run | same |
+| Subprocesses | `Capabilities` | all granted | none granted |
+| Credentials + config | `Session` | host config, contexts, keyring | request's URL + token, host scrubbed |
+| Environment | `Env` | host environment | host + explicit per-request entries |
+| Files | `FS` | host filesystem | request's virtual files (`vfs.MapFS`) |
+| Streams | `Stdout`/`Stderr`/`Stdin` | real process stdio | caller's writers/reader |
+
+Surface reduction is a sixth, orthogonal knob: `BlockedCommands` removes
+host-only commands from the tree per invocation.
+
+### Serialization
+
+The command tree is **package state** — 277 command values wired by `init()`.
+Invocations therefore serialize on a package mutex (`cmd.runMu`), and that
+single fact is what makes the rest of the design safe: swapping process
+streams, mutating environment variables, and installing a filesystem are all
+process-wide operations that would be indefensible under concurrency.
+
+Consequences to internalize before "optimizing" this:
+
+- A server handles one dtctl command at a time per process. `dtctl serve http`
+  says so in its help text.
+- Parallelism comes from more instances or more processes, never more
+  goroutines.
+- A server must not be started *inside* an invocation — it would hold the lock
+  for its lifetime and deadlock its own first request. This is why `main`
+  dispatches `serve` before the command pipeline, and why `dtctl serve http`
+  refuses to run when `cmd.RunActive()` reports an invocation in progress.
+
+### Restriction has four independent axes
+
+Do not conflate these; each answers a different question.
+
+| Axis | Question | Mechanism | Agent error code |
+|---|---|---|---|
+| Safety level | What may this command *do* to the tenant? | `pkg/safety` checks | `safety_blocked` |
+| Profile | Which commands *exist* for this caller? | `applyProfile` mask | `profile_blocked` |
+| Environment | Which commands *make sense* here at all? | `BlockedCommands` mask | `unsupported_in_service` |
+| Capability | Which *host abilities* may this process use? | `cmd.Capabilities` gates | `capability_disabled` |
+
+The masks compose — profile and environment both apply to a run. The
+environment mask additionally guards non-runnable parents, so a blocked
+`config` cannot answer with its own help text and exit 0.
+
+## Rules for contributors
+
+These are the invariants the design rests on. Each has a guard test, because
+each was violated at least once during development — including twice in the
+implementing PR itself.
+
+### 1. User-supplied file paths go through `pkg/vfs`
+
+```go
+// NO — reads the server's disk on a service request
+content, err := os.ReadFile(flagValue)
+
+// YES
+content, err := vfs.ReadFile(flagValue)
+content, err := vfs.ReadFileOrStdin(flagValue) // when "-" means stdin
+```
+
+Applies to every path a **user named**: `-f`, `--file`, `--data-file`, query
+files, and writebacks like `apply --write-id`. Under an embedded invocation
+those files exist only in the request; a direct `os.ReadFile` silently reads the
+*server's* filesystem instead — a broken feature and a traversal into host
+state in one line.
+
+Paths **dtctl chose itself** — editor round-trip temp files, the config file,
+spill buffers — are host state and stay on `os`. That is the whole test: whose
+file is it?
+
+Also never open `/dev/stdin` as a path. The stream seam swaps the `os.Stdin`
+*variable*; a path reaches the process's real fd 0, past the redirection, and
+does not exist on Windows. Use `os.Stdin` (the variable) or
+`vfs.ReadFileOrStdin`.
+
+**Guard:** `TestUserFilePathsGoThroughVFS` (`cmd/vfs_guard_test.go`) fails on any
+direct `os` file call in `cmd/` outside an annotated allowlist.
+
+### 2. Never spawn a subprocess without a capability gate
+
+Every path in `cmd/` that spawns or replaces the process goes through one of the
+five gateway files, each gated on a `cmd.Capabilities` field. Embedded callers
+grant nothing, which makes those paths structurally unreachable rather than
+merely discouraged.
+
+**Guard:** `TestSubprocessSpawnsConfinedToGateways` (`cmd/capabilities_test.go`)
+confines `exec.Command`/`syscall.Exec` in `cmd/` to the gateway files.
+
+### 3. Command bodies never call `os.Exit`
+
+An in-process caller dies with it. Return an error — `*silentExitError` when you
+need a specific exit code with no additional message.
+
+**Guard:** `TestNoOsExitOutsideExecute` (`cmd/silent_exit_test.go`).
+
+### 4. Credentials and config come from the invocation, not the process
+
+Read them through `LoadConfig()`, which a `Session` transparently replaces with
+a synthetic single-context config. Never reach for `os.Getenv("DTCTL_TOKEN")`,
+the keyring, or a config path directly in a command — a session-backed request
+has scrubbed all of them, and code that goes around `LoadConfig` would hand one
+tenant's request the host's (or another tenant's) credentials.
+
+### 5. Output goes to the process streams, and stays byte-identical
+
+Print via `pkg/output`, `fmt.Print*`, or cobra — all of which resolve
+`os.Stdout`/`os.Stderr` dynamically, so the stream seam catches them. Do not
+cache a writer across invocations, and do not add host-environment-dependent
+output (TTY probes are fine; they already resolve to "not a TTY" for a service).
+
+**Guard:** `TestEngineOutputEqualsCLI` (`pkg/engine/equality_test.go`) builds the
+real binary and diffs CLI vs. engine stdout/stderr/exit code.
+
+### 6. Per-run mutation of the command tree must be restorable
+
+If you mutate a command at runtime (hide it, wrap its `RunE`, flip
+`DisableFlagParsing`), the pristine-tree snapshot in `cmd/run.go` must know
+about the field, or the mutation leaks into the next invocation. Add the field
+to the snapshot, and a leak test beside
+`TestRunProfileMaskDoesNotLeakBetweenInvocations` (`cmd/run_test.go`).
+
+### 7. A new top-level command decides whether it belongs in a service
+
+Add it to `unsupportedCommands` in `pkg/engine/policy.go` with a reason if it
+manages host-local state (config, keyring, shell, installed tools, an
+interactive session) or would nest the service in itself. The reason string is
+user-facing: it appears in the `unsupported_in_service` error's suggestions.
+
+## `dtctl serve`
+
+`serve` is a **parent** command; each protocol is a named subcommand. Today:
+
+```
+dtctl serve http     JSON over HTTP (POST /v1/execute, GET /healthz)
+```
+
+Bare `dtctl serve` prints help and exits 0 — naming the protocol is mandatory,
+so no single protocol is the silent default and a future `dtctl serve mcp` lands
+beside `http` rather than competing with an incumbent. An unrecognized protocol
+name is an error with a non-zero exit, not a help dump, so a supervisor cannot
+mistake a typo for a started server.
+
+Adding a protocol: a new file in `pkg/serve/`, a `newXCommand()` constructor
+registered in `NewCommand()`, and the same `cmd.RunActive()` guard in its
+`RunE`. It calls `engine.Execute` per request and translates the result into its
+own wire format — protocol servers hold no dtctl logic of their own.
+
+## Deliberate divergences from the local CLI
+
+The service is not a perfect mirror, and the differences are intentional:
+
+- **Host-only commands are absent** (see the environment axis above).
+- **AI-agent auto-detection is skipped** for session-backed runs. The host's
+  environment must not shape a tenant's output format; envelopes are opt-in per
+  request via `--agent`.
+- **`DTCTL_PROFILE` and `DTCTL_OUTPUT` are scrubbed** along with the credential
+  variables, for the same reason.
+- **`Env` is not exposed over HTTP.** Arbitrary variables reach proxies,
+  exporters, and other process-level behavior. Embedding hosts that need it use
+  `engine.Request.Env` directly, in-process.
+
+## Open questions
+
+- **Instance-per-request via WASM.** A spike measured 20–47 ms per-instance
+  overhead, which would remove the serialization constraint and give hard
+  per-request deadlines. Not pursued yet; the current model is
+  process/instance-level scaling.
+- **Cancellation.** The context gates the *start* of an execution only. Hard
+  deadlines need a process or WASM boundary.
+- **Streaming.** `POST /v1/execute` buffers the whole output. Long-running
+  commands (`--watch`, `logs -f`) are unavailable in the service surface; a
+  streaming endpoint would need a different response shape.

--- a/docs/dev/SERVICE_ENGINE_DESIGN.md
+++ b/docs/dev/SERVICE_ENGINE_DESIGN.md
@@ -1,6 +1,7 @@
 # dtctl as a Service — Engine Design
 
-**Status:** Implemented
+**Status:** Implemented; `dtctl serve` is experimental and gated behind
+`DTCTL_EXPERIMENTAL_SERVE` (see [Maturity](#maturity))
 **Created:** 2026-08-13
 **Audience:** anyone changing `cmd/`, adding a command, or reading a user-supplied file.
 
@@ -245,6 +246,30 @@ The service is not a perfect mirror, and the differences are intentional:
 - **`Env` is not exposed over HTTP.** Arbitrary variables reach proxies,
   exporters, and other process-level behavior. Embedding hosts that need it use
   `engine.Request.Env` directly, in-process.
+
+## Maturity
+
+`pkg/engine` is the stable half: a Go caller opts into it at compile time, and
+the isolation rules above are enforced by guard tests.
+
+`dtctl serve` is **experimental** and registered only when
+`DTCTL_EXPERIMENTAL_SERVE` is set (the `DTCTL_EXPERIMENTAL_ACCOUNT` convention;
+`serve.Experimental()` and the gate in `main`). Without it the command does not
+exist — no help entry, no catalog entry, an ordinary "unknown command". The gate
+comes off when the items below are settled, because each one changes what an
+operator can rely on:
+
+- **No per-request deadline.** A started execution cannot be interrupted, and it
+  holds the single invocation slot. One `wait` with a long timeout, or a `query`
+  against a slow environment, stalls every queued request behind it.
+- **No admission control.** Requests queue on the invocation mutex without a
+  bound; there is no "server busy" answer and no way to shed load.
+- **Unbounded commands are still reachable.** `query --live` never returns on
+  its own. Deciding whether the service surface excludes such commands (as it
+  excludes `inspect`) or the transport imposes deadlines is the open half of the
+  question below.
+- **Per-invocation tracing cost.** `tracing.Init`/shutdown runs per invocation
+  with a 5s flush budget; in a long-lived server that belongs at process scope.
 
 ## Open questions
 

--- a/docs/dev/SERVICE_ENGINE_DESIGN.md
+++ b/docs/dev/SERVICE_ENGINE_DESIGN.md
@@ -130,14 +130,22 @@ content, err := vfs.ReadFileOrStdin(flagValue) // when "-" means stdin
 ```
 
 Applies to every path a **user named**: `-f`, `--file`, `--data-file`, query
-files, and writebacks like `apply --write-id`. Under an embedded invocation
-those files exist only in the request; a direct `os.ReadFile` silently reads the
-*server's* filesystem instead — a broken feature and a traversal into host
-state in one line.
+files, files to `diff`, and writebacks like `apply --write-id`. Under an embedded
+invocation those files exist only in the request; a direct `os.ReadFile` silently
+reads the *server's* filesystem instead — a broken feature and a traversal into
+host state in one line.
+
+The rule follows the path, not the package. `cmd/diff.go` read its `-f` flags
+through the seam while the `pkg/diff` helper one call deeper used `os.ReadFile`,
+which is the same hole with an extra stack frame — and `dtctl inspect` took a
+path argument straight to `os.Open`. Both survived a `cmd/`-only guard; both are
+why the guard now scans `pkg/` too.
 
 Paths **dtctl chose itself** — editor round-trip temp files, the config file,
 spill buffers — are host state and stay on `os`. That is the whole test: whose
-file is it?
+file is it? Host state is only defensible while an embedded invocation cannot
+reach it, so pair it with the thing that keeps it unreachable: a blocked command
+(rule 6) or an ungranted capability (rule 2).
 
 Also never open `/dev/stdin` as a path. The stream seam swaps the `os.Stdin`
 *variable*; a path reaches the process's real fd 0, past the redirection, and
@@ -145,14 +153,22 @@ does not exist on Windows. Use `os.Stdin` (the variable) or
 `vfs.ReadFileOrStdin`.
 
 **Guard:** `TestUserFilePathsGoThroughVFS` (`cmd/vfs_guard_test.go`) fails on any
-direct `os` file call in `cmd/` outside an annotated allowlist.
+direct `os` file call under `cmd/` or `pkg/` outside an annotated allowlist,
+where each entry names what keeps that path unreachable from a service request.
 
-### 2. Never spawn a subprocess without a capability gate
+### 2. Never reach the host without a capability gate
 
 Every path in `cmd/` that spawns or replaces the process goes through one of the
-five gateway files, each gated on a `cmd.Capabilities` field. Embedded callers
-grant nothing, which makes those paths structurally unreachable rather than
-merely discouraged.
+five gateway files, each gated on a `cmd.Capabilities` field. The same applies to
+host-disk features that live outside the vfs seam: result spilling writes a file
+the caller cannot read and that outlives the request, so it is gated on
+`HostDiskSpill`. Embedded callers grant nothing, which makes those paths
+structurally unreachable rather than merely discouraged.
+
+A capability is the right tool when the ability is *conditional* on the host; a
+blocked command (rule 6) is right when the whole command is meaningless without
+one. `--spill` is the former (the rows come back inline instead); `inspect`, a
+reader for spilled files, is the latter.
 
 **Guard:** `TestSubprocessSpawnsConfinedToGateways` (`cmd/capabilities_test.go`)
 confines `exec.Command`/`syscall.Exec` in `cmd/` to the gateway files.

--- a/docs/dev/agent-schema-command.md
+++ b/docs/dev/agent-schema-command.md
@@ -37,6 +37,15 @@ dtctl commands howto                  # Usage-focused reference document
 - `-o` — reuses dtctl's standard output flag. `dtctl commands` defaults to `toon` (the most compact structured format); `json` and `yaml` are also supported. Other formats (table, chart, etc.) are not meaningful here.
 - `howto` subcommand — action-oriented; outputs an LLM-optimized usage guide.
 
+**The catalog is relative to the invocation, not absolute.** Two things vary the
+listed set. Commands can be registered on the root from outside package `cmd` via
+`cmd.AddCommand` — that is how `serve` appears, since `pkg/serve` imports
+`pkg/engine`, which imports `cmd`. And per-invocation masking hides commands from
+the catalog along with help and completion: a command profile
+([COMMAND_PROFILES_DESIGN.md](COMMAND_PROFILES_DESIGN.md)) or, for embedded
+callers, `RunOptions.BlockedCommands`
+([SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md)).
+
 ### Output structure
 
 The following shows the exhaustive `--full` output, which describes dtctl's verb-noun command model in full. (The default bare `dtctl commands` emits only a minimal subset of this — see [Default overview](#default-overview-minimal) — and `--brief` a compact subset.) JSON is used here for readability; the command defaults to the more compact TOON format.

--- a/docs/dev/context-safety-levels.md
+++ b/docs/dev/context-safety-levels.md
@@ -49,6 +49,15 @@ contexts:
     description: "Personal dev environment - anything goes"
 ```
 
+### Per-Invocation Safety Level
+
+An embedded caller can supply the safety level per invocation via
+`cmd.Session.SafetyLevel` instead of a config-file context; an empty value
+selects the `readwrite-all` default. The session materializes as a single
+synthetic context named `session`, so the block messages below read
+`Context 'session' does not allow ...`. See
+[SERVICE_ENGINE_DESIGN.md](SERVICE_ENGINE_DESIGN.md).
+
 ## Operation Permission Matrix
 
 | Safety Level | Read | Create | Update Own | Update Shared | Delete Own | Delete Shared | Delete Bucket |

--- a/docs/site/_docs/ai-agent-mode.md
+++ b/docs/site/_docs/ai-agent-mode.md
@@ -56,7 +56,38 @@ This makes it straightforward for AI agents to parse responses, handle errors, a
 }
 ```
 
-Error codes are stable identifiers that agents can match on programmatically (e.g. `auth_required`, `not_found`, `forbidden`, `rate_limited`).
+Error codes are stable identifiers that agents can match on programmatically:
+
+| Code | Meaning | What to do |
+|---|---|---|
+| `auth_required` | Not authenticated (HTTP 401) | Authenticate, then retry once |
+| `permission_denied` | Authenticated but not allowed (HTTP 403) | Don't retry; report the missing permission |
+| `insufficient_scope` | Token lacks the scopes this command needs | Re-create the token with the `missing` scopes in the envelope |
+| `not_found` | Resource does not exist (HTTP 404) | Verify the ID with `dtctl get <resource>` |
+| `conflict` | Concurrent or duplicate change (HTTP 409) | Re-read the resource, re-apply on top |
+| `bad_request` | The API rejected the request shape (HTTP 400) | Fix the payload; don't retry unchanged |
+| `rate_limited` | Too many requests (HTTP 429) | Back off, then retry |
+| `server_error` | Dynatrace-side failure (HTTP 5xx) | Retry with backoff; escalate if persistent |
+| `timeout` | The operation timed out client-side | Narrow the request (timeframe, limit) and retry |
+| `safety_blocked` | The context's [safety level]({{ '/docs/configuration/#safety-levels' | relative_url }}) forbids this operation | Don't retry; ask a human to widen the level |
+| `profile_blocked` | The active [command profile]({{ '/docs/command-profiles/' | relative_url }}) doesn't expose this command | Re-read `dtctl commands` and pick a supported path |
+| `unsupported_in_service` | Host-only command, unavailable in [server mode]({{ '/docs/serve/' | relative_url }}) | Don't retry; the suggestion says why |
+| `capability_disabled` | A host ability (plugin, alias, hook, editor, browser) isn't granted | Don't retry; use an in-process alternative |
+| `hook_rejected` | A pre-apply hook rejected the resource | Fix the resource, or apply with `--no-hooks` |
+| `validation_error` | Local input validation failed | Fix the file or flags |
+| `unknown_command` | Unknown command or flag | Follow the "did you mean" suggestion; re-read `dtctl commands` |
+| `context_error` | No active context, or the named context is missing | Select a context (`dtctl ctx <name>`) |
+| `config_error` | The dtctl config could not be read or is invalid | Report it; needs human repair |
+| `spill_file_not_found` | The [spilled result file]({{ '/docs/dql-queries/#spilling-large-results-to-a-file' | relative_url }}) is gone | `dtctl inspect --list`, or re-run the query |
+| `spill_file_unreadable` | The spill file exists but cannot be parsed | Re-run the query |
+| `spill_file_wrong_context` | The spill file belongs to another context or tenant | Switch context, or re-query here |
+| `inspect_unknown_field` | `--fields` named a column the file doesn't have | Use `dtctl inspect <path> --schema` |
+| `inspect_bad_flags` | Incompatible `dtctl inspect` flags | Pick one row-access primitive per call |
+| `error` | Unclassified failure | Read `message`; treat as non-retryable |
+
+`dtctl query` additionally passes the DQL API's own error type through as the code
+(lowercased), e.g. `unknown_data_object`. **Treat an unrecognised code as
+`error`** — read `message` and `suggestions` instead of branching on it.
 
 ### Query results: the `result.kind` discriminator
 

--- a/docs/site/_docs/command-profiles.md
+++ b/docs/site/_docs/command-profiles.md
@@ -141,6 +141,12 @@ In [agent mode](ai-agent-mode) the same block is reported as a structured error
 with `code: "profile_blocked"`. The `dtctl commands` catalog also advertises the
 active `profile` and `safety_level` so an agent can see both constraints at once.
 
+Masks **compose**: a command has to survive every active mask to be invocable, and
+the code you get back names the mask that stopped it. In
+[server mode]({{ '/docs/serve/' | relative_url }}), for example, the per-request
+profile and the service's own host-only-command mask both apply, so `config`
+reports `unsupported_in_service` no matter which profile is active.
+
 ## Profiles vs. safety levels
 
 Profiles and [safety levels](configuration#safety-levels) are **orthogonal axes**
@@ -157,3 +163,18 @@ that compose on a context:
 
 Set **both** on a context to express, e.g., "this agent only sees `query`/Davis
 analyzers **and** can never mutate."
+
+Two further axes exist when dtctl is not a local terminal process — they belong to
+the *environment* it runs in, not to your configuration, and they matter because
+an agent has to tell all four blocks apart:
+
+| Axis | Question | Chosen by | [Agent]({{ '/docs/ai-agent-mode/#error-responses' | relative_url }}) code |
+|---|---|---|---|
+| Safety level | "What may this command *do*?" | context, `--safety-level`, or the request | `safety_blocked` |
+| Profile | "Which commands *exist* for this caller?" | `DTCTL_PROFILE`, context, or the request | `profile_blocked` |
+| Environment | "Which commands *make sense* here at all?" | the embedding environment — [server mode]({{ '/docs/serve/' | relative_url }}) removes host-only commands (`config`, `ctx`, `auth`, …) | `unsupported_in_service` |
+| Capability | "Which *host abilities* may this process use?" | the embedding host — plugins, aliases, hooks, editors, and browser opens are all off for embedded callers | `capability_disabled` |
+
+The environment and capability axes are not configurable from a context: a service
+sets them once for its whole process, and they compose with whatever profile and
+safety level a request carries.

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -38,6 +38,7 @@ dtctl [verb] [resource-type] [resource-name] [flags]
 | `doctor` | Health check (config, context, token, connectivity, auth) |
 | `commands` | Machine-readable command catalog for AI agents |
 | `inventory` | Probe the environment: which data, entity types, and capabilities exist here |
+| `serve` | Run dtctl as a server that executes command lines for agents and automation |
 
 ## Global Flags
 
@@ -355,6 +356,29 @@ dtctl inventory --budget-queries 100 --budget-seconds 300 --scan-limit-gbytes 25
 ```
 
 See [Environment Inventory]({{ '/docs/inventory/' | relative_url }}) for the discovery model, verdict semantics, and customization.
+
+## Serve
+
+```bash
+dtctl serve                                      # List the protocols this build can speak
+dtctl serve http                                 # JSON over HTTP on 127.0.0.1:7211
+dtctl serve http --addr 0.0.0.0:8080             # Custom listen address
+dtctl serve http --max-request-bytes 33554432    # Body limit (default 10485760 = 10 MiB)
+```
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /v1/execute` | Run one dtctl command line for one tenant: `{"command": ..., "environmentUrl": ..., "token": ..., "files": ...}` → `{"exitCode": ..., "stdout": ..., "stderr": ..., "files": ..., "durationMs": ...}` |
+| `GET /healthz` | Liveness probe |
+
+Each request brings its own environment URL and token; the local config, keyring,
+and credential environment variables are never read. A failed command still
+answers HTTP 200 — the failure is in `exitCode`/`stderr`. The servers perform **no
+authentication of their own**.
+
+See [Server Mode]({{ '/docs/serve/' | relative_url }}) for the request/response
+contract, the unavailable command set, the concurrency model, and the security
+model.
 
 ## Common Patterns
 

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -38,7 +38,7 @@ dtctl [verb] [resource-type] [resource-name] [flags]
 | `doctor` | Health check (config, context, token, connectivity, auth) |
 | `commands` | Machine-readable command catalog for AI agents |
 | `inventory` | Probe the environment: which data, entity types, and capabilities exist here |
-| `serve` | Run dtctl as a server that executes command lines for agents and automation |
+| `serve` | Run dtctl as a server that executes command lines for agents and automation (experimental: `DTCTL_EXPERIMENTAL_SERVE=1`) |
 
 ## Global Flags
 
@@ -359,7 +359,12 @@ See [Environment Inventory]({{ '/docs/inventory/' | relative_url }}) for the dis
 
 ## Serve
 
+**Experimental**, and not registered unless you opt in — without the variable
+below, `dtctl serve` is an unknown command:
+
 ```bash
+export DTCTL_EXPERIMENTAL_SERVE=1
+
 dtctl serve                                      # List the protocols this build can speak
 dtctl serve http                                 # JSON over HTTP on 127.0.0.1:7211
 dtctl serve http --addr 0.0.0.0:8080             # Custom listen address

--- a/docs/site/_docs/serve.md
+++ b/docs/site/_docs/serve.md
@@ -19,6 +19,24 @@ to dtctl from inside the platform.
 > binds to localhost by default. Put your own authentication and TLS in front
 > before exposing it — see [Security](#security).
 
+## Experimental: opt in first
+
+Server mode is **experimental and off by default**. The request/response
+contract, the one-command-at-a-time concurrency model, and the absence of
+per-request deadlines are all still subject to change, so a released build does
+not expose the command until you ask for it:
+
+```bash
+export DTCTL_EXPERIMENTAL_SERVE=1
+dtctl serve http
+```
+
+Without the variable, `dtctl serve` is an ordinary unknown command — it does not
+appear in `--help` or in the `dtctl commands` catalog. This mirrors
+`DTCTL_EXPERIMENTAL_ACCOUNT`. The gate covers the *command* only:
+[`pkg/engine`](#embedding-pkgengine-instead) is importable Go API, and embedding
+it is a compile-time choice rather than something an operator can trip over.
+
 ## The command surface
 
 `serve` is a **parent** command; each protocol is its own subcommand. Naming the

--- a/docs/site/_docs/serve.md
+++ b/docs/site/_docs/serve.md
@@ -1,0 +1,230 @@
+---
+layout: docs
+title: Server Mode
+---
+
+`dtctl serve` runs dtctl as a **server** instead of a one-shot CLI. One request
+carries one dtctl command line and one tenant (environment URL + token), and the
+response carries what the CLI would have printed for that command: stdout,
+stderr, and the exit code.
+
+The point is that there is no second API to learn. Anything you can type in a
+terminal, a caller can send over the wire — and the bytes coming back are
+byte-identical to the local CLI's. That makes server mode a natural fit for AI
+agents and agent gateways that already know how to drive dtctl, for automation
+that cannot ship a binary, and for Dynatrace Workflow actions that need to talk
+to dtctl from inside the platform.
+
+> **This is a reference implementation with no authentication of its own.** It
+> binds to localhost by default. Put your own authentication and TLS in front
+> before exposing it — see [Security](#security).
+
+## The command surface
+
+`serve` is a **parent** command; each protocol is its own subcommand. Naming the
+protocol is mandatory, so no single one is the silent default and future
+protocols land beside `http` rather than competing with an incumbent.
+
+```bash
+dtctl serve          # prints help: which protocols this build can speak (exit 0)
+dtctl serve http     # JSON over HTTP
+dtctl serve grpc     # unknown protocol: error, exit 1 (never a silent no-op)
+```
+
+A typo'd protocol is an error with a non-zero exit rather than a help dump, so a
+supervisor cannot mistake it for a started server.
+
+### `dtctl serve http`
+
+```bash
+dtctl serve http
+dtctl serve http --addr 0.0.0.0:8080 --max-request-bytes 33554432
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--addr` | `127.0.0.1:7211` | listen address |
+| `--max-request-bytes` | `10485760` (10 MiB) | maximum request body size (virtual files travel inline) |
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /v1/execute` | run one dtctl command line |
+| `GET /healthz` | liveness probe, answers `{"status":"ok"}` |
+
+The server shuts down gracefully on `SIGINT`/`SIGTERM`, letting an in-flight
+execution finish. Invoke `serve` directly, with nothing between it and the binary
+name (`dtctl serve http`, not `dtctl -v serve http`) — the latter is rejected,
+because serving from inside a command invocation would deadlock the first
+request.
+
+## Executing a command
+
+The request body is a dtctl command line plus the tenant to run it against, and
+optionally the files that command line refers to:
+
+```bash
+curl -s http://127.0.0.1:7211/v1/execute \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "command": "apply -f workflow.yaml --write-id --agent",
+    "environmentUrl": "https://abc12345.apps.dynatrace.com",
+    "token": "dt0s16.XXXXXXXX.YYYYYYYY",
+    "safetyLevel": "readwrite-mine",
+    "files": {
+      "workflow.yaml": "title: Daily Health Check\ntasks: {}\n"
+    }
+  }'
+```
+
+| Field | Meaning |
+|-------|---------|
+| `command` | the dtctl command line exactly as typed locally, e.g. `get workflows -o json`. Split with POSIX shell quoting rules — no pipes, redirection, or variable expansion; dtctl is not a shell |
+| `argv` | the pre-split argument vector; takes precedence over `command` (no quoting round-trip) |
+| `environmentUrl` | the Dynatrace environment to run against. Required |
+| `token` | authenticates every API call of this request. Required |
+| `safetyLevel` | bounds mutating operations: `readonly`, `readwrite-mine`, `readwrite-all`, `dangerously-unrestricted`. Omitted means dtctl's default (`readwrite-all`) |
+| `profile` | a built-in [command profile]({{ '/docs/command-profiles/' | relative_url }}) (e.g. `query`) that reduces the visible command surface for this request |
+| `files` | the request's virtual filesystem: name → file content |
+| `stdin` | standard input for commands that read it (`-f -`) |
+
+## The response
+
+```json
+{
+  "exitCode": 0,
+  "stdout": "{\"ok\":true,\"result\":{...}}\n",
+  "stderr": "",
+  "files": {
+    "workflow.yaml": "id: wf-abc123\ntitle: Daily Health Check\ntasks: {}\n"
+  },
+  "durationMs": 412
+}
+```
+
+`files` is the **complete final state of the request's virtual filesystem** — the
+files you sent plus anything the command wrote. That is how writebacks survive a
+stateless request: `apply --write-id` stamps the generated id into
+`workflow.yaml`, and you read the stamped file straight out of the response and
+persist it wherever your source of truth lives.
+
+### A failed command is still HTTP 200
+
+A command that fails answers `200` with a non-zero `exitCode` and a message on
+`stderr`, exactly like a local shell. Non-200 statuses are reserved for requests
+that **never ran**:
+
+| Status | Cause |
+|--------|-------|
+| `400` | malformed JSON body, or a request shape dtctl cannot run (no command, missing `environmentUrl` or `token`, unparsable command string) |
+| `405` | anything other than `POST` on `/v1/execute` |
+| `413` | request body exceeds `--max-request-bytes` |
+
+So `200` means "dtctl ran your command line"; check `exitCode` for whether the
+command succeeded.
+
+## The output is the CLI's output
+
+Same command line, same bytes — a caller must not be able to tell whether it
+reached a terminal or a server. Two consequences worth internalizing:
+
+- **Envelopes are opt-in per request.** Put `--agent` in the `command` string to
+  get the [agent mode]({{ '/docs/ai-agent-mode/' | relative_url }}) JSON
+  envelope; otherwise you get the human table, and `-o json`/`-o yaml`/`-o csv`
+  behave exactly as they do locally.
+- **AI-agent auto-detection is skipped**, and `DTCTL_PROFILE`/`DTCTL_OUTPUT` are
+  scrubbed along with the credential variables. The host process's environment
+  must not shape a tenant's output format.
+
+## Every request brings its own tenant
+
+Servers are multi-tenant per invocation. The local dtctl config file, the
+keyring, and the credential and config environment variables (`DTCTL_TOKEN`,
+`DT_API_TOKEN`, `DTCTL_ACCOUNT_TOKEN`, `DTCTL_CONFIG`, `DTCTL_CONTEXT`) are
+**never read** — they are scrubbed for the duration of each run. Nothing about
+the host process's identity leaks into a request, and nothing from one request
+survives into the next.
+
+File arguments follow the same rule: `-f`, `--data-file`, query files, and
+writebacks resolve against the request's `files` map, never the server's disk.
+Paths are normalized, so `x.yaml`, `./x.yaml`, and `/x.yaml` are the same file. A
+`files` map you did not send is an empty filesystem, not the host filesystem.
+
+## What is unavailable, and why
+
+Server mode is deliberately not a perfect mirror of the local CLI:
+
+- **Host-only commands are removed from the surface**: `config`, `ctx`, `auth`,
+  `account`, `alias`, `edit`, `plugin`, `skills`, `doctor`, `completion`, and
+  `serve` itself. They manage host-local state (a config file, a keyring, a
+  shell, locally installed tools, an interactive session) that does not exist for
+  a service request — or would nest the service inside itself. They are hidden
+  from `--help` and from the `dtctl commands` catalog, and invoking one returns
+  the stable agent error code `unsupported_in_service` with the reason attached.
+- **No subprocesses.** Plugins, shell aliases, pre-apply hooks, interactive
+  editors, and browser opens are all disabled; requesting one yields
+  `capability_disabled`. Everything a request needs happens in-process.
+- **Arbitrary environment variables are not exposed over HTTP.** They reach
+  proxies, exporters, and other process-level behavior. Embedding hosts that
+  genuinely need them use `engine.Request.Env`
+  [in-process](#embedding-pkgengine-instead).
+- **Output is buffered**, so long-running commands (`--watch`, `logs -f`) do not
+  fit the request/response shape.
+
+## One request at a time
+
+dtctl's command tree is process-level state, so **invocations serialize**: a
+server handles one dtctl command at a time per process. This is what makes the
+rest of the model safe — swapping the process's streams, environment, and
+filesystem per request would be indefensible under concurrency.
+
+Scale with **more processes or more instances**, never more goroutines. A
+request's context gates the *start* of an execution — a request cancelled while
+queued never runs — but a run already in flight cannot be killed. Deployments
+that need hard per-request deadlines put the server behind a process boundary.
+
+## Security
+
+The servers under `dtctl serve` are **reference implementations**, and their
+threat model is worth stating plainly:
+
+- **No authentication of their own.** The per-request `token` authenticates
+  against *Dynatrace*, not against the server. Anyone who can reach the port can
+  run dtctl command lines with any token they supply.
+- **Localhost by default.** `--addr` defaults to `127.0.0.1:7211`. Changing it to
+  a routable address is exactly the moment to add your own authentication, TLS,
+  and rate limiting in front — a reverse proxy, a sidecar, or an API gateway.
+- **Not a sandbox.** The isolation described above (scrubbed credentials, virtual
+  files, no subprocesses, reduced surface) is a *correctness* boundary inside one
+  process: it stops an honest command line from reaching host state. It is not
+  designed to contain a hostile one. Untrusted callers belong behind a process
+  boundary.
+- **Tokens travel in the request body.** Terminate TLS in front of the server and
+  keep bodies out of access logs.
+
+Combine `safetyLevel` and `profile` per request to bound what a caller can do:
+`safetyLevel: readonly` refuses mutations, `profile: query` removes everything
+but the query surface. Both are client-side conveniences, though — for real
+restriction, scope the Dynatrace token.
+
+## Embedding `pkg/engine` instead
+
+Running a server is one way to consume this; the other is to call the engine
+directly from Go. `pkg/engine` is the surface `dtctl serve http` is a thin
+wrapper over — same request shape, same isolation, no HTTP hop and no port to
+protect:
+
+```go
+res, err := engine.Execute(ctx, engine.Request{
+    Command:        `apply -f workflow.yaml --write-id --agent`,
+    EnvironmentURL: "https://abc12345.apps.dynatrace.com",
+    Token:          tenantToken,
+    Files:          map[string][]byte{"workflow.yaml": src},
+})
+// res.Stdout is byte-identical to local CLI output;
+// res.Files["workflow.yaml"] now carries the stamped id.
+```
+
+Prefer embedding when you already have an HTTP service (add your own route, with
+your own authentication), when you need `Env`, or when you want to speak a
+protocol dtctl does not ship. The design notes live in
+[`docs/dev/SERVICE_ENGINE_DESIGN.md`](https://github.com/dynatrace-oss/dtctl/blob/main/docs/dev/SERVICE_ENGINE_DESIGN.md).

--- a/docs/site/_docs/serve.md
+++ b/docs/site/_docs/serve.md
@@ -140,26 +140,41 @@ reached a terminal or a server. Two consequences worth internalizing:
 Servers are multi-tenant per invocation. The local dtctl config file, the
 keyring, and the credential and config environment variables (`DTCTL_TOKEN`,
 `DT_API_TOKEN`, `DTCTL_ACCOUNT_TOKEN`, `DTCTL_CONFIG`, `DTCTL_CONTEXT`) are
-**never read** — they are scrubbed for the duration of each run. Nothing about
-the host process's identity leaks into a request, and nothing from one request
-survives into the next.
+**never read** — they are scrubbed for the duration of each run, along with the
+host preferences that would otherwise shape a response's bytes (`DTCTL_PROFILE`,
+`DTCTL_OUTPUT`, `DTCTL_SPILL`, `DTCTL_SPILL_DIR`, `FORCE_COLOR`, `NO_COLOR`).
+Nothing about the host process's identity leaks into a request, and nothing from
+one request survives into the next.
 
-File arguments follow the same rule: `-f`, `--data-file`, query files, and
-writebacks resolve against the request's `files` map, never the server's disk.
-Paths are normalized, so `x.yaml`, `./x.yaml`, and `/x.yaml` are the same file. A
-`files` map you did not send is an empty filesystem, not the host filesystem.
+File arguments follow the same rule: `-f`, `--data-file`, query files, files to
+`diff`, and writebacks resolve against the request's `files` map, never the
+server's disk. Paths are normalized, so `x.yaml`, `./x.yaml`, and `/x.yaml` are
+the same file. A `files` map you did not send is an empty filesystem, not the
+host filesystem. Standard input is the request's `stdin` and nothing else: a
+request that sends none reads an empty stream, never the server's.
+
+These are enforced, not merely intended: `TestUserFilePathsGoThroughVFS` fails
+the build if any file under `cmd/` or `pkg/` reaches the host filesystem outside
+the seam without a documented reason.
 
 ## What is unavailable, and why
 
 Server mode is deliberately not a perfect mirror of the local CLI:
 
 - **Host-only commands are removed from the surface**: `config`, `ctx`, `auth`,
-  `account`, `alias`, `edit`, `plugin`, `skills`, `doctor`, `completion`, and
-  `serve` itself. They manage host-local state (a config file, a keyring, a
-  shell, locally installed tools, an interactive session) that does not exist for
-  a service request — or would nest the service inside itself. They are hidden
-  from `--help` and from the `dtctl commands` catalog, and invoking one returns
-  the stable agent error code `unsupported_in_service` with the reason attached.
+  `account`, `alias`, `edit`, `plugin`, `skills`, `doctor`, `completion`,
+  `inspect`, and `serve` itself. They manage host-local state (a config file, a
+  keyring, a shell, locally installed tools, a spilled result file, an
+  interactive session) that does not exist for a service request — or would nest
+  the service inside itself. They are hidden from `--help` and from the
+  `dtctl commands` catalog, and invoking one returns the stable agent error code
+  `unsupported_in_service` with the reason attached.
+- **Results are never spilled to disk.** Locally, a large result can spill to a
+  file and return a path (`--spill`, `--spill-to`, and automatically in agent
+  mode). A service request has no host disk of its own: the file would outlive
+  the request on the *server's* disk and the path would be unreadable by the
+  caller, so rows always come back inline. Asking for a spill explicitly returns
+  `capability_disabled` rather than quietly inlining the result.
 - **No subprocesses.** Plugins, shell aliases, pre-apply hooks, interactive
   editors, and browser opens are all disabled; requesting one yields
   `capability_disabled`. Everything a request needs happens in-process.

--- a/docs/site/_includes/docs-nav.html
+++ b/docs/site/_includes/docs-nav.html
@@ -33,5 +33,6 @@
   <li><a href="{{ '/docs/output-formats/' | relative_url }}" {% if page.title == "Output Formats" %}class="active"{% endif %}>Output Formats</a></li>
   <li><a href="{{ '/docs/ai-agent-mode/' | relative_url }}" {% if page.title == "AI Agent Mode" %}class="active"{% endif %}>AI Agent Mode</a></li>
   <li><a href="{{ '/docs/command-profiles/' | relative_url }}" {% if page.title == "Command Profiles" %}class="active"{% endif %}>Command Profiles</a></li>
+  <li><a href="{{ '/docs/serve/' | relative_url }}" {% if page.title == "Server Mode" %}class="active"{% endif %}>Server Mode</a></li>
   <li><a href="{{ '/docs/token-scopes/' | relative_url }}" {% if page.title == "Token Scopes" %}class="active"{% endif %}>Token Scopes</a></li>
 </ul>

--- a/main.go
+++ b/main.go
@@ -8,16 +8,22 @@ import (
 )
 
 func main() {
-	// `dtctl serve ...` runs outside the normal command pipeline: every request
-	// the server accepts becomes an engine execution that must acquire the
-	// per-invocation lock, which the pipeline would already be holding for
-	// the serve command itself. See serve.Run.
-	if len(os.Args) > 1 && os.Args[1] == "serve" {
-		os.Exit(serve.Run(os.Args[2:]))
+	// Server mode is experimental and off by default: without the opt-in, serve
+	// is neither dispatched nor registered, so `dtctl serve` is an unknown
+	// command like any other (see serve.ExperimentalEnvVar).
+	if serve.Experimental() {
+		// `dtctl serve ...` runs outside the normal command pipeline: every
+		// request the server accepts becomes an engine execution that must
+		// acquire the per-invocation lock, which the pipeline would already be
+		// holding for the serve command itself. See serve.Run.
+		if len(os.Args) > 1 && os.Args[1] == "serve" {
+			os.Exit(serve.Run(os.Args[2:]))
+		}
+
+		// serve lives outside package cmd (it imports pkg/engine, which imports
+		// cmd); register it here so it appears in help and the command catalog.
+		cmd.AddCommand(serve.NewCommand())
 	}
 
-	// serve lives outside package cmd (it imports pkg/engine, which imports
-	// cmd); register it here so it appears in help and the command catalog.
-	cmd.AddCommand(serve.NewCommand())
 	cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,23 @@
 package main
 
-import "github.com/dynatrace-oss/dtctl/cmd"
+import (
+	"os"
+
+	"github.com/dynatrace-oss/dtctl/cmd"
+	"github.com/dynatrace-oss/dtctl/pkg/serve"
+)
 
 func main() {
+	// `dtctl serve ...` runs outside the normal command pipeline: every request
+	// the server accepts becomes an engine execution that must acquire the
+	// per-invocation lock, which the pipeline would already be holding for
+	// the serve command itself. See serve.Run.
+	if len(os.Args) > 1 && os.Args[1] == "serve" {
+		os.Exit(serve.Run(os.Args[2:]))
+	}
+
+	// serve lives outside package cmd (it imports pkg/engine, which imports
+	// cmd); register it here so it appears in help and the command catalog.
+	cmd.AddCommand(serve.NewCommand())
 	cmd.Execute()
 }

--- a/pkg/apply/writeback.go
+++ b/pkg/apply/writeback.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // writeIDToFile injects the given id into the top of a YAML or JSON source file
@@ -21,7 +23,9 @@ func writeIDToFile(filename, id string) error {
 		return fmt.Errorf("no source file to write ID back to")
 	}
 
-	original, err := os.ReadFile(filename)
+	// Through the vfs seam: for embedded invocations the writeback lands in
+	// the request's virtual filesystem, never on the host.
+	original, err := vfs.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", filename, err)
 	}
@@ -35,7 +39,7 @@ func writeIDToFile(filename, id string) error {
 		return nil
 	}
 
-	return os.WriteFile(filename, updated, 0o644)
+	return vfs.WriteFile(filename, updated, 0o644)
 }
 
 // injectIDIntoFileContent returns the file content with the id field injected,

--- a/pkg/diff/differ.go
+++ b/pkg/diff/differ.go
@@ -3,10 +3,11 @@ package diff
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 type Differ struct {
@@ -290,6 +291,9 @@ func calculateImpact(summary DiffSummary) ImpactLevel {
 	return ImpactLow
 }
 
+// readFile reads a user-named path (`dtctl diff -f a.yaml -f b.yaml`) through
+// the vfs seam, so an embedded invocation compares the files in its request
+// rather than whatever sits at that path on the host's disk.
 func readFile(path string) ([]byte, error) {
-	return os.ReadFile(path)
+	return vfs.ReadFile(path)
 }

--- a/pkg/engine/doc.go
+++ b/pkg/engine/doc.go
@@ -1,0 +1,43 @@
+// Package engine executes dtctl command lines in-process for services.
+//
+// It is the embedding surface of the dtctl-as-a-service design: a caller
+// hands over a command string exactly as a user would type it locally, plus
+// the tenant to run it against (environment URL + token) and an optional set
+// of virtual files, and gets back the exact byte streams the CLI would have
+// printed, the exit code, and the final state of the virtual files.
+//
+//	res, err := engine.Execute(ctx, engine.Request{
+//	    Command:        `apply -f workflow.yaml --write-id --agent`,
+//	    EnvironmentURL: "https://abc12345.apps.dynatrace.com",
+//	    Token:          tenantToken,
+//	    Files:          map[string][]byte{"workflow.yaml": src},
+//	})
+//	// res.Stdout is byte-identical to local CLI output;
+//	// res.Files["workflow.yaml"] now carries the stamped id.
+//
+// Every execution is fully isolated from the host process:
+//
+//   - Credentials come only from the request. The host's config file,
+//     contexts, keyring, and credential environment variables are scrubbed
+//     for the duration of the run (cmd.Session).
+//   - File arguments (-f and friends, including writebacks like `apply
+//     --write-id`) resolve against the request's virtual filesystem, never
+//     the host disk (pkg/vfs).
+//   - No subprocesses: plugins, shell aliases, apply hooks, editors, and
+//     browser opens are all disabled (cmd.Capabilities zero value).
+//   - Host-only commands (config, ctx, auth, ...) are removed from the
+//     surface entirely — hidden from `dtctl commands` and help, and guarded
+//     with the stable agent-mode error code "unsupported_in_service".
+//
+// Concurrency: Execute is safe to call from multiple goroutines, but
+// executions serialize on an internal lock (the command tree is process
+// state — see cmd.Run). A service scales by running more engine processes or
+// instances, not more goroutines; the design's WASM phase gives each request
+// its own instance at 20-47ms overhead.
+//
+// Cancellation: the context gates the start of an execution (a request
+// cancelled while queued never runs). A run already started cannot be killed
+// mid-flight — in-process code cannot be preempted safely. Deployments that
+// need hard per-request deadlines put the engine behind a process boundary or
+// use the WASM instance model, where the host enforces the deadline.
+package engine

--- a/pkg/engine/doc.go
+++ b/pkg/engine/doc.go
@@ -1,10 +1,10 @@
 // Package engine executes dtctl command lines in-process for services.
 //
-// It is the embedding surface of the dtctl-as-a-service design: a caller
-// hands over a command string exactly as a user would type it locally, plus
-// the tenant to run it against (environment URL + token) and an optional set
-// of virtual files, and gets back the exact byte streams the CLI would have
-// printed, the exit code, and the final state of the virtual files.
+// It is the embedding surface described in docs/dev/SERVICE_ENGINE_DESIGN.md: a
+// caller hands over a command string exactly as a user would type it locally,
+// plus the tenant to run it against (environment URL + token) and an optional
+// set of virtual files, and gets back the exact byte streams the CLI would
+// have printed, the exit code, and the final state of the virtual files.
 //
 //	res, err := engine.Execute(ctx, engine.Request{
 //	    Command:        `apply -f workflow.yaml --write-id --agent`,

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1,0 +1,180 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/google/shlex"
+
+	"github.com/dynatrace-oss/dtctl/cmd"
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
+)
+
+// Request is one dtctl invocation for one tenant.
+type Request struct {
+	// Command is the command line exactly as a user would type it after
+	// "dtctl", e.g. `get workflows -o json`. It is split into arguments with
+	// POSIX shell rules (quotes and escapes honored; no variable expansion,
+	// globbing, pipes, or redirection — dtctl is not a shell). Ignored when
+	// Argv is set.
+	Command string
+	// Argv is the pre-split argument vector (os.Args[1:] shape). Callers that
+	// already have discrete arguments should prefer it over Command — no
+	// quoting round-trip. Takes precedence over Command.
+	Argv []string
+
+	// EnvironmentURL is the Dynatrace environment to run against
+	// (e.g. https://abc12345.apps.dynatrace.com). Required.
+	EnvironmentURL string
+	// Token authenticates every API call of this request. Required.
+	Token string
+	// SafetyLevel bounds mutating operations for this request
+	// (readonly | readwrite-mine | readwrite-all | dangerously-unrestricted).
+	// Empty selects the dtctl default (readwrite-all).
+	SafetyLevel string
+	// Profile selects a built-in command profile (e.g. "query") that reduces
+	// the visible command surface for this request. Empty is the full
+	// (service-supported) surface.
+	Profile string
+
+	// Files is the request's virtual filesystem: every file argument
+	// (`-f x.yaml`, `--data-file`, ...) resolves against it, and files the
+	// command writes (e.g. `apply --write-id` stamping an id back into the
+	// source) land in it. Paths are normalized, so "x.yaml", "./x.yaml" and
+	// "/x.yaml" are the same file. nil is an empty filesystem — not the host
+	// disk; the engine never touches host files.
+	Files map[string][]byte
+	// Stdin feeds commands that read standard input (`-f -`). nil is EOF.
+	Stdin []byte
+
+	// Env sets additional environment variables for the run (e.g.
+	// DTCTL_OUTPUT). Applied after credential scrubbing, so entries here win;
+	// grant with care — the engine deliberately does not expose this in its
+	// HTTP reference wrapper. Profile, when set, overrides an Env entry for
+	// DTCTL_PROFILE.
+	Env map[string]string
+}
+
+// Result is the outcome of one execution. Stdout and Stderr are byte-identical
+// to what the dtctl CLI would print for the same command line, credentials,
+// and files — including --agent envelopes, table layouts, and error messages.
+type Result struct {
+	// ExitCode is the CLI process exit code (0 success; sysexits-style codes
+	// for errors, e.g. 64 usage, 77 permission).
+	ExitCode int
+	Stdout   []byte
+	Stderr   []byte
+	// Files is the complete final state of the request's virtual filesystem:
+	// the input files plus anything the command wrote or rewrote.
+	Files map[string][]byte
+}
+
+// Execute runs one dtctl invocation and returns its outcome.
+//
+// A non-nil error means the request never ran: it is malformed (no command,
+// missing tenant credentials, an unparsable command string) or its context
+// was already done. Everything after the run starts — including command
+// failures — is expressed CLI-style in Result: exit code plus stdout/stderr.
+func Execute(ctx context.Context, req Request) (*Result, error) {
+	argv, err := req.argv()
+	if err != nil {
+		return nil, err
+	}
+	if err := req.validate(); err != nil {
+		return nil, err
+	}
+	// The context gates the start only: a request cancelled while waiting in
+	// line must not run, but a run in progress cannot be killed (see the
+	// package documentation on cancellation).
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	env := make(map[string]string, len(req.Env)+1)
+	for k, v := range req.Env {
+		env[k] = v
+	}
+	if req.Profile != "" {
+		env[config.ProfileEnvVar] = req.Profile
+	}
+
+	var stdin io.Reader
+	if req.Stdin != nil {
+		stdin = bytes.NewReader(req.Stdin)
+	}
+
+	files := vfs.NewMapFS(req.Files)
+	var stdout, stderr bytes.Buffer
+	code := cmd.Run(argv, cmd.RunOptions{
+		// Grant nothing: no plugins, shell aliases, hooks, editors, or
+		// browser opens. Everything a request needs happens in-process.
+		Capabilities: &cmd.Capabilities{},
+		Session: &cmd.Session{
+			EnvironmentURL: req.EnvironmentURL,
+			Token:          req.Token,
+			SafetyLevel:    config.SafetyLevel(req.SafetyLevel),
+		},
+		Env:             env,
+		FS:              files,
+		Stdin:           stdin,
+		Stdout:          &stdout,
+		Stderr:          &stderr,
+		BlockedCommands: unsupportedCommands,
+	})
+
+	return &Result{
+		ExitCode: code,
+		Stdout:   stdout.Bytes(),
+		Stderr:   stderr.Bytes(),
+		Files:    files.Files(),
+	}, nil
+}
+
+// argv resolves the request's argument vector: Argv verbatim when set,
+// otherwise Command split with POSIX shell rules.
+func (r *Request) argv() ([]string, error) {
+	if len(r.Argv) > 0 {
+		return r.Argv, nil
+	}
+	if r.Command == "" {
+		return nil, errors.New("engine: request has no command (set Command or Argv)")
+	}
+	argv, err := shlex.Split(r.Command)
+	if err != nil {
+		return nil, fmt.Errorf("engine: parse command: %w", err)
+	}
+	if len(argv) == 0 {
+		return nil, errors.New("engine: request has no command (set Command or Argv)")
+	}
+	return argv, nil
+}
+
+// validate fails fast on request-shape problems, so malformed requests
+// surface as Go errors instead of a CLI error transcript. The same
+// constraints are enforced again inside the run (cmd.Session.validate) —
+// this is the caller-friendly first line.
+func (r *Request) validate() error {
+	if r.EnvironmentURL == "" {
+		return errors.New("engine: EnvironmentURL is required")
+	}
+	if r.Token == "" {
+		return errors.New("engine: Token is required")
+	}
+	if r.SafetyLevel != "" {
+		valid := false
+		for _, l := range config.ValidSafetyLevels() {
+			if config.SafetyLevel(r.SafetyLevel) == l {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return fmt.Errorf("engine: invalid safety level %q", r.SafetyLevel)
+		}
+	}
+	return nil
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -46,9 +46,13 @@ type Request struct {
 	// command writes (e.g. `apply --write-id` stamping an id back into the
 	// source) land in it. Paths are normalized, so "x.yaml", "./x.yaml" and
 	// "/x.yaml" are the same file. nil is an empty filesystem — not the host
-	// disk; the engine never touches host files.
+	// disk: a user-named path resolves here or not at all, which the
+	// TestUserFilePathsGoThroughVFS guard enforces across cmd/ and pkg/.
+	// (Host state dtctl owns — a temp file, a cache — is a separate matter;
+	// the commands that use it are blocked or ungranted in a service.)
 	Files map[string][]byte
-	// Stdin feeds commands that read standard input (`-f -`). nil is EOF.
+	// Stdin feeds commands that read standard input (`-f -`). nil is an empty
+	// stream (immediate EOF) — never the host process's stdin.
 	Stdin []byte
 
 	// Env sets additional environment variables for the run (e.g.
@@ -102,10 +106,11 @@ func Execute(ctx context.Context, req Request) (*Result, error) {
 		env[config.ProfileEnvVar] = req.Profile
 	}
 
-	var stdin io.Reader
-	if req.Stdin != nil {
-		stdin = bytes.NewReader(req.Stdin)
-	}
+	// Always a reader, never nil: a nil RunOptions.Stdin leaves the *host*
+	// process's stdin in place, which a request must never see (and which can
+	// block forever on an open pipe, wedging the serialized engine). A nil
+	// req.Stdin yields an empty reader, i.e. immediate EOF.
+	stdin := io.Reader(bytes.NewReader(req.Stdin))
 
 	files := vfs.NewMapFS(req.Files)
 	var stdout, stderr bytes.Buffer

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1,0 +1,284 @@
+package engine_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace-oss/dtctl/pkg/engine"
+)
+
+// mockEnv is a fake Dynatrace environment recording the Authorization header
+// of every request and how many mutating requests arrived.
+type mockEnv struct {
+	*httptest.Server
+	mu        sync.Mutex
+	authSeen  []string
+	mutations int
+}
+
+func newMockEnv(t *testing.T) *mockEnv {
+	t.Helper()
+	m := &mockEnv{}
+	m.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.authSeen = append(m.authSeen, r.Header.Get("Authorization"))
+		if r.Method != http.MethodGet {
+			m.mutations++
+		}
+		m.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/platform/storage/management/v1/bucket-definitions" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"buckets":[{"bucketName":"engine_bucket","table":"logs","status":"active","retentionDays":35,"version":1,"updatable":true}]}`))
+		case r.URL.Path == "/platform/storage/management/v1/bucket-definitions" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"bucketName":"new_bucket","table":"logs","status":"creating","retentionDays":35,"version":1}`))
+		case r.URL.Path == "/platform/automation/v1/workflows" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"wf-generated-1","title":"engine-created"}`))
+		case r.URL.Path == "/platform/openpipeline/v1/matcher/lqlToDql" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"query":"matchesValue(log.source, \"stdin-test\")"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":404,"message":"not found"}}`))
+		}
+	}))
+	t.Cleanup(m.Server.Close)
+	return m
+}
+
+func TestExecute_RequestValidation(t *testing.T) {
+	for name, req := range map[string]engine.Request{
+		"no command":       {EnvironmentURL: "https://x.example.invalid", Token: "t"},
+		"unparsable quote": {Command: `create bucket -f "unclosed`, EnvironmentURL: "https://x.example.invalid", Token: "t"},
+		"missing url":      {Command: "get buckets", Token: "t"},
+		"missing token":    {Command: "get buckets", EnvironmentURL: "https://x.example.invalid"},
+		"bad safety level": {Command: "get buckets", EnvironmentURL: "https://x.example.invalid", Token: "t", SafetyLevel: "nope"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			res, err := engine.Execute(context.Background(), req)
+			require.Error(t, err, "malformed requests must fail before running")
+			require.Nil(t, res)
+		})
+	}
+}
+
+// TestExecute_CommandString is the core service scenario: a command string
+// exactly as typed locally, executed against the request's tenant — while the
+// host process carries hostile credentials and its own AI-agent environment,
+// none of which may shape the request.
+func TestExecute_CommandString(t *testing.T) {
+	env := newMockEnv(t)
+	t.Setenv("DTCTL_TOKEN", "host-secret")
+	t.Setenv("DTCTL_CONFIG", "/nonexistent/host/config.yaml")
+	// Deliberately NOT scrubbing AI-agent env vars (CLAUDECODE, AI_AGENT, ...):
+	// session-backed runs skip agent auto-detection, so plain table output
+	// here proves host env does not leak into request output.
+
+	res, err := engine.Execute(context.Background(), engine.Request{
+		Command:        "get buckets --plain",
+		EnvironmentURL: env.URL,
+		Token:          "tenant-token",
+	})
+	require.NoError(t, err)
+	require.Zero(t, res.ExitCode, "stderr: %s", res.Stderr)
+	require.Contains(t, string(res.Stdout), "engine_bucket")
+	require.NotContains(t, string(res.Stdout), `"ok":`,
+		"host AI-agent env must not flip output into envelopes")
+
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	require.NotEmpty(t, env.authSeen)
+	for _, auth := range env.authSeen {
+		require.Contains(t, auth, "tenant-token")
+		require.NotContains(t, auth, "host-secret")
+	}
+}
+
+// TestExecute_QuotedFilename: the command string is split with shell quoting
+// rules, so a filename with spaces resolves against the virtual filesystem.
+func TestExecute_QuotedFilename(t *testing.T) {
+	env := newMockEnv(t)
+
+	res, err := engine.Execute(context.Background(), engine.Request{
+		Command:        `create bucket -f "my bucket.yaml" --plain`,
+		EnvironmentURL: env.URL,
+		Token:          "tenant-token",
+		Files: map[string][]byte{
+			"my bucket.yaml": []byte("bucketName: new_bucket\ntable: logs\nretentionDays: 35\n"),
+		},
+	})
+	require.NoError(t, err)
+	require.Zero(t, res.ExitCode, "stderr: %s", res.Stderr)
+
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	require.Equal(t, 1, env.mutations)
+}
+
+// TestExecute_WritebackReachesResultFiles: `apply --write-id` stamps the
+// generated ID into the request's virtual file, and the caller receives the
+// updated file in Result.Files — the full round-trip a LangChain-style
+// virtual filesystem needs.
+func TestExecute_WritebackReachesResultFiles(t *testing.T) {
+	env := newMockEnv(t)
+
+	res, err := engine.Execute(context.Background(), engine.Request{
+		Command:        "apply -f workflow.yaml --write-id --plain",
+		EnvironmentURL: env.URL,
+		Token:          "tenant-token",
+		Files: map[string][]byte{
+			"workflow.yaml": []byte("title: engine-created\ntasks: {}\n"),
+		},
+	})
+	require.NoError(t, err)
+	require.Zero(t, res.ExitCode, "stderr: %s", res.Stderr)
+	require.Contains(t, string(res.Files["workflow.yaml"]), "wf-generated-1",
+		"the generated workflow id must be stamped into the virtual file")
+}
+
+// TestExecute_StdinDash: a stdin-capable command (`-f -`) reads the request's
+// stdin bytes, not the host process stdin.
+func TestExecute_StdinDash(t *testing.T) {
+	env := newMockEnv(t)
+
+	res, err := engine.Execute(context.Background(), engine.Request{
+		Command:        "translate lql-to-dql -f - --plain",
+		EnvironmentURL: env.URL,
+		Token:          "tenant-token",
+		Stdin:          []byte(`log.source="stdin-test"`),
+	})
+	require.NoError(t, err)
+	require.Zero(t, res.ExitCode, "stderr: %s", res.Stderr)
+	require.Contains(t, string(res.Stdout), "matchesValue",
+		"the translation of the stdin-fed expression must be printed")
+}
+
+// TestExecute_UnsupportedCommands: every policy-blocked command must refuse to
+// run. Registered commands answer with the signposted unsupported error;
+// either way the exit code is non-zero and nothing executes.
+func TestExecute_UnsupportedCommands(t *testing.T) {
+	for name := range engine.UnsupportedCommands() {
+		t.Run(name, func(t *testing.T) {
+			res, err := engine.Execute(context.Background(), engine.Request{
+				Argv:           []string{name},
+				EnvironmentURL: "https://x.example.invalid",
+				Token:          "t",
+			})
+			require.NoError(t, err)
+			require.NotZero(t, res.ExitCode)
+		})
+	}
+
+	// With --agent the block renders as a structured envelope with the
+	// stable code, so machine callers can branch on it.
+	res, err := engine.Execute(context.Background(), engine.Request{
+		Command:        "config --agent",
+		EnvironmentURL: "https://x.example.invalid",
+		Token:          "t",
+	})
+	require.NoError(t, err)
+	require.NotZero(t, res.ExitCode)
+	require.Contains(t, string(res.Stdout), `"code":"unsupported_in_service"`)
+}
+
+// TestExecute_BlockedHiddenFromCatalog: an agent bootstrapping from the
+// `dtctl commands` catalog must not see commands the service cannot run.
+func TestExecute_BlockedHiddenFromCatalog(t *testing.T) {
+	res, err := engine.Execute(context.Background(), engine.Request{
+		Command:        "commands",
+		EnvironmentURL: "https://x.example.invalid",
+		Token:          "t",
+	})
+	require.NoError(t, err)
+	require.Zero(t, res.ExitCode, "stderr: %s", res.Stderr)
+	out := string(res.Stdout)
+	require.Contains(t, out, "get", "the resource surface stays visible")
+	// "skills:" (with colon) is the catalog entry for the top-level command;
+	// the bare word also appears in the unrelated "copilot-skills" resource.
+	for _, blocked := range []string{"doctor", "skills:", "completion"} {
+		require.NotContains(t, out, blocked)
+	}
+}
+
+// TestExecute_ReadonlyBlocksMutation: the per-request safety level stops a
+// mutating command before any API request leaves the process.
+func TestExecute_ReadonlyBlocksMutation(t *testing.T) {
+	env := newMockEnv(t)
+
+	res, err := engine.Execute(context.Background(), engine.Request{
+		Command:        "create bucket --name b --table logs --retention 35 --plain",
+		EnvironmentURL: env.URL,
+		Token:          "tenant-token",
+		SafetyLevel:    "readonly",
+	})
+	require.NoError(t, err)
+	require.NotZero(t, res.ExitCode)
+
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	require.Zero(t, env.mutations)
+}
+
+// TestExecute_ProfileMasksSurface: a per-request profile reduces the command
+// surface with the stable profile_blocked code.
+func TestExecute_ProfileMasksSurface(t *testing.T) {
+	res, err := engine.Execute(context.Background(), engine.Request{
+		Command:        "get buckets --agent",
+		EnvironmentURL: "https://x.example.invalid",
+		Token:          "t",
+		Profile:        "query",
+	})
+	require.NoError(t, err)
+	require.NotZero(t, res.ExitCode)
+	require.Contains(t, string(res.Stdout), `"code":"profile_blocked"`)
+}
+
+// TestExecute_ContextCancelledBeforeStart: a request whose context is already
+// done never runs.
+func TestExecute_ContextCancelledBeforeStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res, err := engine.Execute(ctx, engine.Request{
+		Command:        "get buckets",
+		EnvironmentURL: "https://x.example.invalid",
+		Token:          "t",
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, res)
+}
+
+// TestExecute_ConcurrentRequests: Execute is goroutine-safe (requests
+// serialize internally); every caller gets its own complete result.
+func TestExecute_ConcurrentRequests(t *testing.T) {
+	env := newMockEnv(t)
+
+	var wg sync.WaitGroup
+	results := make([]*engine.Result, 4)
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			res, err := engine.Execute(context.Background(), engine.Request{
+				Command:        "get buckets --plain",
+				EnvironmentURL: env.URL,
+				Token:          "tenant-token",
+			})
+			require.NoError(t, err)
+			results[i] = res
+		}(i)
+	}
+	wg.Wait()
+
+	for i, res := range results {
+		require.Zero(t, res.ExitCode, "request %d failed: %s", i, res.Stderr)
+		require.Contains(t, string(res.Stdout), "engine_bucket", "request %d", i)
+	}
+}

--- a/pkg/engine/equality_test.go
+++ b/pkg/engine/equality_test.go
@@ -1,0 +1,165 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace-oss/dtctl/pkg/engine"
+)
+
+// TestEngineOutputEqualsCLI is the E8 acceptance gate: for the same command
+// line, tenant, and environment, the engine's stdout/stderr/exit code are
+// byte-identical to the real dtctl binary's. This is the whole service
+// contract — an agent moving between local CLI and service must not be able
+// to tell the difference.
+//
+// The CLI side runs the actual built binary against a config file pointing at
+// the mock environment; the engine side runs in-process with a Session. Only
+// the envelope's wall-clock duration field is normalized.
+func TestEngineOutputEqualsCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds the dtctl binary; skipped in -short mode")
+	}
+	env := newMockEnv(t)
+	exe := buildCLI(t)
+	cfgPath := writeCLIConfig(t, env.URL)
+
+	for _, command := range []string{
+		"get buckets --agent",
+		"get buckets -o json --plain",
+		"get buckets --plain",
+		"get bucket missing_bucket --agent",
+		"totally-unknown-command --agent",
+		"config --agent",
+	} {
+		t.Run(command, func(t *testing.T) {
+			cliCode, cliStdout, cliStderr := runCLI(t, exe, cfgPath, command)
+
+			res, err := engine.Execute(context.Background(), engine.Request{
+				Command:        command,
+				EnvironmentURL: env.URL,
+				Token:          "tenant-token",
+			})
+			require.NoError(t, err)
+
+			// The one deliberate divergence: host-only commands exist locally
+			// but are unsupported in the service. Everything else must match.
+			if strings.HasPrefix(command, "config") {
+				require.NotZero(t, res.ExitCode)
+				require.Contains(t, string(res.Stdout), `"code":"unsupported_in_service"`)
+				return
+			}
+
+			require.Equal(t, cliCode, res.ExitCode, "exit codes must match\nCLI stderr: %s\nengine stderr: %s", cliStderr, res.Stderr)
+			require.Equal(t, normalizeEnvelope(cliStdout), normalizeEnvelope(string(res.Stdout)),
+				"stdout must be byte-identical to the CLI")
+			require.Equal(t, normalizeEnvelope(cliStderr), normalizeEnvelope(string(res.Stderr)),
+				"stderr must be byte-identical to the CLI")
+		})
+	}
+}
+
+// buildCLI compiles the real dtctl binary once per test run.
+func buildCLI(t *testing.T) string {
+	t.Helper()
+	name := "dtctl"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	exe := filepath.Join(t.TempDir(), name)
+	build := exec.Command("go", "build", "-o", exe, ".")
+	build.Dir = "../.." // module root, where package main lives
+	out, err := build.CombinedOutput()
+	require.NoError(t, err, "go build failed: %s", out)
+	return exe
+}
+
+// writeCLIConfig writes a single-context config equivalent to what the engine
+// synthesizes from the request's Session.
+func writeCLIConfig(t *testing.T, envURL string) string {
+	t.Helper()
+	cfg := fmt.Sprintf(`apiVersion: v1
+kind: Config
+current-context: session
+contexts:
+  - name: session
+    context:
+      environment: %s
+      token-ref: session
+tokens:
+  - name: session
+    token: tenant-token
+`, envURL)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(cfg), 0o600))
+	return path
+}
+
+// runCLI executes the built binary with a scrubbed environment: no dtctl or
+// credential variables, no AI-agent markers, no color overrides — the same
+// neutral conditions the engine guarantees per request.
+func runCLI(t *testing.T, exe, cfgPath, command string) (int, string, string) {
+	t.Helper()
+	args, err := splitTestCommand(command)
+	require.NoError(t, err)
+
+	cli := exec.Command(exe, args...)
+	cli.Env = scrubbedEnviron(map[string]string{
+		"DTCTL_CONFIG":          cfgPath,
+		"DTCTL_DISABLE_KEYRING": "1",
+	})
+	var stdout, stderr bytes.Buffer
+	cli.Stdout, cli.Stderr = &stdout, &stderr
+	runErr := cli.Run()
+	code := 0
+	if exitErr, ok := runErr.(*exec.ExitError); ok {
+		code = exitErr.ExitCode()
+	} else {
+		require.NoError(t, runErr)
+	}
+	return code, stdout.String(), stderr.String()
+}
+
+// splitTestCommand splits on spaces — sufficient for the fixed commands above
+// (none quote); the engine side uses its real shell-words parser.
+func splitTestCommand(command string) ([]string, error) {
+	return strings.Fields(command), nil
+}
+
+func scrubbedEnviron(extra map[string]string) []string {
+	agentVars := map[string]bool{
+		"CLAUDECODE": true, "CLAUDE_CODE": true, "AI_AGENT": true, "CODEX": true,
+		"CURSOR_AGENT": true, "COPILOT_CLI": true, "GITHUB_COPILOT": true,
+		"AGENT_CONTEXT_OUT": true, "KIRO_SESSION_ID": true, "OPENCODE": true,
+		"NO_COLOR": true, "FORCE_COLOR": true,
+	}
+	var out []string
+	for _, kv := range os.Environ() {
+		key, _, _ := strings.Cut(kv, "=")
+		if strings.HasPrefix(key, "DTCTL_") || strings.HasPrefix(key, "DT_") ||
+			strings.HasPrefix(key, "OTEL_") || agentVars[key] {
+			continue
+		}
+		out = append(out, kv)
+	}
+	for k, v := range extra {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+var durationField = regexp.MustCompile(`"duration":"[^"]*"`)
+
+func normalizeEnvelope(s string) string {
+	return durationField.ReplaceAllString(s, `"duration":"<normalized>"`)
+}

--- a/pkg/engine/host_isolation_test.go
+++ b/pkg/engine/host_isolation_test.go
@@ -1,0 +1,120 @@
+package engine_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace-oss/dtctl/pkg/engine"
+)
+
+// The tests here pin the boundary the engine promises: a request sees its own
+// files, its own stdin, and nothing of the host's. Each one corresponds to a
+// hole that existed once — a user-named path that reached the host disk one
+// package deeper than the cmd/-only guard could see, a spill that outlived the
+// request on the server's disk, a nil stdin that fell through to the host's.
+
+// TestExecute_DiffUsesRequestFilesNotHostDisk: `diff -f a -f b` names two files
+// the *user* chose, so both resolve in the request. Reading them from the host
+// disk instead would turn diff into an arbitrary file-read primitive — the
+// unified patch prints the contents it compared.
+func TestExecute_DiffUsesRequestFilesNotHostDisk(t *testing.T) {
+	// A file that exists only on the host, with a name the request also uses.
+	dir := t.TempDir()
+	hostPath := filepath.Join(dir, "left.yaml")
+	require.NoError(t, os.WriteFile(hostPath, []byte("secret: host-only-value\n"), 0o600))
+
+	// Same basename in the request, different content: if the diff reports the
+	// host's value, the seam leaked.
+	res, err := engine.Execute(context.Background(), engine.Request{
+		Command:        "diff -f left.yaml -f right.yaml --plain",
+		EnvironmentURL: "https://x.example.invalid",
+		Token:          "t",
+		Files: map[string][]byte{
+			"left.yaml":  []byte("value: from-request\n"),
+			"right.yaml": []byte("value: from-request\n"),
+		},
+	})
+	require.NoError(t, err)
+	require.Zero(t, res.ExitCode, "identical request files must diff clean; stderr: %s", res.Stderr)
+
+	combined := string(res.Stdout) + string(res.Stderr)
+	require.NotContains(t, combined, "host-only-value")
+
+	// And an absolute host path simply does not exist in the request.
+	res, err = engine.Execute(context.Background(), engine.Request{
+		Command:        "diff -f " + hostPath + " -f right.yaml --plain",
+		EnvironmentURL: "https://x.example.invalid",
+		Token:          "t",
+		Files:          map[string][]byte{"right.yaml": []byte("value: from-request\n")},
+	})
+	require.NoError(t, err)
+	require.NotZero(t, res.ExitCode, "a host path must not resolve")
+	require.NotContains(t, string(res.Stdout)+string(res.Stderr), "host-only-value")
+}
+
+// TestExecute_SpillNeverTouchesHostDisk: spilling writes a result file to the
+// host and hands back a path. In a service that file would outlive the request
+// on the server's disk — readable by whatever runs next — while the path in the
+// response means nothing to the caller. The request is refused, and nothing is
+// written.
+func TestExecute_SpillNeverTouchesHostDisk(t *testing.T) {
+	env := newMockEnv(t)
+	target := filepath.Join(t.TempDir(), "written", "by-tenant.jsonl")
+
+	res, err := engine.Execute(context.Background(), engine.Request{
+		Command:        "query 'fetch logs' --spill-to " + target + " --agent",
+		EnvironmentURL: env.URL,
+		Token:          "tenant-token",
+	})
+	require.NoError(t, err)
+	require.NotZero(t, res.ExitCode)
+	require.Contains(t, string(res.Stdout), `"code":"capability_disabled"`)
+
+	_, statErr := os.Stat(target)
+	require.True(t, os.IsNotExist(statErr), "no file may be written to the host disk")
+	require.NoDirExists(t, filepath.Dir(target), "no directory may be created on the host disk")
+}
+
+// TestExecute_NilStdinIsEOF: a request that sends no stdin gets an empty one,
+// not the host process's. Falling through to the host's stdin lets a request
+// read whatever the operator's terminal or supervisor pipe holds — and, on a
+// pipe that never closes, block forever while holding the invocation lock.
+func TestExecute_NilStdinIsEOF(t *testing.T) {
+	env := newMockEnv(t)
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	orig := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = orig }()
+
+	go func() {
+		_, _ = w.Write([]byte("fetch HOST_STDIN_MARKER\n"))
+		_ = w.Close()
+	}()
+
+	// `query` with no positional argument falls back to reading stdin.
+	res, err := engine.Execute(context.Background(), engine.Request{
+		Command:        "query --plain",
+		EnvironmentURL: env.URL,
+		Token:          "tenant-token",
+		// Stdin deliberately unset.
+	})
+	require.NoError(t, err)
+	require.NotZero(t, res.ExitCode, "an empty stdin yields no query to run")
+	require.NotContains(t, strings.ToUpper(string(res.Stdout)+string(res.Stderr)), "HOST_STDIN_MARKER",
+		"the host process's stdin must never reach a request")
+
+	// The host stream is intact for whoever owns it.
+	buf := make([]byte, 64)
+	n, _ := r.Read(buf)
+	require.Contains(t, string(buf[:n]), "HOST_STDIN_MARKER",
+		"the request must not have consumed the host's stdin")
+}

--- a/pkg/engine/policy.go
+++ b/pkg/engine/policy.go
@@ -26,6 +26,11 @@ var unsupportedCommands = map[string]string{
 	"doctor":     "it diagnoses the local dtctl installation and config",
 	"completion": "it generates shell completion scripts for a local shell",
 	"serve":      "the service cannot be nested inside itself",
+	// inspect is a reader for files dtctl spilled to the local disk. A service
+	// request never spills (the HostDiskSpill capability is not granted, so
+	// results come back inline), and the path it takes would resolve on the
+	// server's disk rather than in the request — host state on both counts.
+	"inspect": "it reads result files spilled to the local disk; a service request receives its rows inline instead",
 }
 
 // UnsupportedCommands returns the top-level commands the engine blocks, keyed

--- a/pkg/engine/policy.go
+++ b/pkg/engine/policy.go
@@ -1,0 +1,40 @@
+package engine
+
+// unsupportedCommands are the top-level dtctl commands the engine removes from
+// the surface: they manage host-local state (config file, keyring, shell,
+// installed tools) that does not exist for a service request, or would nest
+// the service in itself. Everything else — the entire resource surface (get,
+// describe, create, apply, delete, query, exec, ...) — runs as-is.
+//
+// A blocked command is hidden from `dtctl commands` and help, and invoking it
+// returns the stable agent-mode error code "unsupported_in_service" with the
+// reason below (see cmd.UnsupportedCommandError).
+//
+// Note the axis: this list is about the *environment* (service vs. host CLI).
+// What a request may do to its tenant is governed separately by the
+// per-request safety level, and its visible command set optionally by a
+// per-request profile.
+var unsupportedCommands = map[string]string{
+	"config":     "it manages the local dtctl config file; a service request carries its environment and token directly",
+	"ctx":        "it switches between local config contexts; a service request targets exactly one environment",
+	"auth":       "it manages browser-based OAuth login and locally stored credentials; a service request authenticates with its own token",
+	"account":    "it administers platform accounts using locally stored account credentials",
+	"alias":      "it manages command aliases in the local dtctl config file",
+	"edit":       "it opens an interactive editor",
+	"plugin":     "it manages dtctl plugin executables installed on the local machine",
+	"skills":     "it installs skill files for locally installed AI coding assistants",
+	"doctor":     "it diagnoses the local dtctl installation and config",
+	"completion": "it generates shell completion scripts for a local shell",
+	"serve":      "the service cannot be nested inside itself",
+}
+
+// UnsupportedCommands returns the top-level commands the engine blocks, keyed
+// by command name with the human-readable reason as value. The map is a copy;
+// the policy itself is fixed.
+func UnsupportedCommands() map[string]string {
+	out := make(map[string]string, len(unsupportedCommands))
+	for k, v := range unsupportedCommands {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/exec/dql.go
+++ b/pkg/exec/dql.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/version"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 	sdkquery "github.com/dynatrace-oss/dtctl/sdk/api/query"
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
 )
@@ -970,7 +971,7 @@ func (e *DQLExecutor) CancelQuery(requestToken string) {
 
 // ExecuteFromFile executes a DQL query from a file
 func (e *DQLExecutor) ExecuteFromFile(filename string, outputFormat string) error {
-	data, err := os.ReadFile(filename)
+	data, err := vfs.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("failed to read file: %w", err)
 	}

--- a/pkg/exec/function.go
+++ b/pkg/exec/function.go
@@ -2,12 +2,11 @@ package exec
 
 import (
 	"fmt"
-	"io"
-	"os"
 	"strings"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/appengine"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // FunctionExecutor handles function execution
@@ -139,18 +138,14 @@ func (e *FunctionExecutor) GetSDKVersions() (*appengine.SDKVersionsResponse, err
 	return e.handler.GetSDKVersions()
 }
 
-// ReadFileOrStdin reads content from a file or stdin
+// ReadFileOrStdin reads content from a file (through the vfs seam, so
+// embedded invocations resolve virtual request files) or stdin.
 func ReadFileOrStdin(filename string) (string, error) {
-	if filename == "-" {
-		content, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			return "", fmt.Errorf("failed to read from stdin: %w", err)
-		}
-		return string(content), nil
-	}
-
-	content, err := os.ReadFile(filename)
+	content, err := vfs.ReadFileOrStdin(filename)
 	if err != nil {
+		if filename == "-" {
+			return "", err
+		}
 		return "", fmt.Errorf("failed to read file %q: %w", filename, err)
 	}
 	return string(content), nil

--- a/pkg/resources/analyzer/analyzer.go
+++ b/pkg/resources/analyzer/analyzer.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 	sdkana "github.com/dynatrace-oss/dtctl/sdk/api/analyzer"
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
 )
@@ -147,7 +147,7 @@ func fromSDKExecuteResult(s *sdkana.ExecuteResult) *ExecuteResult {
 // ParseInputFromFile reads and parses analyzer input from a file.
 // This is a CLI-layer helper and intentionally not part of the SDK.
 func ParseInputFromFile(filename string) (map[string]interface{}, error) {
-	content, err := os.ReadFile(filename)
+	content, err := vfs.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resources/appengine/functions.go
+++ b/pkg/resources/appengine/functions.go
@@ -3,10 +3,9 @@ package appengine
 import (
 	"context"
 	"fmt"
-	"io"
-	"os"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 	sdkae "github.com/dynatrace-oss/dtctl/sdk/api/appengine"
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
 )
@@ -46,24 +45,11 @@ func fromSDKVersion(s *sdkae.SDKVersion) SDKVersion {
 	return SDKVersion{Version: s.Version, Default: s.Default}
 }
 
-// ReadFileOrStdin reads content from a file or stdin.
+// ReadFileOrStdin reads content from a file (through the vfs seam, so
+// embedded invocations resolve virtual request files) or stdin.
 // This is a CLI-layer helper and intentionally not part of the SDK.
 func ReadFileOrStdin(filename string) (string, error) {
-	var reader io.Reader
-	if filename == "-" {
-		reader = os.Stdin
-	} else {
-		f, err := os.Open(filename)
-		if err != nil {
-			return "", fmt.Errorf("failed to open file: %w", err)
-		}
-		defer func() {
-			_ = f.Close()
-		}()
-		reader = f
-	}
-
-	content, err := io.ReadAll(reader)
+	content, err := vfs.ReadFileOrStdin(filename)
 	if err != nil {
 		return "", fmt.Errorf("failed to read content: %w", err)
 	}

--- a/pkg/resources/lookup/lookup.go
+++ b/pkg/resources/lookup/lookup.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // Handler handles lookup table resources
@@ -315,7 +316,7 @@ func (h *Handler) Create(req CreateRequest) (*UploadResponse, error) {
 			dataContent, err = io.ReadAll(os.Stdin)
 		} else {
 			// Read from file
-			dataContent, err = os.ReadFile(req.DataSource)
+			dataContent, err = vfs.ReadFile(req.DataSource)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to read data: %w", err)

--- a/pkg/resources/previewprocessor/previewprocessor.go
+++ b/pkg/resources/previewprocessor/previewprocessor.go
@@ -10,10 +10,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"os"
 
 	"github.com/dynatrace-oss/dtctl/pkg/client"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 	sdkpreview "github.com/dynatrace-oss/dtctl/sdk/api/previewprocessor"
 	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
 )
@@ -94,22 +93,11 @@ func buildEnvelope(processor json.RawMessage, configID string) (json.RawMessage,
 	return out, nil
 }
 
-// readFileOrStdin reads a file (or stdin when filename is "-") and returns the
-// content as json.RawMessage after a basic JSON validity check.
+// readFileOrStdin reads a file (through the vfs seam, so embedded invocations
+// resolve virtual request files; "-" means stdin) and returns the content as
+// json.RawMessage after a basic JSON validity check.
 func readFileOrStdin(filename string) (json.RawMessage, error) {
-	var reader io.Reader
-	if filename == "-" {
-		reader = os.Stdin
-	} else {
-		f, err := os.Open(filename)
-		if err != nil {
-			return nil, fmt.Errorf("open %q: %w", filename, err)
-		}
-		defer func() { _ = f.Close() }()
-		reader = f
-	}
-
-	data, err := io.ReadAll(reader)
+	data, err := vfs.ReadFileOrStdin(filename)
 	if err != nil {
 		return nil, fmt.Errorf("read processor definition: %w", err)
 	}

--- a/pkg/serve/http.go
+++ b/pkg/serve/http.go
@@ -1,0 +1,215 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/cmd"
+	"github.com/dynatrace-oss/dtctl/pkg/engine"
+)
+
+// executeRequest is the POST /v1/execute body. Command/argv, files, and stdin
+// mirror engine.Request; file contents travel as plain JSON strings (the
+// payloads dtctl consumes — YAML, JSON, DQL — are text).
+type executeRequest struct {
+	// Command is the dtctl command line exactly as typed locally,
+	// e.g. "apply -f workflow.yaml --agent". Ignored when argv is set.
+	Command string `json:"command,omitempty"`
+	// Argv is the pre-split argument vector; takes precedence over command.
+	Argv []string `json:"argv,omitempty"`
+
+	EnvironmentURL string `json:"environmentUrl"`
+	Token          string `json:"token"`
+	SafetyLevel    string `json:"safetyLevel,omitempty"`
+	Profile        string `json:"profile,omitempty"`
+
+	Files map[string]string `json:"files,omitempty"`
+	Stdin string            `json:"stdin,omitempty"`
+}
+
+// executeResponse is the POST /v1/execute response. A command that fails
+// still answers 200: exitCode/stderr are the result, exactly as on a local
+// shell. Non-200 statuses are reserved for requests that never ran.
+type executeResponse struct {
+	ExitCode int    `json:"exitCode"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	// Files is the complete final state of the request's virtual filesystem.
+	Files      map[string]string `json:"files,omitempty"`
+	DurationMs int64             `json:"durationMs"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+// Handler returns the HTTP server's http.Handler:
+//
+//	POST /v1/execute — run one dtctl command line (body: executeRequest)
+//	GET  /healthz    — liveness probe
+//
+// maxRequestBytes bounds the request body (virtual files travel inline).
+func Handler(maxRequestBytes int64) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}` + "\n"))
+	})
+	mux.HandleFunc("/v1/execute", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "use POST")
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBytes)
+
+		var req executeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			var tooLarge *http.MaxBytesError
+			if errors.As(err, &tooLarge) {
+				writeError(w, http.StatusRequestEntityTooLarge,
+					fmt.Sprintf("request body exceeds %d bytes", tooLarge.Limit))
+				return
+			}
+			writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+			return
+		}
+
+		files := make(map[string][]byte, len(req.Files))
+		for name, content := range req.Files {
+			files[name] = []byte(content)
+		}
+		var stdin []byte
+		if req.Stdin != "" {
+			stdin = []byte(req.Stdin)
+		}
+
+		start := time.Now()
+		res, err := engine.Execute(r.Context(), engine.Request{
+			Command:        req.Command,
+			Argv:           req.Argv,
+			EnvironmentURL: req.EnvironmentURL,
+			Token:          req.Token,
+			SafetyLevel:    req.SafetyLevel,
+			Profile:        req.Profile,
+			Files:          files,
+			Stdin:          stdin,
+			// Env is intentionally not exposed over HTTP: arbitrary variables
+			// reach proxies, exporters, and other process-level behavior.
+			// Embedding hosts that need it use engine.Request.Env directly.
+		})
+		if err != nil {
+			// The request never ran: malformed shape or cancelled while queued.
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		outFiles := make(map[string]string, len(res.Files))
+		for name, content := range res.Files {
+			outFiles[name] = string(content)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(executeResponse{
+			ExitCode:   res.ExitCode,
+			Stdout:     string(res.Stdout),
+			Stderr:     string(res.Stderr),
+			Files:      outFiles,
+			DurationMs: time.Since(start).Milliseconds(),
+		})
+	})
+	return mux
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorResponse{Error: msg})
+}
+
+// newHTTPCommand builds `dtctl serve http`.
+func newHTTPCommand() *cobra.Command {
+	var (
+		addr            string
+		maxRequestBytes int64
+	)
+	c := &cobra.Command{
+		Use:   "http",
+		Short: "Serve the dtctl execute API over HTTP (reference implementation)",
+		Long: `Serve dtctl over HTTP: one request executes one dtctl command line for one
+tenant and returns the CLI-identical output.
+
+  POST /v1/execute
+    {"command": "get workflows --agent",
+     "environmentUrl": "https://abc12345.apps.dynatrace.com",
+     "token": "dt0s16....",
+     "safetyLevel": "readonly",
+     "files": {"x.yaml": "..."}}
+  -> {"exitCode": 0, "stdout": "...", "stderr": "...", "files": {...}}
+
+  GET /healthz -> {"status":"ok"}
+
+Each request brings its own environment URL and token; the local dtctl config,
+keyring, and credential environment variables are never read. File arguments
+resolve against the request's "files", and files written back (e.g. by
+apply --write-id) are returned in the response. Requests execute one at a time
+per process.
+
+This is a reference implementation: it performs no authentication of its own
+(the per-request token only authenticates against Dynatrace) and binds to
+localhost by default. Put your own authentication and TLS in front before
+exposing it, or embed pkg/engine directly.`,
+		Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			if cmd.RunActive() {
+				// Reached through the normal pipeline (e.g. `dtctl -v serve
+				// http`, which the main dispatch does not intercept): serving
+				// here would hold the invocation lock for the server's
+				// lifetime and deadlock every request.
+				return errors.New("serve must be invoked directly as `dtctl serve http [flags]`, with no arguments before it")
+			}
+			return runHTTP(command.Context(), addr, maxRequestBytes)
+		},
+	}
+	c.Flags().StringVar(&addr, "addr", "127.0.0.1:7211", "listen address")
+	c.Flags().Int64Var(&maxRequestBytes, "max-request-bytes", 10<<20,
+		"maximum request body size in bytes (virtual files travel inline)")
+	return c
+}
+
+// runHTTP serves until the context is cancelled or SIGINT/SIGTERM arrives,
+// then shuts down gracefully, letting an in-flight execution finish (a started
+// run cannot be interrupted — see the pkg/engine cancellation notes).
+func runHTTP(ctx context.Context, addr string, maxRequestBytes int64) error {
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           Handler(maxRequestBytes),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	errc := make(chan error, 1)
+	go func() {
+		fmt.Fprintf(os.Stderr, "dtctl serve http: listening on http://%s\n", addr)
+		errc <- server.ListenAndServe()
+	}()
+
+	select {
+	case err := <-errc:
+		return err
+	case <-ctx.Done():
+		fmt.Fprintln(os.Stderr, "dtctl serve http: shutting down")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		return server.Shutdown(shutdownCtx)
+	}
+}

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -20,6 +20,22 @@ import (
 	"github.com/dynatrace-oss/dtctl/cmd"
 )
 
+// ExperimentalEnvVar gates the `dtctl serve` command surface. Server mode is
+// still taking shape — the request/response contract, the one-invocation-at-a-
+// time concurrency model, and the absence of per-request deadlines are all
+// subject to change — so released builds do not expose it unless the operator
+// opts in. Set it to a truthy value to register the command.
+//
+// The gate covers the *command* only. pkg/engine stays importable: embedding it
+// is a deliberate Go API choice made at compile time, not a surface an end user
+// can stumble into. Remove this gate — and the env var — when serve is GA.
+const ExperimentalEnvVar = "DTCTL_EXPERIMENTAL_SERVE"
+
+// Experimental reports whether the `dtctl serve` command surface is enabled.
+func Experimental() bool {
+	return cmd.ExperimentalEnabled(ExperimentalEnvVar)
+}
+
 // Run executes `dtctl serve ...` standalone with the given arguments
 // (everything after "serve") and returns the process exit code. main
 // dispatches to it *before* the normal command pipeline: a server must run

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -1,0 +1,104 @@
+// Package serve is the command surface for running dtctl as a server on top
+// of pkg/engine. Each protocol is its own subcommand — `dtctl serve http`
+// today, room for `dtctl serve mcp` and others without redefining what bare
+// `serve` means. This file holds the parent command and the standalone
+// dispatch; each protocol lives in its own file (http.go).
+//
+// The servers here are reference implementations. They carry no
+// authentication of their own: every request brings the tenant token it runs
+// with, and listeners bind to localhost by default. A real deployment puts
+// its own authentication, TLS, and rate limiting in front (or embeds
+// pkg/engine directly instead of shipping one of these servers).
+package serve
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/cmd"
+)
+
+// Run executes `dtctl serve ...` standalone with the given arguments
+// (everything after "serve") and returns the process exit code. main
+// dispatches to it *before* the normal command pipeline: a server must run
+// outside the per-invocation lock, because every request it accepts becomes an
+// engine execution that has to acquire that lock — a server started inside an
+// invocation would deadlock its own first request.
+func Run(argv []string) int {
+	// Register serve on the root too (a second instance — the standalone one
+	// below cannot be parented): requests naming "serve" then get the
+	// signposted "unsupported in service" block instead of a generic unknown
+	// command, and the RunActive guard keeps it inert if ever dispatched.
+	cmd.AddCommand(NewCommand())
+
+	// Hang the standalone instance off a synthetic "dtctl" root so usage lines
+	// read `dtctl serve http ...` rather than `serve http ...`, and so cobra's
+	// auto-added help/completion children attach to that root instead of
+	// showing up as protocols under serve.
+	root := &cobra.Command{Use: "dtctl", SilenceUsage: true}
+	root.AddCommand(NewCommand())
+	root.SetArgs(append([]string{"serve"}, argv...))
+	if err := root.Execute(); err != nil {
+		return 1
+	}
+	return 0
+}
+
+// NewCommand builds the `dtctl serve` command tree. It lives outside package
+// cmd because it imports pkg/engine, which imports cmd — main wires an
+// instance onto the root via cmd.AddCommand for help/catalog visibility, and
+// executes a standalone instance via Run (see there for why).
+//
+// The parent itself is not runnable: naming the protocol is mandatory, so no
+// single one is the silent default. Bare `dtctl serve` prints help and exits 0.
+func NewCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "serve",
+		Short: "Run dtctl as a server (reference implementations)",
+		Long: `Run dtctl as a server that executes command lines for AI agents and
+automation (e.g. Dynatrace Workflow actions), instead of a one-shot CLI.
+
+Each request brings its own Dynatrace environment URL and token — servers are
+multi-tenant and never read the local dtctl config, keyring, or credential
+environment variables. File arguments resolve against per-request virtual
+files, host-only commands (config, ctx, auth, ...) are unavailable, and no
+subprocesses are spawned. Requests execute one at a time per process.
+
+Pick the protocol you want to speak:
+
+  dtctl serve http    JSON over HTTP (POST /v1/execute)
+
+These are reference implementations: they perform no authentication of their
+own (the per-request token only authenticates against Dynatrace) and bind to
+localhost by default. Put your own authentication and TLS in front before
+exposing one, or embed pkg/engine directly.`,
+		// Cobra does not validate arguments on a parent with no Run, so an
+		// unmatched name would silently print help and exit 0 — a typo'd
+		// protocol must not look like a started server to a supervisor.
+		Args: cobra.ArbitraryArgs,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown protocol %q for `dtctl serve` (available: %s)",
+					args[0], strings.Join(protocolNames(c), ", "))
+			}
+			// No protocol named: discovery, not misuse — help and exit 0.
+			return c.Help()
+		},
+	}
+	c.AddCommand(newHTTPCommand())
+	return c
+}
+
+// protocolNames lists the protocols serve can speak, for error messages.
+func protocolNames(serveCmd *cobra.Command) []string {
+	var names []string
+	for _, sub := range serveCmd.Commands() {
+		if sub.Hidden || sub.Name() == "help" || sub.Name() == "completion" {
+			continue
+		}
+		names = append(names, sub.Name())
+	}
+	return names
+}

--- a/pkg/serve/serve_test.go
+++ b/pkg/serve/serve_test.go
@@ -1,0 +1,184 @@
+package serve
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newDynatraceMock is a minimal fake Dynatrace environment for handler tests.
+func newDynatraceMock(t *testing.T) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/platform/storage/management/v1/bucket-definitions" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"buckets":[{"bucketName":"serve_bucket","table":"logs","status":"active","retentionDays":35,"version":1,"updatable":true}]}`))
+		case r.URL.Path == "/platform/storage/management/v1/bucket-definitions" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"bucketName":"new_bucket","table":"logs","status":"creating","retentionDays":35,"version":1}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":404,"message":"not found"}}`))
+		}
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func postExecute(t *testing.T, srv *httptest.Server, body string) (*http.Response, []byte) {
+	t.Helper()
+	resp, err := http.Post(srv.URL+"/v1/execute", "application/json", strings.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(resp.Body)
+	require.NoError(t, err)
+	return resp, buf.Bytes()
+}
+
+func TestHandler_Execute(t *testing.T) {
+	dt := newDynatraceMock(t)
+	srv := httptest.NewServer(Handler(10 << 20))
+	t.Cleanup(srv.Close)
+
+	resp, body := postExecute(t, srv,
+		`{"command":"get buckets --plain","environmentUrl":"`+dt.URL+`","token":"tenant-token"}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out executeResponse
+	require.NoError(t, json.Unmarshal(body, &out))
+	require.Zero(t, out.ExitCode, "stderr: %s", out.Stderr)
+	require.Contains(t, out.Stdout, "serve_bucket")
+}
+
+func TestHandler_FilesRoundTrip(t *testing.T) {
+	dt := newDynatraceMock(t)
+	srv := httptest.NewServer(Handler(10 << 20))
+	t.Cleanup(srv.Close)
+
+	req, err := json.Marshal(executeRequest{
+		Command:        "create bucket -f bucket.yaml --plain",
+		EnvironmentURL: dt.URL,
+		Token:          "tenant-token",
+		Files:          map[string]string{"bucket.yaml": "bucketName: new_bucket\ntable: logs\nretentionDays: 35\n"},
+	})
+	require.NoError(t, err)
+
+	resp, body := postExecute(t, srv, string(req))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out executeResponse
+	require.NoError(t, json.Unmarshal(body, &out))
+	require.Zero(t, out.ExitCode, "stderr: %s", out.Stderr)
+	require.Contains(t, out.Files, "bucket.yaml",
+		"the virtual filesystem's final state travels back to the caller")
+}
+
+// TestHandler_CommandFailureIsHTTP200: a command that fails is still a
+// successful *execution* — the failure lives in exitCode/stderr, exactly as
+// on a local shell. HTTP error statuses are reserved for requests that never
+// ran.
+func TestHandler_CommandFailureIsHTTP200(t *testing.T) {
+	srv := httptest.NewServer(Handler(10 << 20))
+	t.Cleanup(srv.Close)
+
+	resp, body := postExecute(t, srv,
+		`{"command":"config","environmentUrl":"https://x.example.invalid","token":"t"}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out executeResponse
+	require.NoError(t, json.Unmarshal(body, &out))
+	require.NotZero(t, out.ExitCode)
+	require.Contains(t, out.Stderr, "not supported in this environment")
+}
+
+func TestHandler_RequestErrors(t *testing.T) {
+	srv := httptest.NewServer(Handler(1024))
+	t.Cleanup(srv.Close)
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		resp, _ := postExecute(t, srv, `{not json`)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("missing token", func(t *testing.T) {
+		resp, body := postExecute(t, srv,
+			`{"command":"get buckets","environmentUrl":"https://x.example.invalid"}`)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Contains(t, string(body), "Token is required")
+	})
+
+	t.Run("body too large", func(t *testing.T) {
+		resp, _ := postExecute(t, srv,
+			`{"command":"get buckets","stdin":"`+strings.Repeat("x", 2048)+`"}`)
+		require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/v1/execute")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+}
+
+func TestHandler_Healthz(t *testing.T) {
+	srv := httptest.NewServer(Handler(1024))
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestNewCommand_Registered pins the command surface: `serve` is a protocol
+// parent, not a server itself, so a future `serve mcp` lands beside `serve
+// http` instead of competing with an incumbent default.
+func TestNewCommand_Registered(t *testing.T) {
+	c := NewCommand()
+	require.Equal(t, "serve", c.Name())
+	require.Equal(t, []string{"http"}, protocolNames(c),
+		"every server is a named protocol under serve, so a future `serve mcp` "+
+			"lands beside `serve http` rather than competing with a default")
+
+	httpCmd, _, err := c.Find([]string{"http"})
+	require.NoError(t, err)
+	require.NotNil(t, httpCmd.Flags().Lookup("addr"))
+	require.NotNil(t, httpCmd.Flags().Lookup("max-request-bytes"))
+}
+
+// TestBareServePrintsHelp: naming the protocol is mandatory, and omitting it is
+// not an error — help on stdout, exit 0 (Run returns the process exit code).
+func TestBareServePrintsHelp(t *testing.T) {
+	c := NewCommand()
+	var out bytes.Buffer
+	c.SetOut(&out)
+	c.SetErr(&out)
+	c.SetArgs(nil)
+
+	require.NoError(t, c.Execute())
+	require.Contains(t, out.String(), "http")
+	require.Contains(t, out.String(), "Available Commands:")
+}
+
+// TestUnknownProtocolFails: cobra prints help and exits 0 for an unmatched name
+// under a parent with no Run. A supervisor would read that as a started server,
+// so serve validates the protocol name itself.
+func TestUnknownProtocolFails(t *testing.T) {
+	c := NewCommand()
+	c.SetOut(&bytes.Buffer{})
+	c.SetErr(&bytes.Buffer{})
+	c.SetArgs([]string{"grpc"})
+
+	err := c.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unknown protocol "grpc"`)
+	require.Contains(t, err.Error(), "http", "the error must list what is available")
+}

--- a/pkg/serve/serve_test.go
+++ b/pkg/serve/serve_test.go
@@ -5,6 +5,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -181,4 +185,68 @@ func TestUnknownProtocolFails(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `unknown protocol "grpc"`)
 	require.Contains(t, err.Error(), "http", "the error must list what is available")
+}
+
+// TestExperimentalGate: server mode is opt-in. The gate reads the environment
+// the same way the account surface does, so operators learn one convention.
+func TestExperimentalGate(t *testing.T) {
+	for _, c := range []struct {
+		value string
+		want  bool
+	}{
+		{"", false}, {"0", false}, {"false", false}, {"no", false}, {"off", false},
+		{"OFF", false}, {" false ", false},
+		{"1", true}, {"true", true}, {"yes", true}, {"on", true}, {"anything", true},
+	} {
+		t.Setenv(ExperimentalEnvVar, c.value)
+		require.Equalf(t, c.want, Experimental(), "%s=%q", ExperimentalEnvVar, c.value)
+	}
+
+	// Unset is off — the released-build default.
+	t.Setenv(ExperimentalEnvVar, "")
+	require.NoError(t, os.Unsetenv(ExperimentalEnvVar))
+	require.False(t, Experimental())
+}
+
+// TestExperimentalGateHidesCommand builds the real binary and checks the gate
+// end to end: the wiring lives in main (both the dispatch and the registration),
+// which no unit test in this package can reach. Without the opt-in, `serve` must
+// be an ordinary unknown command — not hidden-but-runnable, and not advertised
+// in help or the command catalog.
+func TestExperimentalGateHidesCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds the dtctl binary; skipped in -short mode")
+	}
+	name := "dtctl"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	exe := filepath.Join(t.TempDir(), name)
+	build := exec.Command("go", "build", "-o", exe, ".")
+	build.Dir = filepath.Join("..", "..") // module root, where main lives
+	out, err := build.CombinedOutput()
+	require.NoError(t, err, "build failed: %s", out)
+
+	run := func(env []string, args ...string) (int, string) {
+		c := exec.Command(exe, args...)
+		c.Env = append(os.Environ(), env...)
+		combined, _ := c.CombinedOutput()
+		return c.ProcessState.ExitCode(), string(combined)
+	}
+
+	off := []string{ExperimentalEnvVar + "="}
+	code, output := run(off, "serve", "http", "--addr", "127.0.0.1:0")
+	require.NotZero(t, code, "serve must not run without the opt-in")
+	require.Contains(t, output, `unknown command "serve"`)
+
+	// Matched as a command entry ("  serve   Run dtctl as a server"), so the
+	// assertion does not trip over unrelated prose containing "server".
+	_, output = run(off, "--help")
+	require.NotRegexp(t, `(?m)^\s+serve\s`, output,
+		"an off-by-default surface must not be advertised in help")
+
+	// With the opt-in the command exists again; bare `serve` is discovery.
+	code, output = run([]string{ExperimentalEnvVar + "=1"}, "serve")
+	require.Zero(t, code, "bare serve prints help and exits 0: %s", output)
+	require.Contains(t, output, "http")
 }

--- a/pkg/vfs/mapfs.go
+++ b/pkg/vfs/mapfs.go
@@ -1,0 +1,63 @@
+package vfs
+
+import (
+	"io/fs"
+	"path"
+	"strings"
+	"sync"
+)
+
+// MapFS is an in-memory FS for embedded invocations: the request's virtual
+// files go in, and anything the invocation writes (writebacks, generated
+// files) can be read back out with Files. Safe for concurrent use.
+//
+// Paths are normalized with path.Clean and a stripped leading "/", so
+// "./x.yaml", "x.yaml" and "/x.yaml" address the same entry — a request's
+// virtual namespace has no meaningful root or working directory.
+type MapFS struct {
+	mu    sync.RWMutex
+	files map[string][]byte
+}
+
+// NewMapFS builds a MapFS from the given files (copied; the input map is not
+// retained). A nil map yields an empty filesystem.
+func NewMapFS(files map[string][]byte) *MapFS {
+	m := &MapFS{files: make(map[string][]byte, len(files))}
+	for name, data := range files {
+		m.files[normalizePath(name)] = append([]byte(nil), data...)
+	}
+	return m
+}
+
+func normalizePath(name string) string {
+	return strings.TrimPrefix(path.Clean("/"+name), "/")
+}
+
+func (m *MapFS) ReadFile(name string) ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	data, ok := m.files[normalizePath(name)]
+	if !ok {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	return append([]byte(nil), data...), nil
+}
+
+func (m *MapFS) WriteFile(name string, data []byte, _ fs.FileMode) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.files[normalizePath(name)] = append([]byte(nil), data...)
+	return nil
+}
+
+// Files returns a snapshot of the current contents, keyed by normalized
+// path. Embedders use it to hand written files back to the request's caller.
+func (m *MapFS) Files() map[string][]byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make(map[string][]byte, len(m.files))
+	for name, data := range m.files {
+		out[name] = append([]byte(nil), data...)
+	}
+	return out
+}

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -1,0 +1,74 @@
+// Package vfs is the file-access seam between dtctl commands and the
+// filesystem. CLI invocations read and write the host filesystem directly
+// (the default). Embedded invocations (the service engine, `dtctl serve`)
+// install a per-request FS — typically a MapFS built from the request's
+// virtual files — so `apply -f x.yaml` works against files that exist only
+// in the request, and writebacks (e.g. `apply --write-id`) land back in the
+// request instead of on the host (design work item E6).
+//
+// Only user-supplied paths go through this seam. Internal scratch files
+// (editor round-trip temp files, spill buffers, caches) deliberately stay on
+// the host filesystem: they are implementation detail, not request state.
+package vfs
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+)
+
+// FS is the minimal file-access contract dtctl commands need for
+// user-supplied paths: whole-file reads and whole-file writes.
+type FS interface {
+	ReadFile(name string) ([]byte, error)
+	WriteFile(name string, data []byte, perm fs.FileMode) error
+}
+
+// osFS is the host filesystem.
+type osFS struct{}
+
+func (osFS) ReadFile(name string) ([]byte, error) { return os.ReadFile(name) }
+func (osFS) WriteFile(name string, data []byte, perm fs.FileMode) error {
+	return os.WriteFile(name, data, perm)
+}
+
+// active is the installed implementation. Package-level (rather than
+// threaded through every call chain) because dtctl serializes invocations —
+// see cmd.Run — and the swap happens under that serialization.
+var active FS = osFS{}
+
+// SetActive installs f as the file-access implementation and returns the
+// previous one so callers can restore it. nil selects the host filesystem.
+// Callers own serialization: install/restore must not race with an executing
+// invocation.
+func SetActive(f FS) FS {
+	prev := active
+	if f == nil {
+		f = osFS{}
+	}
+	active = f
+	return prev
+}
+
+// ReadFile reads a user-supplied path through the active FS.
+func ReadFile(name string) ([]byte, error) { return active.ReadFile(name) }
+
+// WriteFile writes a user-supplied path through the active FS.
+func WriteFile(name string, data []byte, perm fs.FileMode) error {
+	return active.WriteFile(name, data, perm)
+}
+
+// ReadFileOrStdin reads name through the active FS, with "-" meaning the
+// process stdin. It is the shared implementation behind the CLI's
+// file-or-stdin flag convention.
+func ReadFileOrStdin(name string) ([]byte, error) {
+	if name == "-" {
+		content, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read from stdin: %w", err)
+		}
+		return content, nil
+	}
+	return ReadFile(name)
+}

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -4,7 +4,7 @@
 // install a per-request FS — typically a MapFS built from the request's
 // virtual files — so `apply -f x.yaml` works against files that exist only
 // in the request, and writebacks (e.g. `apply --write-id`) land back in the
-// request instead of on the host (design work item E6).
+// request instead of on the host (docs/dev/SERVICE_ENGINE_DESIGN.md).
 //
 // Only user-supplied paths go through this seam. Internal scratch files
 // (editor round-trip temp files, spill buffers, caches) deliberately stay on

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -1,0 +1,98 @@
+package vfs
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOSDefaultReadsHostFilesystem(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "x.txt")
+	require.NoError(t, os.WriteFile(path, []byte("host"), 0o600))
+
+	data, err := ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, []byte("host"), data)
+}
+
+func TestSetActiveInstallsAndRestores(t *testing.T) {
+	m := NewMapFS(map[string][]byte{"a.yaml": []byte("virtual")})
+
+	prev := SetActive(m)
+	t.Cleanup(func() { SetActive(prev) })
+
+	data, err := ReadFile("a.yaml")
+	require.NoError(t, err)
+	require.Equal(t, []byte("virtual"), data)
+
+	restored := SetActive(prev)
+	require.Equal(t, FS(m), restored, "SetActive must return what it replaced")
+
+	// Back on the host filesystem: the virtual file no longer resolves.
+	_, err = ReadFile("a.yaml")
+	require.Error(t, err)
+}
+
+func TestSetActiveNilSelectsHostFilesystem(t *testing.T) {
+	prev := SetActive(NewMapFS(nil))
+	SetActive(nil)
+	t.Cleanup(func() { SetActive(prev) })
+
+	path := filepath.Join(t.TempDir(), "y.txt")
+	require.NoError(t, os.WriteFile(path, []byte("host"), 0o600))
+	data, err := ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, []byte("host"), data)
+}
+
+func TestMapFSPathNormalization(t *testing.T) {
+	m := NewMapFS(map[string][]byte{"./dir/../x.yaml": []byte("v")})
+
+	for _, name := range []string{"x.yaml", "./x.yaml", "/x.yaml", "a/../x.yaml"} {
+		data, err := m.ReadFile(name)
+		require.NoError(t, err, "path form %q must resolve", name)
+		require.Equal(t, []byte("v"), data)
+	}
+}
+
+func TestMapFSNotExist(t *testing.T) {
+	m := NewMapFS(nil)
+	_, err := m.ReadFile("missing.yaml")
+	require.True(t, errors.Is(err, fs.ErrNotExist),
+		"missing entries must report fs.ErrNotExist, got %v", err)
+	require.Contains(t, err.Error(), "missing.yaml")
+}
+
+func TestMapFSWriteAndSnapshot(t *testing.T) {
+	m := NewMapFS(map[string][]byte{"in.yaml": []byte("original")})
+
+	require.NoError(t, m.WriteFile("./out.yaml", []byte("written"), 0o644))
+	require.NoError(t, m.WriteFile("in.yaml", []byte("updated"), 0o644))
+
+	files := m.Files()
+	require.Equal(t, []byte("written"), files["out.yaml"])
+	require.Equal(t, []byte("updated"), files["in.yaml"])
+
+	// Snapshot is a copy: mutating it must not affect the FS.
+	files["in.yaml"][0] = 'X'
+	data, err := m.ReadFile("in.yaml")
+	require.NoError(t, err)
+	require.Equal(t, []byte("updated"), data)
+}
+
+func TestMapFSDoesNotRetainInputMap(t *testing.T) {
+	src := map[string][]byte{"a": []byte("one")}
+	m := NewMapFS(src)
+	src["a"][0] = 'X'
+	src["b"] = []byte("late")
+
+	data, err := m.ReadFile("a")
+	require.NoError(t, err)
+	require.Equal(t, []byte("one"), data)
+	_, err = m.ReadFile("b")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Description

Makes dtctl embeddable as a library and adds `dtctl serve`, an **experimental** reference server on top of it. The guiding constraint throughout: **a request through the engine produces byte-identical stdout/stderr/exit code to the same command run on the CLI** — there is one execution path, not two.

`pkg/engine` is the part meant to be relied on. `dtctl serve` ships gated behind `DTCTL_EXPERIMENTAL_SERVE` — without the opt-in the command is not registered at all — because its concurrency model still has no per-request deadline and no admission control. See [Review response](#review-response).

Ten commits, each a self-contained step:

| Commit | What it does |
|---|---|
| `refactor(cmd): return exit codes instead of calling os.Exit` | The five semantic `os.Exit` sites in command bodies (diff, wait, verify query ×2, verify analyzer ×2) now return `*silentExitError`, which `execute()` already translates. An in-process caller must not die with the command. Guard test pins `os.Exit` in `cmd/` to `root.go`'s `Execute`. |
| `feat(cmd): gate subprocess spawns behind an explicit Capabilities set` | New `cmd.Capabilities` (PluginDispatch, ShellAliases, ApplyHooks, Editor, BrowserOpen) gates every path in `cmd/` that spawns or replaces the process. CLI grants all; embedders grant none, making those paths structurally unreachable. `CapabilityError` → `capability_disabled` in the agent envelope. Source-scan guard test confines `exec.Command`/`syscall.Exec` to five gateway files. |
| `feat(cmd): add embeddable Run entrypoint with per-invocation tree isolation` | `cmd.Run(argv, RunOptions)` — never terminates the process, never reads `os.Args`. A one-time snapshot of the as-registered command tree is restored per invocation (RunE/Run/Args/Hidden/DisableFlagParsing), all flags reset to declared defaults, cobra IO writers cleared, capabilities restored. Invocations serialize on a package mutex because the command tree *is* package state (277 commands wired by `init`); parallelism comes from more instances/processes. `Execute()` now routes through `Run`. |
| `feat(cmd): add per-invocation Session and Env seams` | `Session` pins an invocation to one environment URL + token + safety level via a synthetic in-memory single-context config behind `LoadConfig`, with the host's config file, contexts, keyring and credential env vars scrubbed. Host aliases never expand for session-backed runs. `Env` applies per-invocation env vars and restores prior values including unset-ness. |
| `feat: route user-supplied file paths through a pluggable vfs seam` | New `pkg/vfs`. 28 user-input read sites (`-f`, `--file`, `--data-file`, query files) go through `vfs.ReadFile`; default is the host FS, embedders install a per-request `vfs.MapFS`. The three duplicated `ReadFileOrStdin` implementations collapse into one. Editor temp files deliberately stay on the host. A source-scan guard test confines direct `os` file access in `cmd/` to an annotated allowlist. |
| `feat(cmd): redirect process stdio to per-invocation streams` | `RunOptions.Stdout/Stderr/Stdin`. Swapping the process streams (safe under the serialized model) is what makes *every* output path — `fmt.Print*`, `pkg/output`, cobra help, error envelopes — land in the caller's writers as the exact CLI byte stream. Pipes drained concurrently; cleanup blocks until the last byte lands; unread stdin can't wedge cleanup. |
| `feat: add embeddable service engine and dtctl serve reference server` | `pkg/engine.Execute(ctx, Request)` — one command line per request, multi-tenant session, virtual files in and out (including `apply --write-id` writebacks), optional stdin, per-request profile, zero capabilities. Service policy removes host-only commands (`config`, `ctx`, `auth`, `account`, `alias`, `edit`, `plugin`, `skills`, `doctor`, `completion`, `serve`) per invocation via `RunOptions.BlockedCommands`, guarded with the stable `unsupported_in_service` code. `dtctl serve http`: `POST /v1/execute`, `GET /healthz`, localhost by default, no own authn (documented), graceful shutdown. |
| `docs: document the service engine, dtctl serve, and the embedding invariants` | New `docs/dev/SERVICE_ENGINE_DESIGN.md`, the embedding invariants in `AGENTS.md`, a user-facing Server Mode page, and cross-references through the existing architecture/design docs. Detail below. |
| `fix: close host-filesystem escapes in the service engine` | Four host-filesystem escapes found in review, each reproduced through `dtctl serve http` before fixing: `diff -f a -f b` read both paths on the host disk from inside `pkg/diff`; `inspect <path>` did the same and printed the rows; result spilling wrote tenant data anywhere on the host and let one request read another tenant's spilled results; a request with no stdin inherited the host process's. `TestUserFilePathsGoThroughVFS` now scans `pkg/` too — the scoping that let all four stay green. Detail below. |
| `feat(serve): gate server mode behind DTCTL_EXPERIMENTAL_SERVE` | `dtctl serve` is registered only with the opt-in, following the `DTCTL_EXPERIMENTAL_ACCOUNT` convention: a released build answers `unknown command "serve"` and advertises nothing in help, any `dtctl commands` mode, or shell completion. `pkg/engine` stays importable. A new **Maturity** section in the design doc records what must be true before the gate comes off. |

### `dtctl serve` is a protocol parent, not a server

`serve` has one subcommand per protocol — `dtctl serve http` today — so a future `dtctl serve mcp` lands beside it instead of competing with an incumbent default. Bare `dtctl serve` prints help and exits 0 (discovery, not misuse). An unrecognized protocol is an **error with a non-zero exit**: cobra's default for a parent with no `Run` is a help dump and exit 0, which a supervisor would read as a started server, so `serve` validates the protocol name itself.

Adding a protocol is a new file in `pkg/serve/`, a constructor registered in `NewCommand()`, and the same `cmd.RunActive()` deadlock guard in its `RunE`. Protocol servers hold no dtctl logic of their own — they call `engine.Execute` and translate the result.

All of this is behind the experimental gate: with `DTCTL_EXPERIMENTAL_SERVE` unset, none of these commands are registered.

### Four bugs found and fixed along the way

Three of these are pre-existing and affect the CLI today:

- **`apply --write-id` never stamped the id back into the source file** unless apply hooks happened to be configured — `WithSourceFile` was only called inside the hook branches. Caught by the engine's writeback round-trip test.
- **`verify openpipeline-matcher -f` and `verify openpipeline dql-processor -f`** shared a helper that read the user's path with `os.Open`, bypassing the vfs seam entirely — under an embedded invocation both flags read the *server's* disk.
- **`find intents --data-file -` and `open intent --data-file -`** read `"/dev/stdin"` as a *path*. That reaches the process's real fd 0, past the stream seam's `os.Stdin` swap — and doesn't exist on Windows at all.
- **`--agent`/`--plain` on masked commands** rendered a plain error rather than the structured envelope, because masking disables flag parsing. Fixed with a raw-argv fallback in `executeArgs`.

The last three were found by *writing the guard tests*, not by review — which is the main argument for having them.

### Guidelines and enforcement

The seams only hold if future changes don't quietly go around them, so the rules are written down in three places and enforced in one:

- **`docs/dev/SERVICE_ENGINE_DESIGN.md`** (new) — goals/non-goals, the five per-invocation seams, why invocations serialize and what that rules out, the four independent restriction axes (safety / profile / environment / capability), deliberate divergences from the local CLI, and open questions. Its core is *Rules for contributors*: seven invariants, each naming the guard test that enforces it. Seven source comments previously referenced a design document that did not exist in this repository; they now point here.
- **`AGENTS.md`** — the same rules as a CRITICAL section beside the safety checks, because that is the file an agent reads before touching `cmd/`. The sharp edge is rule 1: *whose file is it?* A path the **user** named is request state and goes through `pkg/vfs`; a path **dtctl** chose (editor temp file, config file, spill buffer) is host state and stays on `os`.
- **Guard tests** — `TestUserFilePathsGoThroughVFS` (new) confines direct `os` file access in `cmd/` **and** `pkg/` to an annotated allowlist, each entry naming what keeps that path unreachable from a service request (a blocked command, an ungranted capability), joining the existing `TestSubprocessSpawnsConfinedToGateways`, `TestNoOsExitOutsideExecute`, and `TestEngineOutputEqualsCLI`. Each allowlist entry states why that path is host state rather than request state, so adding one is a deliberate act.

### Docs updated

Determined by auditing every doc that enumerates commands, packages, or error codes:

- **Dev docs**: `SERVICE_ENGINE_DESIGN.md` (new), `ARCHITECTURE.md` (packages, new `cmd/` files, a new "Invocation Model Pattern"), `API_DESIGN.md` ("Embeddable by Construction" as design principle 10, `serve` in the verb list), `IMPLEMENTATION_STATUS.md`, `docs/dev/README.md`, plus cross-references in `PLUGIN_CONVENTIONS`, `ALIAS_DESIGN`, `PRE_APPLY_HOOK_DESIGN`, `COMMAND_PROFILES_DESIGN`, `CONFIG_CONTRACT`, `context-safety-levels`, `agent-schema-command` — each of which described a world without these seams.
- **User docs**: new `docs/site/_docs/serve.md` (Server Mode) covering the request/response contract, the failed-command-is-still-HTTP-200 rule, what is unavailable and why, the concurrency model, and a plainly stated threat model; registered in the hand-maintained nav. `command-reference.md` gains a `serve` row and section. `command-profiles.md` gains the two new restriction axes so all four are documented together.
- **`ai-agent-mode.md`**: the error-code list was four codes in a parenthetical; it is now a full table of every code `errorToDetail` can emit with what an agent should do about each. Verified against source — all 23 codes exist.
- **`README.md`**: an embeddability bullet, a short "Running as a Service" section, and a docs link.

### Compatibility

The CLI keeps its execution path: it grants all capabilities, uses the host filesystem and real process stdio, and `Execute()` keeps its signature — it just delegates to `Run`.

Two **CLI-visible behavior changes** ride along, both consequences of the `apply --write-id` fix, and both intended — worth a release note:

- **`apply --write-id` now actually rewrites the source file.** It was a silent no-op unless apply hooks happened to be configured. Files applied with `--write-id` are now modified in place, which is what the flag always documented.
- **`apply` prints a new hint on stderr.** With the source file now always known, the existing "to update this resource in future runs..." hint fires on every create-via-apply *without* `--write-id`, where it previously stayed silent.

New public surface: `cmd.Run`/`RunOptions`/`Capabilities`/`Session`, `pkg/vfs`, `pkg/engine`, `pkg/serve`, and the `dtctl serve http` command — the last gated experimental, see below.

## Review response

A review of the branch found four host-filesystem escapes reachable through `dtctl serve http`, all of them past a guard test that only scanned `cmd/`. Fixed in `fix: close host-filesystem escapes in the service engine`, each reproduced over HTTP first and pinned by a test:

| Escape | Was | Now |
|---|---|---|
| `diff -f a -f b` | `pkg/diff` read both paths with `os.ReadFile`, printing the **server's** file contents in the patch | reads through `vfs` |
| `inspect <path>` | opened its path argument on the host disk and printed the rows | blocked in the service (`unsupported_in_service`) |
| `--spill-to <path>` / auto-spill in agent mode | wrote tenant data anywhere on the host, created directories, returned a host path the caller cannot read — and since every session shares the `session` partition, one request could enumerate and read another tenant's spilled results | needs the new `HostDiskSpill` capability: automatic spills return rows inline, explicit ones fail with `capability_disabled` |
| a request with no `stdin` | inherited the **host process's** stdin (documented as "nil is EOF") — a `query` with no argument read the operator's terminal, and an open pipe would block forever holding the invocation lock | always an empty reader |

`TestUserFilePathsGoThroughVFS` now scans `cmd/` **and** `pkg/` — the scoping that let all of the above stay green — with each allowlist entry naming what keeps that path unreachable from a service request. `FORCE_COLOR`/`NO_COLOR`/`DTCTL_SPILL`/`DTCTL_SPILL_DIR` join the session scrub list so host settings cannot shape a tenant's output bytes.

### `dtctl serve` is now experimental and off by default

`feat(serve): gate server mode behind DTCTL_EXPERIMENTAL_SERVE` follows the `DTCTL_EXPERIMENTAL_ACCOUNT` convention: the command is not registered unless the operator opts in, so a released build answers `unknown command "serve"` and advertises nothing in `--help` or the `dtctl commands` catalog. `pkg/engine` stays importable — embedding it is a compile-time choice by a Go caller.

The gate buys room for three unsettled operational properties, now written down in a **Maturity** section of the design doc as the conditions for removing it: a started execution cannot be interrupted and holds the single invocation slot; requests queue on that slot with no bound and no way to shed load; and unbounded commands (`query --live`) are still reachable through the service surface.

## Related Issues

n/a

## Testing

- [x] Tests pass (`go test ./...` green in both modules; the isolation, session, stdio and vfs suites run under `-race`)
- [x] Linting passes (`golangci-lint run` — 0 issues in the touched packages; the 21 pre-existing `govet` findings on untouched files are unchanged). `markdownlint` and the docs template check pass on every changed doc.
- [x] Manual end-to-end smoke test of `dtctl serve http`: `/healthz`, a blocked host command returning `unsupported_in_service`, and `apply -f` resolving a file that exists only in the request.
- [x] Each of the four escapes in [Review response](#review-response) reproduced through a running `dtctl serve http` **before** the fix and re-checked after: host paths no longer resolve, `inspect` returns `unsupported_in_service`, `--spill-to` returns `capability_disabled` and writes no file, and virtual-file `diff` still works.
- [x] Gate verified on the built binary: with `DTCTL_EXPERIMENTAL_SERVE` unset, `serve` appears 0 times in `--help` (65 lines), `commands` (180), `commands --brief` (652), `commands --full` (1105), `commands -o json` (450), and `completion bash` (426); with it set, `commands --full` grows to 1110 lines with `serve:` present.

Notable coverage added:

- `TestEngineOutputEqualsCLI` builds the real binary and asserts byte-identical stdout/stderr/exit code between CLI and engine across table, JSON, envelope, error-envelope and unknown-command cases — this is the contract, enforced.
- Race-detector tests for flag-state isolation, profile-mask restore, serialized concurrency, argv pinning, capability restore.
- Session tests against a mock environment: injected token reaches the wire and host secrets never do, readonly sessions block mutations before any request, per-request profiles mask the surface, host aliases stay inert.
- vfs: end-to-end `create bucket -f bucket.yaml` succeeds with the file existing only in the request's MapFS, fails without it.
- `serve`: bare `serve` prints help and exits 0, unknown protocol errors and lists what is available, `http` carries its flags.
- Host isolation (new, `pkg/engine/host_isolation_test.go`): `diff` resolves request files and cannot reach a host path, an explicit spill is refused and creates neither file nor directory on the host, and a request with no stdin reads EOF while the host's stdin stays unconsumed.
- Spill capability (new, `cmd/spill_test.go`): without `HostDiskSpill` an automatic spill degrades quietly to inline rows while an explicit `--spill-to`/`--spill=always` is a `CapabilityError`; the CLI, which grants it, keeps spilling.
- Experimental gate (new, `pkg/serve/serve_test.go`): builds the real binary and asserts both states, since the wiring lives in `main`.

## Notes for reviewers

- The serialized-invocation mutex is the central design decision — worth a look. It is what makes process-stream redirection and env mutation safe, and it caps a single instance to one concurrent command.
- `pkg/serve` is explicitly a *reference* wrapper: localhost-bound, no authentication of its own, and now off by default. Anyone exposing it beyond localhost has to put authn in front.
- The review that produced commits 9–10 is worth reading alongside them: three of the four escapes were **pre-existing** command behaviour that only became reachable once a request could name a path, which is the argument for the guard test covering `pkg/` rather than `cmd/` alone.
- Deliberately **not** fixed, and recorded in the design doc's Maturity section instead: per-request deadlines, admission control, unbounded commands (`query --live`) in the service surface, and per-invocation OTel init. These are what the experimental gate is buying time for.
- Known pre-existing staleness I did **not** fix, to keep the diff scoped: the `## Project Structure` tree in `ARCHITECTURE.md` lists packages and files that no longer exist (`pkg/api/`, `pkg/manifest/`, `cmd/patch.go`, `cmd/label.go`, `cmd/explain.go`) — `AGENTS.md` now carries the accurate tree, so that section is arguably better replaced than patched. Several site pages also use bare relative links (`](serve)`) that resolve incorrectly under `permalink: /docs/:title/`; new links use the `relative_url` form.


