### PR TITLE
fix: make the CLI module importable by pinning a real sdk version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,13 @@ name: Release
 # Note: release-please creates the tag with GITHUB_TOKEN, which would not trigger
 # `on: push: tags` workflows anyway — that is why GoReleaser runs as a gated job
 # in this same workflow rather than in a separate tag-triggered one.
+#
+# sdk/ is a second Go module in this repo, and Go resolves it by the tag
+# `sdk/vX.Y.Z`. release-please only manages the root package, so the tag-sdk job
+# below mirrors each release tag into the sdk namespace at the same commit. That
+# is what makes the root module's `require github.com/dynatrace-oss/dtctl/sdk`
+# resolvable for anyone importing e.g. pkg/engine — the local `replace` in go.mod
+# is ignored downstream. verify-consumable then proves it from outside the repo.
 
 on:
   workflow_dispatch:
@@ -41,6 +48,79 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  tag-sdk:
+    name: Tag SDK Module
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Mirror the release tag into the sdk/ namespace
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          # Resolve the commit release-please tagged, rather than trusting HEAD.
+          # /commits/<ref> dereferences to a commit whether the tag is lightweight
+          # or annotated; Go needs the tag to point at the commit either way.
+          sha=$(gh api "repos/$REPO/commits/$TAG" --jq '.sha')
+          echo "Release $TAG is at $sha"
+          if gh api "repos/$REPO/git/ref/tags/sdk/$TAG" >/dev/null 2>&1; then
+            echo "sdk/$TAG already exists — nothing to do."
+            exit 0
+          fi
+          gh api "repos/$REPO/git/refs" \
+            -f "ref=refs/tags/sdk/$TAG" \
+            -f "sha=$sha" >/dev/null
+          echo "Created sdk/$TAG at $sha"
+
+  verify-consumable:
+    name: Verify Module Is Importable
+    needs: [release-please, tag-sdk]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.5'
+
+      - name: Import pkg/engine from a module outside this repo
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+          # Fetch dtctl itself straight from GitHub: the tags were created seconds
+          # ago, so neither the module proxy nor the checksum database has
+          # observed them yet. Everything else still goes through the proxy.
+          GOPRIVATE: github.com/dynatrace-oss/dtctl
+          GOFLAGS: -mod=mod
+        run: |
+          set -euo pipefail
+          work="$RUNNER_TEMP/consumer"
+          mkdir -p "$work"
+          cd "$work"
+          go mod init example.invalid/consumer
+          cat > main.go <<'EOF'
+          package main
+
+          import (
+          	"fmt"
+
+          	"github.com/dynatrace-oss/dtctl/pkg/engine"
+          )
+
+          func main() {
+          	fmt.Println(len(engine.UnsupportedCommands()))
+          }
+          EOF
+          # Fails if go.mod's sdk require does not name a real sdk/vX.Y.Z tag —
+          # the local `replace` that makes in-repo builds work is ignored here.
+          go get "github.com/dynatrace-oss/dtctl@$TAG"
+          go build ./...
+          echo "pkg/engine is importable from an external module at $TAG"
 
   goreleaser:
     name: GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,25 @@ name: Release
 # is what makes the root module's `require github.com/dynatrace-oss/dtctl/sdk`
 # resolvable for anyone importing e.g. pkg/engine — the local `replace` in go.mod
 # is ignored downstream. verify-consumable then proves it from outside the repo.
+#
+# RECOVERY: tag-sdk only runs on the dispatch that creates the release, because
+# that is the only run where release_created is true. If it fails then (transient
+# API error), simply re-dispatching will NOT retry it — the release already exists,
+# so release_created is false and the job is skipped, leaving a published release
+# whose sdk tag is missing and which therefore cannot be imported. Re-dispatch with
+# the `retag_sdk` input set to that release tag to create the sdk tag and re-verify.
 
 on:
   workflow_dispatch:
+    inputs:
+      retag_sdk:
+        description: >-
+          Recovery only: release tag (e.g. v0.38.0) whose sdk/ tag is missing because
+          the Tag SDK Module job failed after the release was created. Leave empty for
+          a normal release.
+        required: false
+        type: string
+        default: ''
 
 permissions: {}
 
