### PR TITLE
fix(query): stop silently losing DQL quotes on Windows PowerShell

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/signal"
 	"strings"
@@ -83,10 +82,11 @@ Examples:
   metrics | filter startsWith(metric.key, "dt") | limit 10
   EOF
 
-  # PowerShell: Use here-strings to avoid quote issues
-  dtctl query -f - -o json @'
+  # PowerShell: pipe a here-string in -- as an argument, Windows PowerShell 5.1
+  # strips the inner double quotes DQL needs (see docs/WINDOWS.md#quoting)
+  @'
   fetch logs, bucket:{"custom-logs"} | filter contains(host.name, "api")
-  '@
+  '@ | dtctl query -o json
 
   # Pipe query from file
   cat query.dql | dtctl query -o json
@@ -200,35 +200,9 @@ Examples:
 			args = []string{strings.Join(args, " ")}
 		}
 
-		var query string
-
-		if queryFile != "" {
-			// Read query from file (use "-" for stdin)
-			if queryFile == "-" {
-				content, err := io.ReadAll(os.Stdin)
-				if err != nil {
-					return fmt.Errorf("failed to read query from stdin: %w", err)
-				}
-				query = string(content)
-			} else {
-				content, err := vfs.ReadFile(queryFile)
-				if err != nil {
-					return fmt.Errorf("failed to read query file: %w", err)
-				}
-				query = string(content)
-			}
-		} else if len(args) > 0 {
-			// Use inline query
-			query = args[0]
-		} else if !isTerminal(os.Stdin) {
-			// Read from piped stdin
-			content, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				return fmt.Errorf("failed to read query from stdin: %w", err)
-			}
-			query = string(content)
-		} else {
-			return fmt.Errorf("query string or --file is required")
+		query, err := resolveQueryInput(queryFile, args, osStdin())
+		if err != nil {
+			return err
 		}
 
 		// Apply template rendering if --set flags are provided

--- a/cmd/query_input.go
+++ b/cmd/query_input.go
@@ -19,6 +19,10 @@ type queryStdin struct {
 	isTerminal bool
 }
 
+// queryWarnOut receives query-input warnings. It is a variable so tests can
+// capture them.
+var queryWarnOut io.Writer = os.Stderr
+
 // osStdin wraps the process's real stdin.
 func osStdin() queryStdin {
 	return queryStdin{r: os.Stdin, isTerminal: isTerminal(os.Stdin)}
@@ -58,6 +62,11 @@ func resolveQueryInput(queryFile string, args []string, stdin queryStdin) (strin
 		}
 		return string(content), nil
 	case len(args) > 0:
+		// Only an argv-sourced query can have been mangled in transit; a file or
+		// a pipe delivers bytes untouched.
+		if looksQuoteMangled(rawCommandLine(), args[0]) {
+			fmt.Fprintln(queryWarnOut, quoteMangleWarning(args[0]))
+		}
 		return args[0], nil
 	case !stdin.isTerminal:
 		// Piped stdin without --file, e.g. `cat query.dql | dtctl query`.

--- a/cmd/query_input.go
+++ b/cmd/query_input.go
@@ -19,9 +19,12 @@ type queryStdin struct {
 	isTerminal bool
 }
 
-// queryWarnOut receives query-input warnings. It is a variable so tests can
-// capture them.
-var queryWarnOut io.Writer = os.Stderr
+// queryWarnOut resolves the stream query-input warnings go to. It must resolve
+// os.Stderr at call time, not capture it: the stdio seam swaps that variable
+// per invocation (see stdio.go), so a cached writer would send an embedded
+// invocation's warning to the host's stderr instead of the request's. It is a
+// function variable so tests can capture the output.
+var queryWarnOut = func() io.Writer { return os.Stderr }
 
 // osStdin wraps the process's real stdin.
 func osStdin() queryStdin {
@@ -65,7 +68,7 @@ func resolveQueryInput(queryFile string, args []string, stdin queryStdin) (strin
 		// Only an argv-sourced query can have been mangled in transit; a file or
 		// a pipe delivers bytes untouched.
 		if looksQuoteMangled(rawCommandLine(), args[0]) {
-			fmt.Fprintln(queryWarnOut, quoteMangleWarning(args[0]))
+			fmt.Fprintln(queryWarnOut(), quoteMangleWarning(args[0]))
 		}
 		return args[0], nil
 	case !stdin.isTerminal:

--- a/cmd/query_input.go
+++ b/cmd/query_input.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
+)
+
+// queryStdin is the standard input the query-accepting commands read from. The
+// terminal flag is carried alongside the reader so the "nothing to read" case is
+// testable without a pty.
+type queryStdin struct {
+	r          io.Reader
+	isTerminal bool
+}
+
+// osStdin wraps the process's real stdin.
+func osStdin() queryStdin {
+	return queryStdin{r: os.Stdin, isTerminal: isTerminal(os.Stdin)}
+}
+
+// resolveQueryInput returns the DQL query text for the commands that accept one
+// (`query`, `verify query`, `wait`): from --file, from stdin, or from the inline
+// positional argument.
+//
+// It also rejects two combinations that used to fail quietly:
+//
+//   - --file together with an inline query: the inline query was silently
+//     dropped and the file won.
+//   - `--file -` while stdin is a terminal: io.ReadAll blocked until the user
+//     pressed Ctrl+D and then sent an empty query, which reads as a hung CLI.
+//     PowerShell users hit this by transliterating the bash heredoc
+//     (`dtctl query -f - <<'EOF'`) into a here-string (`dtctl query -f - @'...'@`).
+//     A here-string is a plain string *value*, not a redirection, so nothing
+//     ever arrives on stdin.
+func resolveQueryInput(queryFile string, args []string, stdin queryStdin) (string, error) {
+	if queryFile != "" && len(args) > 0 {
+		return "", fmt.Errorf("both --file and an inline query were given -- use one or the other\n\n%s", queryInputHelp())
+	}
+
+	switch {
+	case queryFile == "-":
+		if stdin.isTerminal {
+			return "", fmt.Errorf("--file - reads the query from stdin, but stdin is a terminal -- nothing to read\n\n%s", queryInputHelp())
+		}
+		return readAllQuery(stdin.r)
+	case queryFile != "":
+		// A user-named path goes through the vfs seam: under an embedded
+		// invocation the file exists only in the request (see pkg/vfs).
+		content, err := vfs.ReadFile(queryFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to read query file: %w", err)
+		}
+		return string(content), nil
+	case len(args) > 0:
+		return args[0], nil
+	case !stdin.isTerminal:
+		// Piped stdin without --file, e.g. `cat query.dql | dtctl query`.
+		return readAllQuery(stdin.r)
+	default:
+		return "", errors.New("query string or --file is required")
+	}
+}
+
+func readAllQuery(r io.Reader) (string, error) {
+	content, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("failed to read query from stdin: %w", err)
+	}
+	return string(content), nil
+}
+
+// queryInputHelp lists the working ways to hand a query to dtctl. On Windows it
+// leads with the PowerShell pipe form: passing a query as an argument is where
+// Windows PowerShell 5.1 silently strips the double quotes DQL needs for string
+// literals, so the pipe is the form that always survives.
+func queryInputHelp() string {
+	var b strings.Builder
+	b.WriteString("Pass the query in one of these ways:\n\n")
+	if runtime.GOOS == "windows" {
+		b.WriteString("  # PowerShell here-string piped in (quotes always survive)\n")
+		b.WriteString("  @'\n")
+		b.WriteString("  fetch logs\n")
+		b.WriteString("  | filter loglevel == \"INFO\"\n")
+		b.WriteString("  '@ | dtctl query\n\n")
+		b.WriteString("  # from a file\n")
+		b.WriteString("  dtctl query -f query.dql\n\n")
+		b.WriteString("  # inline -- but see docs/WINDOWS.md#quoting first:\n")
+		b.WriteString("  # Windows PowerShell 5.1 strips the inner double quotes\n")
+		b.WriteString("  dtctl query 'fetch logs | limit 10'\n")
+		return b.String()
+	}
+	b.WriteString("  dtctl query 'fetch logs | filter loglevel == \"INFO\"'\n")
+	b.WriteString("  dtctl query -f query.dql\n")
+	b.WriteString("  cat query.dql | dtctl query\n")
+	b.WriteString("  dtctl query -f - <<'EOF'\n  fetch logs\n  EOF\n")
+	return b.String()
+}

--- a/cmd/query_input_test.go
+++ b/cmd/query_input_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pipedStdin stands in for `... | dtctl query`: a reader that is not a terminal.
+func pipedStdin(content string) queryStdin {
+	return queryStdin{r: strings.NewReader(content), isTerminal: false}
+}
+
+// terminalStdin stands in for an interactive shell. Reading from it must never
+// happen -- that is the hang this package guards against -- so the reader fails
+// the test if it is touched.
+func terminalStdin(t *testing.T) queryStdin {
+	t.Helper()
+	return queryStdin{r: failingReader{t: t}, isTerminal: true}
+}
+
+type failingReader struct{ t *testing.T }
+
+func (f failingReader) Read([]byte) (int, error) {
+	f.t.Error("stdin was read while it is a terminal -- this is the hang")
+	return 0, os.ErrClosed
+}
+
+func TestResolveQueryInput_InlineArgument(t *testing.T) {
+	const want = `fetch logs | filter status == "ERROR"`
+	got, err := resolveQueryInput("", []string{want}, terminalStdin(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveQueryInput_File(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "query.dql")
+	if err := os.WriteFile(path, []byte("fetch logs | limit 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveQueryInput(path, nil, terminalStdin(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "fetch logs | limit 1\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveQueryInput_FileMissing(t *testing.T) {
+	_, err := resolveQueryInput(filepath.Join(t.TempDir(), "nope.dql"), nil, terminalStdin(t))
+	if err == nil {
+		t.Fatal("expected an error for a missing file")
+	}
+	if !strings.Contains(err.Error(), "failed to read query file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveQueryInput_ExplicitStdin(t *testing.T) {
+	got, err := resolveQueryInput("-", nil, pipedStdin("fetch logs | limit 2"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "fetch logs | limit 2" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveQueryInput_PipedStdinWithoutFileFlag(t *testing.T) {
+	// `cat query.dql | dtctl query` -- no --file, no argument.
+	got, err := resolveQueryInput("", nil, pipedStdin("fetch logs | limit 3"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "fetch logs | limit 3" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// `dtctl query -f -` in an interactive shell has nothing to read: io.ReadAll used
+// to block until Ctrl+D and then submit an empty query, which looks like a hung
+// CLI. It must fail fast with guidance instead.
+func TestResolveQueryInput_StdinIsTerminal(t *testing.T) {
+	_, err := resolveQueryInput("-", nil, terminalStdin(t))
+	if err == nil {
+		t.Fatal("expected an error when --file - is used on a terminal")
+	}
+	if !strings.Contains(err.Error(), "stdin is a terminal") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "dtctl query -f query.dql") {
+		t.Fatalf("error is missing actionable guidance: %v", err)
+	}
+}
+
+// A PowerShell here-string is a value, not a redirection, so
+// `dtctl query -f - @'...'@` puts the query in argv while --file - points at an
+// idle terminal. Reporting the conflict beats silently dropping the query.
+func TestResolveQueryInput_FileAndInlineQueryConflict(t *testing.T) {
+	for _, file := range []string{"-", "query.dql"} {
+		t.Run(file, func(t *testing.T) {
+			_, err := resolveQueryInput(file, []string{"fetch logs | limit 1"}, terminalStdin(t))
+			if err == nil {
+				t.Fatal("expected an error when --file and an inline query are combined")
+			}
+			if !strings.Contains(err.Error(), "both --file and an inline query") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(err.Error(), "dtctl query -f query.dql") {
+				t.Fatalf("error is missing actionable guidance: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveQueryInput_NothingProvided(t *testing.T) {
+	_, err := resolveQueryInput("", nil, terminalStdin(t))
+	if err == nil {
+		t.Fatal("expected an error when no query source is given")
+	}
+	if !strings.Contains(err.Error(), "query string or --file is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestQueryInputHelp_ShowsOnlyWorkingForms(t *testing.T) {
+	help := queryInputHelp()
+	if !strings.Contains(help, "dtctl query -f query.dql") {
+		t.Errorf("help should mention the file form:\n%s", help)
+	}
+	// Whatever the platform, the help must never suggest combining `-f -` with
+	// an argument -- that is the form that hangs.
+	if strings.Contains(help, "-f - @'") {
+		t.Errorf("help suggests the hanging form:\n%s", help)
+	}
+}

--- a/cmd/query_mangle.go
+++ b/cmd/query_mangle.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Windows PowerShell 5.1 hands arguments to a native .exe without escaping the
+// double quotes inside them. The Windows command-line parser then reads those
+// quotes as quoting delimiters and drops them, so
+//
+//	dtctl query 'fetch logs | filter loglevel == "INFO"'
+//
+// arrives as `fetch logs | filter loglevel == INFO`. That is *valid* DQL -- a
+// comparison between the fields `loglevel` and `INFO` -- so Grail answers with
+// zero records and no error, after scanning the whole timeframe. Nothing in the
+// response says anything is wrong, which makes it the worst kind of failure to
+// debug.
+//
+// The mangling is detectable, though: it leaves a fingerprint on the raw command
+// line that correctly quoted arguments never have. A well-formed argument
+// carries delimiter quotes only around its outer edges (anything inside is
+// escaped as \"), while a mangled one has bare delimiter quotes in its interior:
+//
+//	mangled:   "fetch logs | filter loglevel == "INFO" | limit 10"
+//	well-formed: "fetch logs | filter loglevel == \"INFO\" | limit 10"
+//
+// rawCommandLine returns the process's unparsed command line, or "" on platforms
+// where the concept does not apply (everything except Windows). It is a variable
+// so tests can supply a command line directly.
+var rawCommandLine = platformRawCommandLine
+
+// rawToken is one argument of the raw command line, both decoded and described.
+type rawToken struct {
+	// decoded is the value the argument parser produces, i.e. what shows up in
+	// os.Args.
+	decoded string
+	// interiorQuote records a delimiter quote somewhere other than the token's
+	// outer edges -- the fingerprint of quote mangling.
+	interiorQuote bool
+}
+
+// looksQuoteMangled reports whether arg appears on rawCmdLine as a token whose
+// double quotes were consumed by the argument parser. arg is the already-parsed
+// value (what dtctl is about to send to Grail).
+func looksQuoteMangled(rawCmdLine, arg string) bool {
+	if arg == "" || !strings.Contains(rawCmdLine, `"`) {
+		return false
+	}
+	for _, tok := range parseRawCommandLine(rawCmdLine) {
+		if tok.decoded == arg && tok.interiorQuote {
+			return true
+		}
+	}
+	return false
+}
+
+// parseRawCommandLine splits a Windows command line into tokens following the
+// Microsoft C runtime rules that Go's own argv parsing implements: whitespace
+// separates tokens outside quotes, a run of 2n backslashes before a quote is n
+// backslashes plus a delimiter quote, and 2n+1 backslashes before a quote is n
+// backslashes plus a literal quote.
+func parseRawCommandLine(cmdline string) []rawToken {
+	var tokens []rawToken
+
+	for i, n := 0, len(cmdline); i < n; {
+		for i < n && (cmdline[i] == ' ' || cmdline[i] == '\t') {
+			i++
+		}
+		if i >= n {
+			break
+		}
+
+		var (
+			decoded    strings.Builder
+			quoteAt    []int
+			inQuotes   bool
+			tokenStart = i
+		)
+
+		for i < n {
+			c := cmdline[i]
+			if !inQuotes && (c == ' ' || c == '\t') {
+				break
+			}
+
+			switch c {
+			case '\\':
+				slashes := 0
+				for i < n && cmdline[i] == '\\' {
+					slashes++
+					i++
+				}
+				if i < n && cmdline[i] == '"' {
+					decoded.WriteString(strings.Repeat(`\`, slashes/2))
+					if slashes%2 == 1 {
+						// Escaped: a literal quote, not a delimiter.
+						decoded.WriteByte('"')
+					} else {
+						quoteAt = append(quoteAt, i)
+						inQuotes = !inQuotes
+					}
+					i++
+				} else {
+					decoded.WriteString(strings.Repeat(`\`, slashes))
+				}
+			case '"':
+				quoteAt = append(quoteAt, i)
+				inQuotes = !inQuotes
+				i++
+			default:
+				decoded.WriteByte(c)
+				i++
+			}
+		}
+
+		tokenEnd := i // exclusive
+		interior := false
+		for _, q := range quoteAt {
+			if q != tokenStart && q != tokenEnd-1 {
+				interior = true
+				break
+			}
+		}
+
+		tokens = append(tokens, rawToken{decoded: decoded.String(), interiorQuote: interior})
+	}
+
+	return tokens
+}
+
+// quoteMangleWarning explains what the shell did to the query and how to avoid
+// it. It names the query dtctl actually received, because that is the piece a
+// user cannot otherwise see without --verbose.
+func quoteMangleWarning(query string) string {
+	var b strings.Builder
+	b.WriteString("Warning: your shell stripped the double quotes from this query.\n")
+	fmt.Fprintf(&b, "dtctl received: %s\n", strings.TrimSpace(oneLine(query)))
+	b.WriteString("\nDQL string literals need double quotes. Without them this is still valid DQL\n")
+	b.WriteString("-- a comparison between two fields -- so it returns no rows instead of an error.\n")
+	b.WriteString("\nWindows PowerShell 5.1 does not preserve double quotes in arguments to native\n")
+	b.WriteString("programs. Pipe the query in instead, which never goes through argument parsing:\n\n")
+	b.WriteString("  @'\n")
+	b.WriteString("  fetch logs\n")
+	b.WriteString("  | filter loglevel == \"INFO\"\n")
+	b.WriteString("  '@ | dtctl query\n\n")
+	b.WriteString("Or read it from a file: dtctl query -f query.dql\n")
+	b.WriteString("Details: https://github.com/dynatrace-oss/dtctl/blob/main/docs/WINDOWS.md#quoting\n")
+	return b.String()
+}
+
+// oneLine collapses a multi-line query so the warning stays compact.
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/cmd/query_mangle.go
+++ b/cmd/query_mangle.go
@@ -28,6 +28,12 @@ import (
 // rawCommandLine returns the process's unparsed command line, or "" on platforms
 // where the concept does not apply (everything except Windows). It is a variable
 // so tests can supply a command line directly.
+//
+// This is host-process state, so it is meaningless for an embedded invocation:
+// under `dtctl serve http` on Windows it is the *server's* command line, not the
+// request's. Harmless in practice -- the request's query would have to appear on
+// it verbatim as a token carrying interior quotes -- but it is why the detector
+// only ever warns and never changes the query.
 var rawCommandLine = platformRawCommandLine
 
 // rawToken is one argument of the raw command line, both decoded and described.
@@ -56,10 +62,19 @@ func looksQuoteMangled(rawCmdLine, arg string) bool {
 }
 
 // parseRawCommandLine splits a Windows command line into tokens following the
-// Microsoft C runtime rules that Go's own argv parsing implements: whitespace
-// separates tokens outside quotes, a run of 2n backslashes before a quote is n
-// backslashes plus a delimiter quote, and 2n+1 backslashes before a quote is n
-// backslashes plus a literal quote.
+// Microsoft C runtime rules: whitespace separates tokens outside quotes, a run
+// of 2n backslashes before a quote is n backslashes plus a delimiter quote, and
+// 2n+1 backslashes before a quote is n backslashes plus a literal quote.
+//
+// It deliberately omits one rule Go's own argv parsing implements (the "prior to
+// 2008" doubled-quote rule, where "" inside a quoted run yields a literal quote:
+// see readNextArg in $GOROOT/src/os/exec_windows.go, which is what builds
+// os.Args on Windows). A command line using that form therefore decodes
+// differently here than it does in os.Args, so the token never matches arg and
+// looksQuoteMangled stays silent. That is the safe direction -- doubled quotes
+// are a well-formed way to pass a quote through cmd.exe and deserve no warning
+// anyway -- and it keeps this splitter simple. Do not rely on the decoded value
+// for anything but the equality check against an already-parsed argument.
 func parseRawCommandLine(cmdline string) []rawToken {
 	var tokens []rawToken
 

--- a/cmd/query_mangle_test.go
+++ b/cmd/query_mangle_test.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLooksQuoteMangled(t *testing.T) {
+	tests := []struct {
+		name string
+		// raw is the command line as Windows hands it to the process.
+		raw string
+		// arg is the already-parsed query, i.e. what lands in os.Args.
+		arg  string
+		want bool
+	}{
+		{
+			// Windows PowerShell 5.1 wraps the argument but leaves the inner
+			// quotes bare, so the parser eats them.
+			name: "powershell 5.1 legacy passing",
+			raw:  `dtctl query "fetch logs | filter loglevel == "INFO" | limit 10"`,
+			arg:  `fetch logs | filter loglevel == INFO | limit 10`,
+			want: true,
+		},
+		{
+			// PowerShell 7.3+ (Standard/Windows mode) escapes correctly.
+			name: "powershell 7.3 standard passing",
+			raw:  `dtctl query "fetch logs | filter loglevel == \"INFO\" | limit 10"`,
+			arg:  `fetch logs | filter loglevel == "INFO" | limit 10`,
+			want: false,
+		},
+		{
+			name: "cmd.exe with escaped quotes",
+			raw:  `dtctl query "fetch logs | filter status == \"ERROR\""`,
+			arg:  `fetch logs | filter status == "ERROR"`,
+			want: false,
+		},
+		{
+			name: "quoted query with no string literals",
+			raw:  `dtctl query "fetch logs | limit 10"`,
+			arg:  `fetch logs | limit 10`,
+			want: false,
+		},
+		{
+			name: "unquoted single-word argument",
+			raw:  `dtctl version`,
+			arg:  `version`,
+			want: false,
+		},
+		{
+			// No spaces, so PowerShell does not wrap it -- the quotes are still
+			// consumed, and they sit in the token's interior.
+			name: "mangled argument without spaces",
+			raw:  `dtctl query loglevel=="INFO"`,
+			arg:  `loglevel==INFO`,
+			want: true,
+		},
+		{
+			name: "mangled bucket parameter",
+			raw:  `dtctl query "fetch logs, bucket:{"custom-logs"} | limit 10"`,
+			arg:  `fetch logs, bucket:{custom-logs} | limit 10`,
+			want: true,
+		},
+		{
+			// Other quoted flags must not implicate the query argument.
+			name: "quoted flag values are not the query",
+			raw:  `dtctl query "fetch logs | limit 10" -S "my-segment?host=HOST-001"`,
+			arg:  `fetch logs | limit 10`,
+			want: false,
+		},
+		{
+			name: "no query on the command line at all",
+			raw:  `dtctl query -f query.dql`,
+			arg:  "fetch logs | limit 10",
+			want: false,
+		},
+		{
+			name: "empty query",
+			raw:  `dtctl query ""`,
+			arg:  "",
+			want: false,
+		},
+		{
+			// POSIX: rawCommandLine() is empty, so detection must stay silent.
+			name: "no raw command line available",
+			raw:  "",
+			arg:  `fetch logs | filter loglevel == INFO`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := looksQuoteMangled(tt.raw, tt.arg); got != tt.want {
+				t.Errorf("looksQuoteMangled(%q, %q) = %v, want %v", tt.raw, tt.arg, got, tt.want)
+			}
+		})
+	}
+}
+
+// The decoded tokens must match what the argument parser would produce,
+// otherwise the lookup by query text never finds the right token.
+func TestParseRawCommandLine_Decoding(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want []string
+	}{
+		{`dtctl query "fetch logs | limit 10"`, []string{"dtctl", "query", "fetch logs | limit 10"}},
+		{`dtctl  query   fetch`, []string{"dtctl", "query", "fetch"}},
+		{`dtctl query "a \"b\" c"`, []string{"dtctl", "query", `a "b" c`}},
+		{`dtctl query "a "b" c"`, []string{"dtctl", "query", `a b c`}},
+		{`dtctl -f C:\path\to\query.dql`, []string{"dtctl", "-f", `C:\path\to\query.dql`}},
+		{`dtctl "C:\dir with space\"" x`, []string{"dtctl", `C:\dir with space"`, "x"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			tokens := parseRawCommandLine(tt.raw)
+			got := make([]string, 0, len(tokens))
+			for _, tok := range tokens {
+				got = append(got, tok.decoded)
+			}
+			if strings.Join(got, "\x00") != strings.Join(tt.want, "\x00") {
+				t.Errorf("parseRawCommandLine(%q) decoded = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuoteMangleWarning_Content(t *testing.T) {
+	warning := quoteMangleWarning("fetch logs\n| filter loglevel == INFO\n| limit 10")
+
+	// The user cannot see what dtctl received without --verbose, so the warning
+	// must show it, collapsed onto one line.
+	if !strings.Contains(warning, "dtctl received: fetch logs | filter loglevel == INFO | limit 10") {
+		t.Errorf("warning should echo the received query on one line:\n%s", warning)
+	}
+	for _, want := range []string{"'@ | dtctl query", "dtctl query -f query.dql", "WINDOWS.md#quoting"} {
+		if !strings.Contains(warning, want) {
+			t.Errorf("warning should mention %q:\n%s", want, warning)
+		}
+	}
+}
+
+// End-to-end through the shared resolver: a mangled argv query still runs (we
+// cannot know for certain the user meant a string literal), but it warns.
+func TestResolveQueryInput_WarnsOnMangledArgument(t *testing.T) {
+	var buf strings.Builder
+	t.Cleanup(swapQueryWarnOut(&buf))
+	t.Cleanup(swapRawCommandLine(`dtctl query "fetch logs | filter loglevel == "INFO" | limit 10"`))
+
+	const arg = `fetch logs | filter loglevel == INFO | limit 10`
+	got, err := resolveQueryInput("", []string{arg}, terminalStdin(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != arg {
+		t.Fatalf("query was altered: %q", got)
+	}
+	if !strings.Contains(buf.String(), "stripped the double quotes") {
+		t.Errorf("expected a warning, got: %q", buf.String())
+	}
+}
+
+func TestResolveQueryInput_NoWarningForWellQuotedArgument(t *testing.T) {
+	var buf strings.Builder
+	t.Cleanup(swapQueryWarnOut(&buf))
+	t.Cleanup(swapRawCommandLine(`dtctl query "fetch logs | filter loglevel == \"INFO\""`))
+
+	if _, err := resolveQueryInput("", []string{`fetch logs | filter loglevel == "INFO"`}, terminalStdin(t)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.String() != "" {
+		t.Errorf("unexpected warning: %q", buf.String())
+	}
+}
+
+// A query from a file or a pipe cannot have been mangled, so it must never warn
+// even if the command line looks suspicious.
+func TestResolveQueryInput_NoWarningForStdinQuery(t *testing.T) {
+	var buf strings.Builder
+	t.Cleanup(swapQueryWarnOut(&buf))
+	t.Cleanup(swapRawCommandLine(`dtctl query -f - "unrelated "quoted" thing"`))
+
+	if _, err := resolveQueryInput("-", nil, pipedStdin(`fetch logs | filter loglevel == INFO`)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.String() != "" {
+		t.Errorf("unexpected warning: %q", buf.String())
+	}
+}
+
+func swapQueryWarnOut(w *strings.Builder) func() {
+	prev := queryWarnOut
+	queryWarnOut = w
+	return func() { queryWarnOut = prev }
+}
+
+func swapRawCommandLine(raw string) func() {
+	prev := rawCommandLine
+	rawCommandLine = func() string { return raw }
+	return func() { rawCommandLine = prev }
+}

--- a/cmd/query_mangle_test.go
+++ b/cmd/query_mangle_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"strings"
 	"testing"
 )
@@ -192,7 +193,7 @@ func TestResolveQueryInput_NoWarningForStdinQuery(t *testing.T) {
 
 func swapQueryWarnOut(w *strings.Builder) func() {
 	prev := queryWarnOut
-	queryWarnOut = w
+	queryWarnOut = func() io.Writer { return w }
 	return func() { queryWarnOut = prev }
 }
 

--- a/cmd/query_mangle_unix.go
+++ b/cmd/query_mangle_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package cmd
+
+// platformRawCommandLine returns "" because only Windows passes a single
+// command-line string to the process for the C runtime to split -- POSIX
+// exec hands over an argv array, so nothing can mangle quotes in transit.
+func platformRawCommandLine() string {
+	return ""
+}

--- a/cmd/query_mangle_windows.go
+++ b/cmd/query_mangle_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package cmd
+
+import "golang.org/x/sys/windows"
+
+// platformRawCommandLine returns the unparsed command line the process was
+// started with, which is where quote mangling is visible -- os.Args has already
+// had the quotes removed.
+func platformRawCommandLine() string {
+	return windows.UTF16PtrToString(windows.GetCommandLine())
+}

--- a/cmd/verify_query.go
+++ b/cmd/verify_query.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
-	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
 // verifyQueryCmd represents the verify query subcommand
@@ -54,10 +52,10 @@ Examples:
   cat query.dql | dtctl verify query
   echo 'fetch logs | limit 10' | dtctl verify query
 
-  # PowerShell: Use here-strings for complex queries
-  dtctl verify query -f - @'
+  # PowerShell: pipe a here-string in (an argument loses the inner quotes on 5.1)
+  @'
   fetch logs, bucket:{"custom-logs"} | filter contains(host.name, "api")
-  '@
+  '@ | dtctl verify query
 
   # Verify with template variables
   dtctl verify query -f query.dql --set host=h-123 --set timerange=1h
@@ -125,35 +123,9 @@ Examples:
 		queryFile, _ := cmd.Flags().GetString("file")
 		setFlags, _ := cmd.Flags().GetStringArray("set")
 
-		var query string
-
-		if queryFile != "" {
-			// Read query from file (use "-" for stdin)
-			if queryFile == "-" {
-				content, err := io.ReadAll(os.Stdin)
-				if err != nil {
-					return fmt.Errorf("failed to read query from stdin: %w", err)
-				}
-				query = string(content)
-			} else {
-				content, err := vfs.ReadFile(queryFile)
-				if err != nil {
-					return fmt.Errorf("failed to read query file: %w", err)
-				}
-				query = string(content)
-			}
-		} else if len(args) > 0 {
-			// Use inline query
-			query = args[0]
-		} else if !isTerminal(os.Stdin) {
-			// Read from piped stdin
-			content, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				return fmt.Errorf("failed to read query from stdin: %w", err)
-			}
-			query = string(content)
-		} else {
-			return fmt.Errorf("query string or --file is required")
+		query, err := resolveQueryInput(queryFile, args, osStdin())
+		if err != nil {
+			return err
 		}
 
 		// Apply template rendering if --set flags are provided

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -3,15 +3,12 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/util/template"
-	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 	"github.com/dynatrace-oss/dtctl/pkg/wait"
 )
 
@@ -92,28 +89,9 @@ Examples:
 		queryFile, _ := cmd.Flags().GetString("file")
 		setFlags, _ := cmd.Flags().GetStringArray("set")
 
-		var query string
-
-		if queryFile != "" {
-			// Read query from file (use "-" for stdin)
-			if queryFile == "-" {
-				content, err := io.ReadAll(os.Stdin)
-				if err != nil {
-					return fmt.Errorf("failed to read query from stdin: %w", err)
-				}
-				query = string(content)
-			} else {
-				content, err := vfs.ReadFile(queryFile)
-				if err != nil {
-					return fmt.Errorf("failed to read query file: %w", err)
-				}
-				query = string(content)
-			}
-		} else if len(args) > 0 {
-			// Use inline query
-			query = args[0]
-		} else {
-			return fmt.Errorf("query string or --file is required")
+		query, err := resolveQueryInput(queryFile, args, osStdin())
+		if err != nil {
+			return err
 		}
 
 		// Apply template rendering if --set flags are provided

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -947,10 +947,10 @@ Execute Dynatrace Query Language (DQL) queries to fetch logs, metrics, events, a
 dtctl query "fetch logs | limit 10"
 
 # Filter logs by status
-dtctl query "fetch logs | filter status='ERROR' | limit 100"
+dtctl query 'fetch logs | filter status == "ERROR" | limit 100'
 
 # Query recent events
-dtctl query "fetch events | filter event.type='CUSTOM_ALERT' | limit 50"
+dtctl query 'fetch events | filter event.type == "CUSTOM_ALERT" | limit 50'
 
 # Summarize data
 dtctl query "fetch logs | summarize count(), by: {status} | sort count desc"
@@ -997,11 +997,18 @@ PowerShell has different quoting rules that can cause problems with inline DQL q
 
 #### The Problem
 
+Windows PowerShell 5.1 does not escape double quotes when it passes an argument to a native `.exe`, so the quotes DQL needs for string literals are eaten by the Windows command-line parser. PowerShell 7.3+ fixed this (`$PSNativeCommandArgumentPassing` defaults to `Windows` mode); check with `$PSVersionTable.PSVersion`.
+
 ```powershell
-# ❌ FAILS - PowerShell removes inner double quotes
+# ❌ FAILS on PowerShell 5.1 - inner double quotes are removed
 dtctl query 'fetch logs, bucket:{"custom-logs"} | filter contains(host.name, "api")'
 # Error: MANDATORY_PARAMETER_HAS_TO_BE_CONSTANT
-# PowerShell passes: bucket:{custom-logs} (missing quotes around "custom-logs")
+# dtctl receives: bucket:{custom-logs} (missing quotes around "custom-logs")
+
+# ❌ WORSE - fails silently with zero records instead of an error
+dtctl query 'fetch logs | filter loglevel == "INFO" | limit 10'
+# dtctl receives: filter loglevel == INFO
+# That is valid DQL (field vs. field), so Grail returns {} with no complaint.
 
 # ❌ FAILS - DQL doesn't support single quotes
 dtctl query "fetch logs, bucket:{'custom-logs'} | filter contains(host.name, 'api')"
@@ -1009,33 +1016,37 @@ dtctl query "fetch logs, bucket:{'custom-logs'} | filter contains(host.name, 'ap
 # Single quotes are not supported. Please use double quotes for strings.
 ```
 
-#### Solution 1: Use PowerShell Here-Strings (Recommended)
+Run any suspicious query with `-vv` to see the exact request body dtctl sent.
 
-PowerShell's here-string syntax (`@'...'@`) preserves all characters exactly:
+#### Solution 1: Pipe a Here-String (Recommended)
+
+A here-string (`@'...'@`) is a string *value*, not a redirection like a bash heredoc — passing it as an argument loses quotes just like any other argument. **Pipe it** instead: the pipeline writes to stdin and never goes through argument parsing, so it works on every PowerShell version.
 
 ```powershell
-# ✅ WORKS - Use @'...'@ for verbatim strings
-dtctl query -f - -o json @'
+# ✅ WORKS - here-string piped to stdin
+@'
 fetch logs, bucket:{"custom-logs"}
 | filter contains(host.name, "api")
 | limit 10
-'@
+'@ | dtctl query -o json
 
 # ✅ More complex example with multiple quotes
-dtctl query -f - -o json @'
+@'
 fetch logs, bucket:{"application-logs"}
 | filter contains(log.source, "backend")
-| filter status = "ERROR"
+| filter status == "ERROR"
 | summarize count(), by:{log.source}
 | limit 100
-'@
+'@ | dtctl query -o json
 
 # ✅ Works with any DQL query structure
-dtctl query -f - -o csv @'
+@'
 timeseries avg(dt.host.cpu.usage), by:{dt.entity.host}
 | filter avg > 80
-'@
+'@ | dtctl query -o csv
 ```
+
+> ⚠️ Do not write `dtctl query -f - @'...'@`. `-f -` makes dtctl read stdin while the here-string is passed as an argument, so dtctl waits on an idle terminal and the command looks like it hangs. dtctl now reports this instead of blocking, but the fix is to pipe.
 
 #### Solution 2: Use a Query File
 
@@ -1065,21 +1076,24 @@ cat query.dql | dtctl query -o json
 
 #### Quick Reference: PowerShell vs Bash
 
-| Shell | Heredoc Syntax | Example |
-|-------|----------------|---------|
-| **Bash/Zsh** | `<<'EOF'` | `dtctl query -f - <<'EOF'`<br>`fetch logs`<br>`EOF` |
-| **PowerShell** | `@'...'@` | `dtctl query -f - @'`<br>`fetch logs`<br>`'@` |
+| Shell | Multi-line query | Example |
+|-------|------------------|---------|
+| **Bash/Zsh** | heredoc `<<'EOF'` (a redirection) | `dtctl query -f - <<'EOF'`<br>`fetch logs`<br>`EOF` |
+| **PowerShell** | here-string `@'...'@` piped in (a value) | `@'`<br>`fetch logs`<br>`'@ \| dtctl query` |
 
 **Why This Matters:**
 - DQL requires double quotes for strings (e.g., `"custom-logs"`, `"ERROR"`, `"api"`)
-- PowerShell's quote parsing can strip or convert these quotes
-- Using `-f -` (stdin) with here-strings bypasses shell quote parsing entirely
+- Windows PowerShell 5.1 strips those quotes from arguments passed to native executables; PowerShell 7.3+ does not
+- Only **stdin** (a pipe, a heredoc, or `-f file`) bypasses argument parsing entirely — a here-string passed as an argument does not
+- On Windows, prefer `@'...'@ | dtctl query` or `dtctl query -f query.dql`
+
+For the full explanation, see [Windows: Quoting](WINDOWS.md#quoting).
 
 **Example query file** (`queries/errors.dql`):
 
 ```dql
 fetch logs
-| filter status = 'ERROR'
+| filter status == "ERROR"
 | filter timestamp > now() - 1h
 | summarize count(), by: {log.source}
 | sort count desc
@@ -1157,7 +1171,7 @@ dtctl query "fetch logs" \
   -o csv > large_export.csv
 
 # Combine with filters for targeted exports
-dtctl query "fetch logs | filter status='ERROR'" \
+dtctl query 'fetch logs | filter status == "ERROR"' \
   --max-result-records 5000 \
   -o csv > error_logs.csv
 ```
@@ -1233,7 +1247,7 @@ Monitor DQL query results in real-time with live mode:
 
 ```bash
 # Live mode with periodic updates (default: 60s)
-dtctl query "fetch logs | filter status='ERROR'" --live
+dtctl query 'fetch logs | filter status == "ERROR"' --live
 
 # Live mode with custom interval
 dtctl query "fetch logs" --live --interval 5s
@@ -1374,10 +1388,10 @@ fi
 #### PowerShell Examples
 
 ```powershell
-# Verify query using here-strings
-dtctl verify query -f - @'
+# Verify query using a piped here-string
+@'
 fetch logs, bucket:{"custom-logs"} | filter contains(host.name, "api")
-'@
+'@ | dtctl verify query
 
 # Validate all queries in a directory
 Get-ChildItem queries/*.dql | ForEach-Object {
@@ -1753,7 +1767,7 @@ Once created, use lookup tables to enrich your query results:
 # Simple lookup join
 dtctl query "
 fetch logs
-| filter status = 'ERROR'
+| filter status == "ERROR"
 | lookup [
     fetch dt.system.files
     | load '/lookups/production/error_codes'
@@ -1774,7 +1788,7 @@ fetch dt.entity.host
 # Map user IDs to names
 dtctl query "
 fetch logs
-| filter log.source = 'api'
+| filter log.source == "api"
 | lookup [
     load '/lookups/users/directory'
   ], sourceField:user_id, lookupField:id, fields:{name, email, department}
@@ -1808,7 +1822,7 @@ dtctl create lookup -f error_codes.csv \
 # Use in query
 dtctl query "
 fetch logs
-| filter status = 'ERROR'
+| filter status == "ERROR"
 | lookup [load '/lookups/monitoring/error_codes'], 
   sourceField:error_code, lookupField:code
 | fields timestamp, error_code, message, severity, documentation_url
@@ -1839,7 +1853,7 @@ dtctl create lookup -f ip_locations.csv \
 # Use in query to geo-locate traffic
 dtctl query "
 fetch logs
-| filter log.source = 'nginx'
+| filter log.source == "nginx"
 | lookup [load '/lookups/infrastructure/ip_locations'], 
   sourceField:client_ip, lookupField:ip_address
 | summarize request_count=count(), by:{city, country, datacenter}
@@ -1870,7 +1884,7 @@ dtctl create lookup -f service_owners.csv \
 # Find errors by team
 dtctl query "
 fetch logs
-| filter status = 'ERROR'
+| filter status == "ERROR"
 | lookup [load '/lookups/services/ownership'], 
   sourceField:service, lookupField:service_id
 | summarize error_count=count(), by:{team, team_email, slack_channel}
@@ -1902,7 +1916,7 @@ dtctl create lookup -f country_codes.csv \
 # Enrich user analytics
 dtctl query "
 fetch logs
-| filter log.source = 'analytics'
+| filter log.source == "analytics"
 | lookup [load '/lookups/reference/countries'], 
   sourceField:country_code, lookupField:code, 
   fields:{name, continent, currency}
@@ -2856,7 +2870,7 @@ dtctl exec copilot "List the top 5 error types" \
 dtctl exec copilot "Write a DQL query to find all ERROR logs from the last hour"
 
 # Understand existing queries
-dtctl exec copilot "Explain this query: fetch logs | filter status='ERROR' | summarize count()"
+dtctl exec copilot 'Explain this query: fetch logs | filter status == "ERROR" | summarize count()'
 
 # Troubleshoot issues
 dtctl exec copilot "Why might my service response time be increasing?"
@@ -2891,7 +2905,7 @@ Get natural language explanations of DQL queries:
 
 ```bash
 # Explain a DQL query
-dtctl exec copilot dql2nl "fetch logs | filter status='ERROR' | summarize count(), by:{host}"
+dtctl exec copilot dql2nl 'fetch logs | filter status == "ERROR" | summarize count(), by:{host}'
 # Output:
 # Summary: Count error logs grouped by host
 # Explanation: This query fetches logs, filters for ERROR status, and counts them by host.
@@ -3770,7 +3784,7 @@ mkdir -p ~/.local/share/dtctl/queries
 # Create reusable queries
 cat > ~/.local/share/dtctl/queries/errors-last-hour.dql <<EOF
 fetch logs
-| filter status = 'ERROR'
+| filter status == "ERROR"
 | filter timestamp > now() - 1h
 | limit {{.limit | default 100}}
 EOF
@@ -3946,7 +3960,7 @@ Export large datasets from DQL queries for offline analysis:
 
 ```bash
 # Export up to 5000 records to CSV
-dtctl query "fetch logs | filter status='ERROR'" \
+dtctl query 'fetch logs | filter status == "ERROR"' \
   --max-result-records 5000 \
   -o csv > error_logs.csv
 

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -191,32 +191,91 @@ Note: In PowerShell, use the backtick (`` ` ``) for line continuation instead of
 
 ### Quoting
 
-PowerShell handles quotes differently from bash/zsh. This matters most with DQL queries that contain double quotes.
+DQL string literals **must** use double quotes (`"ERROR"`); single quotes are a syntax error. Getting those double quotes through PowerShell intact is the single most common Windows problem with dtctl, so it is worth understanding the mechanism.
 
-**Use here-strings** for DQL queries to avoid quoting issues:
+#### The symptom: zero records, no error
 
 ```powershell
-# Here-string preserves all quotes exactly
-dtctl query -f - -o json @'
-fetch logs
-| filter status = "ERROR"
-| limit 10
-'@
+PS> dtctl query 'fetch logs | filter loglevel == "INFO" | limit 10' -o json
+{
+  "records": []
+}
 ```
 
-**Or use query files** to sidestep quoting entirely:
+The same query returns rows in a Dynatrace notebook. Nothing is wrong with your query or your credentials — the double quotes never reached dtctl. Confirm it with `-vv`, which prints the request body dtctl actually sent:
 
 ```powershell
-# Save query to file
-@"
-fetch logs
-| filter status = "ERROR"
-| limit 10
-"@ | Out-File -Encoding UTF8 query.dql
+PS> dtctl query 'fetch logs | filter loglevel == "INFO" | limit 10' -vv
+...
+BODY:
+{"query":"fetch logs | filter loglevel == INFO | limit 10", ...}
+```
 
-# Execute
+`loglevel == INFO` is *valid* DQL — it compares the `loglevel` field to a field named `INFO`. Both are unequal (or absent), so Grail returns an empty result and no error. That is why this fails silently instead of complaining.
+
+#### Why it happens
+
+**Windows PowerShell 5.1** (the blue `powershell.exe`, still the default on most Windows machines) re-quotes every argument before handing it to a native `.exe`, and it does **not** escape double quotes that are inside the argument. dtctl receives `"fetch logs | filter loglevel == "INFO" | limit 10"`, and the Windows command-line parser reads the inner quotes as end/start of quoting — so they vanish.
+
+This affects **every** way of writing the query as an argument, including single-quoted strings and here-strings. A here-string is a plain string *value*, not a redirection like a bash heredoc, so `dtctl query @'...'@` still goes through argument passing and still loses the quotes.
+
+PowerShell 7.3 and later fixed this: [`$PSNativeCommandArgumentPassing`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables#psnativecommandargumentpassing) defaults to `Windows` mode, which escapes arguments correctly for normal executables. Check which one you are on:
+
+```powershell
+$PSVersionTable.PSVersion
+```
+
+If that prints `5.1.x`, use one of the forms below. If it prints `7.3` or later, quoting an argument works as it does on Linux and macOS.
+
+#### Fix 1: pipe the query in (works on every PowerShell version)
+
+The pipeline sends bytes to stdin and never touches argument parsing, so quotes always survive. This is the recommended form:
+
+```powershell
+@'
+fetch logs
+| filter loglevel == "INFO"
+| limit 10
+'@ | dtctl query -o json
+```
+
+> Do **not** write `dtctl query -f - @'...'@`. `-f -` tells dtctl to read stdin while the here-string is passed as an argument, so the two disagree about where the query is. dtctl rejects that combination with a hint (older versions waited on the idle terminal and appeared to hang). Pipe it (`'@ | dtctl query`) instead, with or without `-f -`.
+
+#### Fix 2: use a query file
+
+```powershell
+@'
+fetch logs
+| filter loglevel == "INFO"
+| limit 10
+'@ | Out-File -Encoding UTF8 query.dql
+
 dtctl query -f query.dql
+Get-Content query.dql | dtctl query   # equivalent
 ```
+
+#### Fix 3: inline on one line (5.1 only)
+
+If you must keep everything on one line in Windows PowerShell 5.1, escape the inner quotes with a backslash so the Windows parser hands them to dtctl:
+
+```powershell
+dtctl query 'fetch logs | filter loglevel == \"INFO\" | limit 10'
+```
+
+This is 5.1-specific: on PowerShell 7.3+ the backslashes are passed through literally and DQL rejects them. Prefer fix 1 or 2 in anything shared or scripted.
+
+#### Summary
+
+| Form                                       | PowerShell 5.1 | PowerShell 7.3+ |
+| ------------------------------------------ | -------------- | --------------- |
+| `@'...'@ \| dtctl query`                   | ✅ works       | ✅ works        |
+| `dtctl query -f query.dql`                 | ✅ works       | ✅ works        |
+| `dtctl query 'fetch ... "INFO"'`           | ❌ quotes lost | ✅ works        |
+| `dtctl query @'...'@`                      | ❌ quotes lost | ✅ works        |
+| `dtctl query -f - @'...'@`                 | ❌ rejected    | ❌ rejected     |
+| `dtctl query 'fetch ... \"INFO\"'`         | ✅ works       | ❌ literal `\`  |
+
+When results look suspicious, `-vv` shows the exact query dtctl sent — always check there first.
 
 See the [DQL Queries](QUICK_START.md#powershell-quoting-issues-and-solutions) section in the Quick Start guide for more examples.
 

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -213,6 +213,15 @@ BODY:
 
 `loglevel == INFO` is *valid* DQL — it compares the `loglevel` field to a field named `INFO`. Both are unequal (or absent), so Grail returns an empty result and no error. That is why this fails silently instead of complaining.
 
+dtctl detects this case by inspecting the raw command line and prints a warning before running the query, so you should not have to reach for `-vv`:
+
+```
+Warning: your shell stripped the double quotes from this query.
+dtctl received: fetch logs | filter loglevel == INFO | limit 10
+```
+
+The query still runs — dtctl cannot know for certain that you meant a string literal — but the warning tells you why the result is empty.
+
 #### Why it happens
 
 **Windows PowerShell 5.1** (the blue `powershell.exe`, still the default on most Windows machines) re-quotes every argument before handing it to a native `.exe`, and it does **not** escape double quotes that are inside the argument. dtctl receives `"fetch logs | filter loglevel == "INFO" | limit 10"`, and the Windows command-line parser reads the inner quotes as end/start of quoting — so they vanish.

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -123,7 +123,7 @@ dtctl get workflows --watch
 dtctl get workflows --watch --interval 5s
 
 # Live query results
-dtctl query "fetch logs | filter status='ERROR'" --live
+dtctl query 'fetch logs | filter status == "ERROR"' --live
 
 # Only show changes (skip initial state)
 dtctl get workflows --watch --watch-only
@@ -602,7 +602,7 @@ dtctl query -f query.dql --set host=h-123 --set timerange=2h
 # Wait for Query Results
 # Poll a query until a specific condition is met
 dtctl wait query "fetch spans | filter test_id == 'test-123'" --for=count=1 --timeout 5m
-dtctl wait query "fetch logs | filter status == 'ERROR'" --for=any --timeout 2m
+dtctl wait query 'fetch logs | filter status == "ERROR"' --for=any --timeout 2m
 dtctl wait query -f query.dql --set test_id=my-test --for=count-gte=1
 
 # Wait conditions:
@@ -945,7 +945,7 @@ dtctl exec copilot nl2dql -f prompt.txt          # Read prompt from file
 dtctl exec copilot nl2dql "..." -o json          # Output as JSON (includes messageToken)
 
 # DQL to NL
-dtctl exec copilot dql2nl "fetch logs | filter status='ERROR' | limit 10"
+dtctl exec copilot dql2nl 'fetch logs | filter status == "ERROR" | limit 10'
 dtctl exec copilot dql2nl -f query.dql           # Read query from file
 dtctl exec copilot dql2nl "..." -o json          # Output as JSON (includes summary + explanation)
 
@@ -2004,7 +2004,7 @@ dtctl logs wfe <execution-id> --task <name> # Specific task
 
 ```bash
 # Simple query
-dtctl query "fetch logs | filter status='ERROR' | limit 100"
+dtctl query 'fetch logs | filter status == "ERROR" | limit 100'
 
 # Query with output formatting
 dtctl query "fetch logs | summarize count(), by: {status}" -o json
@@ -2034,7 +2034,7 @@ dtctl wait query "fetch spans | filter test_id == 'integration-test-123'" \
   --timeout 5m
 
 # Wait for any error logs in the last 5 minutes
-dtctl wait query "fetch logs | filter status == 'ERROR' | filter timestamp > now() - 5m" \
+dtctl wait query 'fetch logs | filter status == "ERROR" | filter timestamp > now() - 5m' \
   --for=any \
   --timeout 2m
 

--- a/docs/dev/WATCH_MODE_DESIGN.md
+++ b/docs/dev/WATCH_MODE_DESIGN.md
@@ -42,7 +42,7 @@ dtctl get workflow my-workflow --watch
 dtctl get dashboards --mine --watch
 
 # Live mode for DQL query results
-dtctl query "fetch logs | filter status == 'ERROR'" --live
+dtctl query 'fetch logs | filter status == "ERROR"' --live
 ```
 
 ### Output Behavior
@@ -422,7 +422,7 @@ dtctl get executions --workflow error-handler --watch
 dtctl get slos --watch --interval 10s
 
 # Live mode to monitor failures
-dtctl query "fetch dt.entity.slo | filter status == 'FAILURE'" --live
+dtctl query 'fetch dt.entity.slo | filter status == "FAILURE"' --live
 ```
 
 ### Monitor Dashboard Changes
@@ -443,7 +443,7 @@ dtctl get execution $EXEC_ID --watch | grep -q "COMPLETED"
 echo "Workflow completed!"
 
 # Monitor deployment
-dtctl query "fetch logs | filter deployment_id == '$DEPLOY_ID'" --live
+dtctl query "fetch logs | filter deployment_id == \"$DEPLOY_ID\"" --live
 ```
 
 ---

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -249,7 +249,7 @@ full condition list, polling controls, and exit codes.
 dtctl wait query "fetch spans | filter test_id == 'test-123'" --for=count=1
 
 # Wait for any error logs, with a custom timeout
-dtctl wait query "fetch logs | filter status == 'ERROR'" --for=any --timeout 2m
+dtctl wait query 'fetch logs | filter status == "ERROR"' --for=any --timeout 2m
 
 # Conditions: count=N | count-gte=N | count-gt=N | count-lte=N | count-lt=N | any | none
 # Polling:    --timeout --max-attempts --initial-delay --min-interval --max-interval --backoff-multiplier
@@ -280,7 +280,7 @@ dtctl exec function -f script.js --payload '{"input":"data"}'                   
 # Davis CoPilot
 dtctl exec copilot "What is DQL?" --stream
 dtctl exec copilot nl2dql "error logs from last hour"
-dtctl exec copilot dql2nl "fetch logs | filter status='ERROR'"
+dtctl exec copilot dql2nl 'fetch logs | filter status == "ERROR"'
 dtctl exec copilot document-search "CPU analysis" --collections notebooks
 
 # OpenPipeline processor preview (dry-run against embedded sample records; -f required)

--- a/docs/site/_docs/copilot.md
+++ b/docs/site/_docs/copilot.md
@@ -68,7 +68,7 @@ dtctl exec copilot nl2dql "find hosts with high CPU" -o json
 
 ```bash
 # Explain a DQL query in plain English
-dtctl exec copilot dql2nl "fetch logs | filter status='ERROR' | limit 10"
+dtctl exec copilot dql2nl 'fetch logs | filter status == "ERROR" | limit 10'
 
 # Read the query from a file
 dtctl exec copilot dql2nl -f query.dql

--- a/docs/site/_docs/dql-queries.md
+++ b/docs/site/_docs/dql-queries.md
@@ -52,16 +52,24 @@ echo 'fetch logs | limit 5' | dtctl query
 
 ### PowerShell Quoting
 
-On Windows PowerShell, use here-strings to avoid escaping issues:
+On Windows PowerShell, **pipe** a here-string into dtctl. Passing the query as an
+argument loses the double quotes DQL needs on Windows PowerShell 5.1, which
+silently returns zero records:
 
 ```powershell
-# PowerShell here-string
-dtctl query @'
+# PowerShell here-string piped to stdin
+@'
 fetch logs
 | filter loglevel == "ERROR"
 | limit 10
-'@
+'@ | dtctl query
 ```
+
+A here-string is a string value, not a redirection like a bash heredoc, so
+`dtctl query @'...'@` still goes through argument parsing — and
+`dtctl query -f - @'...'@` is rejected, because `-f -` points at stdin while the
+query sits in the arguments. See
+[Windows: Quoting](https://github.com/dynatrace-oss/dtctl/blob/main/docs/WINDOWS.md#quoting).
 
 ## Template Queries
 
@@ -406,7 +414,7 @@ Stream query results at a regular interval:
 
 ```bash
 # Re-run every 5 seconds
-dtctl query "fetch logs | filter loglevel == 'ERROR' | sort timestamp desc | limit 10" \
+dtctl query 'fetch logs | filter loglevel == "ERROR" | sort timestamp desc | limit 10' \
   --live --interval 5s
 ```
 
@@ -424,7 +432,7 @@ before making assertions.
 dtctl wait query "fetch spans | filter test_id == 'test-123'" --for=count=1
 
 # Wait for any error logs, up to 2 minutes
-dtctl wait query "fetch logs | filter status == 'ERROR'" --for=any --timeout 2m
+dtctl wait query 'fetch logs | filter status == "ERROR"' --for=any --timeout 2m
 
 # Template variables and file-based queries work here too
 dtctl wait query -f query.dql --set test_id=my-test --for=count-gte=1

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -76,7 +76,7 @@ title: Home
 dtctl get workflows
 
 # Run a DQL query
-dtctl query "fetch logs | filter status='ERROR' | limit 10"
+dtctl query 'fetch logs | filter status == "ERROR" | limit 10'
 
 # Apply configuration from a YAML file with template variables
 dtctl apply -f workflow.yaml --set env=prod

--- a/skills/dtctl/references/DQL-reference.md
+++ b/skills/dtctl/references/DQL-reference.md
@@ -47,12 +47,20 @@ preserves them:
 
 | Shell | Command |
 |-------|---------|
-| bash/zsh, PowerShell | `dtctl query 'fetch logs \| filter status == "ERROR"'` (single-quote the query) |
+| bash/zsh | `dtctl query 'fetch logs \| filter status == "ERROR"'` (single-quote the query) |
 | cmd.exe | `dtctl query "fetch logs \| filter status == \"ERROR\""` (escape inner quotes) |
-| any (quote-free) | `dtctl query -f query.dql` or pipe/stdin with `dtctl query -f -` |
+| PowerShell | `@'` / `fetch logs \| filter status == "ERROR"` / `'@ \| dtctl query` (pipe a here-string) |
+| any (quote-free) | `dtctl query -f query.dql`, or pipe into `dtctl query` |
 
 When generating a `dtctl query` command for a user, **prefer the single-quoted
 wrapper** (or `-f`) so the double-quoted DQL values survive intact.
+
+On Windows, do **not** generate the quoted-argument form: Windows PowerShell 5.1
+strips double quotes from arguments to native executables, turning
+`status == "ERROR"` into `status == ERROR` — valid DQL that silently matches
+nothing. Generate the piped here-string or `-f query.dql` instead. Never
+generate `dtctl query -f - @'...'@`: `-f -` reads stdin while the here-string
+goes to argv, so the command blocks on an idle terminal.
 
 ## Data Sources
 

--- a/skills/dtctl/references/troubleshooting.md
+++ b/skills/dtctl/references/troubleshooting.md
@@ -47,7 +47,7 @@ DQL string literals require **double** quotes. Two frequent traps:
 Use double quotes for the value and pick a shell wrapper that preserves them:
 
 ```bash
-# bash/zsh + PowerShell: single-quote the whole query
+# bash/zsh: single-quote the whole query
 dtctl query 'fetch logs | filter status == "ERROR"'
 ```
 ```cmd
@@ -55,13 +55,20 @@ dtctl query 'fetch logs | filter status == "ERROR"'
 dtctl query "fetch logs | filter status == \"ERROR\""
 ```
 ```powershell
-# PowerShell here-string (no escaping headaches)
-dtctl query -f - -o json @'
+# PowerShell: pipe a here-string to stdin. Do NOT pass it as an argument
+# (`dtctl query @'...'@`) — Windows PowerShell 5.1 strips the inner quotes,
+# which produces the silent zero-row case above. Never `-f - @'...'@`: that
+# waits on stdin and looks like a hang.
+@'
 fetch logs | filter status == "ERROR"
-'@
+'@ | dtctl query -o json
 ```
 
 Quote-free everywhere: put the DQL in a file and run `dtctl query -f query.dql`.
+
+If a Windows user reports empty results, have them re-run with `-vv` and compare
+the `BODY:` query against what they typed — missing quotes confirm the shell,
+not the query, is at fault.
 
 ### 401/403 Authentication Errors
 ```bash


### PR DESCRIPTION
## Why

From user feedback: `dtctl query` on Windows PowerShell returns `{"records": []}` for a query that returns rows when pasted into a notebook. `-vv` shows why — the double quotes are gone from the request body:

```
BODY:
{"query":"fetch logs, from:now()-30m\n| filter loglevel == INFO\n| limit 10", ...}
```

Two independent problems came out of that thread.

**1. The quotes are stripped by PowerShell, and the failure is silent.** Windows PowerShell 5.1 re-quotes arguments for native `.exe` programs without escaping embedded `"`, so the Windows command-line parser consumes them. `filter loglevel == INFO` is *valid* DQL — a comparison between the fields `loglevel` and `INFO` — so Grail answers with zero records, no error, and no notification. Reproduced on a live tenant: **0 records, no warning, 13 GB scanned.** PowerShell 7.3+ is unaffected ([`$PSNativeCommandArgumentPassing`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables#psnativecommandargumentpassing) defaults to `Windows` mode).

**2. Our own docs made it worse.** We recommended here-strings as the fix. A here-string is a string *value*, not a redirection like a bash heredoc, so `dtctl query @'...'@` goes through exactly the same argument mangling. Worse, the documented form was `dtctl query -f - @'...'@` — a transliteration of `dtctl query -f - <<'EOF'` — which put the query in argv while `-f -` blocked on `io.ReadAll(os.Stdin)` against an idle terminal. That is the reported "the command just seems to hang". The broken form was in `docs/WINDOWS.md`, `docs/QUICK_START.md` (3×), `dtctl query --help`, `dtctl verify query --help`, and the agent-facing dtctl skill.

The user's workaround was to give up and write queries to temp files.

## What changed

**`fix`: fail fast instead of hanging.** `--file -` with stdin on a terminal now errors with the forms that work, and `--file` combined with an inline query errors instead of silently dropping the query. Input resolution moved into one tested helper shared by `query`, `verify query` and `wait` (`wait` also picked up the piped-stdin fallback the other two already had).

**`feat`: detect the mangling and warn.** Grail gives us nothing to key off, but the mangling leaves a fingerprint on the raw command line — a well-formed argument carries delimiter quotes only at its outer edges (inner ones arrive escaped as `\"`), a mangled one has bare delimiter quotes in its interior:

```
mangled:     "fetch logs | filter loglevel == "INFO" | limit 10"
well-formed: "fetch logs | filter loglevel == \"INFO\" | limit 10"
```

dtctl reads its unparsed command line (`GetCommandLine` on Windows; nothing elsewhere, since POSIX `exec` passes an argv array that cannot be mangled), re-splits it with the same C runtime rules Go's argv parsing uses, and warns when the token matching the query has interior delimiter quotes:

```
Warning: your shell stripped the double quotes from this query.
dtctl received: fetch logs, from:now()-30m | filter loglevel == INFO | limit 10

DQL string literals need double quotes. Without them this is still valid DQL
-- a comparison between two fields -- so it returns no rows instead of an error.

Windows PowerShell 5.1 does not preserve double quotes in arguments to native
programs. Pipe the query in instead, which never goes through argument parsing:

  @'
  fetch logs
  | filter loglevel == "INFO"
  '@ | dtctl query

Or read it from a file: dtctl query -f query.dql
Details: https://github.com/dynatrace-oss/dtctl/blob/main/docs/WINDOWS.md#quoting
```

Because the check reads the raw command line rather than the query text, it cannot misfire on a query that legitimately compares two fields. The query still runs — dtctl cannot know for certain a string literal was intended — and only argv-sourced queries are checked.

**`docs`: fix the guidance.** The recommended form is now `@'...'@ | dtctl query` (the pipeline never touches argument parsing, so it works on every PowerShell version). `WINDOWS.md#quoting` gained the full mechanism: the silent symptom, the `-vv` confirmation step, why 7.3+ differs, and a per-version support table. Also fixed ~20 example queries across the docs and skill references that used single-quoted DQL literals (`filter status = 'ERROR'`) — those fail with `PARSE_ERROR_SINGLE_QUOTES` if copy-pasted, which the same docs warn about elsewhere.

## Behaviour changes

- `dtctl query -f -` on an interactive terminal: hung → errors with guidance.
- `--file` together with an inline query: silently ran the file → errors. Previously the inline query was discarded.
- `dtctl wait query`: now accepts a piped query (previously required an argument or `--file`).

## Testing

- New unit tests for input resolution (file, `-f -`, pipe, argv, terminal, conflicts) and for the detector (PS 5.1 legacy, PS 7.3 standard, cmd.exe escaping, no-space arguments, mangled `bucket:{...}`, quoted flag values, POSIX no-op) plus C-runtime decoding cases.
- Manually verified end-to-end against a live tenant: `-f file`, piped stdin, `-f -` with a pipe, and heredoc all return data; both error paths return immediately (confirmed under a real pty, not just a redirect).
- `go test ./...` green, `golangci-lint run` 0 issues, `GOOS=windows go build/vet` green.

## Note for reviewers

`feat/query-quote-hints` (unmerged) touches the same two skill files and adds a `PARSE_ERROR_SINGLE_QUOTES` hint whose Windows advice recommends `dtctl query 'fetch logs | filter status == "ERROR"'` — the exact form that fails on 5.1. It will conflict here, and that hint needs correcting before it lands.