@@ -52,7 +68,7 @@ jobs:
   tag-sdk:
     name: Tag SDK Module
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' || inputs.retag_sdk != '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -61,9 +77,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          TAG: ${{ needs.release-please.outputs.tag_name }}
+          TAG: ${{ inputs.retag_sdk || needs.release-please.outputs.tag_name }}
         run: |
           set -euo pipefail
+          # TAG can come from a hand-typed recovery input, and a Go module tag is
+          # effectively permanent once the proxy observes it. Reject anything that is
+          # not a release tag rather than minting a ref nobody can retract.
+          # Hyphens are disallowed inside the prerelease on purpose: that is what
+          # rejects a Go pseudo-version (v0.0.0-00010101000000-000000000000) while
+          # still accepting a release candidate (v0.36.0-rc.1). Kept in a variable
+          # because an inline =~ pattern is parsed differently by other shells.
+          release_tag_re='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$'
+          if [[ ! "$TAG" =~ $release_tag_re ]]; then
+            echo "::error::Refusing to tag: '$TAG' is not a release tag (vX.Y.Z[-rc.N])."
+            exit 1
+          fi
           # Resolve the commit release-please tagged, rather than trusting HEAD.
           # /commits/<ref> dereferences to a commit whether the tag is lightweight
           # or annotated; Go needs the tag to point at the commit either way.
@@ -81,7 +109,7 @@ jobs:
   verify-consumable:
     name: Verify Module Is Importable
     needs: [release-please, tag-sdk]
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' || inputs.retag_sdk != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
@@ -91,7 +119,7 @@ jobs:
 
       - name: Import pkg/engine from a module outside this repo
         env:
-          TAG: ${{ needs.release-please.outputs.tag_name }}
+          TAG: ${{ inputs.retag_sdk || needs.release-please.outputs.tag_name }}
           # Fetch dtctl itself straight from GitHub: the tags were created seconds
           # ago, so neither the module proxy nor the checksum database has
           # observed them yet. Everything else still goes through the proxy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@ sdk/            # Separate Go module (github.com/dynatrace-oss/dtctl/sdk)
 
 **SDK delegation pattern**: CLI resource handlers in `pkg/resources/` import types from `sdk/api/` (often via type aliases) and delegate HTTP calls to SDK functions. The `sdk/api/*` packages contain **no file I/O, no CLI concerns, no display logic**. File reading (e.g., `ReadFileOrStdin`, `ParseInputFromFile`) stays in `pkg/resources/`. (`sdk/session` is the deliberate exception on file I/O: it owns the config file and credential stores — that's its job.)
 
+**Two modules, one release**: the root `go.mod` requires `dtctl/sdk` *and* `replace`s it with `./sdk`. Go ignores that `replace` downstream, so the `require` must always name a real `sdk/vX.Y.Z` tag — otherwise the root module cannot be imported at all (e.g. a service embedding `pkg/engine`), while every in-repo build stays green because the replace covers it. The require carries `// x-release-please-version` so release-please keeps it equal to the CLI version, and `.github/workflows/release.yml` mirrors each `vX.Y.Z` into `sdk/vX.Y.Z`. Never hand-edit that version or drop the annotation. *Guard*: `go test ./pkg/version/ -run TestSDKRequireIsResolvable`
+
 **Plugins**: dtctl dispatches unknown commands to `dtctl-<name>` executables on PATH (kubectl semantics; built-ins always win). See [docs/dev/PLUGIN_CONVENTIONS.md](docs/dev/PLUGIN_CONVENTIONS.md) for the env contract (`DTCTL_CONTEXT`, `DTCTL_CONFIG`, `DTCTL_AGENT`, `DTCTL_PLAIN`, `DTCTL_CALLER_VERSION` — never tokens).
 
 ## Agent Output Mode

--- a/docs/dev/SERVICE_ENGINE_DESIGN.md
+++ b/docs/dev/SERVICE_ENGINE_DESIGN.md
@@ -290,11 +290,20 @@ Three pieces keep it honest, and all three are load-bearing:
   missing annotation, a missing replace, and drift between the require and
   `version.Version`.
 
-Consequence for development: between releases, the require names the *previous*
-release's sdk tag. In-repo that is invisible (the replace wins), but a caller
-pinning a pseudo-version off `main` gets the older sdk — and fails to build if
-`main` has started using an sdk symbol added since. Callers pin releases; the
-release is where the two modules are cut from one commit.
+Consequence for development: **only release tags are importable — `main` is not,
+and there are two different windows in which it is broken.** In-repo both are
+invisible, because the replace wins.
+
+- Between a release and the next release PR, the require names the *previous*
+  release's sdk tag. That tag exists, so a caller pinning a pseudo-version off
+  `main` resolves it — and then fails to build if `main` has started using an sdk
+  symbol added since.
+- Between merging a release PR and the dispatch that actually tags it, the require
+  names the *upcoming* sdk tag, which does not exist yet. A caller pinning off
+  `main` there fails outright, the same `unknown revision` as the original bug.
+
+Callers pin releases; the release is the one commit where both modules are cut and
+both tags exist.
 
 ## Maturity
 

--- a/docs/dev/SERVICE_ENGINE_DESIGN.md
+++ b/docs/dev/SERVICE_ENGINE_DESIGN.md
@@ -247,6 +247,55 @@ The service is not a perfect mirror, and the differences are intentional:
   exporters, and other process-level behavior. Embedding hosts that need it use
   `engine.Request.Env` directly, in-process.
 
+## Consuming `pkg/engine` from another module
+
+`pkg/engine` lives in the **root** module, `github.com/dynatrace-oss/dtctl` — not
+in `sdk/`, and it cannot move there: `engine.Execute` runs the real command tree,
+so it depends on `cmd/`, which depends on every `pkg/resources/*`, which depends
+back on `sdk/api/*`. The SDK is deliberately the opposite kind of artifact (a few
+typed API wrappers, 8 direct dependencies, no CLI concerns); the engine pulls in
+601 packages. A service embeds the CLI or it uses the SDK — those are different
+choices, not two doors to the same room.
+
+```go
+import "github.com/dynatrace-oss/dtctl/pkg/engine"
+```
+
+```bash
+go get github.com/dynatrace-oss/dtctl@latest
+```
+
+That works only because of a coupling worth stating explicitly, since it broke
+silently once. This repo holds **two modules**, and Go resolves the inner one by
+the tag `sdk/vX.Y.Z`. The root `go.mod` both requires the sdk module and
+`replace`s it with `./sdk` — and **Go ignores a `replace` directive in a module
+it is consuming as a dependency**. So in-repo builds and all of CI resolve the sdk
+through the replace and never validate the `require`, while every external
+importer resolves the `require` literally. For the module's whole life that line
+read `v0.0.0-00010101000000-000000000000`, and `go get` on the root module failed
+with `invalid version: unknown revision 000000000000`.
+
+Three pieces keep it honest, and all three are load-bearing:
+
+- The require carries `// x-release-please-version`, so release-please rewrites it
+  on every release — the same generic-updater mechanism as
+  `pkg/version/version.go`. The sdk require and the CLI version are therefore
+  equal by construction.
+- The `tag-sdk` job in `.github/workflows/release.yml` mirrors each release tag
+  `vX.Y.Z` into `sdk/vX.Y.Z` at the same commit, which is the tag that require
+  now names. `verify-consumable` then does the real thing from a scratch module
+  outside the repo — `go get` the freshly tagged root module and build a program
+  that imports `pkg/engine`.
+- `TestSDKRequireIsResolvable` (`pkg/version/`) rejects a pseudo-version, a
+  missing annotation, a missing replace, and drift between the require and
+  `version.Version`.
+
+Consequence for development: between releases, the require names the *previous*
+release's sdk tag. In-repo that is invisible (the replace wins), but a caller
+pinning a pseudo-version off `main` gets the older sdk — and fails to build if
+`main` has started using an sdk symbol added since. Callers pin releases; the
+release is where the two modules are cut from one commit.
+
 ## Maturity
 
 `pkg/engine` is the stable half: a Go caller opts into it at compile time, and

--- a/docs/site/_docs/serve.md
+++ b/docs/site/_docs/serve.md
@@ -254,8 +254,8 @@ Note that this is the **CLI** module, not the separate
 [`sdk/` module](https://github.com/dynatrace-oss/dtctl/tree/main/sdk): embedding
 the engine means embedding the whole command surface, because that is what makes
 the output identical. If you want typed API wrappers without the CLI, use the SDK
-instead. Importing the CLI module requires a release **after v0.37.0** — earlier
-tags could not be resolved as a library dependency.
+instead. Importing the CLI module requires **v0.38.0 or newer** — earlier tags
+could not be resolved as a library dependency at all.
 
 ```go
 res, err := engine.Execute(ctx, engine.Request{

--- a/docs/site/_docs/serve.md
+++ b/docs/site/_docs/serve.md
@@ -246,6 +246,17 @@ directly from Go. `pkg/engine` is the surface `dtctl serve http` is a thin
 wrapper over — same request shape, same isolation, no HTTP hop and no port to
 protect:
 
+```bash
+go get github.com/dynatrace-oss/dtctl@latest
+```
+
+Note that this is the **CLI** module, not the separate
+[`sdk/` module](https://github.com/dynatrace-oss/dtctl/tree/main/sdk): embedding
+the engine means embedding the whole command surface, because that is what makes
+the output identical. If you want typed API wrappers without the CLI, use the SDK
+instead. Importing the CLI module requires a release **after v0.37.0** — earlier
+tags could not be resolved as a library dependency.
+
 ```go
 res, err := engine.Execute(ctx, engine.Request{
     Command:        `apply -f workflow.yaml --write-id --agent`,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/adrg/xdg v0.5.3
-	github.com/dynatrace-oss/dtctl/sdk v0.0.0-00010101000000-000000000000
+	github.com/dynatrace-oss/dtctl/sdk v0.37.0 // x-release-please-version
 	github.com/go-resty/resty/v2 v2.17.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/guptarohit/asciigraph v0.10.0
@@ -76,4 +76,9 @@ require (
 	google.golang.org/grpc v1.83.0 // indirect
 )
 
+// Local development builds against the in-tree sdk/. This directive is ignored
+// when this module is consumed as a dependency, so the require above must name a
+// real published sdk/vX.Y.Z tag — release-please keeps it equal to the CLI
+// version (see the x-release-please-version annotation) and the release workflow
+// tags sdk/vX.Y.Z at the same commit. TestSDKRequireIsResolvable guards this.
 replace github.com/dynatrace-oss/dtctl/sdk => ./sdk

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,10 @@ require (
 // Local development builds against the in-tree sdk/. This directive is ignored
 // when this module is consumed as a dependency, so the require above must name a
 // real published sdk/vX.Y.Z tag — release-please keeps it equal to the CLI
-// version (see the x-release-please-version annotation) and the release workflow
-// tags sdk/vX.Y.Z at the same commit. TestSDKRequireIsResolvable guards this.
+// version via the annotation on that require line, and the release workflow tags
+// sdk/vX.Y.Z at the same commit. TestSDKRequireIsResolvable guards this.
+//
+// Keep version numbers out of this comment block. go.mod is a release-please
+// generic extra-file, and the updater rewrites the first semver token on any line
+// that mentions the annotation marker — including a line that only talks about it.
 replace github.com/dynatrace-oss/dtctl/sdk => ./sdk

--- a/pkg/version/release_guard_test.go
+++ b/pkg/version/release_guard_test.go
@@ -1,0 +1,70 @@
+package version
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// sdk/ is a second Go module in this repo. In-tree builds resolve it through the
+// `replace ... => ./sdk` directive in the root go.mod — but Go ignores `replace`
+// directives of a module it is consuming as a dependency, so an external caller
+// (`go get github.com/dynatrace-oss/dtctl` to import pkg/engine) resolves the
+// `require` line literally, against the tag `sdk/vX.Y.Z`.
+//
+// That require line held the placeholder `v0.0.0-00010101000000-000000000000`
+// for the module's whole life, which made the root module unimportable
+// ("invalid version: unknown revision 000000000000") without anyone noticing:
+// every in-repo build, and all of CI, went through the replace. This test is the
+// missing signal.
+var (
+	sdkRequireRe = regexp.MustCompile(
+		`(?m)^\s*github\.com/dynatrace-oss/dtctl/sdk\s+(\S+)\s*//\s*x-release-please-version\s*$`)
+	sdkReplaceRe = regexp.MustCompile(
+		`(?m)^replace\s+github\.com/dynatrace-oss/dtctl/sdk\s+=>\s+\./sdk\s*$`)
+	versionVarRe = regexp.MustCompile(
+		`(?m)^var Version = "([^"]+)"\s*//\s*x-release-please-version\s*$`)
+	releaseTagRe = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+)
+
+func TestSDKRequireIsResolvable(t *testing.T) {
+	goMod := readRepoFile(t, "go.mod")
+
+	m := sdkRequireRe.FindStringSubmatch(goMod)
+	require.NotNil(t, m,
+		"go.mod must require github.com/dynatrace-oss/dtctl/sdk on a single line carrying the "+
+			"`// x-release-please-version` annotation. Without the annotation release-please stops "+
+			"bumping the version on release, and the require silently rots behind the sdk/ tags.")
+
+	require.Regexp(t, releaseTagRe, m[1],
+		"the sdk require must name a released tag (sdk/vX.Y.Z), not a pseudo-version. "+
+			"A pseudo-version or the `v0.0.0-00010101000000-000000000000` placeholder builds fine "+
+			"in-repo (the replace directive covers it) but makes this module impossible to import: "+
+			"`go get github.com/dynatrace-oss/dtctl` fails with `invalid version: unknown revision`.")
+
+	require.Regexp(t, sdkReplaceRe, goMod,
+		"go.mod must keep `replace github.com/dynatrace-oss/dtctl/sdk => ./sdk`. It is ignored "+
+			"downstream, but without it local builds and CI would compile against the last released "+
+			"sdk tag instead of the in-tree sdk/ sources.")
+
+	// The release workflow mirrors every release tag vX.Y.Z into sdk/vX.Y.Z at
+	// the same commit (.github/workflows/release.yml, job tag-sdk), so the two
+	// versions are equal by construction. Checking it here means a hand-edit of
+	// either file fails the build rather than the next `go get`.
+	vm := versionVarRe.FindStringSubmatch(readRepoFile(t, filepath.Join("pkg", "version", "version.go")))
+	require.NotNil(t, vm, "version.go must declare the annotated Version variable")
+	require.Equal(t, "v"+vm[1], m[1],
+		"the sdk require must match the CLI version: the release workflow tags sdk/vX.Y.Z at the "+
+			"same commit as vX.Y.Z, so any other value names a tag that does not exist")
+}
+
+// readRepoFile reads a path relative to the repository root.
+func readRepoFile(t *testing.T, rel string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", rel))
+	require.NoError(t, err)
+	return string(data)
+}

--- a/pkg/version/release_guard_test.go
+++ b/pkg/version/release_guard_test.go
@@ -27,7 +27,16 @@ var (
 		`(?m)^replace\s+github\.com/dynatrace-oss/dtctl/sdk\s+=>\s+\./sdk\s*$`)
 	versionVarRe = regexp.MustCompile(
 		`(?m)^var Version = "([^"]+)"\s*//\s*x-release-please-version\s*$`)
-	releaseTagRe = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+	// vX.Y.Z with an optional semver prerelease of dot-separated alphanumeric
+	// identifiers, so release candidates (v0.36.0-rc.1) are accepted — release-please
+	// writes those into go.mod verbatim, and sdk/vX.Y.Z-rc.N is a valid module tag.
+	//
+	// Hyphens are deliberately disallowed *inside* the prerelease, even though semver
+	// permits them: that is the one thing separating a release tag from a Go
+	// pseudo-version. It is what keeps the placeholder this test exists to catch
+	// (v0.0.0-00010101000000-000000000000) and real pseudo-versions
+	// (v0.37.1-0.20260101120000-abcdef123456) from slipping through.
+	releaseTagRe = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$`)
 )
 
 func TestSDKRequireIsResolvable(t *testing.T) {
@@ -40,10 +49,11 @@ func TestSDKRequireIsResolvable(t *testing.T) {
 			"bumping the version on release, and the require silently rots behind the sdk/ tags.")
 
 	require.Regexp(t, releaseTagRe, m[1],
-		"the sdk require must name a released tag (sdk/vX.Y.Z), not a pseudo-version. "+
-			"A pseudo-version or the `v0.0.0-00010101000000-000000000000` placeholder builds fine "+
-			"in-repo (the replace directive covers it) but makes this module impossible to import: "+
-			"`go get github.com/dynatrace-oss/dtctl` fails with `invalid version: unknown revision`.")
+		"the sdk require must name a released tag (sdk/vX.Y.Z, optionally -rc.N), not a "+
+			"pseudo-version. A pseudo-version or the `v0.0.0-00010101000000-000000000000` "+
+			"placeholder builds fine in-repo (the replace directive covers it) but makes this "+
+			"module impossible to import: `go get github.com/dynatrace-oss/dtctl` fails with "+
+			"`invalid version: unknown revision`.")
 
 	require.Regexp(t, sdkReplaceRe, goMod,
 		"go.mod must keep `replace github.com/dynatrace-oss/dtctl/sdk => ./sdk`. It is ignored "+

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,10 @@
         {
           "type": "generic",
           "path": "pkg/version/version.go"
+        },
+        {
+          "type": "generic",
+          "path": "go.mod"
         }
       ]
     }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Versioning is now aligned with the dtctl CLI.** The SDK is tagged `sdk/vX.Y.Z` at the same commit as the CLI's `vX.Y.Z`, so the next release jumps from `0.2.0` to the CLI's version rather than to `0.3.0`. Nothing about the API changes; the alignment is what makes the CLI module's dependency on the SDK resolvable for external importers (see `docs/dev/SERVICE_ENGINE_DESIGN.md`). A new tag therefore appears on every CLI release, whether or not `sdk/` changed — this file remains the record of what actually moved.
+
 ### Added
 
 - `sdk/inventory` — Environment data-inventory discovery engine: capabilities present/absent/unknown with cited evidence, live entity census, buckets, data-object catalog partition, and a budgeted discovery battery. Execution-agnostic — every query runs through a caller-supplied `Runner` interface, so backend services can embed discovery with their own DQL client. Definitions parsing is byte-based (`ParseDefinitions`); file loading stays in the CLI layer. Definition sets constructed in Go (bypassing `ParseDefinitions`) are checked by `ValidateDefinitions`, which `Discover` runs up front — a malformed or nil definition fails fast instead of being silently skipped.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -8,6 +8,19 @@ A shared Go module for building tools and integrations against the Dynatrace pla
 go get github.com/dynatrace-oss/dtctl/sdk@latest
 ```
 
+## Versioning
+
+The SDK is tagged `sdk/vX.Y.Z` **in lockstep with the dtctl CLI release** it was
+cut from: dtctl `vX.Y.Z` and `sdk/vX.Y.Z` are the same commit. The two modules
+ship from one repository and are compiled against each other in CI, so aligning
+the numbers is what lets the CLI module declare a resolvable dependency on the
+SDK — and lets you pair a CLI version with the SDK that matches it.
+
+Two consequences: a new SDK tag appears on every CLI release, including ones that
+change nothing under `sdk/` (check [CHANGELOG.md](CHANGELOG.md) for what actually
+moved), and the version jumped from `sdk/v0.2.0` straight to the CLI's line when
+this alignment was introduced.
+
 ## What's in the SDK
 
 ### Infrastructure


### PR DESCRIPTION
## Description

`pkg/engine` shipped in #417 as the embedding surface for services that want to run dtctl command lines in-process. It could not be embedded. Neither could any other package of this module.

```console
$ go get github.com/dynatrace-oss/dtctl@v0.37.0
go: github.com/dynatrace-oss/dtctl imports
	github.com/dynatrace-oss/dtctl/cmd imports
	github.com/dynatrace-oss/dtctl/pkg/resources/slo imports
	github.com/dynatrace-oss/dtctl/sdk/api/slo: github.com/dynatrace-oss/dtctl/sdk@v0.0.0-00010101000000-000000000000:
	invalid version: unknown revision 000000000000
```

The root `go.mod` required the inner `sdk` module at the placeholder pseudo-version `v0.0.0-00010101000000-000000000000` and leaned on `replace github.com/dynatrace-oss/dtctl/sdk => ./sdk` to build. **Go ignores a `replace` directive in a module it is consuming as a dependency.** So in-repo builds and 100% of CI resolved the sdk through the replace and never once validated the `require`, while every external importer resolved it literally and failed. The condition existed for the whole life of the module and nothing could have caught it — no test looked at that line.

There is no working consumer-side workaround, either: the newest published sdk tag is `sdk/v0.2.0` from 2026-05-16, 38 commits behind, missing `sdk/api/platformtoken`, `sdk/api/previewprocessor` and others, so pointing a `replace` at it fails with `cannot find module providing package`.

## What this changes

| Change | Why |
|---|---|
| `go.mod`: require `dtctl/sdk v0.37.0 // x-release-please-version` | Names a real tag instead of a placeholder. The annotation is the mechanism already used by `pkg/version/version.go` — release-please's generic updater rewrites it on every release, so the require can never drift behind the tags again. The comment above `replace` deliberately does **not** spell out the marker string: go.mod is now a generic extra-file, and the updater rewrites the first semver token on *any* line mentioning the marker, including one that only talks about it. |
| `release-please-config.json`: `go.mod` added to the root package's `extra-files` | Wires that annotation into the release. |
| `release.yml`: new `tag-sdk` job | `sdk/` is a second Go module; Go resolves it by the tag `sdk/vX.Y.Z`, which nothing was creating. The job mirrors each release tag into the sdk namespace at the same commit, resolving via `/commits/<ref>` so it works for lightweight and annotated tags alike, and no-ops if the tag already exists. |
| `release.yml`: `retag_sdk` dispatch input | Recovery path. `tag-sdk` can only run on the dispatch that creates the release, since that is the only run where `release_created` is true — so a transient failure there was *unrecoverable by re-dispatching* (the release now exists, the job is skipped) and would leave a published, unimportable release. The input re-enables `tag-sdk` and `verify-consumable` for an existing tag. It is validated first: the value can be hand-typed, and a module tag is effectively permanent once the proxy observes it. |
| `release.yml`: new `verify-consumable` job | Proves the property end-to-end instead of asserting it: `go mod init` in a scratch dir outside the repo, `go get` the freshly tagged module, build a program that imports `pkg/engine`. `GOPRIVATE` fetches dtctl straight from GitHub because the tags are seconds old and the proxy has not observed them; everything else still goes through the proxy. |
| `pkg/version/release_guard_test.go`: `TestSDKRequireIsResolvable` | Offline guard. Rejects a pseudo-version, a missing annotation, a missing `replace`, and drift between the require and `version.Version`. Accepts a release candidate (`v0.38.0-rc.1`) — release-please writes a prerelease into the require verbatim, and this repo has cut rc releases before, so a stricter `^v\d+\.\d+\.\d+$` would have failed the next rc release PR. Hyphens stay disallowed *inside* the prerelease: that is the only thing distinguishing a release tag from a pseudo-version, so allowing `-...` outright would re-admit the placeholder the guard exists to catch. |
| Docs | A new **Consuming `pkg/engine` from another module** section in the design doc, a `go get` line plus CLI-module-vs-SDK note in the Server Mode page, the invariant in `AGENTS.md`, and a **Versioning** section in `sdk/README.md`. |

`pkg/engine` stays in the root module. It cannot move into `sdk/`: `engine.Execute` runs the real command tree, so it depends on `cmd/` → every `pkg/resources/*` → back into `sdk/api/*`. The SDK is the opposite kind of artifact by design (8 direct dependencies, no CLI concerns) where the engine pulls in 601 packages. Embedding the CLI and using the SDK are different choices, and the docs now say so.

## Versioning: sdk aligned with the CLI (decided)

**sdk/ versions are now aligned with the CLI's instead of numbered independently**, and this is the agreed direction rather than an open question. The next release tags `sdk/vX.Y.Z` alongside `vX.Y.Z`, so the SDK jumps from `0.2.0` to the CLI's line, and a new SDK tag appears on every CLI release even when nothing under `sdk/` changed. `sdk/CHANGELOG.md` remains the record of what actually moved, and both the changelog and `sdk/README.md` state this explicitly.

Alignment is what makes the require correct *by construction* — the two modules are cut from one commit, so the tag the require names always exists and always matches. The alternative, keeping independent sdk numbering, needs something to write the sdk's new version into the root `go.mod` at release time; the plausible mechanisms are a second release-please package with a `../go.mod` extra-file (path escapes the package dir) or the `linked-versions` plugin (which would touch how the *CLI's* version is computed — more risk in the one pipeline that must not break). Independent numbering was also aspirational rather than real: the SDK released twice while the CLI released 37 times, and the require rotted in exactly that gap.

The alignment takes effect with **v0.38.0**, the first release whose `tag-sdk` run cuts `sdk/v0.38.0`.

## Testing

- [x] `TestSDKRequireIsResolvable` mutation-tested — the guard fails on each regression it claims to catch, and passes on the fixed tree:
  - placeholder pseudo-version restored → rejected
  - a realistic pseudo-version (`v0.37.1-0.20260101120000-abcdef123456`) → rejected
  - annotation removed → require line not found
  - `replace ... => ./sdk` removed → replace assertion fails
  - require set to `v0.36.0` → drift against `version.Version` fails
  - rc release (`v0.38.0-rc.1` in both files) → **passes**, which it did not before the prerelease fix
- [x] `retag_sdk` validation exercised in real bash against the script extracted from the workflow: accepts `v0.38.0` and `v0.36.0-rc.1`; rejects the placeholder, a realistic pseudo-version, `main`, empty, `../evil`, and `v0.38.0 && rm -rf /`. (The pattern is held in a variable — an inline `=~` pattern is parsed differently by non-bash shells.)
- [x] `go.mod` contains exactly one line mentioning the release-please marker (the require), so the updater no longer processes a prose line.
- [x] `go mod tidy` preserves both the annotation and the comment block above `replace` (checked in a minimal two-module reproduction and on the real `go.mod`; `go build ./...` clean, `go.sum` unchanged).
- [x] The original failure reproduced from a scratch module before the fix, and the `sdk/v0.2.0` workaround confirmed non-viable.
- [x] `release.yml` YAML parses; both new `run:` scripts pass `bash -n`; the heredoc'd Go program extracted from the block scalar is `gofmt`-clean with tabs intact.
- [x] `go vet`, `golangci-lint run ./pkg/version/...` (0 issues), `markdownlint` on all five touched Markdown files, `make sdk-check-imports`, `make sdk-check-deps`.
- [x] Confirmed against the release-please and release-please-action sources that this does not disturb the existing release: `setPathOutput` emits **bare** `release_created`/`tag_name` for the root path `.` regardless of package count, so the GoReleaser gate is untouched; and the generic updater's `VERSION_REGEX` replaces the numeric part of `v0.37.0` in place, leaving the `v` prefix.
- [x] The `v`-prefix behaviour additionally verified **empirically**, by running release-please 17.11.1's own updater against these exact files: `go.mod` L7 `v0.37.0` → `v0.38.0` and nothing else in the file changes (also checked for `1.0.0` and the prerelease `0.38.0-rc.1`). `VERSION_REGEX` contains no `v`, so the prefix is outside the match and survives; `Version.toString()` emits no `v`. Precedent: **grafana/alloy** declares `{"type": "generic", "path": "/go.mod"}` for a sibling-module require line in exactly this shape.
- [x] Full `go test ./...` green; external consumability re-confirmed by building a scratch module outside the repo that imports `pkg/engine` — it fails on *only* the missing sdk tag, and succeeds once that tag resolves, so nothing else blocks importing the root module.

`sdk/` is byte-identical between `v0.37.0` and `main`, so the `require v0.37.0` on this branch is internally consistent today.

## Notes for reviewers

- **Resolution starts at v0.38.0**, when `tag-sdk` creates the first `sdk/vX.Y.Z`. Backfilling `sdk/v0.37.0` was considered and deliberately declined — it would have made `main` importable a release earlier, but a module tag is effectively permanent once the proxy observes it, and there is no need for one. `v0.37.0` and earlier stay unimportable as a library; that is accurate and documented.
- **Only release tags are importable — `main` is not, and it is broken in two windows that fail differently.** Between a release and the next release PR, the require names the *previous* release's sdk tag: that tag exists, so a caller pinning a pseudo-version off `main` resolves it and then fails to build if `main` has started using an sdk symbol added since. Between merging a release PR and the dispatch that actually tags it, the require names the *upcoming* tag, which does not exist yet, so such a caller fails outright with the same `unknown revision` as the original bug. Both are invisible in-repo (the replace wins). Callers pin releases; the design doc now spells out both windows.
- `verify-consumable` is the job that will fail loudly if the release plumbing ever breaks again. It runs only on an actual release, which is the only moment the property is checkable — so it **detects rather than prevents**: `goreleaser` gates only on `release-please`, and the git tag and GitHub Release already exist by the time verification runs. Gating artifact publication on it was considered and rejected, since it would only withhold binaries from a release whose module tags are already public. The pre-merge half of the protection is `TestSDKRequireIsResolvable`, which is why every failure mode of the release-please rewrite (wrong prefix, or the line not being matched at all) surfaces on the release PR rather than at release time.


