### PR TITLE
feat: add API spec discovery and a governed HTTP passthrough

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ pkg/
 sdk/            # Separate Go module (github.com/dynatrace-oss/dtctl/sdk)
   ├── session/     # The session layer (docs/dev/CONFIG_CONTRACT.md): config model + load/save, credential stores, OAuth flow/refresh + cross-process lock, client-from-context with parameterized User-Agent, safety semantics
   ├── api/         # Typed API wrappers (one package per Dynatrace API surface)
+  │                #   apispec/ is the odd one out: it reads the environment's *own* API index and
+  │                #   OpenAPI documents (docs/dev/GENERIC_API_ACCESS.md)
   ├── httpclient/  # HTTP client, response helpers, pagination, typed errors
   ├── auth/        # Token type detection
   ├── urls/        # Environment URL validation/normalization
@@ -89,6 +91,7 @@ When adding a new AI agent to the skills system, update **all** of the following
 3. **Commands**: Add to `cmd/get.go`, `cmd/describe.go`, etc. Mutating verbs need a safety check; `-f`/`--file` flags go through `vfs`; no `os.Exit`, no ungated subprocess.
 4. Register in resolver
 5. Add tests: `sdk/api/<name>/*_test.go` (SDK unit tests) + `test/e2e/<name>_test.go` (E2E)
+6. **Claim the coverage**: add the API's base path to `nativeCoverage` in `pkg/resources/api/coverage.go`, so `dtctl get apis` stops listing it as uncovered and `dtctl exec api` points callers at the new command. `Command` must be what a user would actually type (`dtctl query`, not `dtctl get query`). *Guard*: `go test ./cmd/ -run TestNativeCoverageNamesRealCommands`
 
 **SDK handler signature** (in `sdk/api/<name>/`):
 ```go
@@ -98,6 +101,15 @@ func (h *Handler) List(opts ListOptions) ([]Resource, error)
 ```
 
 **CLI handler** (in `pkg/resources/<name>/`): imports SDK types (often via type alias) and wraps with file I/O, display fields, etc.
+
+## Generic API Access
+
+`dtctl get apis` / `describe api` / `exec api` cover the APIs dtctl does **not** wrap natively. Full rationale: [docs/dev/GENERIC_API_ACCESS.md](docs/dev/GENERIC_API_ACCESS.md). Four conventions to respect when touching them:
+
+1. **dtctl mirrors the environment's API index and filters nothing.** A dtctl-side filter would have to hard-code which APIs to conceal, and in an open-source tool that list *is* the disclosure. Resolution consults only what the index returned — never synthesize a candidate path from a name and retry it, which would turn a name lookup into an existence oracle.
+2. **The HTTP method never decides the safety gate.** `resapi.Classify` takes the stricter of the method floor and the specification's declared scope; POST's floor is `OperationRead`, because plenty of read-only endpoints are POSTs. Unresolvable → `OperationDelete`. There is deliberately no flag to assert an operation.
+3. **`exec api` must never be the integration target.** It stays `Hidden` (present in `dtctl commands --full` via `unadvertisedResources` in `pkg/commands/listing.go`, absent from `--help` and the compact catalogs), it names the native command whenever one covers the path, and no command profile grants it.
+4. **No committed artifact names a non-public API.** Help text, examples, golden files, and E2E fixtures are synthetic; live tests assert invariants of the mechanism, never a list of expected APIs.
 
 ## Design Principles
 
@@ -117,6 +129,8 @@ func (h *Handler) List(opts ListOptions) ([]Resource, error)
 | Fix output | `pkg/output/<format>.go` | Test: `dtctl get <resource> -o <format>` |
 | Read a user file | `pkg/vfs/` | `vfs.ReadFile` / `vfs.ReadFileOrStdin` — never `os.ReadFile` |
 | Add a serve protocol | `pkg/serve/<proto>.go` | Copy `pkg/serve/http.go`; register in `NewCommand()` |
+| Wrap a new API natively | `pkg/resources/api/coverage.go` | Add the base path with the *runnable* command (see below) |
+| Gate an irreversible endpoint | `pkg/resources/api/classify.go` | Add a `destructivePatterns` entry (docs/dev/GENERIC_API_ACCESS.md) |
 
 **Tests**: `make test` or `go test ./...` • E2E: `test/e2e/` • Integration: `test/integration/`
 
@@ -166,6 +180,7 @@ make test
 ### Required for These Commands
 
 ✅ `create`, `edit`, `apply`, `delete`, `update` (all modify resources)  
+✅ `exec` — every subcommand, with the operation matching what the execution actually does: `OperationRead` for an analysis or a preview, `OperationCreate` for a run that creates state, `OperationDelete` for ad-hoc code (`exec function --code` can do anything), and for `exec api` the operation derived from the API's own specification. Use `SetupWithSafety(op)`, not the ungated `SetupClient()`. *Guard*: `go test ./cmd/ -run TestExec.*Readonly`  
 ❌ `get`, `describe`, `query`, `logs`, `history`, `ctx`, `doctor`, `commands` (read-only)
 
 ### Pattern (after `LoadConfig()`, before client ops)
@@ -295,7 +310,10 @@ Never put customer names, employee names, usernames, or specific Dynatrace envir
 ✅ **Do** return data, let cmd/ handle output
 
 ❌ **Don't** skip safety checks on mutating commands  
-✅ **Do** add safety checks to ALL create/edit/apply/delete/update commands
+✅ **Do** add safety checks to ALL create/edit/apply/delete/update/exec commands
+
+❌ **Don't** script against `dtctl exec api` — an escape hatch that becomes the integration target has failed  
+✅ **Do** add a native command for the API instead (`dtctl get apis --uncovered` is the backlog)
 
 ❌ **Don't** read a user-supplied path with `os.ReadFile` / `os.Open`  
 ✅ **Do** use `vfs.ReadFile` / `vfs.ReadFileOrStdin` (see Embedding Invariants)
@@ -473,6 +491,7 @@ if r.URL.Query().Get("nextPageKey") != "" {
 - **Architecture**: [docs/dev/ARCHITECTURE.md](docs/dev/ARCHITECTURE.md)
 - **Status**: [docs/dev/IMPLEMENTATION_STATUS.md](docs/dev/IMPLEMENTATION_STATUS.md)
 - **Embedding/service model**: [docs/dev/SERVICE_ENGINE_DESIGN.md](docs/dev/SERVICE_ENGINE_DESIGN.md)
+- **API discovery + passthrough**: [docs/dev/GENERIC_API_ACCESS.md](docs/dev/GENERIC_API_ACCESS.md)
 - **Future Work**: [docs/dev/FUTURE_FEATURES.md](docs/dev/FUTURE_FEATURES.md)
 
 ---

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Token-based authentication and multi-environment configuration are covered in th
 | Users & Groups | get, describe |
 | Live Debugger | breakpoints, workspace filters, snapshot decoding |
 | Platform Tokens | account create/list/delete token (`dt0s16.*` via Account Management API) |
+| API Discovery | get apis (with `--uncovered`), describe api (operation index, one operation in full, raw spec) |
 
 See the **[Command Reference](https://dynatrace-oss.github.io/dtctl/docs/command-reference/)** for the full list of verbs, flags, resource types, and aliases.
 
@@ -144,7 +145,7 @@ Full documentation is available at **[dynatrace-oss.github.io/dtctl](https://dyn
 - [Token Scopes](https://dynatrace-oss.github.io/dtctl/docs/token-scopes/): Required API token scopes per safety level
 - [Server Mode](https://dynatrace-oss.github.io/dtctl/docs/serve/): Running dtctl as a server, the execute API, and embedding `pkg/engine`
 
-Resource-specific guides: [DQL Queries](https://dynatrace-oss.github.io/dtctl/docs/dql-queries/) · [Workflows](https://dynatrace-oss.github.io/dtctl/docs/workflows/) · [Dashboards](https://dynatrace-oss.github.io/dtctl/docs/dashboards/) · [SLOs](https://dynatrace-oss.github.io/dtctl/docs/slos/) · [Settings](https://dynatrace-oss.github.io/dtctl/docs/settings/) · [Extensions](https://dynatrace-oss.github.io/dtctl/docs/extensions/) · [Analyzers](https://dynatrace-oss.github.io/dtctl/docs/analyzers/) · [CoPilot](https://dynatrace-oss.github.io/dtctl/docs/copilot/) · [and more...](https://dynatrace-oss.github.io/dtctl/docs/quick-start/)
+Resource-specific guides: [API Discovery](https://dynatrace-oss.github.io/dtctl/docs/api-discovery/) · [DQL Queries](https://dynatrace-oss.github.io/dtctl/docs/dql-queries/) · [Workflows](https://dynatrace-oss.github.io/dtctl/docs/workflows/) · [Dashboards](https://dynatrace-oss.github.io/dtctl/docs/dashboards/) · [SLOs](https://dynatrace-oss.github.io/dtctl/docs/slos/) · [Settings](https://dynatrace-oss.github.io/dtctl/docs/settings/) · [Extensions](https://dynatrace-oss.github.io/dtctl/docs/extensions/) · [Analyzers](https://dynatrace-oss.github.io/dtctl/docs/analyzers/) · [CoPilot](https://dynatrace-oss.github.io/dtctl/docs/copilot/) · [and more...](https://dynatrace-oss.github.io/dtctl/docs/quick-start/)
 
 ## Contributing
 

--- a/cmd/api_coverage_test.go
+++ b/cmd/api_coverage_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace-oss/dtctl/pkg/commands"
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+	resapi "github.com/dynatrace-oss/dtctl/pkg/resources/api"
+)
+
+// TestNativeCoverageNamesRealCommands walks the coverage map against the real
+// command tree.
+//
+// Every entry is advice dtctl gives out loud — in the DTCTL column of
+// `dtctl get apis`, in the notice `exec api` prints, and in the suggestions on a
+// refusal or a failed call. Advice that does not run teaches a caller that
+// dtctl's suggestions are unreliable, which costs more than the entry was worth.
+// The map is hand-maintained, so this is the only thing keeping it honest.
+func TestNativeCoverageNamesRealCommands(t *testing.T) {
+	coverage := resapi.CoveredBasePaths()
+	require.NotEmpty(t, coverage)
+
+	for basePath, cov := range coverage {
+		require.True(t, strings.HasPrefix(basePath, "/"),
+			"coverage key %q must be an API base path", basePath)
+		require.NotEmpty(t, cov.Resource, "coverage for %q needs a resource label", basePath)
+		require.NotEmpty(t, cov.Command, "coverage for %q needs a command to suggest", basePath)
+
+		argv := strings.Fields(cov.Command)
+		require.Equal(t, "dtctl", argv[0],
+			"Command must be spelled as a caller would type it, got %q", cov.Command)
+
+		found, rest, err := rootCmd.Find(argv[1:])
+		require.NoError(t, err, "coverage for %q suggests %q, which does not resolve",
+			basePath, cov.Command)
+		require.Empty(t, rest,
+			"coverage for %q suggests %q, but %v is not part of the command tree",
+			basePath, cov.Command, rest)
+		require.False(t, found.Hidden,
+			"coverage for %q suggests the hidden command %q", basePath, cov.Command)
+		require.True(t, found.Runnable() || found.HasSubCommands(),
+			"coverage for %q suggests %q, which cannot be run", basePath, cov.Command)
+	}
+}
+
+// TestExecAPIIsUnadvertisedButDocumented pins the deliberate middle state between
+// cobra's two options.
+//
+// Visible would put an escape hatch in --help and in the compact catalogs an agent
+// bootstraps from, right beside the native commands it must not replace. Fully
+// hidden would make it undiscoverable, which pushes a caller who genuinely needs
+// it toward something worse — an ad-hoc AppEngine function holding a bearer token.
+// So: absent from help and from the browsable catalogs, present in the full one.
+func TestExecAPIIsUnadvertisedButDocumented(t *testing.T) {
+	execCmd, _, err := rootCmd.Find([]string{"exec"})
+	require.NoError(t, err)
+
+	apiCmd, _, err := rootCmd.Find([]string{"exec", "api"})
+	require.NoError(t, err)
+	require.True(t, apiCmd.Hidden, "the escape hatch must not be advertised in --help")
+
+	var listed []string
+	for _, sub := range execCmd.Commands() {
+		if !sub.Hidden {
+			listed = append(listed, sub.Name())
+		}
+	}
+	require.NotContains(t, listed, "api")
+
+	full := commands.Build(rootCmd)
+	require.Contains(t, full.Verbs["exec"].Resources, "api",
+		"the full catalog is the one place the escape hatch is documented")
+
+	require.NotContains(t, commands.NewBrief(full).Verbs["exec"].Resources, "api",
+		"--brief is the documented agent bootstrap; it must not tempt one here")
+	require.NotContains(t, commands.NewMinimal(full).Verbs["exec"].Resources, "api")
+
+	// The guardrail travels with the name: the antipatterns are where an agent is
+	// meant to learn `exec api` exists, because there the name arrives with its
+	// constraint attached.
+	joined := strings.Join(full.Antipatterns, "\n")
+	require.Contains(t, joined, "exec api")
+	require.Contains(t, joined, "exec function --code",
+		"the antipattern must name the worse thing it replaces")
+}
+
+// TestNoBuiltinProfileGrantsTheEscapeHatch pins that the presets withhold
+// `exec api` by construction rather than by remembering to exclude it.
+//
+// Profiles are default-deny, so this holds as long as no preset grants the bare
+// `exec` verb. A preset that wants one exec subcommand must name it (as "query"
+// names `exec analyzer`) — and this test is what fails if someone shortens that
+// to `exec` for convenience, which would silently hand a scoped agent profile an
+// unrestricted HTTP client.
+func TestNoBuiltinProfileGrantsTheEscapeHatch(t *testing.T) {
+	names := config.BuiltinProfileNames()
+	require.NotEmpty(t, names)
+
+	env := newMockEnvironmentAt(t, "readonly")
+
+	for _, name := range names {
+		code, out, errOut := runAPI(t, []string{
+			"exec", "api", "/platform/widget/v1/widgets", "--agent",
+		}, RunOptions{Env: map[string]string{"DTCTL_PROFILE": name}})
+
+		require.NotZero(t, code, "profile %q must not expose 'exec api'", name)
+
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &resp), "profile %q: %s%s", name, out, errOut)
+		require.Equal(t, "profile_blocked", resp.Error.Code,
+			"profile %q must mask the command on the surface axis, not merely refuse it", name)
+	}
+
+	require.Zero(t, env.requestCount(),
+		"a masked command must be refused before it can reach the environment")
+}
+
+// TestGetAndDescribeAPIsSurviveARestrictedProfile is the other half: discovery is
+// a read and belongs in a triage profile, so a preset that grants the whole `get`
+// and `describe` subtrees gets the API index with them. Nothing here should have
+// to be special-cased — the test exists to notice if `get apis` ever acquires a
+// reason to be withheld.
+func TestGetAndDescribeAPIsSurviveARestrictedProfile(t *testing.T) {
+	newMockEnvironmentAt(t, "readonly")
+
+	code, out, errOut := runAPI(t, []string{"get", "apis"},
+		RunOptions{Env: map[string]string{"DTCTL_PROFILE": "investigate"}})
+
+	require.Zero(t, code, errOut)
+	require.Contains(t, out, "Widget Service")
+}

--- a/cmd/api_discovery_test.go
+++ b/cmd/api_discovery_test.go
@@ -1,0 +1,500 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Everything the mock environment serves is synthetic. It has to be: a recording
+// of a real environment's API index would commit that environment's published API
+// list to a public repository, and the list is a property of the environment
+// rather than of dtctl.
+const (
+	mockRegistry = `{"urls":[
+		{"name":"Widget Service","url":"/platform/widget/v1/openapi.yaml"},
+		{"name":"Document Service","url":"/platform/document/v1/openapi.yaml"},
+		{"name":"Sprocket Service","url":"/platform/sprocket/v1/openapi.yaml"},
+		{"name":"Legacy Example API","url":"/example-tree/legacy/v1/openapi.yaml"},
+		{"name":"Elsewhere API","url":"https://example.invalid/openapi.yaml"}
+	]}`
+
+	mockWidgetSpec = `openapi: 3.0.3
+info:
+  title: Widget
+  version: 2.4.1
+  x-service-category: Widgets
+  x-summary: Manage widgets.
+servers:
+  - url: /platform/widget/v1
+    x-api-gateway-url: /platform/widget/v1
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      summary: List all widgets.
+      security:
+        - ssoAuth: ["widget:widgets:read"]
+      parameters:
+        - name: page-size
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: How many widgets per page.
+    post:
+      operationId: createWidget
+      summary: Create a widget.
+      security:
+        - ssoAuth: ["widget:widgets:write"]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+                  description: The widget's name.
+                colour:
+                  type: string
+                  description: Optional colour.
+      responses:
+        "201":
+          description: Created.
+          content:
+            application/json:
+              schema:
+                type: object
+  # A POST that only reads. Real platform APIs are full of these (search,
+  # validate, preview, autocomplete), and they are why the method cannot decide
+  # how a request is gated: classifying POST as a write would refuse a read.
+  /widgets:search:
+    post:
+      operationId: searchWidgets
+      summary: Search widgets.
+      security:
+        - ssoAuth: ["widget:widgets:read"]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                match:
+                  type: string
+  /widgets/{id}:
+    put:
+      operationId: replaceWidget
+      summary: Replace a widget.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Widget"
+    delete:
+      operationId: deleteWidget
+      summary: Delete a widget.
+      security:
+        - ssoAuth: ["widget:widgets:delete"]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        name:
+          type: string
+`
+)
+
+// mockEnvironment serves a synthetic API index and specification, and records
+// every path it was asked for so a test can assert what dtctl did *not* request.
+type mockEnvironment struct {
+	server *httptest.Server
+
+	mu       sync.Mutex
+	requests []string
+	// calls records "METHOD /path" for every request, which is what a passthrough
+	// test needs: the interesting assertion is usually that a request the gate
+	// refused never reached the wire at all.
+	calls []string
+	// bodies records the request body per "METHOD /path", so a test can prove that
+	// a body read through the vfs seam arrived intact.
+	bodies map[string]string
+	// specStatus overrides the status for a specification path, e.g. 403 for an
+	// environment that publishes its index but not its documents.
+	specStatus map[string]int
+	// canned holds responses for concrete request paths, keyed "METHOD /path", so
+	// `exec api` can be exercised against the same environment that publishes the
+	// specification it is classified from.
+	canned map[string]mockResponse
+}
+
+// mockResponse is a canned reply for one endpoint.
+type mockResponse struct {
+	status      int
+	contentType string
+	body        string
+}
+
+func newMockEnvironment(t *testing.T) *mockEnvironment {
+	return newMockEnvironmentAt(t, "readonly")
+}
+
+// newMockEnvironmentAt is newMockEnvironment with an explicit safety level, for
+// the tests that assert what each level permits.
+func newMockEnvironmentAt(t *testing.T, safetyLevel string) *mockEnvironment {
+	t.Helper()
+
+	m := &mockEnvironment{
+		specStatus: map[string]int{},
+		canned:     map[string]mockResponse{},
+		bodies:     map[string]string{},
+	}
+	m.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+
+		m.mu.Lock()
+		m.requests = append(m.requests, r.URL.Path)
+		m.calls = append(m.calls, key)
+		m.bodies[key] = string(body)
+		status := m.specStatus[r.URL.Path]
+		canned, hasCanned := m.canned[key]
+		m.mu.Unlock()
+
+		if status != 0 {
+			w.WriteHeader(status)
+			_, _ = fmt.Fprint(w, `{"error":{"code":403,"message":"refused"}}`)
+			return
+		}
+
+		if hasCanned {
+			if canned.contentType != "" {
+				w.Header().Set("Content-Type", canned.contentType)
+			}
+			w.WriteHeader(canned.status)
+			_, _ = fmt.Fprint(w, canned.body)
+			return
+		}
+
+		switch r.URL.Path {
+		case "/platform/metadata/v1/swagger-ui.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, mockRegistry)
+		case "/platform/widget/v1/openapi.yaml":
+			// Deliberately a content type that is not YAML's: the same artifact
+			// ships under four of them, so parsing must never branch on it.
+			w.Header().Set("Content-Type", "application/vnd.oai.openapi")
+			_, _ = fmt.Fprint(w, mockWidgetSpec)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprint(w, `{"error":{"code":404,"message":"not found"}}`)
+		}
+	}))
+	t.Cleanup(m.server.Close)
+
+	writeIsolatedConfig(t, safetyLevelConfig(m.server.URL, safetyLevel))
+	return m
+}
+
+func (m *mockEnvironment) requested(path string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Contains(m.requests, path)
+}
+
+func (m *mockEnvironment) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.requests)
+}
+
+// respond registers a canned reply for one endpoint.
+func (m *mockEnvironment) respond(method, path string, r mockResponse) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.canned[method+" "+path] = r
+}
+
+// called reports whether a request was actually sent. A gate that refuses must
+// refuse *before* the wire, and this is how a test proves it.
+func (m *mockEnvironment) called(method, path string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Contains(m.calls, method+" "+path)
+}
+
+// bodyOf returns the body a request carried.
+func (m *mockEnvironment) bodyOf(method, path string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.bodies[method+" "+path]
+}
+
+// writeIsolatedConfig installs a config file and the agent-detection scrubbing
+// that every Run-level test needs.
+func writeIsolatedConfig(t *testing.T, content string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	t.Setenv("DTCTL_CONFIG", path)
+	t.Setenv("DTCTL_PROFILE", "")
+	for _, v := range []string{
+		"CLAUDECODE", "CLAUDE_CODE", "AI_AGENT", "CODEX", "CURSOR_AGENT",
+		"COPILOT_CLI", "GITHUB_COPILOT", "AGENT_CONTEXT_OUT", "KIRO_SESSION_ID",
+		"OPENCODE",
+	} {
+		t.Setenv(v, "")
+	}
+}
+
+// TestGetAPIsMirrorsTheIndex pins the central rule of the listing: dtctl shows
+// what the environment's index shows, adding and hiding nothing. Any client-side
+// filter would have to name the APIs it hides, and naming them in open source is
+// itself the disclosure.
+func TestGetAPIsMirrorsTheIndex(t *testing.T) {
+	env := newMockEnvironment(t)
+
+	code, out := captureRun(t, []string{"get", "apis"}, RunOptions{})
+	require.Zero(t, code, out)
+
+	for _, name := range []string{"Widget Service", "Document Service", "Sprocket Service",
+		"Legacy Example API", "Elsewhere API"} {
+		require.Contains(t, out, name, "every index entry must be listed")
+	}
+	require.Contains(t, out, "/platform/widget/v1")
+	// The coverage column names the native command for an API dtctl already wraps.
+	require.Regexp(t, `/platform/document/v1\s+document`, out)
+
+	require.Equal(t, 1, env.requestCount(),
+		"the default listing must cost exactly one request — no specification fetches")
+}
+
+// TestGetAPIsUncoveredIsAContributionBacklog pins both filters that make
+// --uncovered a backlog rather than a listing: covered APIs drop out, and so does
+// anything off the public platform tree, which satisfies neither condition of the
+// curation rule it feeds.
+func TestGetAPIsUncoveredIsAContributionBacklog(t *testing.T) {
+	newMockEnvironment(t)
+
+	code, out := captureRun(t, []string{"get", "apis", "--uncovered"}, RunOptions{})
+	require.Zero(t, code, out)
+
+	require.Contains(t, out, "Widget Service", "an uncovered platform API is a candidate")
+	require.NotContains(t, out, "Document Service", "dtctl already wraps it")
+	require.NotContains(t, out, "Legacy Example API", "not on the public platform tree")
+	require.NotContains(t, out, "Elsewhere API", "documented on another host; no base path")
+}
+
+// TestGetAPIsOpsCountFailsSoftPerRow pins that one unreadable document degrades
+// its own row and nothing else. An environment that publishes its index but
+// refuses its documents is a real configuration, and a listing that fails
+// wholesale there would be useless.
+func TestGetAPIsOpsCountFailsSoftPerRow(t *testing.T) {
+	env := newMockEnvironment(t)
+	env.specStatus["/platform/document/v1/openapi.yaml"] = http.StatusForbidden
+
+	code, out := captureRun(t, []string{"get", "apis", "--ops-count", "-o", "json"}, RunOptions{})
+	require.Zero(t, code, out)
+
+	require.Contains(t, out, `"operations": 5`, "the readable specification is still counted")
+	require.Contains(t, out, `"spec_error"`, "the unreadable one carries its reason")
+	require.Contains(t, out, "Document Service", "and keeps its row")
+}
+
+// TestDescribeAPIProjectsRatherThanDumps pins the operation index: every
+// operation is present, and the raw document is not.
+func TestDescribeAPIProjectsRatherThanDumps(t *testing.T) {
+	newMockEnvironment(t)
+
+	code, out := captureRun(t, []string{"describe", "api", "Widget Service"}, RunOptions{})
+	require.Zero(t, code, out)
+
+	require.Contains(t, out, "GET /widgets")
+	require.Contains(t, out, "POST /widgets")
+	require.Contains(t, out, "DELETE /widgets/{id}")
+	require.Contains(t, out, "widget:widgets:read", "the declared scope is part of the projection")
+	require.NotContains(t, out, "openapi: 3.0.3", "the projection is not the document")
+}
+
+// TestDescribeAPIOperationDetailIsEnoughToComposeACall pins the drill-down: a
+// caller must be able to build the request from it without the rest of the
+// document, which is what makes `exec api` usable at all.
+func TestDescribeAPIOperationDetailIsEnoughToComposeACall(t *testing.T) {
+	newMockEnvironment(t)
+
+	code, out := captureRun(t,
+		[]string{"describe", "api", "Widget Service", "--operation", "POST /widgets"}, RunOptions{})
+	require.Zero(t, code, out)
+
+	require.Contains(t, out, "/platform/widget/v1/widgets", "the full request path, already joined")
+	require.Contains(t, out, "widget:widgets:write")
+	require.Contains(t, out, "application/json")
+	require.Contains(t, out, "name", "required body properties are shown")
+	require.Contains(t, out, "dtctl exec api /platform/widget/v1/widgets -X POST",
+		"the detail ends in a runnable invocation")
+}
+
+// TestDescribeAPIUndeclaredScopeIsNotSilence pins that an operation with no
+// declared scope says so. Rendering nothing would read as "no scope required",
+// and two of six sampled APIs declare no per-operation scopes at all.
+func TestDescribeAPIUndeclaredScopeIsNotSilence(t *testing.T) {
+	newMockEnvironment(t)
+
+	code, out := captureRun(t,
+		[]string{"describe", "api", "Widget Service", "--operation", "DELETE /widgets/{id}"}, RunOptions{})
+	require.Zero(t, code, out)
+	require.Contains(t, out, "widget:widgets:delete")
+
+	// PUT declares no security at all, which is common and is not the same as
+	// "no scope required".
+	code, out = captureRun(t,
+		[]string{"describe", "api", "Widget Service", "--operation", "PUT /widgets/{id}"}, RunOptions{})
+	require.Zero(t, code, out)
+	require.Contains(t, out, "not declared in the specification",
+		"an absent declaration must be stated, not rendered as blank")
+}
+
+// TestDescribeAPINameMissIsNotAnExistenceOracle is the disclosure guard. A name
+// dtctl cannot find in the index must fail as a miss: synthesizing a candidate
+// path and probing it would turn the command into a prober that confirms whether
+// an API exists on an environment whose index omits it.
+func TestDescribeAPINameMissIsNotAnExistenceOracle(t *testing.T) {
+	env := newMockEnvironment(t)
+
+	code, out := captureRun(t, []string{"describe", "api", "nonexistent-service"}, RunOptions{})
+	require.NotZero(t, code, "a miss must fail")
+	require.NotContains(t, out, "nonexistent-service/v1",
+		"no synthesized path may appear in the output")
+
+	require.Equal(t, 1, env.requestCount(),
+		"only the index may be requested; a miss must probe nothing")
+	require.True(t, env.requested("/platform/metadata/v1/swagger-ui.json"))
+}
+
+// TestDescribeAPIAcceptsAnExplicitBasePath is the other half of the rule: a
+// caller who already knows a base path is told nothing new by dtctl using it.
+func TestDescribeAPIAcceptsAnExplicitBasePath(t *testing.T) {
+	env := newMockEnvironment(t)
+
+	code, out := captureRun(t, []string{"describe", "api", "/platform/widget/v1"}, RunOptions{})
+	require.Zero(t, code, out)
+	require.Contains(t, out, "GET /widgets")
+	require.True(t, env.requested("/platform/widget/v1/openapi.yaml"))
+}
+
+// TestDescribeAPIRawWritesTheDocumentVerbatim pins that --raw is exactly the
+// bytes the environment served, and that it goes to a file when the caller asks
+// for one rather than flooding stdout.
+func TestDescribeAPIRawWritesTheDocumentVerbatim(t *testing.T) {
+	newMockEnvironment(t)
+	dest := filepath.Join(t.TempDir(), "widget.yaml")
+
+	code, out := captureRun(t,
+		[]string{"describe", "api", "Widget Service", "--raw", "--spill-to", dest}, RunOptions{})
+	require.Zero(t, code, out)
+
+	written, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	require.Equal(t, mockWidgetSpec, string(written), "--raw must not reformat the document")
+}
+
+// TestDescribeAPIRawToStdoutIsTheHumanDefault pins that a human gets the document
+// on stdout, where redirection works, rather than a path to a cache file.
+func TestDescribeAPIRawToStdoutIsTheHumanDefault(t *testing.T) {
+	newMockEnvironment(t)
+
+	code, out := captureRun(t, []string{"describe", "api", "Widget Service", "--raw"}, RunOptions{})
+	require.Zero(t, code, out)
+	require.Contains(t, out, "openapi: 3.0.3")
+	require.Contains(t, out, "x-api-gateway-url: /platform/widget/v1")
+}
+
+// TestAPIIndexUnavailableNamesTheFallback pins the fail-soft contract for an
+// environment with no machine-readable index: a stable error code, no forwarded
+// HTTP body, and the documented explorer as the way forward.
+func TestAPIIndexUnavailableNamesTheFallback(t *testing.T) {
+	env := newMockEnvironment(t)
+	env.specStatus["/platform/metadata/v1/swagger-ui.json"] = http.StatusNotFound
+
+	code, env2 := runAgentEnvelope(t, []string{"get", "apis"})
+	require.NotZero(t, code)
+	require.Equal(t, "api_index_unavailable", errorCode(t, env2))
+
+	detail, _ := env2["error"].(map[string]any)
+	require.NotNil(t, detail)
+	message, _ := detail["message"].(string)
+	require.Contains(t, message, "/platform/metadata/v1/swagger-ui.json")
+	require.NotContains(t, message, "refused", "the upstream body is not forwarded")
+
+	suggestions := fmt.Sprint(detail["suggestions"])
+	require.Contains(t, suggestions, "/platform/swagger-ui/index.html",
+		"the documented explorer is the fallback to name")
+}
+
+// TestAPIIndexRefusedIsNotAnAbsentIndex pins the distinction the 404 message must
+// not swallow.
+//
+// "This environment publishes no machine-readable API index" is a claim about the
+// environment. A 401 is evidence about the credential, and answering it with that
+// claim sends someone to investigate the wrong layer — while a machine consumer
+// reading api_index_unavailable would stop probing an index that is in fact there.
+func TestAPIIndexRefusedIsNotAnAbsentIndex(t *testing.T) {
+	env := newMockEnvironment(t)
+	env.specStatus["/platform/metadata/v1/swagger-ui.json"] = http.StatusUnauthorized
+
+	code, envelope := runAgentEnvelope(t, []string{"get", "apis"})
+	require.NotZero(t, code)
+	require.NotEqual(t, "api_index_unavailable", errorCode(t, envelope),
+		"a refused index must not be reported as an unpublished one")
+
+	detail, _ := envelope["error"].(map[string]any)
+	require.NotNil(t, detail)
+	message, _ := detail["message"].(string)
+	require.Contains(t, message, "not authorized")
+	require.NotContains(t, message, "publishes no",
+		"the message must not make a claim about the environment from evidence about the token")
+
+	suggestions := fmt.Sprint(detail["suggestions"])
+	require.Contains(t, suggestions, "dtctl doctor",
+		"the hint must point at the credential, not at the API explorer")
+}
+
+// TestSpecUnavailableExplainsAValidTokenBeingRefused pins the 403 case, which is
+// the one an environment can produce with a perfectly good token: the raw body
+// talks about SSO and helps nobody, so the status is translated into advice.
+func TestSpecUnavailableExplainsAValidTokenBeingRefused(t *testing.T) {
+	env := newMockEnvironment(t)
+	env.specStatus["/platform/widget/v1/openapi.yaml"] = http.StatusForbidden
+
+	code, envelope := runAgentEnvelope(t, []string{"describe", "api", "Widget Service"})
+	require.NotZero(t, code)
+	require.Equal(t, "api_spec_unavailable", errorCode(t, envelope))
+
+	detail, _ := envelope["error"].(map[string]any)
+	require.NotNil(t, detail)
+	suggestions := fmt.Sprint(detail["suggestions"])
+	require.Contains(t, strings.ToLower(suggestions), "interactive session")
+	require.Contains(t, suggestions, "exec api",
+		"the API itself is still reachable without its specification")
+}

--- a/cmd/check_scopes.go
+++ b/cmd/check_scopes.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"sort"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/client"
 	"github.com/dynatrace-oss/dtctl/pkg/commands"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
+	resapi "github.com/dynatrace-oss/dtctl/pkg/resources/api"
 )
 
 // checkScopes is the --check-scopes persistent flag: resolve the command's
@@ -99,7 +101,7 @@ func installScopePreflight(cmd *cobra.Command) {
 // not run, and an error to abort with. The preflight is intentionally resilient:
 // any failure to determine scopes degrades to "proceed" rather than blocking a
 // command, so it can never turn a working command into a broken one.
-func scopePreflight(c *cobra.Command, _ []string) (skip bool, err error) {
+func scopePreflight(c *cobra.Command, args []string) (skip bool, err error) {
 	// Only do work when explicitly requested or when auto-preflighting in agent mode.
 	if !checkScopes && !agentMode {
 		return false, nil
@@ -108,8 +110,18 @@ func scopePreflight(c *cobra.Command, _ []string) (skip bool, err error) {
 	verb, resource := verbResource(c)
 
 	if checkScopes {
-		required, hasReq := requiredScopesFor(verb, resource)
-		result := computeScopeVerdict(verb, resource, required, hasReq)
+		required, req := requiredScopesFor(verb, resource)
+		if req == scopeRequirementPerCall {
+			// --check-scopes is explicit and terminal: the command body does not run
+			// afterwards, so resolving the requirement from the environment's own
+			// specification spends one round trip the caller asked for. The agent-mode
+			// auto-preflight below deliberately does not do this — it runs ahead of
+			// every command and must stay free.
+			if scopes, ok := resolvePerCallScopes(c, args); ok {
+				required, req = scopes, scopeRequirementKnown
+			}
+		}
+		result := computeScopeVerdict(verb, resource, required, req)
 		// In agent mode the verdict must use the same envelope contract as every
 		// other command: an insufficient verdict reuses the ScopeError path (so it
 		// renders as an `insufficient_scope` error envelope with exit 5, identical
@@ -142,8 +154,12 @@ func scopePreflight(c *cobra.Command, _ []string) (skip bool, err error) {
 	if _, mutating := commands.MutatingVerbs[verb]; !mutating {
 		return false, nil
 	}
-	required, hasReq := requiredScopesFor(verb, resource)
-	if !hasReq {
+	// Only a catalog-known requirement can prove a command will fail. A per-call
+	// requirement would have to be resolved over the network on every single
+	// invocation, which is not a price a preflight may charge — `exec api` reports
+	// the platform's own 403, with the declared scope, when it happens.
+	required, req := requiredScopesFor(verb, resource)
+	if req != scopeRequirementKnown {
 		return false, nil
 	}
 	granted, known := grantedScopesFunc()
@@ -178,24 +194,84 @@ func verbResource(c *cobra.Command) (verb, resource string) {
 	return verb, resource
 }
 
+// scopeRequirement is what the catalog can say about a command's scopes.
+//
+// The two-way answer this replaced could not tell "needs no scope" apart from
+// "cannot say", so it reported both as ok — and an ok verdict for a command
+// nothing was checked against is worse than no verdict at all.
+type scopeRequirement int
+
+const (
+	// scopeRequirementNone: the command touches no platform API (ctx, commands).
+	scopeRequirementNone scopeRequirement = iota
+	// scopeRequirementKnown: the catalog names the scopes.
+	scopeRequirementKnown
+	// scopeRequirementPerCall: the scopes are a property of the invocation, not of
+	// the command, so the catalog cannot hold them.
+	scopeRequirementPerCall
+)
+
+// perCallScopeCommands are `<verb> <resource>` leaves whose required scopes
+// depend on their arguments.
+//
+// `exec api` is the only one: it can reach any endpoint the environment
+// publishes, and each declares its own scope. Listing a union of every scope in
+// the catalog would be both wrong and useless, so the requirement is resolved per
+// call — from the environment's specification — or honestly reported as unknown.
+var perCallScopeCommands = map[string]bool{
+	"exec api": true,
+}
+
 // requiredScopesFor looks up a command's required scopes from the catalog (the
-// single source of truth). Returns (scopes, true) when a scope requirement is
-// known, or (nil, false) for local/no-scope commands.
-func requiredScopesFor(verb, resource string) ([]string, bool) {
+// single source of truth), and reports what kind of answer that is.
+func requiredScopesFor(verb, resource string) ([]string, scopeRequirement) {
+	if perCallScopeCommands[verb+" "+resource] {
+		return nil, scopeRequirementPerCall
+	}
 	listing := commands.Build(rootCmd)
 	v, ok := listing.Verbs[verb]
 	if !ok {
-		return nil, false
+		return nil, scopeRequirementNone
 	}
 	if resource != "" {
 		if s, ok := v.RequiredScopesByResource[resource]; ok && len(s) > 0 {
-			return s, true
+			return s, scopeRequirementKnown
 		}
 	}
 	if len(v.RequiredScopes) > 0 { // DQL verbs (query/verify/wait)
-		return v.RequiredScopes, true
+		return v.RequiredScopes, scopeRequirementKnown
 	}
-	return nil, false
+	return nil, scopeRequirementNone
+}
+
+// resolvePerCallScopes resolves the scopes this specific invocation needs, for a
+// command whose requirement is per-call.
+//
+// It returns false whenever the answer is not certain — an unreadable
+// specification, a path that matches no operation, or an operation that declares
+// no scope. The verdict then stays "unknown", because a preflight that guesses is
+// the one failure mode worse than a preflight that abstains.
+func resolvePerCallScopes(c *cobra.Command, args []string) ([]string, bool) {
+	// `exec api` is the only per-call command; a second one would add a case here.
+	if c.Name() != "api" || c.Parent() == nil || c.Parent().Name() != "exec" || len(args) == 0 {
+		return nil, false
+	}
+
+	method, _ := c.Flags().GetString("method")
+	method = strings.ToUpper(strings.TrimSpace(method))
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	_, client, err := SetupClient()
+	if err != nil {
+		return nil, false
+	}
+	_, op := resapi.NewHandler(client).ResolveForRequest(method, args[0])
+	if op == nil || len(op.Scopes) == 0 {
+		return nil, false
+	}
+	return op.Scopes, true
 }
 
 // grantedScopesFunc reads the active token's granted scopes. Overridable in tests.
@@ -222,16 +298,31 @@ func grantedScopes() (scopes []string, known bool) {
 }
 
 // computeScopeVerdict builds the verdict for the explicit --check-scopes path.
-func computeScopeVerdict(verb, resource string, required []string, hasReq bool) ScopeCheckResult {
+func computeScopeVerdict(verb, resource string, required []string, req scopeRequirement) ScopeCheckResult {
 	res := ScopeCheckResult{
 		Verb:           verb,
 		Resource:       resource,
 		RequiredScopes: required,
 	}
-	if !hasReq {
+	switch req {
+	case scopeRequirementNone:
 		// No platform scopes required (local command); nothing to check.
 		res.Status = scopeStatusOK
 		res.RequiredScopes = []string{}
+		return res
+	case scopeRequirementPerCall:
+		// Resolution was not attempted or did not succeed. Reporting ok here would
+		// assure the caller about a check that never happened — and this is exactly
+		// the command where a false assurance is most expensive, since it can reach
+		// any endpoint the environment publishes.
+		res.Status = scopeStatusUnknown
+		res.RequiredScopes = []string{}
+		res.Suggestions = []string{
+			"this command's required scopes depend on the endpoint it calls, so they are " +
+				"not knowable in advance",
+			"dtctl describe api <name> --operation '<METHOD> <path>'  -- the scope the " +
+				"specification declares for that endpoint",
+		}
 		return res
 	}
 
@@ -298,6 +389,18 @@ func printScopeVerdictHuman(r ScopeCheckResult) {
 	}
 	fmt.Printf("Scope check for %q:\n", target)
 	if len(r.RequiredScopes) == 0 {
+		// An empty requirement means two different things, and the status is what
+		// separates them: nothing is needed, or nothing could be determined. Printing
+		// "no platform scopes required" for the latter would turn an abstention into
+		// a claim.
+		if r.Status == scopeStatusUnknown {
+			fmt.Println("  required: unknown")
+			fmt.Println("  status:   unknown — dtctl could not determine what this call needs")
+			for _, s := range r.Suggestions {
+				fmt.Printf("    - %s\n", s)
+			}
+			return
+		}
 		fmt.Println("  no platform scopes required")
 		return
 	}

--- a/cmd/check_scopes_test.go
+++ b/cmd/check_scopes_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -103,39 +104,45 @@ func TestVerbResource(t *testing.T) {
 }
 
 func TestRequiredScopesFor(t *testing.T) {
-	got, ok := requiredScopesFor("delete", "workflow")
-	require.True(t, ok)
+	got, req := requiredScopesFor("delete", "workflow")
+	require.Equal(t, scopeRequirementKnown, req)
 	require.Equal(t, []string{"automation:workflows:write"}, got)
 
-	got, ok = requiredScopesFor("get", "workflows")
-	require.True(t, ok)
+	got, req = requiredScopesFor("get", "workflows")
+	require.Equal(t, scopeRequirementKnown, req)
 	require.Equal(t, []string{"automation:workflows:read"}, got)
 
 	// DQL verbs carry flat scopes at the verb level.
-	got, ok = requiredScopesFor("query", "")
-	require.True(t, ok)
+	got, req = requiredScopesFor("query", "")
+	require.Equal(t, scopeRequirementKnown, req)
 	require.Contains(t, got, "storage:logs:read")
 
-	got, ok = requiredScopesFor("wait", "query")
-	require.True(t, ok)
+	got, req = requiredScopesFor("wait", "query")
+	require.Equal(t, scopeRequirementKnown, req)
 	require.Contains(t, got, "storage:logs:read")
 
 	// Local commands have no scope requirement.
-	_, ok = requiredScopesFor("ctx", "set")
-	require.False(t, ok)
+	_, req = requiredScopesFor("ctx", "set")
+	require.Equal(t, scopeRequirementNone, req)
+
+	// `exec api` can reach any endpoint the environment publishes, each declaring
+	// its own scope, so the catalog cannot hold the answer. This must be a distinct
+	// verdict from "needs nothing" — see TestComputeScopeVerdict.
+	_, req = requiredScopesFor("exec", "api")
+	require.Equal(t, scopeRequirementPerCall, req)
 }
 
 func TestComputeScopeVerdict(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		withScopeState(t, true, false, "json", []string{"automation:workflows:write", "x"}, true)
-		r := computeScopeVerdict("delete", "workflow", []string{"automation:workflows:write"}, true)
+		r := computeScopeVerdict("delete", "workflow", []string{"automation:workflows:write"}, scopeRequirementKnown)
 		require.Equal(t, scopeStatusOK, r.Status)
 		require.Empty(t, r.MissingScopes)
 	})
 
 	t.Run("insufficient", func(t *testing.T) {
 		withScopeState(t, true, false, "json", []string{"automation:workflows:read"}, true)
-		r := computeScopeVerdict("delete", "workflow", []string{"automation:workflows:write"}, true)
+		r := computeScopeVerdict("delete", "workflow", []string{"automation:workflows:write"}, scopeRequirementKnown)
 		require.Equal(t, scopeStatusInsufficient, r.Status)
 		require.Equal(t, []string{"automation:workflows:write"}, r.MissingScopes)
 		require.NotEmpty(t, r.Suggestions)
@@ -143,7 +150,7 @@ func TestComputeScopeVerdict(t *testing.T) {
 
 	t.Run("unknown", func(t *testing.T) {
 		withScopeState(t, true, false, "json", nil, false)
-		r := computeScopeVerdict("delete", "workflow", []string{"automation:workflows:write"}, true)
+		r := computeScopeVerdict("delete", "workflow", []string{"automation:workflows:write"}, scopeRequirementKnown)
 		require.Equal(t, scopeStatusUnknown, r.Status)
 		require.Empty(t, r.GrantedScopes)
 		require.NotEmpty(t, r.Suggestions)
@@ -151,9 +158,23 @@ func TestComputeScopeVerdict(t *testing.T) {
 
 	t.Run("no scopes required", func(t *testing.T) {
 		withScopeState(t, true, false, "json", nil, false)
-		r := computeScopeVerdict("ctx", "set", nil, false)
+		r := computeScopeVerdict("ctx", "set", nil, scopeRequirementNone)
 		require.Equal(t, scopeStatusOK, r.Status)
 		require.Empty(t, r.RequiredScopes)
+	})
+
+	// A per-call requirement must not borrow the "no scopes required" verdict. The
+	// two are indistinguishable to a caller reading `status: ok` — and for the one
+	// command that can reach any endpoint the environment publishes, an ok verdict
+	// that checked nothing is an assurance dtctl has no basis to give.
+	t.Run("per-call requirement is unknown, never ok", func(t *testing.T) {
+		withScopeState(t, true, false, "json", []string{"automation:workflows:write"}, true)
+		r := computeScopeVerdict("exec", "api", nil, scopeRequirementPerCall)
+		require.Equal(t, scopeStatusUnknown, r.Status,
+			"a check that did not happen must not report ok")
+		require.Empty(t, r.RequiredScopes)
+		require.NotEmpty(t, r.Suggestions, "an unknown verdict must say how to find the answer")
+		require.Contains(t, strings.Join(r.Suggestions, "\n"), "describe api")
 	})
 }
 

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -465,6 +465,78 @@ func TestMutatingVerbsMatchSafetyCheckerUsage(t *testing.T) {
 	}
 }
 
+// TestMutatingVerbFilesPerformSafetyChecks asserts the direction
+// TestMutatingVerbsMatchSafetyCheckerUsage does not: that every command file
+// belonging to a verb the catalog declares *mutating* actually performs a safety
+// check when it builds a client.
+//
+// The forward assertion ("every verb with safety checks is in MutatingVerbs")
+// cannot catch a whole verb family that declares itself mutating and then never
+// checks. That is exactly what happened to `exec`: the catalog advertised
+// `exec: OperationCreate` while every subcommand called SetupClient(), so a
+// readonly context did not block `dtctl exec function --code '…'` — ad-hoc
+// JavaScript that can POST or DELETE anywhere the token reaches.
+func TestMutatingVerbFilesPerformSafetyChecks(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	// Building a client is the observable signal that a file talks to the
+	// platform. The signal must include the *safe* helpers too: listing only the
+	// ungated ones would make the test vacuous the moment a file is fixed, and
+	// would not notice a later regression that reintroduces ungated access
+	// alongside a gated sibling in the same file.
+	clientCtors := []string{
+		"SetupClient()", "Setup()", "SetupWithSafety", "NewClientFromConfig(",
+	}
+	// SetupWithSafetyAndPrinter contains SetupWithSafety, so both are covered.
+	safetyCalls := []string{"NewSafetyChecker", "SetupWithSafety"}
+
+	containsAny := func(s string, needles []string) bool {
+		for _, n := range needles {
+			if strings.Contains(s, n) {
+				return true
+			}
+		}
+		return false
+	}
+
+	checked := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		// Map the file to a verb by exact convention: <verb>.go or <verb>_<rest>.go.
+		// Prefix matching alone would misattribute e.g. "execute_x.go" to "exec".
+		stem := strings.TrimSuffix(name, ".go")
+		verb := strings.SplitN(stem, "_", 2)[0]
+		if _, mutating := commands.MutatingVerbs[verb]; !mutating {
+			continue
+		}
+
+		data, err := os.ReadFile(name)
+		require.NoError(t, err)
+		content := string(data)
+
+		if !containsAny(content, clientCtors) {
+			continue // no platform access in this file
+		}
+		checked++
+		require.True(t, containsAny(content, safetyCalls),
+			"%s belongs to the mutating verb %q and builds a platform client, but performs no "+
+				"safety check (NewSafetyChecker or SetupWithSafety). Every command under a "+
+				"mutating verb must gate on the safety level — see AGENTS.md 'CRITICAL: Safety Checks'.",
+			name, verb)
+	}
+
+	// Guard the guard: if the file-naming convention ever changes, this test must
+	// fail loudly rather than silently passing over an empty set.
+	require.Greater(t, checked, 20,
+		"expected to inspect many mutating-verb command files; found only %d — the "+
+			"<verb>_<resource>.go naming convention may have changed", checked)
+}
+
 // TestResourceAliasesMatchCobraAliases walks the real Cobra command tree and
 // collects all resource-level Aliases defined on subcommands. It then verifies
 // that commands.ResourceAliases contains these aliases (or a documented subset).

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -33,7 +33,7 @@ Supported resources:
   users                   groups                     lookup-tables (lu)
   trash                   azure connection           azure monitoring
   extensions (ext)        extension-configs (extcfg) hub-extensions
-  analyzers (az)`,
+  analyzers (az)          api`,
 	Example: `  # Describe a workflow to see its trigger and task details
   dtctl describe workflow my-workflow
 
@@ -333,4 +333,5 @@ func init() {
 	describeCmd.AddCommand(describeAnomalyDetectorCmd)
 	describeCmd.AddCommand(describeHubExtensionCmd)
 	describeCmd.AddCommand(describeAnalyzerCmd)
+	describeCmd.AddCommand(describeAPICmd)
 }

--- a/cmd/describe_api.go
+++ b/cmd/describe_api.go
@@ -1,0 +1,461 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/exec"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+	resapi "github.com/dynatrace-oss/dtctl/pkg/resources/api"
+)
+
+// describeAPICmd projects one API's specification.
+//
+// It never emits the whole document by default. A published specification runs
+// from roughly 10k to 47k tokens, which is unreadable for a human and
+// unaffordable for an agent, so the default view is the operation index: every
+// operation, at a coarser grain. --operation drills into one operation in full,
+// and --raw streams the unprojected document for a caller that asks for it.
+var describeAPICmd = &cobra.Command{
+	Use:     "api <name|base-path>",
+	Aliases: []string{"apis"},
+	Short:   "Show an API's operations from its published specification",
+	Long: `Show what one API offers, from the specification the environment publishes.
+
+The default view is the operation index: every operation as 'METHOD /path' with
+its summary and the scope the specification declares for it. That is a complete
+view at a coarser grain, not a truncation — drill into any single operation with
+--operation to get its parameters, request body, responses, and a ready-to-run
+'dtctl exec api' invocation.
+
+An API is named as it appears in 'dtctl get apis', or by its base path.
+
+Note that a blank SCOPE means the specification declares none for that
+operation, not that none is required.
+
+Examples:
+  # Operation index for one API
+  dtctl describe api document
+
+  # One operation in full
+  dtctl describe api document --operation 'GET /documents/{id}'
+
+  # Address an API by base path
+  dtctl describe api /platform/document/v1
+
+  # The unprojected specification (large — spills to a file in agent mode)
+  dtctl describe api document --raw
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, c, printer, err := Setup()
+		if err != nil {
+			return err
+		}
+
+		handler := resapi.NewHandler(c)
+		entry, err := handler.Resolve(args[0])
+		if err != nil {
+			return err
+		}
+
+		if raw, _ := cmd.Flags().GetBool("raw"); raw {
+			doc, err := handler.RawSpec(*entry)
+			if err != nil {
+				return err
+			}
+			return emitRawSpec(cmd, cfg, *entry, doc)
+		}
+
+		if operation, _ := cmd.Flags().GetString("operation"); operation != "" {
+			detail, err := handler.DescribeOperation(*entry, operation)
+			if err != nil {
+				return err
+			}
+			if useAPIDescribeTextView() {
+				printOperationDetail(detail)
+				return nil
+			}
+			if ap := enrichAgent(printer, "describe", "api"); ap != nil {
+				ap.Context().Suggestions = []string{
+					detail.Example + "  -- call this operation",
+					fmt.Sprintf("dtctl describe api %s  -- the API's other operations", quoteCommandArg(args[0])),
+				}
+			}
+			return printer.Print(detail)
+		}
+
+		desc, err := handler.Describe(*entry)
+		if err != nil {
+			return err
+		}
+		if useAPIDescribeTextView() {
+			return printAPIDescribe(printer, desc)
+		}
+		if ap := enrichAgent(printer, "describe", "api"); ap != nil {
+			ap.Context().Suggestions = apiDescribeSuggestions(args[0], desc)
+		}
+		return printer.Print(desc)
+	},
+}
+
+// useAPIDescribeTextView reports whether to render the human-readable text view.
+// Agent mode always takes the structured path — it leaves outputFormat at its
+// "table" default, so a bare format check would emit human text into an agent
+// session. "wide" belongs here too: it selects extra columns of the operation
+// table, not a different view.
+func useAPIDescribeTextView() bool {
+	if agentMode {
+		return false
+	}
+	return outputFormat == "" || outputFormat == "table" || outputFormat == "wide"
+}
+
+// apiDescribeSuggestions points at the next step, which for an operation index is
+// always drilling into one operation. Naming a real operation from this very
+// document beats naming a placeholder.
+func apiDescribeSuggestions(query string, d *resapi.APIDescription) []string {
+	out := []string{}
+	if len(d.Operations) > 0 {
+		out = append(out, fmt.Sprintf("dtctl describe api %s --operation '%s'  -- one operation in full",
+			quoteCommandArg(query), d.Operations[0].Operation))
+	}
+	if d.Dtctl != "" {
+		out = append(out, fmt.Sprintf("dtctl get %s  -- the native dtctl command for this API (preferred)", d.Dtctl))
+	}
+	return out
+}
+
+// printAPIDescribe renders the human-readable operation index: a header block
+// plus the operation list through the ordinary table printer, so the operation
+// index looks like every other dtctl listing (and honours -o wide).
+func printAPIDescribe(printer output.Printer, d *resapi.APIDescription) error {
+	const w = 12
+	output.DescribeKV("Name:", w, "%s", d.Name)
+	if d.Title != "" && d.Title != d.Name {
+		output.DescribeKV("Title:", w, "%s", d.Title)
+	}
+	if d.Version != "" {
+		output.DescribeKV("Version:", w, "%s", d.Version)
+	}
+	if d.Category != "" {
+		output.DescribeKV("Category:", w, "%s", d.Category)
+	}
+	output.DescribeKV("Base Path:", w, "%s", d.BasePath)
+	if d.Summary != "" {
+		output.DescribeKV("Summary:", w, "%s", d.Summary)
+	}
+	if d.Dtctl != "" {
+		output.DescribeKV("dtctl:", w, "%s (prefer the native command over 'exec api')", d.Dtctl)
+	}
+
+	fmt.Println()
+	output.DescribeSection(fmt.Sprintf("Operations (%d):", len(d.Operations)))
+	if len(d.Operations) == 0 {
+		fmt.Println("  (the specification declares none)")
+		return nil
+	}
+
+	if err := printer.PrintList(d.Operations); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Printf("  Detail:  dtctl describe api %s --operation '%s'\n",
+		quoteCommandArg(d.Name), d.Operations[0].Operation)
+	return nil
+}
+
+// printOperationDetail renders one operation in full.
+func printOperationDetail(d *resapi.OperationDetail) {
+	const w = 12
+	output.DescribeKV("API:", w, "%s", d.API)
+	output.DescribeKV("Operation:", w, "%s", d.Operation)
+	output.DescribeKV("URL:", w, "%s", d.URL)
+	if d.OperationID != "" {
+		output.DescribeKV("ID:", w, "%s", d.OperationID)
+	}
+	if d.Deprecated {
+		output.DescribeKV("Deprecated:", w, "%s", "yes")
+	}
+	if d.Summary != "" {
+		output.DescribeKV("Summary:", w, "%s", d.Summary)
+	}
+	if len(d.RequiredScopes) > 0 {
+		output.DescribeKV("Scopes:", w, "%s", strings.Join(d.RequiredScopes, ", "))
+	} else {
+		// Saying nothing here would read as "no scope needed", which is not what
+		// an absent declaration means.
+		output.DescribeKV("Scopes:", w, "%s", "(not declared in the specification)")
+	}
+	if d.Description != "" {
+		fmt.Println()
+		fmt.Println(indentBlock(unwrapHTMLBreaks(d.Description), "  "))
+	}
+
+	printOperationParameters(d.Parameters)
+	printOperationBody(d.RequestBody)
+	printOperationResponses(d.Responses)
+
+	fmt.Println()
+	fmt.Printf("  Call it:  %s\n", d.Example)
+}
+
+func printOperationParameters(params []resapi.Parameter) {
+	if len(params) == 0 {
+		return
+	}
+	fmt.Println()
+	output.DescribeSection("Parameters:")
+
+	nameW := 0
+	for _, p := range params {
+		if len(p.Name) > nameW {
+			nameW = len(p.Name)
+		}
+	}
+	for _, p := range params {
+		req := ""
+		if p.Required {
+			req = " (required)"
+		}
+		typ := p.Type
+		if typ == "" {
+			typ = "-"
+		}
+		fmt.Printf("  %-*s  %-6s  %-8s  %s%s\n", nameW, p.Name, p.In, typ,
+			firstLineOf(p.Description), req)
+	}
+}
+
+func printOperationBody(body *resapi.RequestBody) {
+	if body == nil || len(body.Contents) == 0 {
+		return
+	}
+	fmt.Println()
+	title := "Request Body:"
+	if body.Required {
+		title = "Request Body (required):"
+	}
+	output.DescribeSection(title)
+
+	for _, mt := range body.Contents {
+		fmt.Printf("  %s\n", mt.ContentType)
+		fields, ok := resapi.TopLevelFields(mt.Schema)
+		if !ok {
+			fmt.Println("    (schema not introspectable — use -o yaml for the full schema)")
+			continue
+		}
+		printSchemaFieldLines(fields)
+	}
+}
+
+func printOperationResponses(responses []resapi.Response) {
+	if len(responses) == 0 {
+		return
+	}
+	fmt.Println()
+	output.DescribeSection("Responses:")
+	for _, r := range responses {
+		types := make([]string, 0, len(r.Contents))
+		for _, mt := range r.Contents {
+			types = append(types, mt.ContentType)
+		}
+		line := fmt.Sprintf("  %-5s %s", r.Status, firstLineOf(r.Description))
+		if len(types) > 0 {
+			line += fmt.Sprintf("  [%s]", strings.Join(types, ", "))
+		}
+		fmt.Println(line)
+	}
+}
+
+func printSchemaFieldLines(fields []resapi.SchemaField) {
+	if len(fields) == 0 {
+		fmt.Println("    (no properties declared)")
+		return
+	}
+	nameW := 0
+	for _, f := range fields {
+		if len(f.Name) > nameW {
+			nameW = len(f.Name)
+		}
+	}
+	for _, f := range fields {
+		req := ""
+		if f.Required {
+			req = " (required)"
+		}
+		typ := f.Type
+		if typ == "" {
+			typ = "-"
+		}
+		fmt.Printf("    %-*s  %-12s  %s%s\n", nameW, f.Name, typ, f.Description, req)
+	}
+	fmt.Println("    (one level shown — use -o yaml for the full schema)")
+}
+
+// emitRawSpec writes the unprojected specification.
+//
+// A raw document is far too large to hand to an agent inline, so it goes through
+// the same result-spill controls as a large query result: outside agent mode the
+// default is to stream it to stdout (where a human redirects it), and in agent
+// mode it spills to a file above the spill threshold. Spilling is gated on the
+// HostDiskSpill capability, so an embedded caller — which has no host disk of its
+// own — always gets the bytes back instead of a path it could not read.
+//
+// A document that is not spilled goes to stdout unwrapped even in agent mode,
+// for the same reason the query path leaves a non-JSON display encoding alone:
+// --raw is an explicit request for the document as served, and wrapping it would
+// discard the format the caller asked for.
+func emitRawSpec(cmd *cobra.Command, cfg *config.Config, entry resapi.Entry, doc []byte) error {
+	opts, err := resolveSpillOptions(cmd, cfg)
+	if err != nil {
+		return err
+	}
+
+	size := int64(len(doc))
+	spill := opts.Mode == exec.SpillAlways ||
+		(opts.Mode == exec.SpillAuto && size > opts.Threshold)
+	if !spill {
+		if _, werr := os.Stdout.Write(doc); werr != nil {
+			return werr
+		}
+		if size > 0 && doc[size-1] != '\n' {
+			fmt.Println()
+		}
+		return nil
+	}
+
+	// A raw document is written in the encoding the environment served it in, so
+	// --spill-format has nothing to choose.
+	if cmd.Flags().Changed("spill-format") {
+		output.PrintWarning("--spill-format does not apply to --raw: a specification is written in its own encoding")
+	}
+
+	encoding := resapi.RawSpecEncoding(entry)
+	targetPath, baseDir, err := rawSpecTargetPath(cfg, entry, encoding, opts)
+	if err != nil {
+		return err
+	}
+
+	written, err := output.WriteSpillFile(targetPath, func(w io.Writer) error {
+		_, werr := w.Write(doc)
+		return werr
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write %q: %w", targetPath, err)
+	}
+	// Opportunistic, throttled TTL prune of the managed cache — a spilled document
+	// is subject to the same exposure window as a spilled result.
+	if baseDir != "" {
+		output.PruneOldSpills(baseDir, opts.TTL)
+	}
+
+	if agentMode {
+		printer := NewPrinter()
+		if ap := enrichAgent(printer, "describe", "api"); ap != nil {
+			ap.Context().Suggestions = []string{
+				"the file holds the specification exactly as served; read it locally",
+				fmt.Sprintf("dtctl describe api %s  -- the projected operation index (far smaller)",
+					quoteCommandArg(entry.Name)),
+			}
+		}
+		return printer.Print(&output.SpecFileManifest{
+			Kind:     output.KindDocumentFile,
+			Path:     targetPath,
+			Format:   encoding,
+			Bytes:    written,
+			API:      entry.Name,
+			Document: entry.URL,
+		})
+	}
+
+	fmt.Printf("Wrote %s (%d bytes) to %s\n", entry.Name, written, targetPath)
+	return nil
+}
+
+// rawSpecTargetPath resolves where a raw specification is written: an explicit
+// --spill-to destination, or the managed spill cache partitioned by context. The
+// returned baseDir is non-empty only for the managed cache, which is the only
+// location dtctl prunes on a TTL.
+func rawSpecTargetPath(cfg *config.Config, entry resapi.Entry, encoding string, opts exec.SpillOptions) (path, baseDir string, err error) {
+	if opts.ToPath != "" {
+		dir := filepath.Dir(opts.ToPath)
+		if !output.ProbeWritable(dir) {
+			return "", "", fmt.Errorf("spill destination directory %q is not writable", dir)
+		}
+		output.PrintWarning("%s", userChosenSpillPathWarning)
+		return opts.ToPath, "", nil
+	}
+
+	base, managed, err := output.SpillBaseDir(opts.Dir)
+	if err != nil {
+		return "", "", fmt.Errorf("--raw needs a writable location to spill to: %w", err)
+	}
+	dir := base
+	_, contextName := spillProvenance(cfg)
+	if managed {
+		dir = filepath.Join(base, output.SanitizeContextName(contextName))
+	} else {
+		base = ""
+		output.PrintWarning("%s", userChosenSpillPathWarning)
+	}
+
+	// The filename is derived from the document's request path, and the hash is
+	// computed locally: nothing the environment served is ever used verbatim as a
+	// filename.
+	name := "spec-" + output.SpillHash(contextName, entry.URL) + "." + encoding
+	return filepath.Join(dir, name), base, nil
+}
+
+// userChosenSpillPathWarning mirrors the query path's warning: a caller-chosen
+// destination opts out of the managed guarantees.
+const userChosenSpillPathWarning = "spill path is a user-chosen location and opts out of the managed privacy guarantees (no TTL pruning, no per-context partitioning, best-effort 0600 only); you own its lifetime"
+
+// quoteCommandArg quotes a value for a copy-pasteable command line. API names
+// routinely contain spaces, so a suggestion that omits the quotes is a suggestion
+// that does not run.
+func quoteCommandArg(s string) string { return resapi.QuoteArg(s) }
+
+func firstLineOf(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
+}
+
+// unwrapHTMLBreaks turns the <br/> tags that OpenAPI descriptions use for
+// rendered documentation into real line breaks. Left alone they run paragraphs
+// together in a terminal.
+func unwrapHTMLBreaks(s string) string {
+	for _, tag := range []string{"<br/>", "<br />", "<br>"} {
+		s = strings.ReplaceAll(s, tag, "\n")
+	}
+	return strings.TrimSpace(s)
+}
+
+func indentBlock(s, indent string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		l = strings.TrimRight(l, " \t")
+		if l == "" {
+			// No trailing indent on a blank line.
+			continue
+		}
+		lines[i] = indent + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+func init() {
+	describeAPICmd.Flags().String("operation", "", "show one operation in full, addressed as 'METHOD /path'")
+	describeAPICmd.Flags().Bool("raw", false, "emit the unprojected specification document")
+	addSpillFlags(describeAPICmd)
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -51,4 +51,5 @@ func init() {
 	execCmd.AddCommand(execCopilotCmd)
 	execCmd.AddCommand(execSLOCmd)
 	execCmd.AddCommand(execPreviewProcessorCmd)
+	execCmd.AddCommand(execAPICmd)
 }

--- a/cmd/exec_analyzers.go
+++ b/cmd/exec_analyzers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/analyzer"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
 )
 
 // execAnalyzerCmd executes a Davis analyzer
@@ -40,7 +41,9 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		analyzerName := args[0]
 
-		_, c, err := SetupClient()
+		// Running an analyzer computes over data and persists nothing, so it is a
+		// read despite being a POST.
+		_, c, err := SetupWithSafety(safety.OperationRead)
 		if err != nil {
 			return err
 		}

--- a/cmd/exec_api.go
+++ b/cmd/exec_api.go
@@ -1,0 +1,481 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/config"
+	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+	resapi "github.com/dynatrace-oss/dtctl/pkg/resources/api"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
+)
+
+// execAPICmd sends a request to an arbitrary platform API endpoint.
+//
+// It is an escape hatch, and it is deliberately unadvertised: it exists for the
+// APIs dtctl does not wrap natively, not as an alternative to the ones it does.
+// Hidden keeps it out of --help, completion, and the compact command catalogs an
+// agent bootstraps from; pkg/commands surfaces it under `dtctl commands --full`
+// for a caller who goes looking.
+//
+// It is also the *governed* replacement for what callers do today. Reaching an
+// uncovered API currently means `dtctl exec function --code` with ad-hoc
+// JavaScript, which AppEngine hands a bearer token — the least governed path in
+// the tool. This one resolves what the request actually does from the API's own
+// specification and gates it through the same safety checker as every native
+// mutating command.
+var execAPICmd = &cobra.Command{
+	Use:    "api <path>",
+	Short:  "Send a request to a platform API endpoint (escape hatch)",
+	Hidden: true,
+	Long: `Send a request to a platform API endpoint that has no native dtctl command.
+
+Prefer the native command whenever one exists: it validates input, resolves names,
+formats output, and cannot be pointed at the wrong endpoint. This passthrough
+exists for the APIs dtctl does not wrap — and if you find yourself scripting
+against it, that API wants a native command instead.
+
+The path is relative to the environment, so it starts with '/'. Reads need no
+method; anything else requires an explicit -X, because dtctl will not infer a
+mutating method — and therefore a safety operation — you did not type.
+
+What the request is allowed to do is resolved from the API's own specification,
+not from the HTTP method: a POST may need only a read scope, or may delete data.
+When dtctl cannot resolve the operation, it assumes the worst and gates the
+request as a delete. There is deliberately no flag to assert otherwise.
+
+Examples:
+  # A read
+  dtctl exec api /platform/email/v1/emails
+
+  # A write, with an inline body
+  dtctl exec api /platform/email/v1/emails -X POST -d '{"to":["a@example.invalid"]}'
+
+  # A body from a file, or from stdin
+  dtctl exec api /platform/example/v1/things -X POST -d @body.json
+  cat body.json | dtctl exec api /platform/example/v1/things -X POST -d @-
+
+  # An explicit content type (e.g. a multipart upload)
+  dtctl exec api /platform/example/v1/uploads -X POST -d @archive.zip -H 'Content-Type: application/zip'
+
+  # Compose the request and print it without sending
+  dtctl exec api /platform/example/v1/things/42 -X DELETE --dry-run
+
+  # Find out what to call, and how
+  dtctl get apis
+  dtctl describe api <name> --operation 'POST /things'
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: runExecAPI,
+}
+
+// maxErrorBodyBytes caps how much of an error response is quoted back. The
+// platform's own message is the authoritative explanation of a 4xx, so it is
+// preserved — but a multi-megabyte body would bury it.
+const maxErrorBodyBytes = 4096
+
+func runExecAPI(cmd *cobra.Command, args []string) error {
+	requestPath := args[0]
+
+	method, _ := cmd.Flags().GetString("method")
+	data, _ := cmd.Flags().GetString("data")
+	headers, _ := cmd.Flags().GetStringArray("header")
+
+	method = strings.ToUpper(strings.TrimSpace(method))
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	if err := validateRequestPath(requestPath); err != nil {
+		return err
+	}
+	// A body without an explicit method is refused rather than promoted to POST
+	// (which is what curl and gcx do): inferring the method would infer the
+	// safety operation, and this command's whole premise is that the operation is
+	// derived rather than assumed.
+	if data != "" && !cmd.Flags().Changed("method") {
+		return fmt.Errorf("-d/--data needs an explicit method: add -X POST (or PUT, PATCH, ...)\n\n" +
+			"dtctl does not infer a mutating method from the presence of a body — that would " +
+			"infer the safety operation too")
+	}
+
+	body, err := readRequestBody(data)
+	if err != nil {
+		return err
+	}
+
+	headerMap, err := parseHeaderFlags(headers)
+	if err != nil {
+		return err
+	}
+
+	// The client is built before the gate because resolving what the request does
+	// requires reading the API's specification, which is itself a read. The gate
+	// then applies to the caller's request.
+	cfg, c, err := SetupClient()
+	if err != nil {
+		return err
+	}
+
+	handler := resapi.NewHandler(c)
+	apiName, op := handler.ResolveForRequest(method, requestPath)
+	class := resapi.Classify(method, requestPath, apiName, op)
+
+	nativeBase, native := resapi.NativeCoverageForPath(requestPath)
+	warnAboutTarget(requestPath, nativeBase, native.Command)
+
+	if dryRun {
+		return printAPIDryRun(cfg, method, requestPath, headerMap, body, class, native.Command)
+	}
+
+	checker, err := NewSafetyChecker(cfg)
+	if err != nil {
+		return err
+	}
+	if err := checker.CheckError(class.SafetyOp, safety.OwnershipUnknown); err != nil {
+		return &resapi.BlockedError{
+			Method:        method,
+			RequestPath:   requestPath,
+			Class:         class,
+			NativeCommand: native.Command,
+			Cause:         err,
+		}
+	}
+
+	req := c.HTTP().R()
+	for name, value := range headerMap {
+		req.SetHeader(name, value)
+	}
+	if len(body) > 0 {
+		if _, ok := headerMap["Content-Type"]; !ok {
+			// Platform APIs are JSON; an upload declares its own type with -H.
+			req.SetHeader("Content-Type", "application/json")
+		}
+		req.SetBody(body)
+	}
+
+	resp, err := req.Execute(method, requestPath)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, requestPath, err)
+	}
+
+	if resp.StatusCode() >= 400 {
+		return apiRequestError(method, requestPath, resp.StatusCode(), resp.Body(),
+			apiName, op, native.Command)
+	}
+
+	return emitAPIResponse(method, requestPath, resp.StatusCode(),
+		resp.Header().Get("Content-Type"), resp.Body())
+}
+
+// validateRequestPath enforces that the target is a path on the configured
+// environment. An absolute URL is refused rather than followed: the caller's
+// credentials belong to the environment the context names, and a passthrough
+// that leaves it would send them somewhere else.
+func validateRequestPath(p string) error {
+	if resapi.IsAbsoluteURL(p) {
+		return fmt.Errorf("%q is an absolute URL; pass a path on the current environment instead "+
+			"(e.g. /platform/example/v1/things). dtctl sends the context's credentials, so it "+
+			"will not call another host", p)
+	}
+	if !strings.HasPrefix(p, "/") {
+		return fmt.Errorf("path must start with '/' (got %q); it is relative to the environment, "+
+			"e.g. /platform/example/v1/things", p)
+	}
+	return nil
+}
+
+// readRequestBody resolves the -d value: inline text, @file, or @- for stdin —
+// the curl idiom, because that is what a caller reaching for a raw HTTP call
+// already knows.
+//
+// A user-named path goes through pkg/vfs, never os: under the service engine the
+// path names a file in the *request*, and reading it from the host disk would
+// read the server's filesystem on a caller's behalf.
+func readRequestBody(data string) ([]byte, error) {
+	if data == "" {
+		return nil, nil
+	}
+	if !strings.HasPrefix(data, "@") {
+		return []byte(data), nil
+	}
+
+	name := strings.TrimPrefix(data, "@")
+	if name == "" {
+		return nil, fmt.Errorf("-d @ needs a filename, or @- to read stdin")
+	}
+	// ReadFileOrStdin maps "-" to the process stdin, which is the stream seam an
+	// embedded invocation swaps. Opening /dev/stdin as a path would slip past it.
+	content, err := vfs.ReadFileOrStdin(name)
+	if err != nil {
+		return nil, fmt.Errorf("reading request body from %s: %w", data, err)
+	}
+	return content, nil
+}
+
+// parseHeaderFlags parses -H 'Name: value' pairs, canonicalizing the name so a
+// caller-supplied content type is recognised however it was capitalized.
+func parseHeaderFlags(headers []string) (map[string]string, error) {
+	out := make(map[string]string, len(headers))
+	for _, h := range headers {
+		name, value, found := strings.Cut(h, ":")
+		if !found {
+			return nil, fmt.Errorf("invalid header %q: expected 'Name: value'", h)
+		}
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return nil, fmt.Errorf("invalid header %q: the name is empty", h)
+		}
+		out[http.CanonicalHeaderKey(name)] = strings.TrimSpace(value)
+	}
+	return out, nil
+}
+
+// warnAboutTarget prints the two notices that make the escape hatch
+// self-deprecating: one when a native command already covers the path, and one
+// when the path is off the public platform tree.
+//
+// Both are warnings rather than errors. The caller typed the path; dtctl's job is
+// to say what it knows, not to refuse.
+func warnAboutTarget(requestPath, nativeBase, nativeCommand string) {
+	if nativeCommand != "" {
+		output.PrintWarning(
+			"%s is covered by '%s' — prefer the native command, which validates input, "+
+				"resolves names, and formats output",
+			nativeBase, nativeCommand)
+	}
+	if !strings.HasPrefix(requestPath, "/platform/") {
+		// Deliberately phrased in terms of the public tree rather than naming any
+		// particular non-public prefix: this is open source, and the warning is
+		// about stability, not about what exists.
+		output.PrintWarning(
+			"%s is outside the public /platform/ API tree; APIs there carry no compatibility "+
+				"guarantee and may change or disappear without notice",
+			requestPath)
+	}
+}
+
+// printAPIDryRun prints the composed request and the gate that would apply,
+// without sending anything.
+//
+// It reports the safety verdict instead of enforcing it — a dry run's job is to
+// show what would happen, and "this would be blocked, here is why" is more useful
+// than an error that hides the composed request.
+func printAPIDryRun(cfg *config.Config, method, requestPath string, headers map[string]string,
+	body []byte, class resapi.Classification, nativeCommand string) error {
+
+	const w = 14
+	output.DescribeKV("Method:", w, "%s", method)
+	output.DescribeKV("Path:", w, "%s", requestPath)
+	if len(headers) > 0 {
+		output.DescribeKV("Headers:", w, "%s", strings.Join(redactedHeaderLines(headers), ", "))
+	}
+	if len(body) > 0 {
+		output.DescribeKV("Body:", w, "%d bytes", len(body))
+	}
+	output.DescribeKV("Gated as:", w, "%s", string(class.SafetyOp))
+	output.DescribeKV("Because:", w, "%s", class.Reason)
+	if nativeCommand != "" {
+		output.DescribeKV("Native:", w, "%s (preferred)", nativeCommand)
+	}
+
+	verdict := "permitted in this context"
+	if checker, err := NewSafetyChecker(cfg); err == nil {
+		if serr := checker.CheckError(class.SafetyOp, safety.OwnershipUnknown); serr != nil {
+			verdict = "BLOCKED in this context — " + safetyRefusalReason(serr)
+		}
+	}
+	output.DescribeKV("Safety:", w, "%s", verdict)
+
+	fmt.Println()
+	fmt.Println("  Nothing was sent (--dry-run).")
+	return nil
+}
+
+// safetyRefusalReason extracts the one-line reason from a safety refusal.
+//
+// SafetyError.Error() opens with "Operation not allowed:" and puts the reason on a
+// later line, so the first line alone says nothing. The dry run has room for one
+// line, and it should be the one that explains the verdict.
+func safetyRefusalReason(err error) string {
+	var safetyErr *safety.SafetyError
+	if errors.As(err, &safetyErr) && safetyErr.Reason != "" {
+		return safetyErr.Reason
+	}
+	return firstLineOf(err.Error())
+}
+
+// redactedHeaderLines renders headers for display with credential-bearing values
+// masked. dtctl never puts the token in a -H flag itself, but a caller can, and a
+// dry run's output is exactly the thing that gets pasted into a bug report.
+func redactedHeaderLines(headers map[string]string) []string {
+	sensitive := map[string]bool{
+		"Authorization": true, "Cookie": true, "X-Api-Key": true, "Api-Token": true,
+	}
+	out := make([]string, 0, len(headers))
+	for name, value := range headers {
+		if sensitive[name] {
+			value = "<redacted>"
+		}
+		out = append(out, name+": "+value)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// emitAPIResponse renders a successful response.
+//
+// The output protocol is declared, not emergent: a JSON body goes through the
+// normal printer — so -o json/yaml and the agent envelope behave exactly as they
+// do for every other command — and anything else is passed through verbatim,
+// even under --agent. A generic passthrough can return YAML, CSV, Prometheus
+// text, or a binary archive, and wrapping those in an envelope would corrupt
+// them; the alternative (refusing to emit them) would make the command useless
+// for the uploads and exports it exists to reach.
+func emitAPIResponse(method, requestPath string, status int, contentType string, body []byte) error {
+	if isHTMLResponse(contentType, body) {
+		// An HTML body from an API path is almost always a login redirect or an
+		// error page, not a result. Say so, because a caller piping this into a
+		// parser will otherwise see a confusing failure downstream.
+		output.PrintWarning(
+			"the response is HTML, not API data — %s %s may not be an API endpoint on this environment",
+			method, requestPath)
+	}
+
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return emitEmptyAPIResponse(status)
+	}
+
+	var decoded any
+	if json.Unmarshal(trimmed, &decoded) != nil {
+		// Not JSON: verbatim passthrough (the declared raw protocol class).
+		if _, err := os.Stdout.Write(body); err != nil {
+			return err
+		}
+		if body[len(body)-1] != '\n' {
+			fmt.Println()
+		}
+		return nil
+	}
+
+	if agentMode || (outputFormat != "" && outputFormat != "table" && outputFormat != "wide") {
+		printer := NewPrinter()
+		if ap := enrichAgent(printer, "exec", "api"); ap != nil {
+			ap.Context().Suggestions = []string{
+				"dtctl describe api <name> --operation '" + method + " <path>'  -- the operation's schema",
+			}
+		}
+		return printer.Print(decoded)
+	}
+
+	// Human default: the body as served, indented. json.Indent preserves key
+	// order, so this is the platform's own response — just readable.
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, trimmed, "", "  "); err != nil {
+		_, err := os.Stdout.Write(body)
+		return err
+	}
+	fmt.Println(pretty.String())
+	return nil
+}
+
+// emitEmptyAPIResponse reports a body-less success (a 204, or a 200 with nothing
+// in it). Printing nothing at all would leave a caller unable to tell success
+// from a swallowed response.
+func emitEmptyAPIResponse(status int) error {
+	if agentMode {
+		printer := NewPrinter()
+		enrichAgent(printer, "exec", "api")
+		return printer.Print(map[string]any{
+			"status": status,
+			"body":   nil,
+		})
+	}
+	fmt.Printf("%d %s (no body)\n", status, http.StatusText(status))
+	return nil
+}
+
+// isHTMLResponse reports whether a response is an HTML document. The content type
+// is checked first, and the body sniffed as a fallback: an SSO redirect page is
+// not always labelled.
+func isHTMLResponse(contentType string, body []byte) bool {
+	if strings.Contains(strings.ToLower(contentType), "text/html") {
+		return true
+	}
+	head := strings.ToLower(string(body[:min(len(body), 256)]))
+	head = strings.TrimSpace(head)
+	return strings.HasPrefix(head, "<!doctype html") || strings.HasPrefix(head, "<html")
+}
+
+// apiRequestError turns a 4xx/5xx into a structured error that preserves what the
+// platform said and adds what dtctl knows.
+//
+// dtctl deliberately does not validate a body against the specification before
+// sending: specifications are per-environment and per-version, and a client-side
+// validator that rejects a request the platform would have accepted is strictly
+// worse than the platform's own 400. So the specification is used here, on the
+// failure path, where it costs nothing when the call succeeds — the caller that
+// guessed a payload learns what the payload should have been in one round trip
+// instead of iterating blind.
+func apiRequestError(method, requestPath string, status int, body []byte,
+	apiName string, op *resapi.Operation, nativeCommand string) error {
+
+	message := strings.TrimSpace(string(body))
+	if len(message) > maxErrorBodyBytes {
+		message = message[:maxErrorBodyBytes] + fmt.Sprintf("… (%d bytes truncated)",
+			len(message)-maxErrorBodyBytes)
+	}
+	if message == "" {
+		message = http.StatusText(status)
+	}
+
+	var suggestions []string
+	switch {
+	case op != nil:
+		suggestions = append(suggestions, fmt.Sprintf(
+			"dtctl describe api %s --operation '%s'  -- its parameters, request body schema, and required scope",
+			quoteCommandArg(apiName), op.ID()))
+		if len(op.Scopes) > 0 {
+			suggestions = append(suggestions, fmt.Sprintf(
+				"the specification declares scope %s for this operation",
+				strings.Join(op.Scopes, ", ")))
+		}
+	case apiName != "":
+		suggestions = append(suggestions, fmt.Sprintf(
+			"dtctl describe api %s  -- this API's operations, to check the path and method",
+			quoteCommandArg(apiName)))
+	default:
+		suggestions = append(suggestions,
+			"dtctl get apis  -- the APIs this environment publishes, to check the path")
+	}
+	if nativeCommand != "" {
+		suggestions = append(suggestions, fmt.Sprintf(
+			"%s  -- the native dtctl command for this API (preferred)", nativeCommand))
+	}
+
+	return &diagnostic.Error{
+		Operation:   fmt.Sprintf("call %s %s", method, requestPath),
+		StatusCode:  status,
+		Message:     message,
+		Suggestions: suggestions,
+	}
+}
+
+func init() {
+	execAPICmd.Flags().StringP("method", "X", http.MethodGet, "HTTP method")
+	execAPICmd.Flags().StringP("data", "d", "",
+		"request body: inline, @file, or @- for stdin (requires an explicit -X)")
+	execAPICmd.Flags().StringArrayP("header", "H", nil,
+		"extra request header, 'Name: value' (repeatable)")
+}

--- a/cmd/exec_api.go
+++ b/cmd/exec_api.go
@@ -96,7 +96,13 @@ func runExecAPI(cmd *cobra.Command, args []string) error {
 		method = http.MethodGet
 	}
 
-	if err := validateRequestPath(requestPath); err != nil {
+	// canonicalPath is the spelling classification runs on; requestPath, the
+	// caller's spelling, is what goes on the wire. The two may differ only in
+	// benign percent-encoding — a spelling that changes *structure* under
+	// normalization is refused here, because it would let the gate classify a
+	// different endpoint than the server routes.
+	canonicalPath, err := validateRequestPath(requestPath)
+	if err != nil {
 		return err
 	}
 	// A body without an explicit method is refused rather than promoted to POST
@@ -128,11 +134,11 @@ func runExecAPI(cmd *cobra.Command, args []string) error {
 	}
 
 	handler := resapi.NewHandler(c)
-	apiName, op := handler.ResolveForRequest(method, requestPath)
-	class := resapi.Classify(method, requestPath, apiName, op)
+	apiName, op := handler.ResolveForRequest(method, canonicalPath)
+	class := resapi.Classify(method, canonicalPath, apiName, op)
 
-	nativeBase, native := resapi.NativeCoverageForPath(requestPath)
-	warnAboutTarget(requestPath, nativeBase, native.Command)
+	nativeBase, native := resapi.NativeCoverageForPath(canonicalPath)
+	warnAboutTarget(canonicalPath, nativeBase, native.Command)
 
 	if dryRun {
 		return printAPIDryRun(cfg, method, requestPath, headerMap, body, class, native.Command)
@@ -179,20 +185,23 @@ func runExecAPI(cmd *cobra.Command, args []string) error {
 }
 
 // validateRequestPath enforces that the target is a path on the configured
-// environment. An absolute URL is refused rather than followed: the caller's
-// credentials belong to the environment the context names, and a passthrough
-// that leaves it would send them somewhere else.
-func validateRequestPath(p string) error {
+// environment, and returns the canonical spelling classification must run on.
+// An absolute URL is refused rather than followed: the caller's credentials
+// belong to the environment the context names, and a passthrough that leaves
+// it would send them somewhere else. A path that changes under normalization
+// (dot segments, duplicate slashes, an encoded separator) is refused too — the
+// gate must classify the endpoint the server routes, not a spelling of it.
+func validateRequestPath(p string) (canonical string, err error) {
 	if resapi.IsAbsoluteURL(p) {
-		return fmt.Errorf("%q is an absolute URL; pass a path on the current environment instead "+
+		return "", fmt.Errorf("%q is an absolute URL; pass a path on the current environment instead "+
 			"(e.g. /platform/example/v1/things). dtctl sends the context's credentials, so it "+
 			"will not call another host", p)
 	}
 	if !strings.HasPrefix(p, "/") {
-		return fmt.Errorf("path must start with '/' (got %q); it is relative to the environment, "+
+		return "", fmt.Errorf("path must start with '/' (got %q); it is relative to the environment, "+
 			"e.g. /platform/example/v1/things", p)
 	}
-	return nil
+	return resapi.CanonicalRequestPath(p)
 }
 
 // readRequestBody resolves the -d value: inline text, @file, or @- for stdin —
@@ -225,6 +234,10 @@ func readRequestBody(data string) ([]byte, error) {
 
 // parseHeaderFlags parses -H 'Name: value' pairs, canonicalizing the name so a
 // caller-supplied content type is recognised however it was capitalized.
+//
+// Auth headers are refused: the context is the identity, and dtctl attaches
+// its credentials itself. A -H that replaced them would fight the client's own
+// auth silently — whichever writes last wins, and nothing would say so.
 func parseHeaderFlags(headers []string) (map[string]string, error) {
 	out := make(map[string]string, len(headers))
 	for _, h := range headers {
@@ -236,7 +249,12 @@ func parseHeaderFlags(headers []string) (map[string]string, error) {
 		if name == "" {
 			return nil, fmt.Errorf("invalid header %q: the name is empty", h)
 		}
-		out[http.CanonicalHeaderKey(name)] = strings.TrimSpace(value)
+		canonical := http.CanonicalHeaderKey(name)
+		if canonical == "Authorization" || canonical == "Proxy-Authorization" {
+			return nil, fmt.Errorf("refusing -H %s: dtctl sends the current context's credentials; "+
+				"to call as a different identity, switch contexts (dtctl ctx use <name>)", canonical)
+		}
+		out[canonical] = strings.TrimSpace(value)
 	}
 	return out, nil
 }
@@ -320,7 +338,8 @@ func safetyRefusalReason(err error) string {
 // dry run's output is exactly the thing that gets pasted into a bug report.
 func redactedHeaderLines(headers map[string]string) []string {
 	sensitive := map[string]bool{
-		"Authorization": true, "Cookie": true, "X-Api-Key": true, "Api-Token": true,
+		"Authorization": true, "Proxy-Authorization": true, "Cookie": true,
+		"X-Api-Key": true, "Api-Token": true,
 	}
 	out := make([]string, 0, len(headers))
 	for name, value := range headers {

--- a/cmd/exec_api_test.go
+++ b/cmd/exec_api_test.go
@@ -1,0 +1,314 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace-oss/dtctl/pkg/vfs"
+)
+
+// runAPI invokes dtctl through the embedding entrypoint with both streams
+// captured, which is what these tests need: a refusal is written to stderr while
+// a response goes to stdout, and several assertions here are about which stream
+// carried what.
+func runAPI(t *testing.T, argv []string, opts RunOptions) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	opts.Stdout, opts.Stderr = &out, &errOut
+	code = Run(argv, opts)
+	return code, out.String(), errOut.String()
+}
+
+// TestExecAPIReadIsPermittedInAReadonlyContext is the baseline: a GET is a read
+// by every measure available, so the strictest context still allows it.
+func TestExecAPIReadIsPermittedInAReadonlyContext(t *testing.T) {
+	env := newMockEnvironmentAt(t, "readonly")
+	env.respond(http.MethodGet, "/platform/widget/v1/widgets", mockResponse{
+		status:      200,
+		contentType: "application/json",
+		body:        `{"widgets":[{"name":"one"}]}`,
+	})
+
+	code, out, errOut := runAPI(t, []string{"exec", "api", "/platform/widget/v1/widgets"}, RunOptions{})
+	require.Zero(t, code, errOut)
+	require.Contains(t, out, `"name": "one"`, "the response body is the output")
+}
+
+// TestExecAPIMethodDoesNotDecideTheGate is the load-bearing test of the whole
+// classification design.
+//
+// Both requests below are POSTs to the same API in the same readonly context. One
+// is permitted and one is refused, and the only thing that separates them is the
+// scope their operation declares in the environment's own specification. A gate
+// keyed on the HTTP method could not produce this result in either direction: it
+// would refuse the search (breaking reads) or permit the create (breaking the
+// point of readonly).
+func TestExecAPIMethodDoesNotDecideTheGate(t *testing.T) {
+	env := newMockEnvironmentAt(t, "readonly")
+	env.respond(http.MethodPost, "/platform/widget/v1/widgets:search", mockResponse{
+		status:      200,
+		contentType: "application/json",
+		body:        `{"matches":[]}`,
+	})
+	env.respond(http.MethodPost, "/platform/widget/v1/widgets", mockResponse{
+		status: 201,
+		body:   `{"name":"new"}`,
+	})
+
+	t.Run("a POST declaring a read scope is a read", func(t *testing.T) {
+		code, out, errOut := runAPI(t, []string{
+			"exec", "api", "/platform/widget/v1/widgets:search",
+			"-X", "POST", "-d", `{"match":"o"}`,
+		}, RunOptions{})
+		require.Zero(t, code, errOut)
+		require.Contains(t, out, "matches")
+		require.Equal(t, `{"match":"o"}`,
+			env.bodyOf(http.MethodPost, "/platform/widget/v1/widgets:search"),
+			"the body must reach the endpoint unaltered")
+	})
+
+	t.Run("a POST declaring a write scope is a write", func(t *testing.T) {
+		code, _, errOut := runAPI(t, []string{
+			"exec", "api", "/platform/widget/v1/widgets",
+			"-X", "POST", "-d", `{"name":"new"}`,
+		}, RunOptions{})
+		require.NotZero(t, code, "a readonly context must refuse a declared write")
+		require.Contains(t, errOut, "widget:widgets:write",
+			"the refusal must name the scope it classified from")
+		require.False(t, env.called(http.MethodPost, "/platform/widget/v1/widgets"),
+			"a refused request must never reach the wire")
+	})
+}
+
+// TestExecAPIUnresolvedRequestIsGatedAsTheStrictestOperation pins the fail-closed
+// fallback, and pins that the message does not advertise a way around it.
+func TestExecAPIUnresolvedRequestIsGatedAsTheStrictestOperation(t *testing.T) {
+	env := newMockEnvironmentAt(t, "readwrite-mine")
+
+	code, _, errOut := runAPI(t, []string{
+		"exec", "api", "/platform/sprocket/v1/sprockets", "-X", "POST", "-d", `{}`,
+	}, RunOptions{})
+
+	require.NotZero(t, code)
+	require.Contains(t, errOut, "cannot tell what POST does")
+	require.Contains(t, errOut, "no flag to assert the operation",
+		"the refusal must say the escape hatch has no escape hatch")
+	require.NotContains(t, errOut, "--op",
+		"the message must not name an override that does not exist")
+	require.False(t, env.called(http.MethodPost, "/platform/sprocket/v1/sprockets"))
+}
+
+// TestExecAPIDoesNotUndercutTheCommandItShadows pins the reason the curated
+// destructive table exists: without it this request would pass at readwrite-all
+// while `dtctl delete bucket` demands dangerously-unrestricted, making the
+// passthrough a weaker gate than the native command.
+func TestExecAPIDoesNotUndercutTheCommandItShadows(t *testing.T) {
+	const path = "/platform/storage/management/v1/bucket-definitions/custom_example"
+	env := newMockEnvironmentAt(t, "readwrite-all")
+
+	code, _, errOut := runAPI(t, []string{"exec", "api", path, "-X", "DELETE"}, RunOptions{})
+
+	require.NotZero(t, code)
+	require.Contains(t, errOut, "dangerously-unrestricted")
+	require.Contains(t, errOut, "dtctl get buckets",
+		"a refusal must point at the native command")
+	require.False(t, env.called(http.MethodDelete, path))
+}
+
+// TestExecAPIRefusesToInferAMethod pins that a body does not promote a request to
+// POST the way curl does. Inferring the method would infer the safety operation,
+// which is the one thing this command must never do.
+func TestExecAPIRefusesToInferAMethod(t *testing.T) {
+	env := newMockEnvironmentAt(t, "readonly")
+
+	code, _, errOut := runAPI(t, []string{
+		"exec", "api", "/platform/widget/v1/widgets", "-d", `{"name":"x"}`,
+	}, RunOptions{})
+
+	require.NotZero(t, code)
+	require.Contains(t, errOut, "needs an explicit method")
+	require.Zero(t, env.requestCount(), "the refusal must not cost a request")
+}
+
+// TestExecAPIRefusesToLeaveTheEnvironment pins that the passthrough cannot be
+// pointed at another host. dtctl attaches the context's credentials to whatever it
+// sends, so following an absolute URL would hand them to an arbitrary server.
+func TestExecAPIRefusesToLeaveTheEnvironment(t *testing.T) {
+	env := newMockEnvironmentAt(t, "readonly")
+
+	for _, target := range []string{"https://example.invalid/x", "widgets"} {
+		code, _, errOut := runAPI(t, []string{"exec", "api", target}, RunOptions{})
+		require.NotZero(t, code, "target %q", target)
+		require.NotEmpty(t, errOut)
+	}
+	require.Zero(t, env.requestCount(), "validation must precede every request")
+}
+
+// TestExecAPIBodyFileComesFromTheRequestFilesystem is the embedding guard for
+// `-d @file`.
+//
+// The path names a file that exists only in the invocation's filesystem — there is
+// no such file on the host disk. An os.ReadFile in this path would fail here, and
+// in a service it would read the *server's* disk on a caller's behalf.
+func TestExecAPIBodyFileComesFromTheRequestFilesystem(t *testing.T) {
+	env := newMockEnvironmentAt(t, "readonly")
+	env.respond(http.MethodPost, "/platform/widget/v1/widgets:search", mockResponse{
+		status:      200,
+		contentType: "application/json",
+		body:        `{"matches":[]}`,
+	})
+
+	code, _, errOut := runAPI(t, []string{
+		"exec", "api", "/platform/widget/v1/widgets:search", "-X", "POST", "-d", "@search.json",
+	}, RunOptions{
+		FS: vfs.NewMapFS(map[string][]byte{"search.json": []byte(`{"match":"from-vfs"}`)}),
+	})
+
+	require.Zero(t, code, errOut)
+	require.Equal(t, `{"match":"from-vfs"}`,
+		env.bodyOf(http.MethodPost, "/platform/widget/v1/widgets:search"),
+		"the body must come from the request's filesystem, not the host's")
+}
+
+// TestExecAPIBodyFromStdinUsesTheStreamSeam pins the other half of the same rule:
+// "@-" must resolve to the invocation's stdin, not to /dev/stdin as a path.
+func TestExecAPIBodyFromStdinUsesTheStreamSeam(t *testing.T) {
+	env := newMockEnvironmentAt(t, "readonly")
+	env.respond(http.MethodPost, "/platform/widget/v1/widgets:search", mockResponse{
+		status:      200,
+		contentType: "application/json",
+		body:        `{"matches":[]}`,
+	})
+
+	code, _, errOut := runAPI(t, []string{
+		"exec", "api", "/platform/widget/v1/widgets:search", "-X", "POST", "-d", "@-",
+	}, RunOptions{Stdin: strings.NewReader(`{"match":"from-stdin"}`)})
+
+	require.Zero(t, code, errOut)
+	require.Equal(t, `{"match":"from-stdin"}`,
+		env.bodyOf(http.MethodPost, "/platform/widget/v1/widgets:search"))
+}
+
+// TestExecAPIDryRunShowsTheVerdictWithoutSendingOrLeaking pins the two properties
+// of --dry-run: nothing is sent, and the output is safe to paste into a bug report
+// even when the caller passed a credential in a header.
+func TestExecAPIDryRunShowsTheVerdictWithoutSendingOrLeaking(t *testing.T) {
+	env := newMockEnvironmentAt(t, "readonly")
+
+	code, out, errOut := runAPI(t, []string{
+		"exec", "api", "/platform/widget/v1/widgets", "-X", "POST", "-d", `{"name":"x"}`,
+		"-H", "Authorization: Bearer super-secret", "--dry-run",
+	}, RunOptions{})
+
+	require.Zero(t, code, errOut)
+	require.Contains(t, out, "Nothing was sent")
+	require.Contains(t, out, "create", "the dry run reports the gate it would apply")
+	require.Contains(t, out, "BLOCKED in this context",
+		"a dry run reports the verdict rather than hiding the composed request behind it")
+	require.Contains(t, out, "<redacted>")
+	require.NotContains(t, out, "super-secret")
+	require.False(t, env.called(http.MethodPost, "/platform/widget/v1/widgets"))
+}
+
+// TestExecAPIOutputProtocolIsDeclaredNotSniffed pins the contract that makes the
+// passthrough usable from a program: a JSON body goes through the envelope like
+// every other command, anything else is passed through byte-for-byte even under
+// --agent, and a failure is always structured.
+func TestExecAPIOutputProtocolIsDeclaredNotSniffed(t *testing.T) {
+	t.Run("json is wrapped in the envelope", func(t *testing.T) {
+		env := newMockEnvironmentAt(t, "readonly")
+		env.respond(http.MethodGet, "/platform/widget/v1/widgets", mockResponse{
+			status:      200,
+			contentType: "application/json",
+			body:        `{"widgets":[{"name":"one"}]}`,
+		})
+
+		code, out, errOut := runAPI(t, []string{
+			"exec", "api", "/platform/widget/v1/widgets", "--agent",
+		}, RunOptions{})
+		require.Zero(t, code, errOut)
+
+		var resp struct {
+			OK     bool           `json:"ok"`
+			Result map[string]any `json:"result"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &resp), "stdout must be one envelope: %s", out)
+		require.True(t, resp.OK)
+		require.Contains(t, resp.Result, "widgets")
+	})
+
+	t.Run("a non-json body is passed through verbatim", func(t *testing.T) {
+		const csv = "name,colour\none,red\n"
+		env := newMockEnvironmentAt(t, "readonly")
+		env.respond(http.MethodGet, "/platform/widget/v1/widgets", mockResponse{
+			status:      200,
+			contentType: "text/csv",
+			body:        csv,
+		})
+
+		code, out, errOut := runAPI(t, []string{
+			"exec", "api", "/platform/widget/v1/widgets", "--agent",
+		}, RunOptions{})
+		require.Zero(t, code, errOut)
+		require.Equal(t, csv, out,
+			"wrapping a CSV export in an envelope would corrupt it; refusing to emit it "+
+				"would make the command useless for the exports it exists to reach")
+	})
+
+	t.Run("a failure keeps the platform's own message", func(t *testing.T) {
+		env := newMockEnvironmentAt(t, "readonly")
+		env.respond(http.MethodGet, "/platform/widget/v1/widgets", mockResponse{
+			status:      400,
+			contentType: "application/json",
+			body:        `{"error":{"message":"page-size must be positive"}}`,
+		})
+
+		code, out, _ := runAPI(t, []string{
+			"exec", "api", "/platform/widget/v1/widgets", "--agent",
+		}, RunOptions{})
+		require.NotZero(t, code)
+
+		var resp struct {
+			OK    bool `json:"ok"`
+			Error struct {
+				Message     string   `json:"message"`
+				StatusCode  int      `json:"status_code"`
+				Suggestions []string `json:"suggestions"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &resp), "stdout: %s", out)
+		require.False(t, resp.OK)
+		require.Equal(t, 400, resp.Error.StatusCode)
+		require.Contains(t, resp.Error.Message, "page-size must be positive",
+			"the platform's explanation is the authoritative one and must survive")
+		require.Contains(t, strings.Join(resp.Error.Suggestions, "\n"), "describe api",
+			"a failed guess must come back with the operation's schema, not just a status")
+	})
+}
+
+// TestExecAPIWarnsWhenANativeCommandAlreadyCoversThePath pins the notice that
+// keeps the escape hatch self-deprecating, and pins that it goes to stderr so a
+// program parsing stdout is unaffected.
+func TestExecAPIWarnsWhenANativeCommandAlreadyCoversThePath(t *testing.T) {
+	env := newMockEnvironmentAt(t, "readonly")
+	env.respond(http.MethodGet, "/platform/document/v1/documents", mockResponse{
+		status:      200,
+		contentType: "application/json",
+		body:        `{"documents":[]}`,
+	})
+
+	code, out, errOut := runAPI(t, []string{
+		"exec", "api", "/platform/document/v1/documents", "--agent",
+	}, RunOptions{})
+
+	require.Zero(t, code, errOut)
+	require.Contains(t, errOut, "dtctl get documents")
+	require.NotContains(t, out, "Warning",
+		"the notice must not contaminate the stream a program parses")
+	require.NoError(t, json.Unmarshal([]byte(out), new(map[string]any)))
+}

--- a/cmd/exec_api_test.go
+++ b/cmd/exec_api_test.go
@@ -120,6 +120,64 @@ func TestExecAPIDoesNotUndercutTheCommandItShadows(t *testing.T) {
 	require.False(t, env.called(http.MethodDelete, path))
 }
 
+// TestExecAPIEncodedSpellingDoesNotDefeatTheGate mirrors
+// TestExecAPIDoesNotUndercutTheCommandItShadows for a percent-encoded spelling:
+// the server router decodes before routing, so `foo%3Atruncate` truncates the
+// bucket exactly as `foo:truncate` would, and it must be gated identically.
+func TestExecAPIEncodedSpellingDoesNotDefeatTheGate(t *testing.T) {
+	const path = "/platform/storage/management/v1/bucket-definitions/custom_example%3Atruncate"
+	env := newMockEnvironmentAt(t, "readwrite-all")
+
+	code, _, errOut := runAPI(t, []string{"exec", "api", path, "-X", "POST"}, RunOptions{})
+
+	require.NotZero(t, code)
+	require.Contains(t, errOut, "dangerously-unrestricted",
+		"an encoded colon must not gate a truncate below the literal spelling")
+	require.False(t, env.called(http.MethodPost, path))
+}
+
+// TestExecAPIRefusesAmbiguousPathSpellings pins that a path which changes under
+// normalization never becomes a request: dot segments, duplicate slashes, and
+// encoded separators are the spellings that make the gate classify a different
+// endpoint than the server routes, so they are refused outright — before any
+// client is built or any request is spent.
+func TestExecAPIRefusesAmbiguousPathSpellings(t *testing.T) {
+	env := newMockEnvironmentAt(t, "dangerously-unrestricted")
+
+	for _, target := range []string{
+		"/platform/storage/management/v1/x/../bucket-definitions/foo",
+		"/platform/storage/management//v1/bucket-definitions/foo",
+		"/platform/widget/v1/widgets%2Fsub",
+		"/platform/widget/v1/widgets/",
+		"/platform/widget/v1/widgets;jsessionid=x",
+	} {
+		code, _, errOut := runAPI(t, []string{"exec", "api", target}, RunOptions{})
+		require.NotZero(t, code, "spelling %q must be refused", target)
+		require.NotEmpty(t, errOut)
+	}
+	require.Zero(t, env.requestCount(), "a refused spelling must not cost a request")
+}
+
+// TestExecAPIRefusesCallerSuppliedAuthHeaders pins that -H cannot supply or
+// replace credentials. The context is the identity; a caller-supplied
+// Authorization would silently fight the client's own auth.
+func TestExecAPIRefusesCallerSuppliedAuthHeaders(t *testing.T) {
+	env := newMockEnvironmentAt(t, "readonly")
+
+	for _, header := range []string{
+		"Authorization: Bearer sneaky",
+		"authorization: Bearer sneaky",
+		"Proxy-Authorization: Basic sneaky",
+	} {
+		code, _, errOut := runAPI(t, []string{
+			"exec", "api", "/platform/widget/v1/widgets", "-H", header,
+		}, RunOptions{})
+		require.NotZero(t, code, "header %q must be refused", header)
+		require.Contains(t, errOut, "context", "the refusal must point at contexts as the way to change identity")
+	}
+	require.Zero(t, env.requestCount(), "the refusal must precede every request")
+}
+
 // TestExecAPIRefusesToInferAMethod pins that a body does not promote a request to
 // POST the way curl does. Inferring the method would infer the safety operation,
 // which is the one thing this command must never do.
@@ -196,13 +254,16 @@ func TestExecAPIBodyFromStdinUsesTheStreamSeam(t *testing.T) {
 
 // TestExecAPIDryRunShowsTheVerdictWithoutSendingOrLeaking pins the two properties
 // of --dry-run: nothing is sent, and the output is safe to paste into a bug report
-// even when the caller passed a credential in a header.
+// even when the caller passed a credential in a header. (Authorization itself is
+// refused before it gets this far — see
+// TestExecAPIRefusesCallerSuppliedAuthHeaders — so the credential here rides in a
+// header that is still permitted.)
 func TestExecAPIDryRunShowsTheVerdictWithoutSendingOrLeaking(t *testing.T) {
 	env := newMockEnvironmentAt(t, "readonly")
 
 	code, out, errOut := runAPI(t, []string{
 		"exec", "api", "/platform/widget/v1/widgets", "-X", "POST", "-d", `{"name":"x"}`,
-		"-H", "Authorization: Bearer super-secret", "--dry-run",
+		"-H", "X-Api-Key: super-secret", "--dry-run",
 	}, RunOptions{})
 
 	require.Zero(t, code, errOut)

--- a/cmd/exec_copilot.go
+++ b/cmd/exec_copilot.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/copilot"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/vfs"
 )
 
@@ -36,7 +37,7 @@ Examples:
   dtctl exec copilot "List top errors" --instruction "Answer in bullet points"
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, c, err := SetupClient()
+		_, c, err := SetupWithSafety(safety.OperationRead)
 		if err != nil {
 			return err
 		}
@@ -120,7 +121,7 @@ Examples:
   dtctl exec copilot nl2dql "find hosts with high CPU" -o json
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, c, err := SetupClient()
+		_, c, err := SetupWithSafety(safety.OperationRead)
 		if err != nil {
 			return err
 		}
@@ -177,7 +178,7 @@ Examples:
   dtctl exec copilot dql2nl "fetch logs | limit 10" -o json
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, c, err := SetupClient()
+		_, c, err := SetupWithSafety(safety.OperationRead)
 		if err != nil {
 			return err
 		}
@@ -238,7 +239,7 @@ Examples:
   dtctl exec copilot document-search "kubernetes" --collections notebooks -o json
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, c, err := SetupClient()
+		_, c, err := SetupWithSafety(safety.OperationRead)
 		if err != nil {
 			return err
 		}

--- a/cmd/exec_dql.go
+++ b/cmd/exec_dql.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/output"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
 )
 
 // execDQLCmd executes a DQL query (DEPRECATED)
@@ -32,7 +33,7 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Show deprecation warning
 		output.PrintWarning("'dtctl exec dql' is deprecated. Use 'dtctl query' instead.")
-		cfg, c, err := SetupClient()
+		cfg, c, err := SetupWithSafety(safety.OperationRead)
 		if err != nil {
 			return err
 		}

--- a/cmd/exec_functions.go
+++ b/cmd/exec_functions.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
 )
 
 // execFunctionCmd executes an app function or ad-hoc code
@@ -42,13 +43,6 @@ Examples:
   dtctl exec function -f script.js --payload '{"input":"data"}'
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, c, err := SetupClient()
-		if err != nil {
-			return err
-		}
-
-		executor := exec.NewFunctionExecutor(c)
-
 		// Get flags
 		method, _ := cmd.Flags().GetString("method")
 		payload, _ := cmd.Flags().GetString("payload")
@@ -56,6 +50,26 @@ Examples:
 		sourceCode, _ := cmd.Flags().GetString("code")
 		sourceCodeFile, _ := cmd.Flags().GetString("file")
 		defer_, _ := cmd.Flags().GetBool("defer")
+
+		// Ad-hoc JavaScript is unclassifiable by construction: AppEngine injects a
+		// bearer on relative fetch(), so the code can POST or DELETE against any
+		// platform API the token reaches. It is gated as a delete — the strictest
+		// generally-reachable operation — for the same reason `exec api` escalates a
+		// request whose operation it cannot resolve. Gating it any lower would make
+		// that gate theatre, since a caller blocked on `exec api` could reach the
+		// same endpoint through --code. A *named* app function runs the app's own
+		// reviewed code and is gated as a create, matching the `exec` verb.
+		op := safety.OperationCreate
+		if sourceCode != "" || sourceCodeFile != "" {
+			op = safety.OperationDelete
+		}
+
+		_, c, err := SetupWithSafety(op)
+		if err != nil {
+			return err
+		}
+
+		executor := exec.NewFunctionExecutor(c)
 
 		opts := exec.FunctionExecuteOptions{
 			Method:         method,

--- a/cmd/exec_preview_processor.go
+++ b/cmd/exec_preview_processor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/previewprocessor"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
 )
 
 // execPreviewProcessorCmd executes a processor definition against sample
@@ -58,7 +59,7 @@ Examples:
 			return fmt.Errorf("--file is required")
 		}
 
-		_, c, printer, err := Setup()
+		_, c, printer, err := SetupWithSafetyAndPrinter(safety.OperationRead)
 		if err != nil {
 			return err
 		}

--- a/cmd/exec_safety_test.go
+++ b/cmd/exec_safety_test.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// safetyLevelConfig points dtctl at env with the given safety level.
+func safetyLevelConfig(env, level string) string {
+	return fmt.Sprintf(`current-context: c
+contexts:
+  - name: c
+    context:
+      environment: %s
+      token-ref: t
+      safety-level: %s
+tokens:
+  - name: t
+    token: dt0c01.EXAMPLE
+`, env, level)
+}
+
+// isolatedContext points dtctl at a live local server whose every response is a
+// 404, at the given safety level.
+//
+// A reachable server matters for the tests that assert an invocation is *not*
+// blocked: they need it to fail fast on the platform call instead of burning the
+// client's connection-refused retry budget (3×1s per attempt).
+func isolatedContext(t *testing.T, level string) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"message":"not found"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(safetyLevelConfig(srv.URL, level)), 0o600))
+	t.Setenv("DTCTL_CONFIG", path)
+	t.Setenv("DTCTL_PROFILE", "")
+	// Suppress agent-mode auto-detection so --agent is the only thing shaping
+	// output (mirrors isolatedConfig in run_test.go).
+	for _, v := range []string{
+		"CLAUDECODE", "CLAUDE_CODE", "AI_AGENT", "CODEX", "CURSOR_AGENT",
+		"COPILOT_CLI", "GITHUB_COPILOT", "AGENT_CONTEXT_OUT", "KIRO_SESSION_ID",
+		"OPENCODE",
+	} {
+		t.Setenv(v, "")
+	}
+}
+
+// runAgentEnvelope invokes argv with --agent and returns the exit code plus the
+// decoded JSON envelope. Agent mode is used because it renders a blocked
+// operation as a machine-checkable {"ok":false,"error":{"code":"safety_blocked"}}
+// on stdout, rather than prose on stderr.
+func runAgentEnvelope(t *testing.T, argv []string) (int, map[string]any) {
+	t.Helper()
+
+	code, out := captureRun(t, append(argv, "--agent"), RunOptions{})
+
+	// A few exec commands print a progress line before their envelope, so scan
+	// for the last line that parses as JSON rather than decoding the whole
+	// stream. (That prose is itself an agent-mode wart, but it is pre-existing
+	// and orthogonal to what these tests pin.)
+	var env map[string]any
+	found := false
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var candidate map[string]any
+		if json.Unmarshal([]byte(line), &candidate) == nil {
+			env, found = candidate, true
+		}
+	}
+	require.True(t, found, "expected a JSON agent envelope, got:\n%s", out)
+	return code, env
+}
+
+// errorCode extracts error.code from an agent envelope, or "" when the envelope
+// reports success.
+func errorCode(t *testing.T, env map[string]any) string {
+	t.Helper()
+	if ok, _ := env["ok"].(bool); ok {
+		return ""
+	}
+	errObj, isMap := env["error"].(map[string]any)
+	require.True(t, isMap, "a failed envelope must carry an error object: %v", env)
+	code, _ := errObj["code"].(string)
+	return code
+}
+
+// TestExecFunctionAdHocCodeBlockedInReadonly closes the hole that made the
+// generic-API work necessary: `pkg/commands/listing.go` declares
+// `exec: OperationCreate`, but every exec subcommand used to call SetupClient()
+// instead of SetupWithSafety(), so a readonly context did not block ad-hoc
+// JavaScript that can POST or DELETE against any platform API the token reaches.
+func TestExecFunctionAdHocCodeBlockedInReadonly(t *testing.T) {
+	isolatedContext(t, "readonly")
+
+	code, env := runAgentEnvelope(t, []string{
+		"exec", "function", "--code", "export default async function() { return 1 }",
+	})
+
+	require.NotZero(t, code, "ad-hoc code must not run in a readonly context")
+	require.Equal(t, "safety_blocked", errorCode(t, env))
+}
+
+// TestExecFunctionAdHocCodeBlockedInReadWriteMine pins the deliberate extra
+// strictness: ad-hoc JavaScript is gated as a *delete*, not a create.
+//
+// AppEngine injects a bearer on relative fetch(), so `--code` can reach any
+// endpoint the token can. Gating it as a create would leave it permitted at
+// readwrite-mine while `exec api` escalates an unclassifiable request to
+// OperationDelete — making that gate theatre, since a caller blocked on
+// `exec api` could reach the same endpoint through `--code`.
+func TestExecFunctionAdHocCodeBlockedInReadWriteMine(t *testing.T) {
+	isolatedContext(t, "readwrite-mine")
+
+	code, env := runAgentEnvelope(t, []string{
+		"exec", "function", "--code", "export default async function() { return 1 }",
+	})
+
+	require.NotZero(t, code)
+	require.Equal(t, "safety_blocked", errorCode(t, env),
+		"ad-hoc code is classified as a delete, which readwrite-mine refuses "+
+			"against unknown ownership")
+}
+
+// TestExecNamedFunctionAllowedInReadWriteMine is the counterpart: a *named* app
+// function runs the app's own reviewed code and stays a create, so the extra
+// strictness above must not spill onto it.
+func TestExecNamedFunctionAllowedInReadWriteMine(t *testing.T) {
+	isolatedContext(t, "readwrite-mine")
+
+	_, env := runAgentEnvelope(t, []string{"exec", "function", "myapp/myfunction"})
+
+	require.NotEqual(t, "safety_blocked", errorCode(t, env),
+		"invoking a named app function is a create, which readwrite-mine permits")
+}
+
+// TestExecReadShapedSubcommandsAllowedInReadonly is the other half of the fix.
+// The exec family is declared mutating at the verb level, but several of its
+// members are read-shaped POSTs: the platform declares a :read scope for them
+// and they persist nothing. Gating the whole family as OperationCreate would
+// wrongly block them in a readonly context — the same over-blocking that
+// disqualified method-based inference for `exec api`.
+//
+// These invocations pass the safety gate and then fail on the local server's
+// 404, so the assertion is on the error *code*: anything but safety_blocked
+// means the gate let them through.
+func TestExecReadShapedSubcommandsAllowedInReadonly(t *testing.T) {
+	cases := []struct {
+		name string
+		argv []string
+	}{
+		{"analyzer", []string{"exec", "analyzer", "dt.statistics.Example", "--query", "timeseries avg(x)"}},
+		{"slo", []string{"exec", "slo", "example-slo-id"}},
+		{"copilot", []string{"exec", "copilot", "hello"}},
+		{"preview-processor", []string{"exec", "preview-processor", "-f", "missing.json"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolatedContext(t, "readonly")
+
+			_, env := runAgentEnvelope(t, tc.argv)
+
+			require.NotEqual(t, "safety_blocked", errorCode(t, env),
+				"%s is a read-shaped POST and must not be blocked in a readonly context", tc.name)
+		})
+	}
+}
+
+// TestExecWorkflowBlockedInReadonly pins the genuinely-mutating member: a
+// workflow execution runs actions that create and modify resources.
+func TestExecWorkflowBlockedInReadonly(t *testing.T) {
+	isolatedContext(t, "readonly")
+
+	code, env := runAgentEnvelope(t, []string{"exec", "workflow", "example-workflow-id"})
+
+	require.NotZero(t, code)
+	require.Equal(t, "safety_blocked", errorCode(t, env))
+}

--- a/cmd/exec_slos.go
+++ b/cmd/exec_slos.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/slo"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
 )
 
 // execSLOCmd evaluates an SLO
@@ -38,7 +39,10 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sloID := args[0]
 
-		_, c, err := SetupClient()
+		// SLO evaluation is a read-shaped POST: it computes a result and persists
+		// nothing (the API declares a :read scope), so gating it as a create would
+		// wrongly block it in a readonly context.
+		_, c, err := SetupWithSafety(safety.OperationRead)
 		if err != nil {
 			return err
 		}

--- a/cmd/exec_workflows.go
+++ b/cmd/exec_workflows.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
 	workflowpkg "github.com/dynatrace-oss/dtctl/pkg/resources/workflow"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
 )
 
 // execWorkflowResult is the structured response for agent mode.
@@ -93,7 +94,9 @@ var execWorkflowCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		workflowID := args[0]
 
-		_, c, err := SetupClient()
+		// Triggering a workflow runs actions that create and modify resources, so
+		// it is gated as a create — the `exec` verb's declared operation.
+		_, c, err := SetupWithSafety(safety.OperationCreate)
 		if err != nil {
 			return err
 		}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -39,7 +39,7 @@ Supported resources:
   lookup-tables (lu)      trash                     workflow-executions (wfe)
   wfe-task-result         extensions (ext)          extension-configs (extcfg)
   documents (doc)         anomaly-detectors (ad)    hub-extensions
-  hub-extension-releases
+  hub-extension-releases  apis
 
 Use 'dtctl get <resource> --help' for resource-specific options.`,
 	Example: `  # List all workflows
@@ -152,4 +152,5 @@ func init() {
 	getCmd.AddCommand(getAnomalyDetectorsCmd)
 	getCmd.AddCommand(getHubExtensionsCmd)
 	getCmd.AddCommand(getHubExtensionReleasesCmd)
+	getCmd.AddCommand(getAPIsCmd)
 }

--- a/cmd/get_apis.go
+++ b/cmd/get_apis.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtctl/pkg/output"
+	resapi "github.com/dynatrace-oss/dtctl/pkg/resources/api"
+)
+
+// getAPIsCmd lists the APIs the environment publishes specifications for.
+//
+// The listing mirrors the environment's own API index — the same document its
+// Swagger UI reads — and neither adds nor filters entries. What is on it is a
+// property of the environment, not of dtctl.
+var getAPIsCmd = &cobra.Command{
+	Use:     "apis",
+	Aliases: []string{"api"},
+	Short:   "List the APIs this environment publishes specifications for",
+	Long: `List the APIs this environment publishes OpenAPI specifications for.
+
+The list comes from the environment's own API index, so it shows exactly what
+that environment publishes — dtctl neither adds nor hides entries.
+
+The DTCTL column names the dtctl resource that already wraps an API. A blank
+means there is no native command for it yet; --uncovered filters to those, which
+makes the gap between the platform and dtctl visible and actionable.
+
+Drill down with 'dtctl describe api <name>' for an API's operations, and call an
+operation with 'dtctl exec api <path>'.
+
+Examples:
+  # What does this environment publish?
+  dtctl get apis
+
+  # Which of those has no native dtctl command yet?
+  dtctl get apis --uncovered
+
+  # Include operation counts and categories (one request per API)
+  dtctl get apis --ops-count -o wide
+
+  # Structured output
+  dtctl get apis -o json
+`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_, c, printer, err := Setup()
+		if err != nil {
+			return err
+		}
+
+		uncovered, _ := cmd.Flags().GetBool("uncovered")
+		opsCount, _ := cmd.Flags().GetBool("ops-count")
+
+		handler := resapi.NewHandler(c)
+		rows, err := handler.List(resapi.ListOptions{Uncovered: uncovered, OpsCount: opsCount})
+		if err != nil {
+			return err
+		}
+
+		ap := enrichAgent(printer, "get", "apis")
+		if ap != nil {
+			ap.Context().Suggestions = []string{
+				"dtctl describe api <name>  -- list an API's operations",
+				"dtctl describe api <name> --operation 'GET /path'  -- one operation in full",
+				"dtctl get apis --uncovered  -- APIs with no native dtctl command",
+			}
+		}
+		warnUnreadableSpecs(ap, rows)
+
+		return printer.PrintList(rows)
+	},
+}
+
+// warnUnreadableSpecs surfaces rows whose specification could not be read. The
+// count goes to the caller rather than the log: a blank OPS cell otherwise looks
+// like "zero operations", and the per-row reason is in the structured output.
+func warnUnreadableSpecs(ap *output.AgentPrinter, rows []resapi.APIInfo) {
+	failed := 0
+	for _, r := range rows {
+		if r.SpecError != "" {
+			failed++
+		}
+	}
+	if failed == 0 {
+		return
+	}
+
+	const format = "%d of %d specifications could not be read; those rows have no operation count (use -o json to see spec_error)"
+	if ap != nil {
+		ap.Context().Warnings = append(ap.Context().Warnings,
+			fmt.Sprintf(format, failed, len(rows)))
+		return
+	}
+	output.PrintWarning(format, failed, len(rows))
+}
+
+func init() {
+	getAPIsCmd.Flags().Bool("uncovered", false, "only APIs with no native dtctl command")
+	getAPIsCmd.Flags().Bool("ops-count", false, "fetch every specification to fill in operation counts and categories (one request per API)")
+}

--- a/cmd/plugin_dispatch_test.go
+++ b/cmd/plugin_dispatch_test.go
@@ -127,7 +127,14 @@ func TestPluginEnv_StripsCredentialEnvVars(t *testing.T) {
 	env := pluginEnv([]string{"--plain"})
 
 	joined := strings.Join(env, "\n")
-	for _, forbidden := range []string{"DTCTL_TOKEN=", "DT_API_TOKEN=", "DTCTL_ACCOUNT_TOKEN=", "SECRET"} {
+	// Scan for the planted credential *values*, not a bare substring like
+	// "SECRET": the plugin env inherits the host environment, and any machine
+	// exporting e.g. AWS_SECRET_ACCESS_KEY would trip a substring match on the
+	// variable's name alone.
+	for _, forbidden := range []string{
+		"DTCTL_TOKEN=", "DT_API_TOKEN=", "DTCTL_ACCOUNT_TOKEN=",
+		"dt0s16.SECRET", "dt0c01.SECRET",
+	} {
 		if strings.Contains(joined, forbidden) {
 			t.Errorf("credential material leaked into plugin env (%s)", forbidden)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/exec"
 	"github.com/dynatrace-oss/dtctl/pkg/inspect"
 	"github.com/dynatrace-oss/dtctl/pkg/output"
+	resapi "github.com/dynatrace-oss/dtctl/pkg/resources/api"
 	"github.com/dynatrace-oss/dtctl/pkg/safety"
 	"github.com/dynatrace-oss/dtctl/pkg/suggest"
 	"github.com/dynatrace-oss/dtctl/pkg/tracing"
@@ -247,9 +248,13 @@ func executeArgs(argv []string) int {
 		// Check for auth-related hints (e.g., expired OAuth session)
 		authHints := getAuthHintsForError(err)
 
-		allHints := make([]string, 0, len(urlHints)+len(authHints))
+		// Check for a missing API specification index (`get apis` / `describe api`)
+		indexHints := getAPIIndexHintsForError(err)
+
+		allHints := make([]string, 0, len(urlHints)+len(authHints)+len(indexHints))
 		allHints = append(allHints, urlHints...)
 		allHints = append(allHints, authHints...)
+		allHints = append(allHints, indexHints...)
 
 		// Record the error on the root span so it appears in traces.
 		rootSpan.SetStatus(codes.Error, err.Error())
@@ -579,6 +584,20 @@ func errorToDetail(err error) *output.ErrorDetail {
 		}
 	}
 
+	// resapi.BlockedError — a generic `exec api` request refused by the gate. It
+	// wraps the safety refusal, so this case must come first: the same
+	// safety_blocked code, but the message says why the request was classified as
+	// it was, which is what tells a caller what to do differently.
+	var apiBlockedErr *resapi.BlockedError
+	if errors.As(err, &apiBlockedErr) {
+		return &output.ErrorDetail{
+			Code:        "safety_blocked",
+			Message:     apiBlockedErr.Headline(),
+			Operation:   fmt.Sprintf("call %s %s", apiBlockedErr.Method, apiBlockedErr.RequestPath),
+			Suggestions: apiBlockedErr.Suggestions(),
+		}
+	}
+
 	// safety.SafetyError — operation blocked by safety level
 	var safetyErr *safety.SafetyError
 	if errors.As(err, &safetyErr) {
@@ -684,6 +703,41 @@ func errorToDetail(err error) *output.ErrorDetail {
 		return detail
 	}
 
+	// apispec.RegistryUnavailableError — the environment publishes no
+	// machine-readable API index. A distinct code because it is an expected
+	// property of an environment, not a failure of the command: a consumer should
+	// stop probing for specifications rather than retry.
+	var registryErr *resapi.RegistryUnavailableError
+	if errors.As(err, &registryErr) {
+		// A refused index is not a missing one, and a consumer must be able to tell
+		// them apart without parsing the message: only the former is worth retrying
+		// with a different credential.
+		if registryErr.StatusCode == 401 || registryErr.StatusCode == 403 {
+			return &output.ErrorDetail{
+				Code:       output.ClassifyHTTPError(registryErr.StatusCode),
+				Message:    registryErr.Error(),
+				StatusCode: registryErr.StatusCode,
+			}
+		}
+		return &output.ErrorDetail{
+			Code:       "api_index_unavailable",
+			Message:    registryErr.Error(),
+			StatusCode: registryErr.StatusCode,
+		}
+	}
+
+	// apispec.SpecUnavailableError — a listed specification could not be read.
+	// Distinct from the generic HTTP classification so a consumer can tell "no
+	// specification" apart from "the API call failed".
+	var specErr *resapi.SpecUnavailableError
+	if errors.As(err, &specErr) {
+		return &output.ErrorDetail{
+			Code:       "api_spec_unavailable",
+			Message:    specErr.Error(),
+			StatusCode: specErr.StatusCode,
+		}
+	}
+
 	// inspect.Error — `dtctl inspect` carries a stable envelope code (spill_file_*,
 	// inspect_bad_flags, inspect_unknown_field) plus actionable suggestions.
 	var inspectErr *inspect.Error
@@ -752,6 +806,54 @@ func getAuthHintsForError(err error) []string {
 	return []string{
 		"Run 'dtctl auth login' to re-authenticate",
 	}
+}
+
+// getAPIIndexHintsForError returns recovery hints when an environment publishes
+// no machine-readable API index.
+//
+// The index is an observed convention rather than a documented contract, so its
+// absence is an expected outcome with two concrete fallbacks — not a failure to
+// merely report. Hints flow to both audiences: they become envelope suggestions
+// in agent mode and printed hints for a human.
+func getAPIIndexHintsForError(err error) []string {
+	var registryErr *resapi.RegistryUnavailableError
+	if errors.As(err, &registryErr) {
+		// A refused index is a fact about the credential, not about the environment,
+		// and it must not be answered with advice about the environment: someone told
+		// their index is unpublished will go looking at the wrong layer entirely.
+		if registryErr.StatusCode == 401 || registryErr.StatusCode == 403 {
+			return []string{
+				"the index request was rejected, so this says nothing about whether the " +
+					"environment publishes one — check the credential first",
+				"run 'dtctl doctor' to verify the active context's token",
+			}
+		}
+		return []string{
+			"browse this environment's own API explorer at " + resapi.SwaggerUIPath,
+			"address an API by base path, e.g. dtctl describe api /platform/document/v1",
+		}
+	}
+
+	// A listed document that cannot be read. The status carries the whole story,
+	// and the body does not: a 403 here is answered with a page about SSO, which
+	// would otherwise be forwarded verbatim to a caller it cannot help.
+	var specErr *resapi.SpecUnavailableError
+	if errors.As(err, &specErr) {
+		switch specErr.StatusCode {
+		case 401, 403:
+			return []string{
+				"this environment refused the specification document even though your token is valid — " +
+					"some environments serve specifications only to an interactive session",
+				"open " + resapi.SwaggerUIPath + " in a browser against this environment instead",
+				"the API itself is unaffected: 'dtctl exec api <path>' does not need the specification",
+			}
+		case 404:
+			return []string{
+				"the environment's API index lists this API but publishes no specification document for it",
+			}
+		}
+	}
+	return nil
 }
 
 // isTokenRefreshError returns true if the error looks like an OAuth token
@@ -934,6 +1036,16 @@ func SetupWithSafety(op safety.Operation) (*config.Config, *client.Client, error
 		return nil, nil, err
 	}
 	return cfg, c, nil
+}
+
+// SetupWithSafetyAndPrinter is SetupWithSafety plus a Printer, for mutating
+// commands that render their result through the normal output pipeline.
+func SetupWithSafetyAndPrinter(op safety.Operation) (*config.Config, *client.Client, output.Printer, error) {
+	cfg, c, err := SetupWithSafety(op)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return cfg, c, NewPrinter(), nil
 }
 
 // NewSafetyChecker creates a new safety checker for the current context

--- a/docs/dev/GENERIC_API_ACCESS.md
+++ b/docs/dev/GENERIC_API_ACCESS.md
@@ -185,6 +185,17 @@ declared delete into a create. The live E2E test asserts precisely this invarian
 across every operation the environment publishes — no verdict is ever looser than
 the method's floor.
 
+**Accepted tradeoff, eyes open:** for POST, gate correctness in a `readonly`
+context depends entirely on the accuracy of the specification the environment
+serves at request time — a POST is admitted as a read exactly when the document
+declares only `:read` scopes for it. This is deliberate. Any stricter POST floor
+is wrong in both directions (it refuses the DQL API's read-only POSTs, and it
+still under-gates the POST that deletes), and the specification is the
+environment's own statement about its own endpoint. An environment that
+misdeclares a mutating POST as `:read` is lying to every client, not just this
+one — but it is worth stating that the gate inherits that lie rather than
+detecting it.
+
 ### Unknown means delete
 
 When no operation matched — the path belongs to no listed API, the specification
@@ -216,6 +227,27 @@ the command it shadows.** That is the failure mode the table exists to prevent, 
 It currently holds three entries (bucket deletion, bucket truncation, record
 deletion). Add one whenever an irreversible endpoint's destructiveness is invisible
 in its URL.
+
+**The table matches spellings, not just strings.** The server-side router
+percent-decodes and normalizes a path before routing, so
+`bucket-definitions/foo%3Atruncate`, `x/../bucket-definitions/foo`, and
+`management//v1/bucket-definitions/foo` all reach the endpoint the canonical
+spelling names — and a table matched only against the literal request text
+would gate each of them one level too low. Two mechanisms close this:
+
+1. `escalateDestructive` matches every *routable spelling* of the path — the
+   literal text, each successive percent-decoding (to a bounded fixpoint, for
+   double-encoding), and the dot-segment/duplicate-slash-normalized form of
+   each. This is safe precisely because escalation only ever raises the gate.
+2. `exec api` refuses any spelling that changes **structure** under
+   normalization (`CanonicalRequestPath`): dot segments, duplicate or trailing
+   slashes, encoded separators, control characters, and router-delimiter
+   characters (`;`, `\`, decoded `?`/`#`). Benign percent-encoding (`%20` in an
+   identifier) is accepted, and classification runs on the *decoded* form —
+   the path the server routes — while the caller's spelling goes on the wire.
+
+`TestClassify_NormalizationDoesNotDefeatEscalation` and
+`TestExecAPIRefusesAmbiguousPathSpellings` pin both halves.
 
 ### Never the integration target
 
@@ -268,6 +300,10 @@ Path matching uses the longest base-path prefix at a segment boundary, so
 - **A body requires an explicit `-X`.** curl promotes `-d` to POST; dtctl refuses.
   Inferring the method would infer the safety operation, which contradicts the
   command's premise.
+- **`-H` cannot supply credentials.** `Authorization` and `Proxy-Authorization`
+  are refused: the context is the identity, dtctl attaches its credentials
+  itself, and a caller-supplied value would silently fight the client's own
+  auth (whichever writes last wins). Changing identity means changing context.
 - **The output protocol is declared, not sniffed.** A JSON body goes through the
   normal printer, so `-o json/yaml` and the agent envelope behave as they do
   everywhere else. Anything else is passed through **verbatim, even under

--- a/docs/dev/GENERIC_API_ACCESS.md
+++ b/docs/dev/GENERIC_API_ACCESS.md
@@ -1,0 +1,371 @@
+# Generic API Access — Spec Discovery and HTTP Passthrough
+
+**Status:** Implemented
+**Created:** 2026-08-13
+**Audience:** anyone extending API discovery, the passthrough, or the native-coverage map.
+
+> **Implementation:** `sdk/api/apispec/` (registry + specification parsing, scope
+> classification), `pkg/resources/api/` (CLI handler, display projections,
+> `Classify`, the coverage map), `cmd/get_apis.go`, `cmd/describe_api.go`,
+> `cmd/exec_api.go`, `cmd/check_scopes.go` (per-call scope verdict),
+> `pkg/commands/listing.go` (unadvertised resources).
+
+## Overview
+
+dtctl wraps roughly twenty Dynatrace APIs natively. An environment publishes many
+more. Until now the gap had no governed answer: a caller who needed an unwrapped
+API either dropped out of dtctl entirely or reached for
+`dtctl exec function --code` with ad-hoc JavaScript — which AppEngine runs with a
+bearer token, making the least governed path in the tool also the most convenient
+one.
+
+This feature closes the gap in two halves, and the second only makes sense
+because of the first.
+
+**Part A — discovery.** `dtctl get apis` lists what the environment publishes
+specifications for; `dtctl describe api <name>` projects one specification into an
+operation index, or one operation in full.
+
+**Part B — passthrough.** `dtctl exec api <path>` sends a request to any endpoint,
+gated by the same safety checker as every native mutating command — with the
+operation class derived from the API's *own specification* rather than guessed
+from the HTTP method.
+
+```bash
+dtctl get apis --uncovered              # what has no native command yet
+dtctl describe api example              # its operations, at a coarse grain
+dtctl describe api example --operation 'POST /things'
+dtctl exec api /platform/example/v1/things -X POST -d @body.json
+```
+
+## Goals
+
+1. **Make the platform's surface visible.** An agent that can list APIs and read
+   one operation's schema can use an unwrapped API correctly on the first try.
+2. **Govern the escape hatch instead of pretending it does not exist.** A
+   passthrough inside dtctl inherits contexts, safety levels, profiles, agent
+   envelopes, and audit-visible output. The alternative callers already use
+   inherits none of that.
+3. **Derive authority from the specification.** What a request may do is a
+   property of the endpoint, published by the environment — not of the verb the
+   caller typed.
+4. **Never become the integration target.** See below; this is a design
+   constraint, not a caveat.
+5. **Disclose nothing.** dtctl mirrors the environment's index and filters
+   nothing, and no committed artifact names a non-public API.
+
+## Non-Goals
+
+- **Client-side request validation.** Specifications are per-environment and
+  per-version; a validator that rejects a request the platform would have accepted
+  is strictly worse than the platform's own 400. The specification is used on the
+  *failure* path instead (`apiRequestError`), where it costs nothing when the call
+  succeeds and tells a caller what the payload should have been in one round trip.
+- **A generic write E2E.** No endpoint is harmless on every tenant, so the live
+  tests exercise reads and classify writes without sending them.
+- **Reaching another host.** An absolute URL is refused, not followed: the
+  context's credentials belong to the environment it names.
+- **A local spec cache.** Every invocation reads the index fresh. A stale cache
+  would answer "this API does not exist" about an environment that now publishes
+  it.
+
+## Part A — Discovery
+
+### Conventions, not a documented contract
+
+Three facts about the platform underpin discovery, and all three are
+**conventions observed to hold**, not published contracts:
+
+| Convention | Value |
+|---|---|
+| API index | `/platform/metadata/v1/swagger-ui.json` (the document the environment's own Swagger UI reads) |
+| Specification document | `<base-path>/openapi.yaml` |
+| Classic environment API | `<base-path>/spec3.json` (JSON, and the one documented exception) |
+
+The index is an array of `{name, url}` pairs. A base path is derived from the
+document URL by stripping the filename, which is why `Entry.BasePath()` and
+`SpecPathForBase()` are inverses and why the E2E test asserts they round-trip on a
+live index.
+
+Two hard rules follow from "convention, not contract":
+
+- **Always parse as YAML, never branch on `Content-Type`.** YAML is a superset of
+  JSON, so one parser reads both `openapi.yaml` and `spec3.json`. Branching on the
+  served content type would break the day a gateway relabels a document — and it
+  has no upside.
+- **Failures are typed and expected.** An environment may publish the index and
+  refuse the documents (an interactive-session-only SSO policy does exactly
+  this). `SpecUnavailableError` degrades one row of `get apis`; it never breaks the
+  listing.
+
+### "Not published" and "refused" are different answers
+
+`RegistryUnavailableError` carries the HTTP status and phrases itself from it:
+
+| Status | Message |
+|---|---|
+| 404 / no response | this environment publishes no machine-readable API index at `<path>` |
+| 401 / 403 | not authorized to read the API index at `<path>` (HTTP n) |
+| 5xx | the API index is temporarily unavailable |
+
+This distinction was not theoretical. During development a stale token produced a
+401, dtctl reported "this environment publishes no API index", and the E2E suite
+skipped — a statement about the *environment* made from evidence about the
+*credential*. Only a 404 licenses that claim. The agent-mode hints follow the same
+split: on a 401/403 the suggestion is to check the token, and the hint says
+explicitly that the refusal says nothing about whether an index exists.
+
+### The projection is the feature
+
+A published specification runs from roughly 10k to 47k tokens. Handing that to an
+agent is unaffordable and handing it to a human is unreadable, so
+`describe api` has three views at different grains:
+
+| View | Output |
+|---|---|
+| default | operation index — every operation as `METHOD /path`, its summary, its declared scope |
+| `--operation 'METHOD /path'` | one operation in full: parameters, request-body schema (one level), responses, required scopes, and a ready-to-run `dtctl exec api` invocation |
+| `--raw` | the unprojected document, in the encoding it was served in |
+
+The default view is **complete at a coarser grain**, not truncated — every
+operation appears, so no drill-down target is hidden. `--raw` goes through the
+same result-spill machinery as a large query result, gated on the `HostDiskSpill`
+capability so an embedded caller gets bytes rather than a path it cannot read.
+
+Two projection details worth keeping:
+
+- An operation's ID is `METHOD /path`, and it must round-trip back into
+  `--operation`. A specification may key an operation on the **empty** path
+  (meaning the base path itself is the endpoint); left alone that yields the
+  ID `"GET "`, which no caller can pass back and which never matches a request,
+  because `Match` normalizes an incoming base path to `/`. `collectOperations`
+  normalizes `""` → `"/"` at parse time. Three live specifications on one tenant
+  hit this.
+- A blank SCOPE means *the specification declares none*, not that none is
+  required. The help text says so, because the opposite reading is the dangerous
+  one.
+
+## Part B — The Passthrough
+
+### The HTTP method does not decide the gate
+
+This is the load-bearing decision of the whole feature.
+
+The obvious design keys safety on the verb: GET is a read, POST is a create,
+DELETE is a delete. It is wrong, and measurably so. A sweep of one production
+index turned up **15 POST operations, across three publicly documented APIs, that
+declare only a read scope** — verification, validation, and search endpoints that
+are POSTs purely because they take a body. (The narrower sample quoted in
+`methodFloor`'s comment found 12 such POSTs in 64 specified operations, plus one
+POST that declares `:delete`.) A method-keyed gate would refuse the reads in a
+`readonly` context, which is exactly the context where a caller most wants them —
+and in the other direction it would wave the delete through as a create.
+
+So classification takes the **stricter of two independent lower bounds**:
+
+```
+verdict = escalateDestructive( stricter( methodFloor(method), accessFloor(method, access) ) )
+```
+
+| Method | `methodFloor` | Why |
+|---|---|---|
+| GET, HEAD | Read | conventional |
+| **POST** | **Read** | POST carries no information (see above) |
+| PUT, PATCH | Update | modifies something that exists |
+| DELETE | Delete | conventional |
+| anything else | Delete | unclassifiable fails closed |
+
+`accessFloor` reads the scope verbs the specification declares for the operation
+(`…:read`, `…:write`, `…:delete` → `AccessRead/Write/Delete`). `AccessWrite` on a
+POST is a create; on a PUT/PATCH an update.
+
+Taking the stricter of two floors means **neither source can weaken the other**: a
+specification cannot turn a DELETE into a read, and a method cannot turn a
+declared delete into a create. The live E2E test asserts precisely this invariant
+across every operation the environment publishes — no verdict is ever looser than
+the method's floor.
+
+### Unknown means delete
+
+When no operation matched — the path belongs to no listed API, the specification
+could not be read, or it declares no scope — a non-read method is gated as
+`OperationDelete`: the strictest generally-reachable operation. Escalating rather
+than asking means existing safety semantics apply unchanged (with unknown
+ownership, `OperationDelete` proceeds only at `readwrite-all`), so no new safety
+level had to be invented for "might be anything".
+
+**There is deliberately no flag to assert the operation.** A `--op create` flag
+would let the caller who knows least about the endpoint overrule the gate, which
+is the entire value of the gate. The error message says so explicitly — but only
+when the verdict really was unresolved, which is why `Classification.Escalated`
+exists: a curated escalation is a *deliberate* classification, and apologising for
+being unable to classify it would be a lie.
+
+### The one curated table
+
+`destructivePatterns` is the single place a hard-coded override is unavoidable,
+and it is the only place classification errs *lax* rather than strict.
+`OperationDeleteBucket` sits above `OperationDelete` — only
+`dangerously-unrestricted` permits it — and nothing about a URL says "this
+destroys a data store". Without the table, deleting a bucket through the
+passthrough would pass at `readwrite-all` while `dtctl delete bucket` demands
+`dangerously-unrestricted`: **the passthrough would be a strictly weaker gate than
+the command it shadows.** That is the failure mode the table exists to prevent, and
+`TestExecAPIDoesNotUndercutTheCommandItShadows` is what keeps it prevented.
+
+It currently holds three entries (bucket deletion, bucket truncation, record
+deletion). Add one whenever an irreversible endpoint's destructiveness is invisible
+in its URL.
+
+### Never the integration target
+
+An escape hatch that becomes the normal way to use dtctl has failed, even while
+working. Every native command validates input, resolves names, formats output, and
+cannot be pointed at the wrong endpoint; a passthrough does none of that. So the
+design pushes callers away from it at four points:
+
+1. **Unadvertised.** `exec api` is `Hidden`, so it is absent from `--help`,
+   completion, and the compact catalogs an agent bootstraps from — but
+   `pkg/commands` lists it under `dtctl commands --full`. Cobra's two states are
+   both wrong for an escape hatch: visible puts it next to the native commands it
+   must not replace, and hidden makes it undiscoverable, which pushes a caller who
+   genuinely needs it toward something worse. The `unadvertisedResources` map is
+   that third state — findable by a caller who goes looking, invisible to one who
+   is browsing.
+2. **It names its replacement.** When a path is covered natively, the command
+   warns with the *runnable* native command, and a refusal repeats it as the
+   preferred route.
+3. **The help text says it.** "If you find yourself scripting against it, that API
+   wants a native command instead."
+4. **No profile grants it.** Neither builtin profile (`query`, `investigate`)
+   includes it; a profiled caller gets `profile_blocked`.
+   `TestNoBuiltinProfileGrantsTheEscapeHatch` pins that.
+
+`get apis --uncovered` is the constructive half of the same principle: it turns
+the gap between the platform and dtctl into a contribution backlog. It filters to
+entries on the public `/platform/` tree, because a native command should only be
+proposed for a state-of-the-art, publicly supported API.
+
+### The coverage map
+
+`pkg/resources/api/coverage.go` maps a base path to `{Resource, Command}`.
+`Resource` is the label in the DTCTL column; `Command` is what a caller should
+type — and it is deliberately **not** derived from `Resource`, because not every
+wrapped API is reached through `get <resource>` (`dtctl query`,
+`dtctl exec copilot`, `dtctl exec preview-processor`). A suggestion that does not
+run is worse than none: it teaches a caller that dtctl's advice is unreliable.
+The first draft suggested `dtctl get query`, `dtctl get copilot`, and
+`dtctl get lookup-tables`, none of which exist —
+`TestNativeCoverageNamesRealCommands` walks every entry through `rootCmd.Find`,
+which is how the third one was caught.
+
+Path matching uses the longest base-path prefix at a segment boundary, so
+`/platform/storage/management/v1` does not claim
+`/platform/storage/management/v1x`.
+
+### Other passthrough decisions
+
+- **A body requires an explicit `-X`.** curl promotes `-d` to POST; dtctl refuses.
+  Inferring the method would infer the safety operation, which contradicts the
+  command's premise.
+- **The output protocol is declared, not sniffed.** A JSON body goes through the
+  normal printer, so `-o json/yaml` and the agent envelope behave as they do
+  everywhere else. Anything else is passed through **verbatim, even under
+  `--agent`** — a passthrough can return YAML, CSV, Prometheus text, or a binary
+  archive, and wrapping those would corrupt them, while refusing them would make
+  the command useless for the exports it exists to reach. An HTML body earns a
+  warning on stderr (it is almost always a login redirect), which keeps agent-mode
+  stdout pure.
+- **`--dry-run` reports the verdict instead of enforcing it.** Showing the composed
+  request plus "this would be BLOCKED, here is why" is more useful than an error
+  that hides the request. Credential-bearing headers are redacted in that output,
+  because a dry run is what gets pasted into a bug report.
+- **Errors preserve the platform's message** (capped at 4 KiB) and add what dtctl
+  knows: the operation's schema command, its declared scope, the native command.
+
+### `--check-scopes` gained a third verdict
+
+Scope preflight is a static table keyed by `verb resource`. `exec api` has no
+static answer — the required scope depends on the path — so
+`scopeRequirement` became three-way: `None`, `Known`, `PerCall`.
+
+- **Explicit `--check-scopes`** resolves `PerCall` → `Known` by reading the
+  specification for the path the caller passed. It is explicit and terminal, so
+  spending a request is exactly what the caller asked for.
+- **The agent-mode auto-preflight** deliberately does not: it runs ahead of *every*
+  command and must stay free. It bails on anything that is not `Known`.
+- Otherwise the verdict is `scopeStatusUnknown`, with suggestions pointing at
+  `describe api`. "No platform scopes required" would have been a lie.
+
+## Disclosure rules
+
+These are requirements, inherited from the design review and reflected in the
+tests.
+
+1. **dtctl mirrors the index and filters nothing.** Any dtctl-side filter of the
+   API list would have to hard-code which APIs to conceal — and since dtctl is
+   open source, *that list would itself be the disclosure*. What an environment
+   publishes is decided by whoever configures it.
+2. **Resolution never guesses.** `Resolve` consults only what the registry
+   returned; it never synthesizes a candidate path from a name and retries it,
+   which would turn a name lookup into an existence oracle for APIs an environment
+   deliberately omits. A fully-qualified base path the caller already typed is
+   accepted as given, because echoing it back discloses nothing.
+3. **No committed artifact names a real non-public API.** Help text, examples,
+   docs, golden files, and E2E fixtures use synthetic names
+   (`/platform/example/v1/things`, `@example.invalid`).
+4. **Golden output must not vary by tenant class.** All golden fixtures are
+   synthetic; none is captured from a live environment.
+5. **E2E tests assert mechanism invariants, never an API list.** A fixture list of
+   expected APIs would be both a leak and a bug — the index is a property of the
+   environment, so a hard-coded expectation would encode one tenant's shape and
+   fail on another, which is the very problem this feature exists to solve.
+6. **The stability warning is phrased in terms of the public tree** ("outside the
+   public `/platform/` API tree"), never by naming a non-public prefix. It is a
+   statement about compatibility guarantees, not about what exists.
+
+## Embedding notes
+
+The passthrough obeys the [service engine](SERVICE_ENGINE_DESIGN.md) invariants:
+
+- `-d @file` goes through `vfs.ReadFileOrStdin`, so under an embedded invocation it
+  reads the *request's* file and `@-` reaches the swapped `os.Stdin`. Never
+  `/dev/stdin`.
+- `--raw` spilling is gated on `HostDiskSpill`; an embedded caller gets the bytes.
+- No `os.Exit`, no subprocess, credentials only via `LoadConfig()`/`Setup*`.
+- Output goes through `pkg/output`/`fmt`, so the stream seam catches it.
+
+`exec api` is **not** in `unsupportedCommands`: it is a plain HTTP call against the
+request's own environment, which is exactly what a service embedding dtctl wants
+to be able to do.
+
+## Testing
+
+| Layer | Where | What it pins |
+|---|---|---|
+| Spec parsing | `sdk/api/apispec/apispec_test.go` | YAML+JSON, `$ref` resolution, path templating, the collection-root normalization |
+| Scope classification | `sdk/api/apispec/classify_test.go` | scope verb → access |
+| Gate | `pkg/resources/api/classify_test.go` | both floors, escalation table, message wording |
+| Command behavior | `cmd/exec_api_test.go` | method-does-not-decide-the-gate, unresolved → delete, no undercutting, path/method refusals, vfs + stdin seams, dry-run leakage, output protocol |
+| Discovery commands | `cmd/api_discovery_test.go` | listing, `--uncovered`, `--ops-count`, refused-index messaging |
+| Conventions | `cmd/api_coverage_test.go` | coverage commands exist, unadvertised-but-documented, no profile grants it, discovery survives a restricted profile |
+| Output | `pkg/output/golden_test.go` | 11 golden files across both resources and six formats |
+| Live | `test/e2e/api_test.go` (`integration`) | index parses, entries round-trip, specs parse or fail typed, no verdict looser than its floor, coverage claims vs. the live index |
+
+`TestExecAPIMethodDoesNotDecideTheGate` is the one to keep working: same API, same
+`readonly` context, a read-scoped POST permitted and a write-scoped POST refused.
+It was mutation-tested in both directions.
+
+## Open questions
+
+- **Coverage-map drift.** Two entries look stale against live indexes: `settings`
+  is keyed on the classic environment-API base path while at least one environment
+  publishes a `/platform/settings/v1`, and no checked environment publishes the
+  GraphQL base path claimed for breakpoints. The E2E test logs (does not fail) such
+  claims, because coverage spans every tenant shape and no single tenant runs every
+  service.
+- **Escalation table maintenance.** It only grows by someone noticing. A periodic
+  sweep for irreversible endpoints (`:truncate`, `record-deletion`, and successors)
+  is the realistic mechanism.
+- **`--ops-count` costs one request per API.** Fine at ~100 APIs, and it is
+  opt-in. A concurrency bound would help if indexes grow.

--- a/docs/dev/IMPLEMENTATION_STATUS.md
+++ b/docs/dev/IMPLEMENTATION_STATUS.md
@@ -90,6 +90,7 @@ This document tracks the current implementation status of dtctl. For future plan
 | intent | ✅ | ✅ | - | - | - | - |
 | segment | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | anomaly-detector | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| api | ✅ | ✅ | - | - | - | - |
 
 #### Account Management
 
@@ -135,6 +136,20 @@ This document tracks the current implementation status of dtctl. For future plan
 | copilot | - | ✅ | - | - | - | - | - | - |
 | segment | - | - | - | - | - | - | - | ✅ |
 | anomaly-detector | - | - | - | - | - | - | - | - |
+| api | - | ✅ | - | - | - | - | - | - |
+
+### Generic API Access Features
+- [x] List the APIs an environment publishes specifications for: `dtctl get apis` (mirrors the environment's own API index — dtctl adds and filters nothing)
+- [x] DTCTL column names the native command that already wraps an API; `--uncovered` filters to the gap
+- [x] Operation counts and categories on demand: `--ops-count` (one request per API)
+- [x] Operation index for one API: `dtctl describe api <name|base-path>`
+- [x] One operation in full (parameters, request body, responses, scopes, ready-to-run invocation): `--operation 'METHOD /path'`
+- [x] Unprojected specification: `--raw` (spills to a file in agent mode, gated on the `HostDiskSpill` capability)
+- [x] Governed HTTP passthrough (unadvertised escape hatch): `dtctl exec api <path> [-X] [-d] [-H] [--dry-run]`
+- [x] Safety operation derived from the API's published specification, not from the HTTP method; unresolved requests gate as `OperationDelete`
+- [x] Curated escalation for irreversible endpoints, so the passthrough never gates looser than the command it shadows
+- [x] Per-call scope verdict in `--check-scopes`, resolved from the specification when asked explicitly
+- [x] Design doc: [GENERIC_API_ACCESS.md](GENERIC_API_ACCESS.md)
 
 ### Watch Mode Features
 - [x] Watch all `get` commands: `dtctl get workflows --watch`

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -73,6 +73,17 @@ dtctl as an in-process library a service calls once per request:
 
 ---
 
+### [GENERIC_API_ACCESS.md](GENERIC_API_ACCESS.md)
+API spec discovery and the governed HTTP passthrough:
+- **Discovery** - `dtctl get apis`, `dtctl describe api`, and the (undocumented) index/spec conventions
+- **The Gate** - why the HTTP method does not decide the safety operation, and what does
+- **Never the Integration Target** - unadvertised commands, native-command suggestions, the coverage map
+- **Disclosure Rules** - dtctl mirrors the environment's index and filters nothing
+
+**Use this for**: touching `sdk/api/apispec/`, `pkg/resources/api/`, `cmd/exec_api.go`, or the native-coverage map.
+
+---
+
 ### [../LIVE_DEBUGGER.md](../LIVE_DEBUGGER.md)
 User-facing Live Debugger workflow documentation:
 - **Workspace Filters** - Target runtimes with `dtctl update breakpoint --filters`

--- a/docs/site/_docs/api-discovery.md
+++ b/docs/site/_docs/api-discovery.md
@@ -1,0 +1,92 @@
+---
+layout: docs
+title: API Discovery
+---
+
+`dtctl get apis` and `dtctl describe api` show which Dynatrace APIs your environment publishes machine-readable specifications for, and what each one offers. Where [`dtctl inventory`]({{ '/docs/inventory/' | relative_url }}) answers *"what data is there?"*, API discovery answers *"what endpoints exist, and what does each one need?"*
+
+The listing comes from the environment's own API index — the same document its Swagger UI reads — so it shows exactly what that environment publishes. dtctl neither adds nor hides entries.
+
+```bash
+# What does this environment publish?
+dtctl get apis
+
+# Which of those has no native dtctl command yet?
+dtctl get apis --uncovered
+
+# Operation counts and categories (one request per API)
+dtctl get apis --ops-count -o wide
+
+# Structured output
+dtctl get apis -o json
+```
+
+## The DTCTL column
+
+`dtctl get apis` marks every API that already has a native dtctl command (operation counts shown here with `--ops-count`, which is off by default because it costs one request per API):
+
+```
+NAME               BASE PATH               OPS   DTCTL
+Widget Service     /platform/widget/v1     14    widget
+Sprocket Service   /platform/sprocket/v1   3
+Cog Service        /platform/cog/v1
+Elsewhere API
+```
+
+(Names above are illustrative — what your environment lists is up to your environment.) A row with no base path at all, like `Elsewhere API`, is an entry whose specification is documented on another host; `-o wide` marks those with `EXTERNAL: true`.
+
+A blank DTCTL cell means there is no native command for that API yet. `--uncovered` filters to exactly those rows, which turns the gap between the platform and dtctl into a concrete list — useful both for deciding what to contribute and for knowing when you have to fall back to a raw HTTP call.
+
+If a specification cannot be read (some environments publish the index but restrict the documents), that row keeps its name and base path, loses its operation count, and dtctl prints a warning saying how many rows were affected. Use `-o json` to see the per-row `spec_error`.
+
+## Describing one API
+
+```bash
+# The operation index for one API
+dtctl describe api document
+
+# Address it by base path instead of by name
+dtctl describe api /platform/document/v1
+
+# One operation in full
+dtctl describe api document --operation 'GET /documents/{id}'
+
+# The unprojected specification document
+dtctl describe api document --raw
+```
+
+The default view is the **operation index**: every operation as `METHOD /path`, with its summary and the scope the specification declares for it. That is a complete view at a coarser grain, not a truncation — published specifications run to tens of thousands of tokens, which is unreadable for a human and unaffordable for an AI agent, so the detail is one drill-down away instead of always present.
+
+`--operation` gives you everything you need to compose a call: parameters, the request-body schema, the responses, the required scopes, and a ready-to-run invocation.
+
+> A blank SCOPE means the specification declares no scope for that operation — **not** that no scope is required.
+
+`--raw` streams the document exactly as the environment served it (YAML for most APIs, JSON for the classic environment API). It is large: outside agent mode it goes to stdout so you can redirect it; in agent mode it spills to a file above the spill threshold, like a large query result.
+
+## Calling an API without a native command
+
+When an API has no native dtctl command, `dtctl exec api` sends a request to it directly:
+
+```bash
+dtctl exec api /platform/example/v1/things
+dtctl exec api /platform/example/v1/things -X POST -d '{"name":"demo"}'
+dtctl exec api /platform/example/v1/things -X POST -d @body.json
+dtctl exec api /platform/example/v1/things/42 -X DELETE --dry-run
+```
+
+**Prefer a native command whenever one exists.** A native command validates input, resolves names to IDs, formats output, and cannot be pointed at the wrong endpoint; a raw call does none of that. `exec api` exists for the APIs dtctl does not wrap — and if you find yourself scripting against it, that API wants a native command instead. dtctl warns you when the path you passed is already covered natively, and names the command to use.
+
+A few behaviors worth knowing:
+
+- **The path is relative to your environment.** An absolute URL is refused: dtctl sends the active context's credentials, so it will not call another host.
+- **Reads need no method; anything else needs an explicit `-X`.** dtctl will not infer a mutating method — and therefore a safety operation — from the presence of a body.
+- **What the request may do is read from the API's specification, not from the HTTP method.** A POST may need only a read scope, or may delete data. When dtctl cannot resolve the operation it assumes the worst and gates the request as a delete, which your context's [safety level]({{ '/docs/configuration/#safety-levels' | relative_url }}) then permits or refuses. There is no flag to assert otherwise.
+- **`--dry-run` shows the composed request and the safety verdict** without sending anything. Credential-bearing headers are redacted, so the output is safe to paste into a bug report.
+- **JSON responses go through the normal printer**, so `-o json`/`-o yaml` and `--agent` behave as they do everywhere else. Anything else — YAML, CSV, text, a binary archive — is passed through verbatim.
+- **`--check-scopes` resolves the scope for the path you passed** by reading the specification, instead of guessing from the verb.
+
+## Required scopes
+
+Discovery itself needs no special scope beyond what your context already uses to reach the environment; the index and the specification documents are served to any authenticated caller the environment allows. `exec api` needs whatever scope the endpoint itself requires — which is what `dtctl describe api <name> --operation '<METHOD> <path>'` tells you.
+
+See [Token Scopes]({{ '/docs/token-scopes/' | relative_url }}) for the scopes the native commands need.

--- a/docs/site/_docs/command-reference.md
+++ b/docs/site/_docs/command-reference.md
@@ -90,6 +90,7 @@ dtctl supports both singular and plural resource names, plus short aliases.
 | `notifications` | `notification` | get, describe, delete, watch |
 | `edgeconnects` | `edgeconnect`, `ec` | get, describe, create, delete, apply |
 | `breakpoints` | `breakpoint` | get, describe, create, update, delete |
+| `apis` | `api` | get, describe ([API Discovery]({{ '/docs/api-discovery/' | relative_url }})) |
 
 ## Configuration Commands
 

--- a/docs/site/_includes/docs-nav.html
+++ b/docs/site/_includes/docs-nav.html
@@ -10,6 +10,7 @@
 <ul>
   <li><a href="{{ '/docs/dql-queries/' | relative_url }}" {% if page.title == "DQL Queries" %}class="active"{% endif %}>DQL Queries</a></li>
   <li><a href="{{ '/docs/inventory/' | relative_url }}" {% if page.title == "Environment Inventory" %}class="active"{% endif %}>Environment Inventory</a></li>
+  <li><a href="{{ '/docs/api-discovery/' | relative_url }}" {% if page.title == "API Discovery" %}class="active"{% endif %}>API Discovery</a></li>
   <li><a href="{{ '/docs/dashboards/' | relative_url }}" {% if page.title == "Dashboards & Notebooks" %}class="active"{% endif %}>Dashboards & Notebooks</a></li>
   <li><a href="{{ '/docs/documents/' | relative_url }}" {% if page.title == "Documents (any type)" %}class="active"{% endif %}>Documents (any type)</a></li>
   <li><a href="{{ '/docs/workflows/' | relative_url }}" {% if page.title == "Workflows" %}class="active"{% endif %}>Workflows</a></li>

--- a/pkg/auth/resource_scopes.go
+++ b/pkg/auth/resource_scopes.go
@@ -157,6 +157,17 @@ var ResourceScopes = map[string]AccessScopes{
 	"aws":   {Read: []string{"settings:objects:read", "extensions:configurations:read"}, Write: []string{"settings:objects:write", "extensions:configurations:write"}},
 	"azure": {Read: []string{"settings:objects:read", "extensions:configurations:read"}, Write: []string{"settings:objects:write", "extensions:configurations:write"}},
 	"gcp":   {Read: []string{"settings:objects:read", "extensions:configurations:read"}, Write: []string{"settings:objects:write", "extensions:configurations:write"}},
+
+	// API specifications — the environment's own API index and each API's
+	// OpenAPI document. Reading them needs a valid token but no resource scope:
+	// they are the same documents the environment serves to its Swagger UI.
+	//
+	// The Run level is deliberately empty rather than guessed. `exec api` calls
+	// an arbitrary operation, so the scope it needs is whatever that operation's
+	// specification declares — resolved per call (see pkg/resources/api), never
+	// from a static table. An entry here claiming a single scope for every
+	// possible target would be wrong for almost all of them.
+	"api": {},
 }
 
 // localResources are catalog subcommands that operate entirely on the local

--- a/pkg/commands/listing.go
+++ b/pkg/commands/listing.go
@@ -138,6 +138,33 @@ var hiddenCommands = map[string]bool{
 	"version":    true, // utility, not an operational command
 }
 
+// unadvertisedResources are `<verb> <resource>` leaves that are hidden on the
+// command line but still documented in the full catalog.
+//
+// The two states cobra offers — visible or hidden — are both wrong for an escape
+// hatch. Visible puts it in --help and in the compact catalogs an agent
+// bootstraps from, next to the native commands it must not replace. Hidden makes
+// it undiscoverable, which pushes a caller who genuinely needs it toward
+// something worse (an ad-hoc AppEngine function with a bearer token). So it is
+// omitted from `--brief`/minimal and present in `--full`: findable by a caller
+// who goes looking, invisible to one who is browsing.
+var unadvertisedResources = map[string]bool{
+	"exec api": true,
+}
+
+// advertisedResources drops the unadvertised leaves of a verb, for the catalog
+// projections that are meant to be browsed rather than searched.
+func advertisedResources(verb string, resources []string) []string {
+	var out []string
+	for _, r := range resources {
+		if unadvertisedResources[verb+" "+r] {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
 // patterns are recommended usage patterns for AI agents.
 var defaultPatterns = []string{
 	"Use 'dtctl apply -f' for idempotent resource management",
@@ -147,17 +174,26 @@ var defaultPatterns = []string{
 	"Use '--agent' for JSON output with operational metadata",
 	"Use 'dtctl wait' in CI/CD to poll for conditions",
 	"Always specify '--context' in automation scripts",
+	"Discover the APIs an environment publishes with 'dtctl get apis'; 'dtctl describe api <name> --operation \"<METHOD> <path>\"' gives the parameters, body schema, and required scope",
 	"Query Smartscape topology nodes with: dtctl query 'smartscapeNodes \"<TYPE>\" | limit 50'",
 	"Discover all Smartscape node types in the tenant with: dtctl query 'smartscapeNodes \"*\" | dedup type | fields type'",
 }
 
 // antipatterns are common mistakes agents should avoid.
+//
+// Two of these name 'exec api', which unadvertisedResources keeps out of the
+// resource lists. That is deliberate and not a contradiction: the resource list
+// is where an escape hatch tempts a caller away from a native command, whereas an
+// antipattern carries the constraint along with the name — the only form in which
+// it should be discovered.
 var defaultAntipatterns = []string{
 	"Don't use 'dtctl create' followed by 'dtctl edit' — use 'dtctl apply -f' instead",
 	"Don't parse table output — use '-o json' or '--agent'",
 	"Don't hardcode resource IDs — use 'dtctl get' to discover them",
 	"Don't skip 'dtctl diff' before 'dtctl apply' in production contexts",
 	"Don't guess Smartscape node type IDs — run 'smartscapeNodes \"*\" | dedup type | fields type' first to enumerate valid types",
+	"Don't call a platform API by writing JavaScript for 'dtctl exec function --code' — use 'dtctl exec api <path>', which derives what the request does from the API's specification and gates it like any mutating command",
+	"Don't reach for 'dtctl exec api' when a native command exists, and don't script against it — it is an escape hatch for APIs dtctl doesn't wrap, and repeated use means that API wants a dedicated command",
 }
 
 var defaultTimeFormats = &TimeFormats{
@@ -248,7 +284,13 @@ func buildVerbs(root *cobra.Command) map[string]*Verb {
 			hasResources := false
 
 			for _, sub := range subs {
-				if sub.Hidden || sub.Name() == "help" {
+				if sub.Name() == "help" {
+					continue
+				}
+				// A hidden leaf is normally absent from the catalog too. An
+				// unadvertised one is the exception: the full catalog is the only
+				// place it is documented.
+				if sub.Hidden && !unadvertisedResources[name+" "+sub.Name()] {
 					continue
 				}
 
@@ -495,18 +537,18 @@ func NewMinimal(l *Listing) *Minimal {
 		Aliases:       l.Aliases,
 	}
 	for name, v := range l.Verbs {
-		m.Verbs[name] = newMinimalVerb(v)
+		m.Verbs[name] = newMinimalVerb(name, v)
 	}
 	return m
 }
 
 // newMinimalVerb strips a verb down to its resources and nested subcommands.
-func newMinimalVerb(v *Verb) *MinimalVerb {
-	mv := &MinimalVerb{Resources: v.Resources}
+func newMinimalVerb(verb string, v *Verb) *MinimalVerb {
+	mv := &MinimalVerb{Resources: advertisedResources(verb, v.Resources)}
 	if len(v.Subcommands) > 0 {
 		mv.Subcommands = make(map[string]*MinimalVerb, len(v.Subcommands))
 		for name, sub := range v.Subcommands {
-			mv.Subcommands[name] = newMinimalVerb(sub)
+			mv.Subcommands[name] = newMinimalVerb(verb+" "+name, sub)
 		}
 	}
 	return mv
@@ -543,7 +585,7 @@ func NewBrief(l *Listing) *Listing {
 		bv := &Verb{
 			Mutating:  verb.Mutating,
 			Access:    verb.Access,
-			Resources: verb.Resources,
+			Resources: advertisedResources(name, verb.Resources),
 			// DQL scopes are not derivable from resource_scopes, so retain them.
 			RequiredScopes: verb.RequiredScopes,
 		}

--- a/pkg/output/golden_test.go
+++ b/pkg/output/golden_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dynatrace-oss/dtctl/pkg/resources/analyzer"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/anomalydetector"
+	"github.com/dynatrace-oss/dtctl/pkg/resources/api"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/appengine"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/azureconnection"
 	"github.com/dynatrace-oss/dtctl/pkg/resources/azuremonitoringconfig"
@@ -2867,6 +2868,110 @@ func TestGolden_ExecPreviewProcessor(t *testing.T) {
 				t.Fatalf("PrintList failed: %v", err)
 			}
 			assertGolden(t, "exec/preview-processor-"+name, buf.String())
+		})
+	}
+}
+
+// apiInfoFixtures covers the three states a row of `dtctl get apis` can be in,
+// because each renders differently and each has been got wrong: an API dtctl
+// wraps natively, one it does not, and one documented at an absolute URL on
+// another host (no base path, nothing dtctl can fetch).
+//
+// All of it is synthetic. A recording of a real environment's index would commit
+// that environment's published API list to a public repository — and the list is a
+// property of the environment, not of dtctl.
+func apiInfoFixtures() []api.APIInfo {
+	fourteen := 14
+	three := 3
+	return []api.APIInfo{
+		{
+			Name:       "Widget Service",
+			BasePath:   "/platform/widget/v1",
+			Category:   "Widgets",
+			Operations: &fourteen,
+			Dtctl:      "widget",
+		},
+		{
+			Name:       "Sprocket Service",
+			BasePath:   "/platform/sprocket/v1",
+			Category:   "Sprockets",
+			Operations: &three,
+		},
+		{
+			// Operations is nil: the count is unknown rather than zero, and the OPS
+			// cell must come out blank. A -1 sentinel used to print "-1" here.
+			Name:     "Cog Service",
+			BasePath: "/platform/cog/v1",
+		},
+		{
+			Name:     "Elsewhere API",
+			External: true,
+		},
+	}
+}
+
+func TestGolden_GetAPIs(t *testing.T) {
+	apis := apiInfoFixtures()
+
+	formats := map[string]string{
+		"table": "table",
+		"wide":  "wide",
+		"json":  "json",
+		"yaml":  "yaml",
+		"csv":   "csv",
+		"toon":  "toon",
+	}
+
+	for name, format := range formats {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printer := NewPrinterWithWriter(format, &buf)
+			if err := printer.PrintList(apis); err != nil {
+				t.Fatalf("PrintList failed: %v", err)
+			}
+			assertGolden(t, "get/apis-"+name, buf.String())
+		})
+	}
+}
+
+// operationSummaryFixtures pins the operation index, including the two rows that
+// carry meaning by being empty: an operation whose specification declares no scope
+// (blank, and not the same as "needs nothing"), and a deprecated one, which is
+// wide-only so the default view stays narrow.
+func operationSummaryFixtures() []api.OperationSummary {
+	return []api.OperationSummary{
+		{Operation: "GET /widgets", Summary: "List all widgets.", Scope: "widget:widgets:read"},
+		{Operation: "POST /widgets", Summary: "Create a widget.", Scope: "widget:widgets:write"},
+		{Operation: "POST /widgets:search", Summary: "Search widgets.", Scope: "widget:widgets:read"},
+		{Operation: "PUT /widgets/{id}", Summary: "Replace a widget."},
+		{
+			Operation:  "GET /widgets/{id}/legacy",
+			Summary:    "Fetch the legacy representation.",
+			Scope:      "widget:widgets:read",
+			Deprecated: true,
+		},
+	}
+}
+
+func TestGolden_DescribeAPIOperations(t *testing.T) {
+	ops := operationSummaryFixtures()
+
+	formats := map[string]string{
+		"table": "table",
+		"wide":  "wide",
+		"json":  "json",
+		"yaml":  "yaml",
+		"toon":  "toon",
+	}
+
+	for name, format := range formats {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printer := NewPrinterWithWriter(format, &buf)
+			if err := printer.PrintList(ops); err != nil {
+				t.Fatalf("PrintList failed: %v", err)
+			}
+			assertGolden(t, "describe/api-operations-"+name, buf.String())
 		})
 	}
 }

--- a/pkg/output/manifest.go
+++ b/pkg/output/manifest.go
@@ -24,6 +24,12 @@ const (
 	// new kind, so a pre-inspect consumer treats it as opaque and falls back to
 	// context — non-breaking by construction (D31).
 	KindFileSummary = "file-summary"
+	// KindDocumentFile means an opaque document — not a row set — was written to
+	// disk and the payload is a handle to it. It is emitted by
+	// `dtctl describe api --raw`, whose payload is one published OpenAPI document
+	// rather than records, so none of the row/column primitives apply. Another new
+	// kind, opaque to older consumers (D31).
+	KindDocumentFile = "document-file"
 	// KindFileList is emitted by `dtctl inspect --list`: an enumeration of the
 	// spilled files visible in the active context's partition, each with its
 	// sidecar provenance. It lets an agent recover a file handle that has aged out
@@ -62,6 +68,21 @@ type SampleStats struct {
 type InlineRecords struct {
 	Kind    string                   `json:"kind"`
 	Records []map[string]interface{} `json:"records"`
+}
+
+// SpecFileManifest is the result payload for the KindDocumentFile envelope: a
+// handle to a written document plus enough provenance to know what it is. It is
+// deliberately not ResultFileManifest — that shape promises rows, columns and a
+// row sample, and every one of those would be a lie about an API specification.
+type SpecFileManifest struct {
+	Kind   string `json:"kind"`
+	Path   string `json:"path"`
+	Format string `json:"format"`
+	Bytes  int64  `json:"bytes"`
+	// API is the API the document describes, as the environment's index names it.
+	API string `json:"api,omitempty"`
+	// Document is the environment-relative path the document was fetched from.
+	Document string `json:"document,omitempty"`
 }
 
 // ResultFileManifest is the result payload for the KindResultFile /

--- a/pkg/output/testdata/golden/describe/api-operations-json.golden
+++ b/pkg/output/testdata/golden/describe/api-operations-json.golden
@@ -1,0 +1,27 @@
+[
+  {
+    "operation": "GET /widgets",
+    "summary": "List all widgets.",
+    "scope": "widget:widgets:read"
+  },
+  {
+    "operation": "POST /widgets",
+    "summary": "Create a widget.",
+    "scope": "widget:widgets:write"
+  },
+  {
+    "operation": "POST /widgets:search",
+    "summary": "Search widgets.",
+    "scope": "widget:widgets:read"
+  },
+  {
+    "operation": "PUT /widgets/{id}",
+    "summary": "Replace a widget."
+  },
+  {
+    "operation": "GET /widgets/{id}/legacy",
+    "summary": "Fetch the legacy representation.",
+    "scope": "widget:widgets:read",
+    "deprecated": true
+  }
+]

--- a/pkg/output/testdata/golden/describe/api-operations-table.golden
+++ b/pkg/output/testdata/golden/describe/api-operations-table.golden
@@ -1,0 +1,6 @@
+OPERATION                  SUMMARY                            SCOPE                  
+GET /widgets               List all widgets.                  widget:widgets:read    
+POST /widgets              Create a widget.                   widget:widgets:write   
+POST /widgets:search       Search widgets.                    widget:widgets:read    
+PUT /widgets/{id}          Replace a widget.                                         
+GET /widgets/{id}/legacy   Fetch the legacy representation.   widget:widgets:read    

--- a/pkg/output/testdata/golden/describe/api-operations-toon.golden
+++ b/pkg/output/testdata/golden/describe/api-operations-toon.golden
@@ -1,0 +1,16 @@
+[#5]:
+  - operation: GET /widgets
+    scope: "widget:widgets:read"
+    summary: List all widgets.
+  - operation: POST /widgets
+    scope: "widget:widgets:write"
+    summary: Create a widget.
+  - operation: "POST /widgets:search"
+    scope: "widget:widgets:read"
+    summary: Search widgets.
+  - operation: "PUT /widgets/{id}"
+    summary: Replace a widget.
+  - deprecated: true
+    operation: "GET /widgets/{id}/legacy"
+    scope: "widget:widgets:read"
+    summary: Fetch the legacy representation.

--- a/pkg/output/testdata/golden/describe/api-operations-wide.golden
+++ b/pkg/output/testdata/golden/describe/api-operations-wide.golden
@@ -1,0 +1,6 @@
+OPERATION                  SUMMARY                            SCOPE                  DEPRECATED   
+GET /widgets               List all widgets.                  widget:widgets:read    false        
+POST /widgets              Create a widget.                   widget:widgets:write   false        
+POST /widgets:search       Search widgets.                    widget:widgets:read    false        
+PUT /widgets/{id}          Replace a widget.                                         false        
+GET /widgets/{id}/legacy   Fetch the legacy representation.   widget:widgets:read    true         

--- a/pkg/output/testdata/golden/describe/api-operations-yaml.golden
+++ b/pkg/output/testdata/golden/describe/api-operations-yaml.golden
@@ -1,0 +1,15 @@
+- operation: GET /widgets
+  summary: List all widgets.
+  scope: widget:widgets:read
+- operation: POST /widgets
+  summary: Create a widget.
+  scope: widget:widgets:write
+- operation: POST /widgets:search
+  summary: Search widgets.
+  scope: widget:widgets:read
+- operation: PUT /widgets/{id}
+  summary: Replace a widget.
+- operation: GET /widgets/{id}/legacy
+  summary: Fetch the legacy representation.
+  scope: widget:widgets:read
+  deprecated: true

--- a/pkg/output/testdata/golden/get/apis-csv.golden
+++ b/pkg/output/testdata/golden/get/apis-csv.golden
@@ -1,0 +1,5 @@
+NAME,BASE PATH,CATEGORY,OPS,DTCTL,EXTERNAL
+Widget Service,/platform/widget/v1,Widgets,14,widget,false
+Sprocket Service,/platform/sprocket/v1,Sprockets,3,,false
+Cog Service,/platform/cog/v1,,,,false
+Elsewhere API,,,,,true

--- a/pkg/output/testdata/golden/get/apis-json.golden
+++ b/pkg/output/testdata/golden/get/apis-json.golden
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Widget Service",
+    "base_path": "/platform/widget/v1",
+    "category": "Widgets",
+    "operations": 14,
+    "dtctl": "widget"
+  },
+  {
+    "name": "Sprocket Service",
+    "base_path": "/platform/sprocket/v1",
+    "category": "Sprockets",
+    "operations": 3
+  },
+  {
+    "name": "Cog Service",
+    "base_path": "/platform/cog/v1"
+  },
+  {
+    "name": "Elsewhere API",
+    "base_path": "",
+    "external": true
+  }
+]

--- a/pkg/output/testdata/golden/get/apis-table.golden
+++ b/pkg/output/testdata/golden/get/apis-table.golden
@@ -1,0 +1,5 @@
+NAME               BASE PATH               OPS   DTCTL    
+Widget Service     /platform/widget/v1     14    widget   
+Sprocket Service   /platform/sprocket/v1   3              
+Cog Service        /platform/cog/v1                       
+Elsewhere API                                             

--- a/pkg/output/testdata/golden/get/apis-toon.golden
+++ b/pkg/output/testdata/golden/get/apis-toon.golden
@@ -1,0 +1,15 @@
+[#4]:
+  - base_path: /platform/widget/v1
+    category: Widgets
+    dtctl: widget
+    name: Widget Service
+    operations: 14
+  - base_path: /platform/sprocket/v1
+    category: Sprockets
+    name: Sprocket Service
+    operations: 3
+  - base_path: /platform/cog/v1
+    name: Cog Service
+  - base_path: ""
+    external: true
+    name: Elsewhere API

--- a/pkg/output/testdata/golden/get/apis-wide.golden
+++ b/pkg/output/testdata/golden/get/apis-wide.golden
@@ -1,0 +1,5 @@
+NAME               BASE PATH               CATEGORY    OPS   DTCTL    EXTERNAL   
+Widget Service     /platform/widget/v1     Widgets     14    widget   false      
+Sprocket Service   /platform/sprocket/v1   Sprockets   3              false      
+Cog Service        /platform/cog/v1                                   false      
+Elsewhere API                                                         true       

--- a/pkg/output/testdata/golden/get/apis-yaml.golden
+++ b/pkg/output/testdata/golden/get/apis-yaml.golden
@@ -1,0 +1,14 @@
+- name: Widget Service
+  base_path: /platform/widget/v1
+  category: Widgets
+  operations: 14
+  dtctl: widget
+- name: Sprocket Service
+  base_path: /platform/sprocket/v1
+  category: Sprockets
+  operations: 3
+- name: Cog Service
+  base_path: /platform/cog/v1
+- name: Elsewhere API
+  base_path: ""
+  external: true

--- a/pkg/resources/api/api.go
+++ b/pkg/resources/api/api.go
@@ -10,6 +10,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -251,6 +252,15 @@ func (h *Handler) ResolveForRequest(method, requestPath string) (apiName string,
 	// The classification is about the endpoint, not the query.
 	if i := strings.IndexAny(requestPath, "?#"); i >= 0 {
 		requestPath = requestPath[:i]
+	}
+	// Resolution models the router, and the router decodes before matching: a
+	// path spelled with %3A must resolve to the same operation as one spelled
+	// with ':'. Structure-changing spellings never reach a request — the
+	// command refuses them (see CanonicalRequestPath) — and if one arrives
+	// here anyway, decoding at worst makes this lookup miss, which the
+	// classifier gates closed.
+	if decoded, err := url.PathUnescape(requestPath); err == nil {
+		requestPath = decoded
 	}
 
 	reg, err := h.Registry()

--- a/pkg/resources/api/api.go
+++ b/pkg/resources/api/api.go
@@ -1,0 +1,464 @@
+// Package api is the CLI layer over the platform's own OpenAPI documents. It
+// backs `dtctl get apis`, `dtctl describe api`, and the request classification
+// `dtctl exec api` gates on.
+//
+// It delegates all HTTP and parsing to sdk/api/apispec and adds the parts that
+// are dtctl's rather than the platform's: which APIs already have a native
+// command, how a specification-declared scope maps onto a safety operation, and
+// what the projections look like on screen.
+package api
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dynatrace-oss/dtctl/pkg/client"
+	"github.com/dynatrace-oss/dtctl/sdk/api/apispec"
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+// Re-exported so callers need not import the SDK package alongside this one.
+type (
+	// Entry is one API the environment's registry publishes.
+	Entry = apispec.Entry
+	// Registry is the environment's index of published specifications.
+	Registry = apispec.Registry
+	// Spec is a parsed, projected OpenAPI document.
+	Spec = apispec.Spec
+	// Operation is one path+method pair from a specification.
+	Operation = apispec.Operation
+	// Parameter is one path, query, header or cookie parameter.
+	Parameter = apispec.Parameter
+	// RequestBody is an operation's request body across its media types.
+	RequestBody = apispec.RequestBody
+	// Response is one documented response status.
+	Response = apispec.Response
+	// MediaType pairs a content type with its schema.
+	MediaType = apispec.MediaType
+	// RegistryUnavailableError reports an environment with no usable API index.
+	RegistryUnavailableError = apispec.RegistryUnavailableError
+	// SpecUnavailableError reports a listed specification that could not be read.
+	SpecUnavailableError = apispec.SpecUnavailableError
+)
+
+// SwaggerUIPath is the human-facing API explorer every environment serves. It is
+// the documented entry point, and therefore the fallback to name whenever the
+// machine-readable index is unavailable.
+const SwaggerUIPath = "/platform/swagger-ui/index.html"
+
+// Handler resolves and projects the specifications one environment publishes.
+type Handler struct {
+	spec *apispec.Handler
+}
+
+// NewHandler creates an API-specification handler.
+func NewHandler(c *client.Client) *Handler {
+	return &Handler{spec: apispec.NewHandler(httpclient.Wrap(c.HTTP()))}
+}
+
+// Registry returns the environment's specification index.
+func (h *Handler) Registry() (*Registry, error) { return h.spec.Registry() }
+
+// Spec returns the parsed specification for a registry entry.
+func (h *Handler) Spec(e Entry) (*Spec, error) { return h.spec.SpecForEntry(e) }
+
+// RawSpec returns the specification document exactly as the environment served
+// it, for `describe api --raw`.
+func (h *Handler) RawSpec(e Entry) ([]byte, error) { return h.spec.RawDocumentForEntry(e) }
+
+// QuoteArg single-quotes a value that a shell would otherwise split, so a
+// suggested command can be pasted and run. API names contain spaces, and a
+// suggestion the caller has to repair is a suggestion that gets retyped wrong.
+func QuoteArg(s string) string {
+	if !strings.ContainsAny(s, " \t") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// IsAbsoluteURL reports whether a target is an absolute URL rather than a path on
+// the current environment. `exec api` refuses the former: the context's
+// credentials belong to the environment it names.
+func IsAbsoluteURL(s string) bool { return apispec.IsAbsoluteURL(s) }
+
+// RawSpecEncoding reports the on-disk encoding of a raw specification document,
+// derived from the document's own path rather than sniffed from its bytes: the
+// same artifact is served under four different content types, so the filename is
+// the only reliable signal.
+func RawSpecEncoding(e Entry) string {
+	if strings.HasSuffix(e.URL, ".json") {
+		return "json"
+	}
+	return "yaml"
+}
+
+// APIInfo is one row of `dtctl get apis`.
+//
+// The DTCTL column is the coverage report: it names the native resource that
+// wraps the API, or is blank. That makes the gap between what the platform
+// publishes and what dtctl wraps visible and, via --uncovered, actionable.
+type APIInfo struct {
+	Name     string `json:"name" yaml:"name" table:"NAME"`
+	BasePath string `json:"base_path" yaml:"base_path" table:"BASE PATH"`
+	// Category comes from the specification, so it is known only when the
+	// specification was fetched (--ops-count). It is a wide column rather than a
+	// default one for exactly that reason.
+	Category string `json:"category,omitempty" yaml:"category,omitempty" table:"CATEGORY,wide"`
+	// Operations is the operation count, populated only when specifications were
+	// fetched (--ops-count). A nil pointer means "not counted", which renders as
+	// a blank cell rather than a misleading 0.
+	Operations *int `json:"operations,omitempty" yaml:"operations,omitempty" table:"OPS"`
+	// Dtctl names the native dtctl resource covering this API, or is empty.
+	Dtctl string `json:"dtctl,omitempty" yaml:"dtctl,omitempty" table:"DTCTL"`
+	// External marks an entry documented at an absolute URL on another host.
+	// dtctl lists it (the environment published it) but cannot fetch it, and it
+	// has no gateway base path — which is why the column is worth showing.
+	External bool `json:"external,omitempty" yaml:"external,omitempty" table:"EXTERNAL,wide"`
+	// SpecError records why this row could not be enriched, when a specification
+	// fetch failed. One bad document degrades its own row and never fails the
+	// listing.
+	SpecError string `json:"spec_error,omitempty" yaml:"spec_error,omitempty" table:"-"`
+}
+
+// ListOptions shapes `dtctl get apis`.
+type ListOptions struct {
+	// Uncovered filters to APIs with no native dtctl command.
+	Uncovered bool
+	// OpsCount fetches every specification to fill in the operation count. It
+	// fans out one request per API, so the default listing leaves it off and
+	// costs exactly one request.
+	OpsCount bool
+}
+
+// List projects the environment's registry into displayable rows.
+//
+// dtctl mirrors the registry: it adds nothing and filters nothing. Whatever this
+// returns, the environment's own Swagger UI already shows, because both read the
+// same index. Any client-side filtering would have to hard-code knowledge of
+// which APIs to conceal — and since dtctl is open source, that list would itself
+// be the disclosure. Deciding what to publish belongs to whoever configures the
+// environment.
+func (h *Handler) List(opts ListOptions) ([]APIInfo, error) {
+	reg, err := h.Registry()
+	if err != nil {
+		return nil, err
+	}
+
+	rows := make([]APIInfo, 0, len(reg.Entries))
+	for _, e := range reg.Entries {
+		info := APIInfo{
+			Name:     e.Name,
+			BasePath: e.BasePath(),
+			External: e.External(),
+			Dtctl:    NativeResourceFor(e.BasePath()),
+		}
+
+		if opts.OpsCount && !e.External() {
+			spec, specErr := h.Spec(e)
+			if specErr != nil {
+				// Fail soft: the index listed a document that could not be read.
+				// The row loses its detail; the listing still renders.
+				info.SpecError = specErr.Error()
+			} else {
+				count := len(spec.Operations)
+				info.Operations = &count
+				if spec.Category != "" {
+					info.Category = spec.Category
+				}
+			}
+		}
+
+		if opts.Uncovered {
+			if info.Dtctl != "" {
+				continue
+			}
+			// An entry outside the public /platform/ tree is not a contribution
+			// candidate: the backlog feeds the curation rule, which requires a
+			// state-of-the-art, publicly supported API. Such entries still appear
+			// in the plain listing — the environment published them — but
+			// proposing native commands for them would be wrong.
+			if !isPublicPlatformPath(info.BasePath) {
+				continue
+			}
+		}
+
+		rows = append(rows, info)
+	}
+
+	return rows, nil
+}
+
+// isPublicPlatformPath reports whether a base path is on the public platform API
+// tree. Anything else (a non-platform prefix, or an external URL with no base
+// path at all) is out of scope for the contribution backlog.
+func isPublicPlatformPath(basePath string) bool {
+	return strings.HasPrefix(basePath, "/platform/")
+}
+
+// Resolve maps a user-supplied name or base path to a registry entry.
+//
+// Resolution consults only what the registry returned. A miss is a miss: dtctl
+// never synthesizes a candidate path from a name and retries it, which would
+// turn a name lookup into an existence oracle for APIs an environment
+// deliberately omits from its own index.
+//
+// An explicit, fully-qualified base path is accepted as given — the caller
+// already knows it, so echoing it back discloses nothing.
+func (h *Handler) Resolve(query string) (*Entry, error) {
+	reg, err := h.Registry()
+	if err != nil {
+		return nil, err
+	}
+
+	if e, ok := reg.FindEntry(query); ok {
+		return e, nil
+	}
+
+	// An explicit base path the registry does not list is still addressable: the
+	// caller supplied it, and the conventional specification path under it either
+	// resolves or 404s on its own merits.
+	if strings.HasPrefix(query, "/") {
+		return &Entry{Name: query, URL: apispec.SpecPathForBase(query)}, nil
+	}
+
+	candidates := reg.Candidates(query)
+	switch len(candidates) {
+	case 0:
+		return nil, fmt.Errorf(
+			"no API named %q in this environment's API index; run 'dtctl get apis' to list them, "+
+				"or pass an explicit base path (e.g. /platform/example/v1)", query)
+	default:
+		var b strings.Builder
+		fmt.Fprintf(&b, "ambiguous API name %q — %d matches:\n", query, len(candidates))
+		for _, c := range candidates {
+			fmt.Fprintf(&b, "  %s (%s)\n", c.Name, c.BasePath())
+		}
+		b.WriteString("\nUse the exact name or the base path.")
+		return nil, fmt.Errorf("%s", b.String())
+	}
+}
+
+// ResolveForRequest identifies the API and the operation a concrete request path
+// belongs to.
+//
+// Every failure is soft and reported as "not resolved": the environment may
+// publish no index, the path may belong to no listed API, the document may be
+// unreadable, and the specification may declare nothing for that path+method.
+// All four are ordinary, and none of them may stop a request — the classifier
+// gates an unresolved request strictly instead (see [Classify]).
+func (h *Handler) ResolveForRequest(method, requestPath string) (apiName string, op *Operation) {
+	// The classification is about the endpoint, not the query.
+	if i := strings.IndexAny(requestPath, "?#"); i >= 0 {
+		requestPath = requestPath[:i]
+	}
+
+	reg, err := h.Registry()
+	if err != nil {
+		return "", nil
+	}
+	entry, ok := reg.EntryForPath(requestPath)
+	if !ok {
+		return "", nil
+	}
+
+	spec, err := h.Spec(*entry)
+	if err != nil {
+		return entry.Name, nil
+	}
+	if matched, ok := spec.Match(method, requestPath); ok {
+		return entry.Name, matched
+	}
+	return entry.Name, nil
+}
+
+// OperationSummary is one line of an operation index — the compact projection
+// `dtctl describe api <name>` emits.
+//
+// A raw specification runs from 10k to 47k tokens, which is unusable for an
+// agent and unreadable for a human. Projecting to this shape costs roughly 300
+// tokens for a 38-operation API. It is a complete view at a coarser grain, not a
+// truncation: every operation appears, and the full detail of any one of them is
+// one drill-down away.
+type OperationSummary struct {
+	Operation string `json:"operation" yaml:"operation" table:"OPERATION"`
+	Summary   string `json:"summary,omitempty" yaml:"summary,omitempty" table:"SUMMARY"`
+	// Scope is the specification-declared scope, or empty when the document
+	// declares none. Empty is meaningful and common: it is why `exec api` cannot
+	// treat a declared scope as guaranteed.
+	Scope      string `json:"scope,omitempty" yaml:"scope,omitempty" table:"SCOPE"`
+	Deprecated bool   `json:"deprecated,omitempty" yaml:"deprecated,omitempty" table:"DEPRECATED,wide"`
+}
+
+// APIDescription is the operation index for one API.
+type APIDescription struct {
+	Name       string             `json:"name" yaml:"name"`
+	Title      string             `json:"title,omitempty" yaml:"title,omitempty"`
+	Version    string             `json:"version,omitempty" yaml:"version,omitempty"`
+	Category   string             `json:"category,omitempty" yaml:"category,omitempty"`
+	Summary    string             `json:"summary,omitempty" yaml:"summary,omitempty"`
+	BasePath   string             `json:"base_path" yaml:"base_path"`
+	Dtctl      string             `json:"dtctl,omitempty" yaml:"dtctl,omitempty"`
+	Operations []OperationSummary `json:"operations" yaml:"operations"`
+}
+
+// Describe projects a specification to its operation index.
+func (h *Handler) Describe(e Entry) (*APIDescription, error) {
+	spec, err := h.Spec(e)
+	if err != nil {
+		return nil, err
+	}
+
+	desc := &APIDescription{
+		Name:     e.Name,
+		Title:    spec.Title,
+		Version:  spec.Version,
+		Category: spec.Category,
+		Summary:  spec.Summary,
+		BasePath: spec.BasePath,
+		Dtctl:    NativeResourceFor(spec.BasePath),
+	}
+	if desc.Name == "" {
+		desc.Name = spec.Title
+	}
+
+	for _, op := range spec.Operations {
+		desc.Operations = append(desc.Operations, OperationSummary{
+			Operation:  op.ID(),
+			Summary:    op.Summary,
+			Scope:      strings.Join(op.Scopes, ", "),
+			Deprecated: op.Deprecated,
+		})
+	}
+	sort.SliceStable(desc.Operations, func(i, j int) bool {
+		return desc.Operations[i].Operation < desc.Operations[j].Operation
+	})
+
+	return desc, nil
+}
+
+// OperationDetail is one operation in full — everything needed to compose the
+// call without the rest of the document.
+//
+// The bar here is deliberately higher than "a summary of the operation":
+// composing a real request needs every parameter with its type and
+// required-ness, the request body schema, and the response shapes. This is the
+// prerequisite that makes `exec api` usable at all, which is why the operation
+// index and this view are two grains of the same feature rather than
+// alternatives.
+type OperationDetail struct {
+	API         string `json:"api" yaml:"api"`
+	BasePath    string `json:"base_path" yaml:"base_path"`
+	Operation   string `json:"operation" yaml:"operation"`
+	OperationID string `json:"operation_id,omitempty" yaml:"operation_id,omitempty"`
+	Summary     string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Deprecated  bool   `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	// URL is the full request path to call, base path plus operation path, so the
+	// caller does not have to concatenate them (and cannot get it wrong).
+	URL string `json:"url" yaml:"url"`
+	// RequiredScopes is what the document declares. Empty means it declares
+	// nothing — see [Classification] for what dtctl does in that case.
+	RequiredScopes []string             `json:"required_scopes,omitempty" yaml:"required_scopes,omitempty"`
+	Parameters     []apispec.Parameter  `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	RequestBody    *apispec.RequestBody `json:"request_body,omitempty" yaml:"request_body,omitempty"`
+	Responses      []apispec.Response   `json:"responses,omitempty" yaml:"responses,omitempty"`
+	// Example is a ready-to-run `dtctl exec api` invocation for this operation.
+	Example string `json:"example" yaml:"example"`
+}
+
+// DescribeOperation resolves one operation of a specification in full. The
+// operation is addressed as "METHOD /path" (its [Operation.ID]).
+func (h *Handler) DescribeOperation(e Entry, operationID string) (*OperationDetail, error) {
+	spec, err := h.Spec(e)
+	if err != nil {
+		return nil, err
+	}
+
+	op, ok := spec.FindByID(operationID)
+	if !ok {
+		return nil, unknownOperationError(spec, operationID)
+	}
+
+	name := e.Name
+	if name == "" {
+		name = spec.Title
+	}
+
+	detail := &OperationDetail{
+		API:            name,
+		BasePath:       spec.BasePath,
+		Operation:      op.ID(),
+		OperationID:    op.OperationID,
+		Summary:        op.Summary,
+		Description:    op.Description,
+		Deprecated:     op.Deprecated,
+		URL:            operationURL(spec.BasePath, op.Path),
+		RequiredScopes: op.Scopes,
+		Parameters:     op.Parameters,
+		RequestBody:    op.RequestBody,
+		Responses:      op.Responses,
+	}
+	detail.Example = ExampleInvocation(detail.URL, *op)
+	return detail, nil
+}
+
+// operationURL joins a base path and an operation path into the path a caller
+// would pass to `exec api`.
+//
+// The "/" case is the collection root — an operation the specification keys on the
+// empty path — where naive concatenation yields a trailing slash that is not the
+// endpoint's own spelling. The URL here is copied into a suggested command, so it
+// has to be the path that actually works.
+func operationURL(basePath, opPath string) string {
+	if opPath == "/" {
+		return basePath
+	}
+	return basePath + opPath
+}
+
+// unknownOperationError names the closest available operations rather than only
+// reporting the miss, so a caller that guessed an identifier can correct it
+// without re-listing the whole API.
+func unknownOperationError(spec *Spec, operationID string) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "no operation %q in %s", operationID, spec.Title)
+
+	needle := strings.ToLower(operationID)
+	if _, path, found := strings.Cut(needle, " "); found {
+		needle = strings.TrimSpace(path)
+	}
+
+	var near []string
+	for _, op := range spec.Operations {
+		if needle != "" && strings.Contains(strings.ToLower(op.Path), needle) {
+			near = append(near, op.ID())
+		}
+	}
+	sort.Strings(near)
+	if len(near) > 8 {
+		near = near[:8]
+	}
+	if len(near) > 0 {
+		b.WriteString("\n\nDid you mean:")
+		for _, id := range near {
+			fmt.Fprintf(&b, "\n  %s", id)
+		}
+	}
+	b.WriteString("\n\nOperations are addressed as 'METHOD /path'; list them with 'dtctl describe api <name>'.")
+	return fmt.Errorf("%s", b.String())
+}
+
+// ExampleInvocation renders a ready-to-run `dtctl exec api` command for an
+// operation, with path placeholders left in place so the caller sees exactly
+// what it has to substitute.
+func ExampleInvocation(url string, op Operation) string {
+	cmd := "dtctl exec api " + url
+	if op.Method != "GET" {
+		cmd += " -X " + op.Method
+	}
+	if op.RequestBody != nil && len(op.RequestBody.Contents) > 0 {
+		cmd += " -d @body.json"
+	}
+	return cmd
+}

--- a/pkg/resources/api/classify.go
+++ b/pkg/resources/api/classify.go
@@ -1,0 +1,353 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
+	"github.com/dynatrace-oss/dtctl/sdk/api/apispec"
+)
+
+// Classification is dtctl's verdict on what a generic request may do, and why.
+//
+// Nothing here is asserted by the caller. There is deliberately no flag that
+// lets a caller declare the operation: a caller-asserted classification is a
+// bypass, and the place the gate matters most is exactly where an agent is most
+// likely to reach for the flag that makes the error go away.
+type Classification struct {
+	// SafetyOp is the operation the request is gated as.
+	SafetyOp safety.Operation
+	// Resolved reports whether a specification determined the access level. When
+	// false, the gate is the strict fallback rather than a derived answer, and
+	// the caller should say so.
+	Resolved bool
+	// Access is the specification-derived access level, or AccessUnknown.
+	Access apispec.Access
+	// Escalated reports that the verdict came from the curated destructive table
+	// rather than from the method/specification floors. It is a *deliberate*
+	// classification even when Resolved is false, so an error message must not
+	// apologise for being unable to classify the request.
+	Escalated bool
+	// Scopes are the scopes the specification declares for the matched operation.
+	// Empty means the specification declares none — which is common and is not
+	// the same as "none required".
+	Scopes []string
+	// APIName and OperationID identify what the request path matched, when it
+	// matched anything. They are what makes an error message actionable.
+	APIName     string
+	OperationID string
+	// Reason explains the verdict in one sentence, for the error message and for
+	// --dry-run.
+	Reason string
+}
+
+// operationStrictness orders safety operations from most to least permissive, so
+// two independent lower bounds can be combined by taking the stricter.
+//
+// Create sits below Update because readwrite-mine permits a create outright but
+// refuses an update against unknown ownership.
+var operationStrictness = map[safety.Operation]int{
+	safety.OperationRead:         0,
+	safety.OperationCreate:       1,
+	safety.OperationUpdate:       2,
+	safety.OperationDelete:       3,
+	safety.OperationDeleteBucket: 4,
+}
+
+// stricter returns whichever of two operations gates more tightly.
+func stricter(a, b safety.Operation) safety.Operation {
+	if operationStrictness[b] > operationStrictness[a] {
+		return b
+	}
+	return a
+}
+
+// methodFloor is the lower bound the HTTP method establishes on its own — what
+// the request may do regardless of what any specification claims.
+//
+// POST's floor is Read, and that is the whole point: POST carries no information.
+// Measured across 64 specified operations, 12 POSTs needed only a `:read` scope
+// while one needed `:delete`, so a POST floor above Read would block reads (the
+// Grail DQL query API is five-sixths POST and almost entirely non-mutating) and a
+// POST floor of Create would permit that one delete as a create. The method
+// contributes nothing here; the specification, or the strict fallback, decides.
+func methodFloor(method string) safety.Operation {
+	switch strings.ToUpper(method) {
+	case "GET", "HEAD":
+		return safety.OperationRead
+	case "POST":
+		return safety.OperationRead
+	case "PUT", "PATCH":
+		return safety.OperationUpdate
+	case "DELETE":
+		return safety.OperationDelete
+	default:
+		// An unrecognised method is unclassifiable, so it fails closed.
+		return safety.OperationDelete
+	}
+}
+
+// accessFloor is the lower bound the specification establishes.
+//
+// AccessUnknown resolves to Delete for anything but a conventional read: the
+// strictest generally-reachable operation. Escalating rather than asking means
+// existing safety semantics apply unchanged — with unknown ownership,
+// OperationDelete proceeds only at readwrite-all — so no new safety level has to
+// be invented for "might be anything".
+func accessFloor(method string, access apispec.Access) safety.Operation {
+	switch access {
+	case apispec.AccessRead:
+		return safety.OperationRead
+	case apispec.AccessWrite:
+		// The specification says "this writes"; the method says which kind. A POST
+		// creates, a PUT or PATCH modifies something that already exists.
+		if strings.EqualFold(method, "POST") {
+			return safety.OperationCreate
+		}
+		return safety.OperationUpdate
+	case apispec.AccessDelete:
+		return safety.OperationDelete
+	default:
+		if apispec.MethodIsRead(method) {
+			return safety.OperationRead
+		}
+		return safety.OperationDelete
+	}
+}
+
+// Classify determines how a generic request must be gated.
+//
+// The verdict is the stricter of two independent lower bounds — what the method
+// guarantees and what the specification declares — then escalated for paths whose
+// destructiveness a URL cannot convey (see [escalateDestructive]). Taking the
+// stricter of two floors, rather than reading one table, means neither source can
+// weaken the other: a specification cannot turn a DELETE into a read, and a
+// method cannot turn a declared delete into a create.
+//
+// spec may be nil, and op may be nil when no operation matched. Both are ordinary
+// outcomes: an environment may not publish the specification, the path may belong
+// to no listed API, or the API may declare nothing per operation. In every such
+// case classification still returns a usable verdict rather than refusing to run.
+func Classify(method, requestPath string, apiName string, op *Operation) Classification {
+	method = strings.ToUpper(method)
+
+	c := Classification{
+		Access:  apispec.AccessUnknown,
+		APIName: apiName,
+	}
+
+	if op != nil {
+		c.OperationID = op.ID()
+		c.Scopes = op.Scopes
+		c.Access = op.Access()
+	}
+	c.Resolved = c.Access != apispec.AccessUnknown
+
+	c.SafetyOp = stricter(methodFloor(method), accessFloor(method, c.Access))
+
+	if escalated, why := escalateDestructive(method, requestPath, c.SafetyOp); why != "" {
+		c.SafetyOp = escalated
+		c.Reason = why
+		c.Escalated = true
+		return c
+	}
+
+	c.Reason = classificationReason(method, c)
+	return c
+}
+
+// classificationReason renders the one-sentence explanation shown in errors and
+// in --dry-run.
+func classificationReason(method string, c Classification) string {
+	switch {
+	case c.Resolved:
+		return fmt.Sprintf("%s declares scope %s, so this is gated as %s",
+			c.OperationID, strings.Join(c.Scopes, ", "), c.SafetyOp)
+	case apispec.MethodIsRead(method):
+		return fmt.Sprintf("%s is a read by convention, so this is gated as %s", method, c.SafetyOp)
+	case c.OperationID != "":
+		return fmt.Sprintf(
+			"%s declares no scope, so dtctl cannot tell what it does and gates it as %s",
+			c.OperationID, c.SafetyOp)
+	case c.APIName != "":
+		// The path belongs to a known API, but no operation was matched — either its
+		// specification could not be read or nothing in it covers this path. Saying
+		// "no specification covers this path" here would be wrong twice: the API is
+		// known, and it may well publish one.
+		return fmt.Sprintf(
+			"dtctl could not match this path to an operation in %s's specification, so it "+
+				"cannot tell what %s does and gates it as %s", c.APIName, method, c.SafetyOp)
+	default:
+		return fmt.Sprintf(
+			"no published specification covers this path, so dtctl cannot tell what %s does "+
+				"and gates it as %s", method, c.SafetyOp)
+	}
+}
+
+// destructivePattern escalates a request whose destructiveness the URL alone does
+// not convey.
+type destructivePattern struct {
+	// methods the pattern applies to; empty means any.
+	methods []string
+	path    *regexp.Regexp
+	op      safety.Operation
+	why     string
+}
+
+// destructivePatterns is the one place a curated override is unavoidable.
+//
+// Everywhere else, classification errs strict on its own. Here it errs *lax*,
+// because OperationDeleteBucket sits above OperationDelete — both readwrite-mine
+// and readwrite-all refuse it, and only dangerously-unrestricted permits it — and
+// nothing about a URL says "this destroys a data store". Without this table,
+// deleting a bucket through the passthrough would pass at readwrite-all while
+// `dtctl delete bucket` demands dangerously-unrestricted: the passthrough would be
+// a strictly weaker gate than the command it shadows.
+//
+// The table is short today. The test that walks it is what keeps it honest as new
+// irreversible endpoints appear.
+var destructivePatterns = []destructivePattern{
+	{
+		// DELETE /platform/storage/management/v1/bucket-definitions/<name>
+		// — the endpoint behind `dtctl delete bucket`.
+		methods: []string{"DELETE"},
+		path:    regexp.MustCompile(`^/platform/storage/management/v[0-9]+/bucket-definitions/[^/]+$`),
+		op:      safety.OperationDeleteBucket,
+		why: "deleting a bucket destroys all data in it, so it requires the same " +
+			"dangerously-unrestricted context as 'dtctl delete bucket'",
+	},
+	{
+		// POST /platform/storage/management/v1/bucket-definitions/<name>:truncate
+		// — irreversible data loss without deleting the bucket itself. It is a
+		// POST, so nothing but this table would raise it above a create.
+		methods: []string{"POST"},
+		path:    regexp.MustCompile(`^/platform/storage/management/v[0-9]+/bucket-definitions/[^/]+:truncate$`),
+		op:      safety.OperationDeleteBucket,
+		why: "truncating a bucket irreversibly destroys the records in it, so it " +
+			"requires a dangerously-unrestricted context",
+	},
+	{
+		// DELETE on Grail records — bulk record deletion.
+		methods: []string{"POST", "DELETE"},
+		path:    regexp.MustCompile(`^/platform/storage/management/v[0-9]+/record-deletion`),
+		op:      safety.OperationDeleteBucket,
+		why: "deleting stored records is irreversible, so it requires a " +
+			"dangerously-unrestricted context",
+	},
+}
+
+// escalateDestructive raises the gate for a curated set of irreversible
+// endpoints. It returns the empty string when no pattern applies, and never
+// lowers an operation.
+func escalateDestructive(method, requestPath string, current safety.Operation) (safety.Operation, string) {
+	// Strip any query string: the classification is about the endpoint.
+	if i := strings.IndexAny(requestPath, "?#"); i >= 0 {
+		requestPath = requestPath[:i]
+	}
+
+	for _, p := range destructivePatterns {
+		if !matchesMethod(p.methods, method) {
+			continue
+		}
+		if !p.path.MatchString(requestPath) {
+			continue
+		}
+		escalated := stricter(current, p.op)
+		if escalated == current {
+			return current, ""
+		}
+		return escalated, p.why
+	}
+	return current, ""
+}
+
+func matchesMethod(methods []string, method string) bool {
+	if len(methods) == 0 {
+		return true
+	}
+	for _, m := range methods {
+		if strings.EqualFold(m, method) {
+			return true
+		}
+	}
+	return false
+}
+
+// DestructivePatternCount reports how many curated escalations exist. The test
+// that pins the table uses it to notice a silently emptied list.
+func DestructivePatternCount() int { return len(destructivePatterns) }
+
+// BlockedError explains a refusal in terms a caller can act on, naming the native
+// command when one covers the path.
+//
+// "Denied" with no next step is what makes an agent start guessing, so the
+// message always offers both routes: the native command (preferred) and the
+// context change that would permit the request.
+type BlockedError struct {
+	Method      string
+	RequestPath string
+	Class       Classification
+	// NativeCommand is the dtctl command covering this path as a caller would type
+	// it, or "" when none does.
+	NativeCommand string
+	// Cause is the underlying safety refusal.
+	Cause error
+}
+
+func (e *BlockedError) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "cannot run %s %s — %s", e.Method, e.RequestPath, e.Class.Reason)
+
+	if e.NativeCommand != "" {
+		fmt.Fprintf(&b, "\n\n  Native command:  %s  (preferred)", e.NativeCommand)
+	}
+	// The note explains an *unresolved* verdict. An escalated one is deliberate,
+	// and its reason already says exactly why — apologising for being unable to
+	// classify it would be both wrong and an invitation to look for the override.
+	if !e.Class.Resolved && !e.Class.Escalated {
+		b.WriteString("\n\n  There is deliberately no flag to assert the operation: dtctl gates what " +
+			"it cannot classify as the strictest reachable operation.")
+	}
+	if e.Cause != nil {
+		fmt.Fprintf(&b, "\n\n%s", e.Cause)
+	}
+	return b.String()
+}
+
+// Unwrap exposes the safety refusal, so errors.As still finds it. The agent
+// envelope keeps its own case ahead of the generic safety one, because the
+// classification — why this request counts as a delete — is the part that tells a
+// caller what to do differently.
+func (e *BlockedError) Unwrap() error { return e.Cause }
+
+// Headline is the refusal in one line, without the appended explanations. The
+// envelope carries those as suggestions instead.
+func (e *BlockedError) Headline() string {
+	return fmt.Sprintf("cannot run %s %s — %s", e.Method, e.RequestPath, e.Class.Reason)
+}
+
+// Suggestions are the routes out of the refusal: the native command when one
+// covers the path, the operation's own documentation when the specification
+// matched, and whatever the safety checker advised (usually the context change
+// that would permit it).
+func (e *BlockedError) Suggestions() []string {
+	var s []string
+	if e.NativeCommand != "" {
+		s = append(s, fmt.Sprintf("%s  -- the native dtctl command for this API (preferred)", e.NativeCommand))
+	}
+	if e.Class.APIName != "" && e.Class.OperationID != "" {
+		s = append(s, fmt.Sprintf("dtctl describe api %s --operation '%s'  -- what this operation does",
+			QuoteArg(e.Class.APIName), e.Class.OperationID))
+	}
+	var safetyErr *safety.SafetyError
+	if errors.As(e.Cause, &safetyErr) {
+		s = append(s, safetyErr.Suggestions...)
+	}
+	if !e.Class.Resolved && !e.Class.Escalated {
+		s = append(s, "there is no flag to assert the operation: dtctl gates a request it cannot "+
+			"classify as the strictest reachable operation")
+	}
+	return s
+}

--- a/pkg/resources/api/classify.go
+++ b/pkg/resources/api/classify.go
@@ -3,6 +3,8 @@ package api
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"path"
 	"regexp"
 	"strings"
 
@@ -241,17 +243,28 @@ var destructivePatterns = []destructivePattern{
 // escalateDestructive raises the gate for a curated set of irreversible
 // endpoints. It returns the empty string when no pattern applies, and never
 // lowers an operation.
+//
+// Patterns are matched against every routable spelling of the path, not just
+// the literal one: the server-side router percent-decodes and normalizes
+// before routing, so `foo%3Atruncate`, `x/../bucket-definitions/foo`, and
+// `bucket-definitions//foo` all reach the endpoint the literal spelling would
+// have named — and a table that matched only the literal spelling would gate
+// them one level too low.
 func escalateDestructive(method, requestPath string, current safety.Operation) (safety.Operation, string) {
-	// Strip any query string: the classification is about the endpoint.
-	if i := strings.IndexAny(requestPath, "?#"); i >= 0 {
-		requestPath = requestPath[:i]
-	}
+	spellings := routableSpellings(requestPath)
 
 	for _, p := range destructivePatterns {
 		if !matchesMethod(p.methods, method) {
 			continue
 		}
-		if !p.path.MatchString(requestPath) {
+		matched := false
+		for _, s := range spellings {
+			if p.path.MatchString(s) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
 			continue
 		}
 		escalated := stricter(current, p.op)
@@ -261,6 +274,104 @@ func escalateDestructive(method, requestPath string, current safety.Operation) (
 		return escalated, p.why
 	}
 	return current, ""
+}
+
+// routableSpellings returns every path a server-side router could reduce the
+// request to: the spelling as given (query stripped), each successive
+// percent-decoding, and the dot-segment/duplicate-slash-normalized form of
+// each. A router decodes once; a misbehaving proxy chain can decode more than
+// once, so decoding runs to a bounded fixpoint.
+//
+// Matching all of them is safe precisely because escalation only ever raises
+// the gate: one spelling too many over-gates a bizarrely named resource, one
+// too few reopens the bucket under-block through an encoded or dotted
+// spelling.
+func routableSpellings(requestPath string) []string {
+	// Strip any query string: the classification is about the endpoint.
+	if i := strings.IndexAny(requestPath, "?#"); i >= 0 {
+		requestPath = requestPath[:i]
+	}
+
+	spellings := make([]string, 0, 8)
+	seen := make(map[string]bool)
+	add := func(s string) {
+		if !seen[s] {
+			seen[s] = true
+			spellings = append(spellings, s)
+		}
+	}
+
+	form := requestPath
+	for range 4 {
+		add(form)
+		add(path.Clean(form))
+		decoded, err := url.PathUnescape(form)
+		if err != nil || decoded == form {
+			break
+		}
+		form = decoded
+	}
+	add(form)
+	add(path.Clean(form))
+	return spellings
+}
+
+// CanonicalRequestPath returns the spelling of a request path that resolution
+// and classification must run on, refusing spellings that change meaning under
+// the normalization a server-side router performs before matching a route.
+//
+// The gate reasons about paths textually — the destructive table is a set of
+// patterns, specification templates are segment patterns — while the platform
+// router decodes and normalizes before routing. Any spelling a router reduces
+// to a *different* path is therefore a way to make the text the gate sees
+// disagree with the endpoint the server executes. Those spellings are refused
+// outright: no legitimate caller writes `x/../y`, `a//b`, or an encoded `/`,
+// and gating them "correctly" would mean guessing which router semantics the
+// environment uses.
+//
+// Benign percent-encoding is different: `%20` in an identifier is the only way
+// to spell a space, so it is accepted — and the *decoded* form is returned,
+// because that is the path the server routes on. `%3A` and `:` must classify
+// identically, or encoding a colon would spell `:truncate` past the
+// destructive table.
+func CanonicalRequestPath(requestPath string) (string, error) {
+	p := requestPath
+	if i := strings.IndexAny(p, "?#"); i >= 0 {
+		p = p[:i]
+	}
+	if !strings.HasPrefix(p, "/") {
+		return "", fmt.Errorf("path %q must start with '/'", p)
+	}
+
+	decoded, err := url.PathUnescape(p)
+	if err != nil {
+		return "", fmt.Errorf("invalid percent-encoding in path %q: %v", p, err)
+	}
+	if strings.Count(decoded, "/") != strings.Count(p, "/") {
+		return "", fmt.Errorf("path %q percent-encodes a '/': an encoded separator makes the routed "+
+			"endpoint ambiguous, so dtctl refuses it — spell path separators literally", p)
+	}
+	for _, r := range decoded {
+		if r < 0x20 || r == 0x7f {
+			return "", fmt.Errorf("path %q contains a control character after decoding; that is not a "+
+				"spellable endpoint", p)
+		}
+	}
+	// ';' is a path-parameter delimiter to servlet routers, '\' a separator to
+	// others, and a decoded '?' or '#' is indistinguishable from a query or
+	// fragment delimiter once the path is inspected as text. Each one makes the
+	// endpoint the gate classifies diverge from the endpoint a router may
+	// route, and none appears in a legitimate platform identifier.
+	if i := strings.IndexAny(decoded, `;\?#`); i >= 0 {
+		return "", fmt.Errorf("path %q contains %q, which routers treat as a delimiter: the routed "+
+			"endpoint would be ambiguous, so dtctl refuses it", p, decoded[i])
+	}
+	if cleaned := path.Clean(decoded); cleaned != decoded {
+		return "", fmt.Errorf("path %q normalizes to %q: dot segments and duplicate or trailing slashes "+
+			"make the gate see a different endpoint than the server routes, so dtctl refuses the "+
+			"spelling — write the path canonically", p, cleaned)
+	}
+	return decoded, nil
 }
 
 func matchesMethod(methods []string, method string) bool {

--- a/pkg/resources/api/classify_test.go
+++ b/pkg/resources/api/classify_test.go
@@ -1,0 +1,342 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
+	"github.com/dynatrace-oss/dtctl/sdk/api/apispec"
+)
+
+// op builds a matched operation with the given declared scopes. A nil scope slice
+// models an operation whose specification declares nothing.
+func op(method, path string, scopes ...string) *Operation {
+	return &apispec.Operation{Method: method, Path: path, Scopes: scopes}
+}
+
+// TestClassify_SpecResolvedOperations covers the case the whole design turns on:
+// the HTTP method does not predict mutation, so a declared scope must be able to
+// move the verdict in both directions.
+func TestClassify_SpecResolvedOperations(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		op     *Operation
+		want   safety.Operation
+		why    string
+	}{
+		{
+			name:   "GET with a read scope",
+			method: "GET",
+			path:   "/platform/widget/v1/widgets",
+			op:     op("GET", "/widgets", "widget:widgets:read"),
+			want:   safety.OperationRead,
+		},
+		{
+			name:   "read-shaped POST is a read",
+			method: "POST",
+			path:   "/platform/widget/v1/widgets/search",
+			op:     op("POST", "/widgets/search", "widget:widgets:read"),
+			want:   safety.OperationRead,
+			why: "12 of 64 measured operations are POSTs needing only a :read scope; " +
+				"method inference would block them in a readonly context",
+		},
+		{
+			name:   "POST with a write scope is a create",
+			method: "POST",
+			path:   "/platform/widget/v1/widgets",
+			op:     op("POST", "/widgets", "widget:widgets:write"),
+			want:   safety.OperationCreate,
+			why: "the specification says it writes and the method says it creates, " +
+				"which readwrite-mine permits",
+		},
+		{
+			name:   "POST with a delete scope is a delete",
+			method: "POST",
+			path:   "/platform/widget/v1/widgets:purge",
+			op:     op("POST", "/widgets:purge", "widget:widgets:delete"),
+			want:   safety.OperationDelete,
+			why: "the dangerous direction: method inference calls this a create, which " +
+				"readwrite-mine permits while it blocks deletes",
+		},
+		{
+			name:   "PATCH with a write scope is an update",
+			method: "PATCH",
+			path:   "/platform/widget/v1/widgets/abc",
+			op:     op("PATCH", "/widgets/{id}", "widget:widgets:write"),
+			want:   safety.OperationUpdate,
+		},
+		{
+			name:   "PUT with a read scope is still floored at update",
+			method: "PUT",
+			path:   "/platform/widget/v1/widgets/abc",
+			op:     op("PUT", "/widgets/{id}", "widget:widgets:read"),
+			want:   safety.OperationUpdate,
+			why:    "a PUT is never a read, whatever the specification claims",
+		},
+		{
+			name:   "DELETE with a write scope is still a delete",
+			method: "DELETE",
+			path:   "/platform/widget/v1/widgets/abc",
+			op:     op("DELETE", "/widgets/{id}", "widget:widgets:write"),
+			want:   safety.OperationDelete,
+			why:    "the method is explicit; a weaker declared scope cannot lower it",
+		},
+		{
+			name:   "DELETE with a delete scope",
+			method: "DELETE",
+			path:   "/platform/widget/v1/widgets/abc",
+			op:     op("DELETE", "/widgets/{id}", "widget:widgets:delete"),
+			want:   safety.OperationDelete,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Classify(tc.method, tc.path, "Widget Service", tc.op)
+			require.Equal(t, tc.want, c.SafetyOp, tc.why)
+			require.True(t, c.Resolved, "a declared scope must count as resolved")
+			require.NotEmpty(t, c.Reason)
+		})
+	}
+}
+
+// TestClassify_UnresolvedFailsClosed pins the fallback. A substantial fraction of
+// requests cannot be classified — two of six sampled APIs declare no
+// per-operation scopes, one of them the largest — and every one of those is gated
+// as the strictest generally-reachable operation rather than guessed at.
+func TestClassify_UnresolvedFailsClosed(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		op     *Operation
+		want   safety.Operation
+		why    string
+	}{
+		{
+			name:   "GET with no matched operation stays a read",
+			method: "GET",
+			want:   safety.OperationRead,
+			why:    "GET is a read by convention, so an unknown GET is still permitted",
+		},
+		{
+			name:   "HEAD with no matched operation stays a read",
+			method: "HEAD",
+			want:   safety.OperationRead,
+		},
+		{
+			name:   "POST with no matched operation is a delete",
+			method: "POST",
+			want:   safety.OperationDelete,
+			why:    "POST carries no information, so an unclassifiable POST assumes the worst",
+		},
+		{
+			name:   "POST with an operation that declares no scope is a delete",
+			method: "POST",
+			op:     op("POST", "/workflows"),
+			want:   safety.OperationDelete,
+			why:    "an operation found but undeclared is no better than one not found",
+		},
+		{
+			name:   "POST declaring an explicitly empty scope list is a delete",
+			method: "POST",
+			op:     op("POST", "/query:execute"),
+			want:   safety.OperationDelete,
+			why: "`ssoAuth: []` declares nothing; treating it as free access is the " +
+				"single most dangerous misreading available here",
+		},
+		{
+			name:   "PUT with no matched operation is a delete",
+			method: "PUT",
+			want:   safety.OperationDelete,
+		},
+		{
+			name:   "PATCH with no matched operation is a delete",
+			method: "PATCH",
+			want:   safety.OperationDelete,
+		},
+		{
+			name:   "DELETE with no matched operation is a delete",
+			method: "DELETE",
+			want:   safety.OperationDelete,
+		},
+		{
+			name:   "an unrecognised scope verb is unresolved",
+			method: "POST",
+			op:     op("POST", "/things", "widget:widgets:teleport"),
+			want:   safety.OperationDelete,
+			why:    "a newly appearing verb must fall into the strict class, not default to read",
+		},
+		{
+			name:   "an unknown method fails closed",
+			method: "PROPFIND",
+			want:   safety.OperationDelete,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Classify(tc.method, "/platform/example/v1/things", "", tc.op)
+			require.Equal(t, tc.want, c.SafetyOp, tc.why)
+			require.False(t, c.Resolved)
+			require.NotEmpty(t, c.Reason, "an unresolved verdict must still explain itself")
+		})
+	}
+}
+
+// TestClassify_NoOperationIsEverLowered is the invariant behind taking the
+// stricter of two floors: neither source can weaken the other. It is asserted
+// exhaustively rather than by example, so a future edit to either floor cannot
+// quietly introduce a case where a specification downgrades a method.
+func TestClassify_NoOperationIsEverLowered(t *testing.T) {
+	methods := []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"}
+	scopeSets := [][]string{
+		nil,
+		{"widget:widgets:read"},
+		{"widget:widgets:write"},
+		{"widget:widgets:delete"},
+		{"widget:widgets:teleport"},
+	}
+
+	for _, m := range methods {
+		for _, scopes := range scopeSets {
+			c := Classify(m, "/platform/example/v1/things", "", op(m, "/things", scopes...))
+			require.GreaterOrEqual(t,
+				operationStrictness[c.SafetyOp], operationStrictness[methodFloor(m)],
+				"%s with scopes %v was gated below the floor its method guarantees", m, scopes)
+		}
+	}
+}
+
+// TestClassify_BucketPathsEscalate closes the one under-block the design found:
+// OperationDeleteBucket sits *above* OperationDelete and needs
+// dangerously-unrestricted, but nothing about a URL says "this destroys a data
+// store". Without escalation the passthrough would be a weaker gate than the
+// native command it shadows.
+func TestClassify_BucketPathsEscalate(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		want   safety.Operation
+	}{
+		{
+			name:   "deleting a bucket definition",
+			method: "DELETE",
+			path:   "/platform/storage/management/v1/bucket-definitions/my_bucket",
+			want:   safety.OperationDeleteBucket,
+		},
+		{
+			name:   "truncating a bucket",
+			method: "POST",
+			path:   "/platform/storage/management/v1/bucket-definitions/my_bucket:truncate",
+			want:   safety.OperationDeleteBucket,
+		},
+		{
+			name:   "deleting stored records",
+			method: "POST",
+			path:   "/platform/storage/management/v1/record-deletion",
+			want:   safety.OperationDeleteBucket,
+		},
+		{
+			name:   "listing bucket definitions is untouched",
+			method: "GET",
+			path:   "/platform/storage/management/v1/bucket-definitions",
+			want:   safety.OperationRead,
+		},
+		{
+			name:   "reading one bucket definition is untouched",
+			method: "GET",
+			path:   "/platform/storage/management/v1/bucket-definitions/my_bucket",
+			want:   safety.OperationRead,
+		},
+		{
+			name:   "updating a bucket definition is not a bucket deletion",
+			method: "PATCH",
+			path:   "/platform/storage/management/v1/bucket-definitions/my_bucket",
+			want:   safety.OperationUpdate,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Declared scopes are supplied so the verdict is otherwise *resolved*:
+			// escalation has to fire even when classification succeeded, which is
+			// the case the native command exposed.
+			scope := "storage:bucket-definitions:read"
+			switch tc.method {
+			case "DELETE":
+				scope = "storage:bucket-definitions:delete"
+			case "POST", "PATCH":
+				scope = "storage:bucket-definitions:write"
+			}
+			c := Classify(tc.method, tc.path, "Bucket Service", op(tc.method, "/bucket-definitions/{name}", scope))
+			require.Equal(t, tc.want, c.SafetyOp)
+		})
+	}
+}
+
+// TestClassify_BucketEscalationMatchesNativeCommand pins the passthrough against
+// the command it shadows. `dtctl delete bucket` gates on OperationDeleteBucket
+// (cmd/get_buckets.go); the same request through the passthrough must not be
+// easier to make.
+func TestClassify_BucketEscalationMatchesNativeCommand(t *testing.T) {
+	c := Classify("DELETE", "/platform/storage/management/v1/bucket-definitions/my_bucket",
+		"Bucket Service", nil)
+
+	require.Equal(t, safety.OperationDeleteBucket, c.SafetyOp,
+		"the passthrough must never be a weaker gate than 'dtctl delete bucket'")
+	require.Contains(t, c.Reason, "dangerously-unrestricted",
+		"the reason must name what the caller actually needs")
+}
+
+// TestClassify_EscalationNeverLowers guards the escalation table itself: a
+// pattern is an override that raises the gate, never one that relaxes it.
+func TestClassify_EscalationNeverLowers(t *testing.T) {
+	require.Positive(t, DestructivePatternCount(),
+		"an emptied escalation table would silently reopen the bucket under-block")
+
+	// A path matching a DeleteBucket pattern that somehow arrived already at
+	// dangerously-unrestricted strictness must stay there.
+	got, why := escalateDestructive("DELETE",
+		"/platform/storage/management/v1/bucket-definitions/b", safety.OperationDeleteBucket)
+	require.Equal(t, safety.OperationDeleteBucket, got)
+	require.Empty(t, why, "no escalation to report when the gate is already at least as strict")
+}
+
+func TestClassify_QueryStringDoesNotDefeatEscalation(t *testing.T) {
+	c := Classify("DELETE",
+		"/platform/storage/management/v1/bucket-definitions/my_bucket?force=true", "", nil)
+	require.Equal(t, safety.OperationDeleteBucket, c.SafetyOp,
+		"a query string must not let a request slip past a path pattern")
+}
+
+func TestClassify_CarriesScopesAndIdentity(t *testing.T) {
+	c := Classify("POST", "/platform/widget/v1/widgets", "Widget Service",
+		op("POST", "/widgets", "widget:widgets:write"))
+
+	require.Equal(t, "Widget Service", c.APIName)
+	require.Equal(t, "POST /widgets", c.OperationID)
+	require.Equal(t, []string{"widget:widgets:write"}, c.Scopes)
+	require.Equal(t, apispec.AccessWrite, c.Access)
+}
+
+func TestBlockedError_NamesNativeCommandAndRefusesToOfferAnEscape(t *testing.T) {
+	c := Classify("POST", "/platform/automation/v1/workflows", "Automation", op("POST", "/workflows"))
+	_, native := NativeCoverageForPath("/platform/automation/v1/workflows")
+	err := &BlockedError{
+		Method:        "POST",
+		RequestPath:   "/platform/automation/v1/workflows",
+		Class:         c,
+		NativeCommand: native.Command,
+	}
+
+	msg := err.Error()
+	require.Contains(t, msg, "dtctl get workflows",
+		"a refusal without a next step is what makes an agent start guessing")
+	require.Contains(t, msg, "no flag to assert the operation")
+	require.NotContains(t, msg, "--op",
+		"the message must not advertise an override that does not exist")
+}

--- a/pkg/resources/api/classify_test.go
+++ b/pkg/resources/api/classify_test.go
@@ -313,6 +313,95 @@ func TestClassify_QueryStringDoesNotDefeatEscalation(t *testing.T) {
 		"a query string must not let a request slip past a path pattern")
 }
 
+// TestClassify_NormalizationDoesNotDefeatEscalation pins the escalation table
+// against re-spellings a server-side router reduces to the destructive path: the
+// router percent-decodes and normalizes before routing, so the request still
+// truncates or deletes the bucket, and the gate must see through the spelling.
+func TestClassify_NormalizationDoesNotDefeatEscalation(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{
+			name:   "percent-encoded colon in a truncate call",
+			method: "POST",
+			path:   "/platform/storage/management/v1/bucket-definitions/foo%3Atruncate",
+		},
+		{
+			name:   "double-encoded colon in a truncate call",
+			method: "POST",
+			path:   "/platform/storage/management/v1/bucket-definitions/foo%253Atruncate",
+		},
+		{
+			name:   "dot segment routed back into a bucket deletion",
+			method: "DELETE",
+			path:   "/platform/storage/management/v1/x/../bucket-definitions/foo",
+		},
+		{
+			name:   "duplicate slashes in a bucket deletion",
+			method: "DELETE",
+			path:   "/platform/storage/management//v1/bucket-definitions/foo",
+		},
+		{
+			name:   "encoded dot segments in a bucket deletion",
+			method: "DELETE",
+			path:   "/platform/storage/management/v1/x/%2E%2E/bucket-definitions/foo",
+		},
+		{
+			name:   "encoded record deletion",
+			method: "POST",
+			path:   "/platform/storage/management/v1/record%2Ddeletion",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Classify(tc.method, tc.path, "", nil)
+			require.Equal(t, safety.OperationDeleteBucket, c.SafetyOp,
+				"the spelling %q must not gate below the endpoint it routes to", tc.path)
+		})
+	}
+}
+
+// TestCanonicalRequestPath pins which spellings the passthrough accepts at all.
+// Benign percent-encoding is legitimate (an identifier can contain a space or a
+// colon) and canonicalizes to its decoded form; anything that changes structure
+// under normalization is refused, because the gate would classify a different
+// endpoint than the server routes.
+func TestCanonicalRequestPath(t *testing.T) {
+	accepted := []struct{ in, want string }{
+		{"/platform/example/v1/things", "/platform/example/v1/things"},
+		{"/platform/example/v1/things?filter=x%2Fy", "/platform/example/v1/things"},
+		{"/platform/example/v1/things/a%20b", "/platform/example/v1/things/a b"},
+		{"/platform/storage/management/v1/bucket-definitions/foo%3Atruncate",
+			"/platform/storage/management/v1/bucket-definitions/foo:truncate"},
+		{"/", "/"},
+	}
+	for _, tc := range accepted {
+		got, err := CanonicalRequestPath(tc.in)
+		require.NoError(t, err, "spelling %q must be accepted", tc.in)
+		require.Equal(t, tc.want, got)
+	}
+
+	refused := []string{
+		"/platform/example/v1/x/../things",       // dot segment
+		"/platform/example/v1//things",           // duplicate slash
+		"/platform/example/v1/things/",           // trailing slash
+		"/platform/example/v1/things%2Fsub",      // encoded separator
+		"/platform/example/v1/x/%2E%2E/things",   // encoded dot segment
+		"/platform/example/v1/things%00",         // control character
+		"/platform/example/v1/things;jsessionid", // path-parameter delimiter
+		"/platform/example/v1/things%3Fq",        // decoded query delimiter
+		"/platform/example/v1/things%zz",         // invalid encoding
+		"platform/example/v1/things",             // not rooted
+	}
+	for _, in := range refused {
+		_, err := CanonicalRequestPath(in)
+		require.Error(t, err, "spelling %q must be refused", in)
+	}
+}
+
 func TestClassify_CarriesScopesAndIdentity(t *testing.T) {
 	c := Classify("POST", "/platform/widget/v1/widgets", "Widget Service",
 		op("POST", "/widgets", "widget:widgets:write"))

--- a/pkg/resources/api/coverage.go
+++ b/pkg/resources/api/coverage.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"maps"
+	"strings"
+)
+
+// Coverage records what dtctl already offers for an API base path.
+type Coverage struct {
+	// Resource is the short label shown in the DTCTL column of `dtctl get apis`.
+	Resource string
+	// Command is the command a caller should prefer, spelled as they would type
+	// it. It is deliberately not derived from Resource: not every wrapped API is
+	// reached through `get <resource>` — some have a verb of their own
+	// (`dtctl query`), some live under a nested exec subcommand, and the plural
+	// is not always the resource name. A suggestion that does not run is worse
+	// than none, because it teaches a caller that dtctl's advice is unreliable.
+	Command string
+}
+
+// nativeCoverage maps a platform API base path to what already wraps it.
+//
+// It powers two things: the DTCTL column of `dtctl get apis` (and its inverse,
+// `--uncovered`, which is a contribution backlog derived from the environment
+// rather than hand-maintained), and the runtime notice `exec api` prints when a
+// caller reaches for the passthrough on a path that already has a native
+// command. That notice is what keeps the escape hatch self-deprecating.
+//
+// Every Command here is asserted against the real command tree by a test in
+// cmd/, so an entry naming a command that no longer exists fails the build
+// rather than misdirecting a caller.
+var nativeCoverage = map[string]Coverage{
+	"/platform/automation/v1":                   {"workflow", "dtctl get workflows"},
+	"/platform/document/v1":                     {"document", "dtctl get documents"},
+	"/platform/slo/v1":                          {"slo", "dtctl get slos"},
+	"/platform/storage/query/v1":                {"query", "dtctl query"},
+	"/platform/storage/management/v1":           {"bucket", "dtctl get buckets"},
+	"/platform/storage/filter-segments/v1":      {"segment", "dtctl get segments"},
+	"/platform/storage/resource-store/v1":       {"lookup", "dtctl get lookups"},
+	"/platform/classic/environment-api/v2":      {"settings", "dtctl get settings"},
+	"/platform/extensions/v2":                   {"extension", "dtctl get extensions"},
+	"/platform/hub/v1":                          {"hub-extension", "dtctl get hub-extensions"},
+	"/platform/iam/v1":                          {"user", "dtctl get users"},
+	"/platform/notification/v2":                 {"notification", "dtctl get notifications"},
+	"/platform/openpipeline/v1":                 {"preview-processor", "dtctl exec preview-processor"},
+	"/platform/davis/analyzers/v1":              {"analyzer", "dtctl get analyzers"},
+	"/platform/davis/copilot/v1":                {"copilot", "dtctl exec copilot"},
+	"/platform/app-engine/registry/v1":          {"app", "dtctl get apps"},
+	"/platform/app-engine/app-functions/v1":     {"function", "dtctl get functions"},
+	"/platform/app-engine/function-executor/v1": {"function", "dtctl exec function"},
+	"/platform/app-engine/edge-connect/v1":      {"edgeconnect", "dtctl get edgeconnect"},
+	"/platform/dob/graphql":                     {"breakpoint", "dtctl get breakpoints"},
+}
+
+// NativeResourceFor returns the dtctl resource covering an API base path, or ""
+// when the API has no native command.
+func NativeResourceFor(basePath string) string {
+	if basePath == "" {
+		return ""
+	}
+	return nativeCoverage[strings.TrimSuffix(basePath, "/")].Resource
+}
+
+// NativeCoverageForPath returns the coverage for a concrete request path,
+// matching on the longest base path that prefixes it. It is what `exec api` uses
+// to notice that a caller is bypassing a native command.
+func NativeCoverageForPath(requestPath string) (basePath string, cov Coverage) {
+	for base, c := range nativeCoverage {
+		if !strings.HasPrefix(requestPath, base) {
+			continue
+		}
+		// Require a segment boundary so /platform/storage/query/v1 does not claim
+		// /platform/storage/query/v1beta.
+		rest := requestPath[len(base):]
+		if rest != "" && !strings.HasPrefix(rest, "/") {
+			continue
+		}
+		if len(base) > len(basePath) {
+			basePath, cov = base, c
+		}
+	}
+	return basePath, cov
+}
+
+// CoveredBasePaths returns every base path with native coverage. Used by the
+// drift test that keeps the map honest.
+func CoveredBasePaths() map[string]Coverage {
+	out := make(map[string]Coverage, len(nativeCoverage))
+	maps.Copy(out, nativeCoverage)
+	return out
+}

--- a/pkg/resources/api/schema.go
+++ b/pkg/resources/api/schema.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SchemaField is one property of a schema, projected one level deep.
+//
+// A request-body schema is the part of an operation a caller most needs and the
+// part that is least readable raw: nested objects, allOf compositions and
+// unresolved `$ref`s. One level is enough to answer "what do I put in the body",
+// and the full schema is always one `-o yaml` away — the same
+// complete-at-a-coarser-grain trade the operation index makes.
+type SchemaField struct {
+	Name        string `json:"name" yaml:"name"`
+	Type        string `json:"type,omitempty" yaml:"type,omitempty"`
+	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// Nested marks a field whose own shape is not shown here, so a caller knows
+	// to look at the full schema rather than assuming a scalar.
+	Nested bool `json:"nested,omitempty" yaml:"nested,omitempty"`
+}
+
+// TopLevelFields projects an object schema's own properties. The bool reports
+// whether the schema was introspectable at all: a schema that is a bare `$ref`,
+// an `allOf` composition or an untyped free-form object yields false, which a
+// caller should render as "not introspectable" rather than "no fields".
+func TopLevelFields(schema any) ([]SchemaField, bool) {
+	m, ok := schema.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	props, ok := m["properties"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	required := map[string]bool{}
+	if list, ok := m["required"].([]any); ok {
+		for _, r := range list {
+			if s, ok := r.(string); ok {
+				required[s] = true
+			}
+		}
+	}
+
+	fields := make([]SchemaField, 0, len(props))
+	for name, raw := range props {
+		f := SchemaField{Name: name, Required: required[name]}
+		if pm, ok := raw.(map[string]any); ok {
+			f.Type, f.Nested = schemaTypeName(pm)
+			if d, ok := pm["description"].(string); ok {
+				f.Description = firstLine(d)
+			}
+		}
+		fields = append(fields, f)
+	}
+
+	// Required fields first, then alphabetically: composing a call starts with
+	// what is mandatory.
+	sort.SliceStable(fields, func(i, j int) bool {
+		if fields[i].Required != fields[j].Required {
+			return fields[i].Required
+		}
+		return fields[i].Name < fields[j].Name
+	})
+	return fields, true
+}
+
+// schemaTypeName renders a property's type compactly, and reports whether its
+// own shape was elided.
+func schemaTypeName(prop map[string]any) (name string, nested bool) {
+	if ref, ok := prop["$ref"].(string); ok {
+		return refName(ref), true
+	}
+
+	t, _ := prop["type"].(string)
+	switch t {
+	case "array":
+		items, _ := prop["items"].(map[string]any)
+		if items == nil {
+			return "array", true
+		}
+		inner, innerNested := schemaTypeName(items)
+		return inner + "[]", innerNested
+	case "object":
+		return "object", true
+	case "":
+		// No declared type: an enum, a composition, or free-form.
+		if _, ok := prop["enum"]; ok {
+			return "enum", false
+		}
+		return "", true
+	}
+
+	if f, ok := prop["format"].(string); ok && f != "" {
+		return fmt.Sprintf("%s(%s)", t, f), false
+	}
+	return t, false
+}
+
+// refName reduces "#/components/schemas/Widget" to "Widget".
+func refName(ref string) string {
+	if i := strings.LastIndex(ref, "/"); i >= 0 && i < len(ref)-1 {
+		return ref[i+1:]
+	}
+	return ref
+}
+
+// firstLine trims a description to its first line: OpenAPI descriptions are
+// often multi-paragraph markdown, and a table cell holds one line.
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
+}

--- a/sdk/api/apispec/apispec.go
+++ b/sdk/api/apispec/apispec.go
@@ -1,0 +1,914 @@
+// Package apispec discovers and projects the OpenAPI documents a Dynatrace
+// environment publishes about itself.
+//
+// Two conventions carry this package, and neither is a documented contract:
+//
+//   - every platform API serves its specification at
+//     `<api-base-path>/openapi.yaml`, and
+//   - the environment publishes a machine-readable index of those documents at
+//     [RegistryPath] — the same `configUrl` the environment's own Swagger UI
+//     consumes.
+//
+// They are stable, uniform, observed conventions. Because they are not
+// guaranteed, every entry point here fails soft: a missing index is a typed
+// [*RegistryUnavailableError] rather than a raw 404, and one unreadable document
+// never invalidates the rest of a listing.
+//
+// Raw specifications are far too large to hand to a caller verbatim — the
+// largest observed is ~47k tokens for a single API — so the useful output is a
+// projection: an operation index for choosing an operation, and one fully
+// resolved operation for composing a call.
+package apispec
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+// RegistryPath is the environment's machine-readable index of published API
+// specifications.
+const RegistryPath = "/platform/metadata/v1/swagger-ui.json"
+
+// SpecFileName is the conventional specification filename under an API base path.
+const SpecFileName = "openapi.yaml"
+
+// ClassicSpecFileName is the classic environment API's specification filename.
+// The `openapi.yaml` convention does not hold for the classic surface — it is a
+// 404 there — so classic entries are recognised by this name instead.
+const ClassicSpecFileName = "spec3.json"
+
+// Handler fetches and projects the specifications one environment publishes.
+//
+// Parsed documents are memoized for the Handler's lifetime, which makes a
+// drill-down (index, then one operation) cost a single fetch per API. The cache
+// is deliberately in-memory only: a spec is tenant- and version-specific, and a
+// cross-invocation disk cache would be host state outliving the request.
+type Handler struct {
+	client *httpclient.Client
+
+	mu       sync.Mutex
+	registry *Registry
+	specs    map[string]*Spec // keyed by document path
+}
+
+// NewHandler creates a specification handler bound to one environment.
+func NewHandler(c *httpclient.Client) *Handler {
+	return &Handler{client: c, specs: make(map[string]*Spec)}
+}
+
+// Entry is one API specification the environment's registry publishes.
+type Entry struct {
+	// Name is the registry's own display name, e.g. "Document Service".
+	Name string `json:"name" yaml:"name"`
+	// URL is the location of the specification document, usually a path relative
+	// to the environment (e.g. "/platform/document/v1/openapi.yaml") but
+	// occasionally absolute for documents hosted elsewhere.
+	URL string `json:"url" yaml:"url"`
+}
+
+// External reports whether the entry points at an absolute URL rather than a
+// path on this environment. Such entries (classic UI links) are listed but never
+// fetched: they are not reachable through the platform gateway with a platform
+// token.
+func (e Entry) External() bool {
+	return strings.Contains(e.URL, "://")
+}
+
+// Classic reports whether the entry is a classic environment-API document, which
+// uses spec3.json rather than the openapi.yaml convention.
+func (e Entry) Classic() bool {
+	return strings.HasSuffix(e.docPath(), "/"+ClassicSpecFileName)
+}
+
+// docPath is the entry URL with any query string or fragment removed. A registry
+// URL may carry a cache-busting query (`?hash=…`); it is preserved for fetching
+// but must never take part in path derivation — nor, in any caller, be used to
+// build a filename.
+func (e Entry) docPath() string {
+	path := e.URL
+	if i := strings.IndexAny(path, "?#"); i >= 0 {
+		path = path[:i]
+	}
+	return path
+}
+
+// BasePath is the API base path the entry documents — the specification path
+// with its filename removed, e.g. "/platform/document/v1". It is empty for
+// external entries, whose base path is not on this environment.
+func (e Entry) BasePath() string {
+	if e.External() {
+		return ""
+	}
+	path := e.docPath()
+	i := strings.LastIndex(path, "/")
+	if i <= 0 {
+		return ""
+	}
+	return path[:i]
+}
+
+// Registry is the environment's index of published specifications, in the order
+// the environment returned them.
+type Registry struct {
+	Entries []Entry
+}
+
+// registryDocument is the on-the-wire shape of [RegistryPath].
+type registryDocument struct {
+	URLs []Entry `json:"urls" yaml:"urls"`
+}
+
+// RegistryUnavailableError reports that the environment's API index could not be
+// read. It is a distinct type because it is an expected outcome, not a bug: the
+// index is an observed convention, so a caller should explain it and name the
+// Swagger UI as the fallback — never surface a raw response body.
+type RegistryUnavailableError struct {
+	Path string
+	// StatusCode is the HTTP status, or 0 when the request never completed or
+	// failed after a successful response (a body that would not parse).
+	StatusCode int
+	Err        error
+}
+
+// Error distinguishes "not published" from "refused", because they call for
+// opposite responses from the caller.
+//
+// Reporting a 401 as "this environment publishes no API index" is a statement
+// about the environment made from evidence about the credential, and it sends
+// someone to check the wrong thing entirely. Only a 404 licenses that claim.
+func (e *RegistryUnavailableError) Error() string {
+	switch {
+	case e.StatusCode == 401 || e.StatusCode == 403:
+		return fmt.Sprintf("not authorized to read the API index at %s (HTTP %d)",
+			e.Path, e.StatusCode)
+	case e.StatusCode >= 500:
+		return fmt.Sprintf("the API index at %s is temporarily unavailable (HTTP %d)",
+			e.Path, e.StatusCode)
+	case e.StatusCode != 0 && e.StatusCode != 404:
+		return fmt.Sprintf("the API index at %s could not be read (HTTP %d)",
+			e.Path, e.StatusCode)
+	default:
+		return fmt.Sprintf("this environment publishes no machine-readable API index at %s", e.Path)
+	}
+}
+
+func (e *RegistryUnavailableError) Unwrap() error { return e.Err }
+
+// Registry fetches the environment's specification index. It is one HTTP
+// request, and the result is memoized.
+func (h *Handler) Registry() (*Registry, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.registry != nil {
+		return h.registry, nil
+	}
+
+	resp, err := h.client.HTTP().R().Get(RegistryPath)
+	if err != nil {
+		return nil, &RegistryUnavailableError{Path: RegistryPath, Err: err}
+	}
+	if apiErr := httpclient.CheckResponse(resp); apiErr != nil {
+		return nil, &RegistryUnavailableError{
+			Path:       RegistryPath,
+			StatusCode: resp.StatusCode(),
+			Err:        apiErr,
+		}
+	}
+
+	// Parsed as YAML even though the endpoint serves JSON: YAML is a superset,
+	// and the one rule that has held across every specification endpoint is
+	// "parse as YAML, never branch on Content-Type" (the same artifact ships as
+	// four different media types).
+	var doc registryDocument
+	if err := yaml.Unmarshal(resp.Body(), &doc); err != nil {
+		return nil, &RegistryUnavailableError{Path: RegistryPath, Err: err}
+	}
+
+	reg := &Registry{}
+	for _, e := range doc.URLs {
+		if e.URL == "" {
+			continue
+		}
+		reg.Entries = append(reg.Entries, e)
+	}
+	if len(reg.Entries) == 0 {
+		return nil, &RegistryUnavailableError{
+			Path: RegistryPath,
+			Err:  fmt.Errorf("index contains no specification entries"),
+		}
+	}
+
+	h.registry = reg
+	return reg, nil
+}
+
+// Spec is the projection of one OpenAPI document: its identity, its base path,
+// and its operations. The original bytes are retained so a caller that explicitly
+// asks for the raw document does not have to fetch it twice.
+type Spec struct {
+	// Title, Version, Category and Summary come from `info` — Category and
+	// Summary from the `x-service-category` and `x-summary` extensions, which
+	// make an API's grouping machine-readable.
+	Title    string
+	Version  string
+	Category string
+	Summary  string
+	// BasePath is the API's gateway-relative base path, taken from
+	// `servers[0].x-api-gateway-url` where present.
+	BasePath string
+	// Operations are in document order.
+	Operations []Operation
+	// Raw is the document exactly as served.
+	Raw []byte
+
+	doc map[string]any
+}
+
+// Operation is one path+method pair, projected to what a caller needs to choose
+// it (identity, summary, scope) and to compose it (parameters, bodies).
+type Operation struct {
+	Method      string `json:"method" yaml:"method"`
+	Path        string `json:"path" yaml:"path"`
+	OperationID string `json:"operation_id,omitempty" yaml:"operation_id,omitempty"`
+	Summary     string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Deprecated  bool   `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	// Scopes are the scopes the document declares for this operation. Empty means
+	// the document declares none — which is common and must not be read as "no
+	// scope required": two of six APIs sampled declare no per-operation scopes at
+	// all, and one declares an explicitly empty list.
+	Scopes      []string     `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	Parameters  []Parameter  `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	RequestBody *RequestBody `json:"request_body,omitempty" yaml:"request_body,omitempty"`
+	Responses   []Response   `json:"responses,omitempty" yaml:"responses,omitempty"`
+}
+
+// ID is the operation's stable human-facing identity, "METHOD /path". It is what
+// `describe api --operation` accepts and what an operation index lists.
+func (o Operation) ID() string { return o.Method + " " + o.Path }
+
+// Parameter is one path, query, header or cookie parameter.
+type Parameter struct {
+	Name        string `json:"name" yaml:"name"`
+	In          string `json:"in" yaml:"in"`
+	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
+	Type        string `json:"type,omitempty" yaml:"type,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// Schema is the parameter's schema with a top-level $ref resolved, present
+	// when it carries more than a scalar type.
+	Schema any `json:"schema,omitempty" yaml:"schema,omitempty"`
+}
+
+// RequestBody is an operation's request body across its media types.
+type RequestBody struct {
+	Required bool        `json:"required,omitempty" yaml:"required,omitempty"`
+	Contents []MediaType `json:"contents,omitempty" yaml:"contents,omitempty"`
+}
+
+// Response is one documented response status.
+type Response struct {
+	Status      string      `json:"status" yaml:"status"`
+	Description string      `json:"description,omitempty" yaml:"description,omitempty"`
+	Contents    []MediaType `json:"contents,omitempty" yaml:"contents,omitempty"`
+}
+
+// MediaType pairs a content type with its schema. The schema has its top-level
+// $ref resolved — one hop, which is what makes it usable without the rest of the
+// document, and is where resolution deliberately stops.
+type MediaType struct {
+	ContentType string `json:"content_type" yaml:"content_type"`
+	Schema      any    `json:"schema,omitempty" yaml:"schema,omitempty"`
+}
+
+// SpecPathForBase returns the conventional specification path for an API base
+// path.
+func SpecPathForBase(basePath string) string {
+	return strings.TrimSuffix(basePath, "/") + "/" + SpecFileName
+}
+
+// Spec fetches and parses the specification document at docPath, a path relative
+// to the environment. Results are memoized per Handler.
+func (h *Handler) Spec(docPath string) (*Spec, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if s, ok := h.specs[docPath]; ok {
+		return s, nil
+	}
+
+	body, err := h.fetch(docPath)
+	if err != nil {
+		return nil, err
+	}
+
+	spec, err := ParseSpec(body)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", docPath, err)
+	}
+	if spec.BasePath == "" {
+		// Fall back to the document's own location, which is the base path plus
+		// the specification filename.
+		if i := strings.LastIndex(docPath, "/"); i > 0 {
+			spec.BasePath = docPath[:i]
+		}
+	}
+
+	h.specs[docPath] = spec
+	return spec, nil
+}
+
+// SpecUnavailableError reports that a document the index listed could not be
+// fetched.
+//
+// It is typed, and carries the status, because "the index lists it but you
+// cannot read it" is an ordinary property of an environment rather than a bug: a
+// listed document may 404, and an environment may serve its specifications only
+// to an interactive session, in which case an authenticated token gets a 403
+// whose body talks about SSO and explains nothing. The status is what lets a
+// caller say something useful instead of forwarding that.
+type SpecUnavailableError struct {
+	DocPath string
+	// StatusCode is the HTTP status, or 0 when the request never completed.
+	StatusCode int
+	Err        error
+}
+
+func (e *SpecUnavailableError) Error() string {
+	return fmt.Sprintf("fetching %s: %v", e.DocPath, e.Err)
+}
+
+func (e *SpecUnavailableError) Unwrap() error { return e.Err }
+
+// fetch retrieves a document. It takes no lock, so it is callable from a method
+// that already holds one.
+func (h *Handler) fetch(docPath string) ([]byte, error) {
+	resp, err := h.client.HTTP().R().Get(docPath)
+	if err != nil {
+		return nil, &SpecUnavailableError{DocPath: docPath, Err: err}
+	}
+	if apiErr := httpclient.CheckResponse(resp); apiErr != nil {
+		return nil, &SpecUnavailableError{DocPath: docPath, StatusCode: resp.StatusCode(), Err: apiErr}
+	}
+	return resp.Body(), nil
+}
+
+// SpecForEntry fetches the document a registry entry points at. External entries
+// are refused rather than fetched: they live on another host and are not
+// reachable through the platform gateway with a platform token.
+func (h *Handler) SpecForEntry(e Entry) (*Spec, error) {
+	if e.External() {
+		return nil, errExternalEntry(e)
+	}
+	return h.Spec(e.URL)
+}
+
+// RawDocument returns a specification document exactly as served, without
+// projecting it. It is deliberately independent of parsing: a document dtctl
+// cannot parse is precisely the case where a caller wants the bytes. A document
+// already fetched for its projection is served from memory rather than re-fetched.
+func (h *Handler) RawDocument(docPath string) ([]byte, error) {
+	h.mu.Lock()
+	cached, ok := h.specs[docPath]
+	h.mu.Unlock()
+	if ok {
+		return cached.Raw, nil
+	}
+	return h.fetch(docPath)
+}
+
+// RawDocumentForEntry returns the unparsed document a registry entry points at.
+func (h *Handler) RawDocumentForEntry(e Entry) ([]byte, error) {
+	if e.External() {
+		return nil, errExternalEntry(e)
+	}
+	return h.RawDocument(e.URL)
+}
+
+func errExternalEntry(e Entry) error {
+	return fmt.Errorf("%q is documented at an external URL (%s), which dtctl does not fetch", e.Name, e.URL)
+}
+
+// ParseSpec projects an OpenAPI document. The input is always parsed as YAML:
+// JSON is a subset, so this handles the classic `spec3.json` documents and every
+// observed Content-Type variant with one code path.
+func ParseSpec(body []byte) (*Spec, error) {
+	var doc map[string]any
+	if err := yaml.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("not a parseable OpenAPI document: %w", err)
+	}
+	if doc == nil {
+		return nil, fmt.Errorf("not a parseable OpenAPI document: empty")
+	}
+	if _, hasPaths := doc["paths"]; !hasPaths {
+		return nil, fmt.Errorf("not an OpenAPI document: no `paths` section")
+	}
+
+	spec := &Spec{Raw: body, doc: doc}
+
+	info := mapAt(doc, "info")
+	spec.Title = strAt(info, "title")
+	spec.Version = strAt(info, "version")
+	spec.Category = strAt(info, "x-service-category")
+	spec.Summary = strAt(info, "x-summary")
+
+	for _, srv := range sliceAt(doc, "servers") {
+		s, ok := srv.(map[string]any)
+		if !ok {
+			continue
+		}
+		// x-api-gateway-url is the relative base path through the platform
+		// gateway; `url` may be absolute or templated.
+		if gw := strAt(s, "x-api-gateway-url"); gw != "" {
+			spec.BasePath = strings.TrimSuffix(gw, "/")
+			break
+		}
+		if u := strAt(s, "url"); u != "" && spec.BasePath == "" {
+			spec.BasePath = strings.TrimSuffix(u, "/")
+		}
+	}
+
+	// Document-level security is the fallback when an operation declares none.
+	docScopes := securityScopes(doc, doc)
+
+	spec.Operations = collectOperations(doc, docScopes)
+	return spec, nil
+}
+
+// httpMethods are the OpenAPI path-item keys that denote an operation. Anything
+// else under a path (`parameters`, `summary`, `servers`, extensions) is not one.
+var httpMethods = []string{"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+
+// collectOperations walks `paths` and projects every operation, in document
+// order for paths and in fixed method order within a path so output is stable.
+func collectOperations(doc map[string]any, docScopes []string) []Operation {
+	paths := mapAt(doc, "paths")
+	if paths == nil {
+		return nil
+	}
+
+	// yaml.Unmarshal into map[string]any loses document order, so paths are
+	// sorted for determinism. (Order within a spec carries no meaning; stable
+	// output does.)
+	pathNames := sortedKeys(paths)
+
+	var ops []Operation
+	for _, p := range pathNames {
+		item := mapAt(paths, p)
+		if item == nil {
+			continue
+		}
+		// A published specification may key an operation on the empty path, meaning
+		// the base path itself is the endpoint. Left as-is it produces the operation
+		// ID "GET " — which cannot be passed back to --operation — and it never
+		// matches a request, because Match normalizes an incoming base path to "/".
+		// Normalizing here makes the collection root an ordinary operation instead of
+		// one that is listed but unreachable.
+		if p == "" {
+			p = "/"
+		}
+		// Path-level parameters apply to every operation under the path.
+		shared := collectParameters(doc, sliceAt(item, "parameters"))
+
+		for _, m := range httpMethods {
+			opMap := mapAt(item, m)
+			if opMap == nil {
+				continue
+			}
+			op := Operation{
+				Method:      strings.ToUpper(m),
+				Path:        p,
+				OperationID: strAt(opMap, "operationId"),
+				Summary:     strAt(opMap, "summary"),
+				Description: strAt(opMap, "description"),
+				Deprecated:  boolAt(opMap, "deprecated"),
+			}
+
+			if _, declared := opMap["security"]; declared {
+				op.Scopes = securityScopes(opMap, doc)
+			} else {
+				op.Scopes = docScopes
+			}
+
+			op.Parameters = append(append([]Parameter(nil), shared...),
+				collectParameters(doc, sliceAt(opMap, "parameters"))...)
+			op.RequestBody = collectRequestBody(doc, mapAt(opMap, "requestBody"))
+			op.Responses = collectResponses(doc, mapAt(opMap, "responses"))
+
+			ops = append(ops, op)
+		}
+	}
+	return ops
+}
+
+// securityScopes extracts the scopes a `security` block declares. A block may
+// list several schemes; every non-empty scope list contributes.
+//
+// An explicitly empty list (`ssoAuth: []`) yields no scopes, which is correct
+// and load-bearing: it means the document declares nothing about this
+// operation's scope, not that the operation needs none.
+func securityScopes(holder, doc map[string]any) []string {
+	var scopes []string
+	seen := map[string]bool{}
+	for _, req := range sliceAt(holder, "security") {
+		entry, ok := deref(doc, req).(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, raw := range entry {
+			for _, s := range toStrings(raw) {
+				if s == "" || seen[s] {
+					continue
+				}
+				seen[s] = true
+				scopes = append(scopes, s)
+			}
+		}
+	}
+	return scopes
+}
+
+// collectParameters projects a `parameters` list, resolving each entry's $ref one
+// hop.
+func collectParameters(doc map[string]any, raw []any) []Parameter {
+	var params []Parameter
+	for _, entry := range raw {
+		p, ok := deref(doc, entry).(map[string]any)
+		if !ok {
+			continue
+		}
+		schema := deref(doc, p["schema"])
+		param := Parameter{
+			Name:        strAt(p, "name"),
+			In:          strAt(p, "in"),
+			Required:    boolAt(p, "required"),
+			Description: strAt(p, "description"),
+			Type:        schemaType(schema),
+		}
+		// A bare scalar type is already carried by Type; keep the schema only
+		// when it says more (enums, objects, item types), so a parameter list
+		// stays compact for the common case.
+		if m, ok := schema.(map[string]any); ok && len(m) > 1 {
+			param.Schema = schema
+		}
+		if param.Name != "" {
+			params = append(params, param)
+		}
+	}
+	return params
+}
+
+// collectRequestBody projects a `requestBody`, resolving the body's $ref and each
+// media type's schema $ref one hop.
+func collectRequestBody(doc map[string]any, raw map[string]any) *RequestBody {
+	if raw == nil {
+		return nil
+	}
+	body, ok := deref(doc, raw).(map[string]any)
+	if !ok {
+		return nil
+	}
+	rb := &RequestBody{Required: boolAt(body, "required")}
+	rb.Contents = collectContents(doc, mapAt(body, "content"))
+	if len(rb.Contents) == 0 && !rb.Required {
+		return nil
+	}
+	return rb
+}
+
+// collectResponses projects a `responses` map in sorted status order.
+func collectResponses(doc map[string]any, raw map[string]any) []Response {
+	if raw == nil {
+		return nil
+	}
+	var out []Response
+	for _, status := range sortedKeys(raw) {
+		r, ok := deref(doc, raw[status]).(map[string]any)
+		if !ok {
+			continue
+		}
+		out = append(out, Response{
+			Status:      status,
+			Description: strAt(r, "description"),
+			Contents:    collectContents(doc, mapAt(r, "content")),
+		})
+	}
+	return out
+}
+
+// collectContents projects a `content` map to media types with one-hop resolved
+// schemas.
+func collectContents(doc map[string]any, content map[string]any) []MediaType {
+	if content == nil {
+		return nil
+	}
+	var out []MediaType
+	for _, ct := range sortedKeys(content) {
+		mt, ok := content[ct].(map[string]any)
+		if !ok {
+			out = append(out, MediaType{ContentType: ct})
+			continue
+		}
+		out = append(out, MediaType{
+			ContentType: ct,
+			Schema:      deref(doc, mt["schema"]),
+		})
+	}
+	return out
+}
+
+// schemaType renders a schema's type compactly: "string", "array[string]",
+// "object", or "" when the schema says nothing useful.
+func schemaType(schema any) string {
+	m, ok := schema.(map[string]any)
+	if !ok {
+		return ""
+	}
+	t := strAt(m, "type")
+	if t == "array" {
+		if inner := schemaType(deref(m, m["items"])); inner != "" {
+			return "array[" + inner + "]"
+		}
+		return "array"
+	}
+	if t == "" {
+		// A composed schema has no `type`; name the composition so the caller
+		// knows to look at the schema rather than seeing a blank column.
+		for _, key := range []string{"oneOf", "anyOf", "allOf"} {
+			if _, has := m[key]; has {
+				return key
+			}
+		}
+	}
+	if f := strAt(m, "format"); f != "" && t != "" {
+		return t + "(" + f + ")"
+	}
+	return t
+}
+
+// deref resolves a local `$ref` one hop and returns the target. A non-ref value,
+// an external ref, and an unresolvable ref are all returned unchanged — the
+// caller gets the ref back rather than a nil hole.
+//
+// Resolution stops after one hop on purpose: it is what makes a single operation
+// self-contained without pulling in the rest of the document, which is the whole
+// reason a projection is affordable.
+func deref(doc map[string]any, node any) any {
+	m, ok := node.(map[string]any)
+	if !ok {
+		return node
+	}
+	ref, ok := m["$ref"].(string)
+	if !ok || !strings.HasPrefix(ref, "#/") {
+		return node
+	}
+	target := resolvePointer(doc, ref)
+	if target == nil {
+		return node
+	}
+	return target
+}
+
+// resolvePointer walks a local JSON pointer ("#/components/schemas/Foo") through
+// the document.
+func resolvePointer(doc map[string]any, ref string) any {
+	var current any = doc
+	for _, token := range strings.Split(strings.TrimPrefix(ref, "#/"), "/") {
+		// JSON-pointer escaping: ~1 is "/", ~0 is "~". Unescaped in that order.
+		token = strings.ReplaceAll(token, "~1", "/")
+		token = strings.ReplaceAll(token, "~0", "~")
+
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil
+		}
+		current, ok = m[token]
+		if !ok {
+			return nil
+		}
+	}
+	return current
+}
+
+// Find returns the operation with the given method and exact template path.
+func (s *Spec) Find(method, templatePath string) (*Operation, bool) {
+	method = strings.ToUpper(method)
+	for i := range s.Operations {
+		if s.Operations[i].Method == method && s.Operations[i].Path == templatePath {
+			return &s.Operations[i], true
+		}
+	}
+	return nil, false
+}
+
+// FindByID returns the operation whose [Operation.ID] matches id ("METHOD /path"),
+// case-insensitively on the method. A bare path with no method matches when
+// exactly one operation has that path.
+func (s *Spec) FindByID(id string) (*Operation, bool) {
+	id = strings.TrimSpace(id)
+	if method, path, found := strings.Cut(id, " "); found {
+		return s.Find(method, strings.TrimSpace(path))
+	}
+
+	var match *Operation
+	for i := range s.Operations {
+		if s.Operations[i].Path != id {
+			continue
+		}
+		if match != nil {
+			return nil, false // ambiguous without a method
+		}
+		match = &s.Operations[i]
+	}
+	return match, match != nil
+}
+
+// Match resolves a concrete request path to the operation that serves it. The
+// request path may be absolute (including the API base path) or already relative
+// to it.
+//
+// When several templates match, the one with the fewest placeholders wins, so a
+// literal path beats a templated one (`/documents/search` over
+// `/documents/{id}`).
+func (s *Spec) Match(method, requestPath string) (*Operation, bool) {
+	method = strings.ToUpper(method)
+
+	relative := requestPath
+	if s.BasePath != "" && strings.HasPrefix(requestPath, s.BasePath) {
+		relative = strings.TrimPrefix(requestPath, s.BasePath)
+	}
+	if !strings.HasPrefix(relative, "/") {
+		relative = "/" + relative
+	}
+	relative = strings.TrimSuffix(relative, "/")
+	if relative == "" {
+		relative = "/"
+	}
+
+	var best *Operation
+	bestPlaceholders := -1
+	for i := range s.Operations {
+		op := &s.Operations[i]
+		if op.Method != method {
+			continue
+		}
+		if !pathTemplateMatches(op.Path, relative) {
+			continue
+		}
+		n := strings.Count(op.Path, "{")
+		if bestPlaceholders < 0 || n < bestPlaceholders {
+			best, bestPlaceholders = op, n
+		}
+	}
+	return best, best != nil
+}
+
+// placeholderPattern matches an OpenAPI path placeholder.
+var placeholderPattern = regexp.MustCompile(`\{[^{}]*\}`)
+
+// templateCache memoizes compiled path-template regexps. Spec matching happens
+// per request in `exec api`, and a spec can carry 70+ templates.
+var (
+	templateCacheMu sync.Mutex
+	templateCache   = map[string]*regexp.Regexp{}
+)
+
+// pathTemplateMatches reports whether a concrete path is an instance of an
+// OpenAPI path template.
+//
+// Placeholders are matched within a segment rather than as whole segments,
+// because Dynatrace paths put custom actions in the same segment as an
+// identifier (`/documents/{id}:favorite`). A placeholder never spans a `/`.
+func pathTemplateMatches(template, path string) bool {
+	re, err := compileTemplate(template)
+	if err != nil {
+		return template == path
+	}
+	return re.MatchString(path)
+}
+
+func compileTemplate(template string) (*regexp.Regexp, error) {
+	templateCacheMu.Lock()
+	if re, ok := templateCache[template]; ok {
+		templateCacheMu.Unlock()
+		return re, nil
+	}
+	templateCacheMu.Unlock()
+
+	var b strings.Builder
+	b.WriteString("^")
+	last := 0
+	for _, loc := range placeholderPattern.FindAllStringIndex(template, -1) {
+		b.WriteString(regexp.QuoteMeta(template[last:loc[0]]))
+		// A path parameter is one or more characters within a single segment.
+		b.WriteString(`[^/]+`)
+		last = loc[1]
+	}
+	b.WriteString(regexp.QuoteMeta(template[last:]))
+	b.WriteString("$")
+
+	re, err := regexp.Compile(b.String())
+	if err != nil {
+		return nil, err
+	}
+
+	templateCacheMu.Lock()
+	templateCache[template] = re
+	templateCacheMu.Unlock()
+	return re, nil
+}
+
+// FindEntry resolves a name or base path to a registry entry, matching only
+// against what the registry actually returned.
+//
+// Resolution order: exact base path, then exact (case-insensitive) name, then a
+// case-insensitive substring of the name or base path. A miss returns
+// (nil, false) — callers must never synthesize a candidate path from a name,
+// which would turn dtctl into a prober that confirms the existence of APIs an
+// environment deliberately omits from its own index.
+func (r *Registry) FindEntry(query string) (*Entry, bool) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, false
+	}
+	lower := strings.ToLower(q)
+	normalized := "/" + strings.Trim(q, "/")
+
+	for i := range r.Entries {
+		if r.Entries[i].BasePath() == normalized {
+			return &r.Entries[i], true
+		}
+	}
+	for i := range r.Entries {
+		if strings.EqualFold(r.Entries[i].Name, q) {
+			return &r.Entries[i], true
+		}
+	}
+
+	var matches []*Entry
+	for i := range r.Entries {
+		e := &r.Entries[i]
+		if strings.Contains(strings.ToLower(e.Name), lower) ||
+			strings.Contains(strings.ToLower(e.BasePath()), lower) {
+			matches = append(matches, e)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], true
+	}
+	return nil, false
+}
+
+// Candidates returns every entry whose name or base path contains query,
+// case-insensitively. It backs a caller's disambiguation message and, like
+// [Registry.FindEntry], never looks beyond what the registry returned.
+func (r *Registry) Candidates(query string) []Entry {
+	lower := strings.ToLower(strings.TrimSpace(query))
+	var out []Entry
+	for _, e := range r.Entries {
+		if lower == "" ||
+			strings.Contains(strings.ToLower(e.Name), lower) ||
+			strings.Contains(strings.ToLower(e.BasePath()), lower) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// EntryForPath returns the registry entry whose base path is the longest prefix
+// of requestPath — the API that owns a given request. The longest prefix wins so
+// that a nested base path is preferred over the shorter one it sits under.
+func (r *Registry) EntryForPath(requestPath string) (*Entry, bool) {
+	var best *Entry
+	for i := range r.Entries {
+		base := r.Entries[i].BasePath()
+		if base == "" || !strings.HasPrefix(requestPath, base) {
+			continue
+		}
+		// Require a segment boundary so /platform/storage/query/v1 does not
+		// claim /platform/storage/query/v1beta.
+		rest := requestPath[len(base):]
+		if rest != "" && !strings.HasPrefix(rest, "/") {
+			continue
+		}
+		if best == nil || len(base) > len(best.BasePath()) {
+			best = &r.Entries[i]
+		}
+	}
+	return best, best != nil
+}
+
+// IsAbsoluteURL reports whether s is an absolute URL rather than a path on the
+// environment. Callers use it to reject a passthrough target that would leave
+// the configured environment.
+func IsAbsoluteURL(s string) bool {
+	u, err := url.Parse(s)
+	return err == nil && u.Scheme != ""
+}

--- a/sdk/api/apispec/apispec_test.go
+++ b/sdk/api/apispec/apispec_test.go
@@ -1,0 +1,595 @@
+package apispec
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace-oss/dtctl/sdk/httpclient"
+)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return b
+}
+
+func widgetSpec(t *testing.T) *Spec {
+	t.Helper()
+	spec, err := ParseSpec(loadFixture(t, "widget-openapi.yaml"))
+	require.NoError(t, err)
+	return spec
+}
+
+func TestParseSpec_Metadata(t *testing.T) {
+	spec := widgetSpec(t)
+
+	require.Equal(t, "Widget Service", spec.Title)
+	require.Equal(t, "Core", spec.Category)
+	require.Equal(t, "Manage widgets and their sprockets.", spec.Summary)
+	// x-api-gateway-url wins over the absolute `url`: it is the path the
+	// platform gateway serves the API on, which is what a passthrough needs.
+	require.Equal(t, "/platform/widget/v1", spec.BasePath)
+	// An unquoted `version: 2.7` is a YAML float, not a string. Rendering it
+	// rather than dropping it is the point of strAt's default branch.
+	require.Equal(t, "2.7", spec.Version)
+}
+
+func TestParseSpec_OperationsAreProjected(t *testing.T) {
+	spec := widgetSpec(t)
+
+	ids := make([]string, 0, len(spec.Operations))
+	for _, op := range spec.Operations {
+		ids = append(ids, op.ID())
+	}
+
+	require.ElementsMatch(t, []string{
+		"GET /",
+		"GET /widgets",
+		"POST /widgets",
+		"POST /widgets/search",
+		"GET /widgets/{id}",
+		"PATCH /widgets/{id}",
+		"DELETE /widgets/{id}",
+		"POST /widgets/{id}:favorite",
+		"POST /widgets:purge",
+		"POST /sprockets:verify",
+		"GET /sprockets",
+	}, ids)
+}
+
+// TestParseSpec_CollectionRootIsAReachableOperation pins the empty-path case.
+//
+// A specification may key an operation on "" — the base path itself is the
+// endpoint. Carried through verbatim it produced the operation ID "GET ", which a
+// caller cannot pass back to --operation, and which Match could never resolve,
+// because an incoming request for the base path normalizes to "/". The operation
+// was therefore listed and unreachable at once: `exec api` on it would fall to the
+// strict fallback and gate a read as a delete.
+func TestParseSpec_CollectionRootIsAReachableOperation(t *testing.T) {
+	spec := widgetSpec(t)
+
+	op, ok := spec.FindByID("GET /")
+	require.True(t, ok, "the collection root must be addressable by a usable ID")
+	require.Equal(t, "/", op.Path)
+	require.Equal(t, []string{"widget:widgets:read"}, op.Scopes)
+
+	matched, ok := spec.Match("GET", "/platform/widget/v1")
+	require.True(t, ok, "a request for the base path must resolve to the collection root")
+	require.Equal(t, "GET /", matched.ID())
+
+	// A trailing slash is the same endpoint.
+	matched, ok = spec.Match("GET", "/platform/widget/v1/")
+	require.True(t, ok)
+	require.Equal(t, "GET /", matched.ID())
+}
+
+func TestParseSpec_ScopesAndInheritance(t *testing.T) {
+	spec := widgetSpec(t)
+
+	cases := []struct {
+		id     string
+		scopes []string
+		access Access
+		why    string
+	}{
+		{"GET /widgets", []string{"widget:widgets:read"}, AccessRead,
+			"a declared read scope"},
+		{"POST /widgets", []string{"widget:widgets:write"}, AccessWrite,
+			"a declared write scope"},
+		{"POST /widgets/search", []string{"widget:widgets:read"}, AccessRead,
+			"a read-shaped POST: method inference would wrongly call this a mutation"},
+		{"POST /widgets/{id}:favorite", []string{"widget:widgets:read"}, AccessRead,
+			"a custom action that only reads"},
+		{"POST /widgets:purge", []string{"widget:widgets:delete"}, AccessDelete,
+			"a POST that deletes: method inference would permit it as a create, " +
+				"which readwrite-mine allows while blocking deletes"},
+		{"DELETE /widgets/{id}", []string{"widget:widgets:delete"}, AccessDelete,
+			"a declared delete scope"},
+		{"POST /sprockets:verify", nil, AccessUnknown,
+			"`ssoAuth: []` declares nothing, so the operation is unclassifiable"},
+		{"GET /sprockets", []string{"widget:widgets:read"}, AccessRead,
+			"no operation-level security: inherits the document's declaration"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			op, ok := spec.FindByID(tc.id)
+			require.True(t, ok, "operation %s not found", tc.id)
+			require.Equal(t, tc.scopes, op.Scopes, tc.why)
+			require.Equal(t, tc.access, op.Access(), tc.why)
+		})
+	}
+}
+
+// TestParseSpec_EmptySecurityIsNotFreeAccess isolates the single most dangerous
+// misreading available here: an explicitly empty scope list looks like "no scope
+// needed" and is actually "the document says nothing".
+func TestParseSpec_EmptySecurityIsNotFreeAccess(t *testing.T) {
+	spec := widgetSpec(t)
+
+	op, ok := spec.FindByID("POST /sprockets:verify")
+	require.True(t, ok)
+	require.Empty(t, op.Scopes)
+	require.Equal(t, AccessUnknown, op.Access(),
+		"an empty declaration must never classify as AccessRead")
+}
+
+func TestParseSpec_ParametersMergeAndDeref(t *testing.T) {
+	spec := widgetSpec(t)
+
+	t.Run("operation parameters with a $ref", func(t *testing.T) {
+		op, ok := spec.FindByID("GET /widgets")
+		require.True(t, ok)
+
+		byName := map[string]Parameter{}
+		for _, p := range op.Parameters {
+			byName[p.Name] = p
+		}
+
+		require.Equal(t, "integer(int32)", byName["page-size"].Type)
+		require.Equal(t, "query", byName["page-size"].In)
+
+		// page-key arrives only through #/components/parameters/PageKey, so its
+		// presence proves the one-hop resolution ran.
+		pk, found := byName["page-key"]
+		require.True(t, found, "a $ref'd parameter must be resolved, not dropped")
+		require.Equal(t, "string", pk.Type)
+		require.Equal(t, "Cursor from a previous page.", pk.Description)
+	})
+
+	t.Run("path-level parameters apply to every operation", func(t *testing.T) {
+		// `id` is declared once on the path, not on the three operations under it.
+		for _, id := range []string{"GET /widgets/{id}", "PATCH /widgets/{id}", "DELETE /widgets/{id}"} {
+			op, ok := spec.FindByID(id)
+			require.True(t, ok)
+			require.Len(t, op.Parameters, 1, "%s should inherit the path parameter", id)
+			require.Equal(t, "id", op.Parameters[0].Name)
+			require.Equal(t, "path", op.Parameters[0].In)
+			require.True(t, op.Parameters[0].Required)
+		}
+	})
+}
+
+func TestParseSpec_RequestBodySchemaIsDereferenced(t *testing.T) {
+	spec := widgetSpec(t)
+
+	op, ok := spec.FindByID("POST /widgets")
+	require.True(t, ok)
+	require.NotNil(t, op.RequestBody)
+	require.True(t, op.RequestBody.Required)
+	require.Len(t, op.RequestBody.Contents, 1)
+	require.Equal(t, "application/json", op.RequestBody.Contents[0].ContentType)
+
+	// The fixture writes `$ref: '#/components/schemas/Widget'`. Resolving it is
+	// what makes the operation composable without the rest of the document — the
+	// acceptance bar for `describe api --operation`.
+	schema, isMap := op.RequestBody.Contents[0].Schema.(map[string]any)
+	require.True(t, isMap, "request body schema must resolve to an object, got %T",
+		op.RequestBody.Contents[0].Schema)
+	require.Equal(t, "object", schema["type"])
+
+	props, isMap := schema["properties"].(map[string]any)
+	require.True(t, isMap)
+	require.Contains(t, props, "name")
+	require.Contains(t, props, "sprockets")
+}
+
+// TestParseSpec_RefResolutionStopsAfterOneHop pins the deliberate limit. The
+// WidgetList schema's `widgets.items` is itself a $ref, and it stays a $ref:
+// resolving transitively is what makes a projection as expensive as the raw
+// document.
+func TestParseSpec_RefResolutionStopsAfterOneHop(t *testing.T) {
+	spec := widgetSpec(t)
+
+	op, ok := spec.FindByID("GET /widgets")
+	require.True(t, ok)
+	require.NotEmpty(t, op.Responses)
+
+	var listSchema map[string]any
+	for _, r := range op.Responses {
+		if r.Status != "200" {
+			continue
+		}
+		require.Len(t, r.Contents, 1)
+		listSchema, _ = r.Contents[0].Schema.(map[string]any)
+	}
+	require.NotNil(t, listSchema, "the top-level response $ref must be resolved")
+
+	props, _ := listSchema["properties"].(map[string]any)
+	widgets, _ := props["widgets"].(map[string]any)
+	items, _ := widgets["items"].(map[string]any)
+	require.Contains(t, items, "$ref",
+		"a nested $ref must remain unresolved: resolution is one hop by design")
+}
+
+func TestSpec_MatchConcretePaths(t *testing.T) {
+	spec := widgetSpec(t)
+
+	cases := []struct {
+		method, path string
+		want         string
+		why          string
+	}{
+		{"GET", "/platform/widget/v1/widgets", "GET /widgets",
+			"an absolute path is matched after stripping the base path"},
+		{"GET", "/widgets", "GET /widgets",
+			"a path already relative to the base is matched as-is"},
+		{"GET", "/platform/widget/v1/widgets/abc-123", "GET /widgets/{id}",
+			"a placeholder matches one segment"},
+		{"POST", "/platform/widget/v1/widgets/search", "POST /widgets/search",
+			"a literal path beats the templated sibling it collides with"},
+		{"POST", "/platform/widget/v1/widgets/abc-123:favorite", "POST /widgets/{id}:favorite",
+			"a placeholder can be part of a segment, not just a whole one"},
+		{"DELETE", "/platform/widget/v1/widgets/abc-123", "DELETE /widgets/{id}",
+			"method selects among operations on the same template"},
+		{"GET", "/platform/widget/v1/widgets/", "GET /widgets",
+			"a trailing slash does not change the target"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			op, ok := spec.Match(tc.method, tc.path)
+			require.True(t, ok, tc.why)
+			require.Equal(t, tc.want, op.ID(), tc.why)
+		})
+	}
+
+	t.Run("an unmatched path is a miss, not a guess", func(t *testing.T) {
+		_, ok := spec.Match("GET", "/platform/widget/v1/gadgets")
+		require.False(t, ok)
+	})
+
+	t.Run("a placeholder never spans a segment boundary", func(t *testing.T) {
+		// /widgets/{id} must not swallow /widgets/a/b.
+		_, ok := spec.Match("GET", "/platform/widget/v1/widgets/a/b")
+		require.False(t, ok)
+	})
+}
+
+// TestParseSpec_ClassicJSONDocument covers the one base path where the
+// openapi.yaml convention does not hold. The classic surface serves spec3.json,
+// and because JSON is a subset of YAML the same parser handles it — so a classic
+// entry must never be a silent parse failure.
+func TestParseSpec_ClassicJSONDocument(t *testing.T) {
+	spec, err := ParseSpec(loadFixture(t, "legacy-spec3.json"))
+	require.NoError(t, err)
+
+	require.Equal(t, "Legacy Example API", spec.Title)
+	require.Equal(t, "/platform/classic/example-api/v2", spec.BasePath,
+		"with no x-api-gateway-url, servers[0].url is the base path")
+	require.Len(t, spec.Operations, 1)
+	require.Equal(t, "GET /things", spec.Operations[0].ID())
+}
+
+func TestParseSpec_Rejects(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty", ""},
+		{"not a document", "just a string"},
+		{"no paths section", "openapi: 3.0.3\ninfo:\n  title: X\n"},
+		{"malformed yaml", "openapi: [unterminated\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseSpec([]byte(tc.body))
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestParseSpec_TolerantOfMalformedSections is the fail-soft requirement at the
+// document level: a section of the wrong type degrades that section only. The
+// whole package rests on an undocumented convention, so a document that drifts
+// must lose a field rather than the whole listing.
+func TestParseSpec_TolerantOfMalformedSections(t *testing.T) {
+	spec, err := ParseSpec([]byte(`
+openapi: 3.0.3
+info: "a string where a mapping belongs"
+servers: "also wrong"
+paths:
+  /ok:
+    get:
+      summary: Still projected
+      parameters: "not a list"
+      responses: "not a map"
+`))
+	require.NoError(t, err, "a wrongly-typed section must not fail the parse")
+	require.Empty(t, spec.Title)
+	require.Len(t, spec.Operations, 1)
+	require.Equal(t, "GET /ok", spec.Operations[0].ID())
+	require.Empty(t, spec.Operations[0].Parameters)
+}
+
+func TestRegistry_EntryHelpers(t *testing.T) {
+	cases := []struct {
+		url      string
+		basePath string
+		external bool
+		classic  bool
+	}{
+		{"/platform/widget/v1/openapi.yaml", "/platform/widget/v1", false, false},
+		{"/platform/classic/example-api/v2/spec3.json", "/platform/classic/example-api/v2", false, true},
+		// A cache-busting query must not leak into the derived base path — and,
+		// per gcx's hard-won lesson, must never become part of a filename.
+		{"/platform/widget/v1/openapi.yaml?hash=abc123", "/platform/widget/v1", false, false},
+		{"https://example.invalid/api/v2/spec3.json", "", true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			e := Entry{Name: "Example", URL: tc.url}
+			require.Equal(t, tc.basePath, e.BasePath())
+			require.Equal(t, tc.external, e.External())
+			require.Equal(t, tc.classic, e.Classic())
+		})
+	}
+}
+
+func testRegistry() *Registry {
+	return &Registry{Entries: []Entry{
+		{Name: "Widget Service", URL: "/platform/widget/v1/openapi.yaml"},
+		{Name: "Sprocket Service", URL: "/platform/sprocket/v1/openapi.yaml"},
+		{Name: "Sprocket Admin Service", URL: "/platform/sprocket/admin/v1/openapi.yaml"},
+		{Name: "Legacy Example API", URL: "/platform/classic/example-api/v2/spec3.json"},
+		{Name: "External Docs", URL: "https://example.invalid/api/v2/spec3.json"},
+	}}
+}
+
+func TestRegistry_FindEntry(t *testing.T) {
+	reg := testRegistry()
+
+	t.Run("exact base path", func(t *testing.T) {
+		e, ok := reg.FindEntry("/platform/widget/v1")
+		require.True(t, ok)
+		require.Equal(t, "Widget Service", e.Name)
+	})
+
+	t.Run("exact name, case-insensitive", func(t *testing.T) {
+		e, ok := reg.FindEntry("widget service")
+		require.True(t, ok)
+		require.Equal(t, "Widget Service", e.Name)
+	})
+
+	t.Run("unique substring", func(t *testing.T) {
+		e, ok := reg.FindEntry("widget")
+		require.True(t, ok)
+		require.Equal(t, "Widget Service", e.Name)
+	})
+
+	t.Run("ambiguous substring is a miss", func(t *testing.T) {
+		_, ok := reg.FindEntry("sprocket")
+		require.False(t, ok, "two entries match; resolving one of them silently would be wrong")
+
+		require.Len(t, reg.Candidates("sprocket"), 2,
+			"the caller needs the candidates to disambiguate")
+	})
+
+	t.Run("an exact name wins over being a substring of another", func(t *testing.T) {
+		e, ok := reg.FindEntry("Sprocket Service")
+		require.True(t, ok)
+		require.Equal(t, "Sprocket Service", e.Name)
+	})
+
+	// The no-oracle rule: a miss must fail as a miss. Nothing here may consult,
+	// construct, or probe a path the registry did not return — that would let
+	// dtctl confirm the existence of APIs an environment deliberately omits.
+	t.Run("a miss returns nothing and synthesizes no path", func(t *testing.T) {
+		for _, q := range []string{"nonexistent", "/platform/nonexistent/v1", ""} {
+			_, ok := reg.FindEntry(q)
+			require.False(t, ok, "query %q must miss", q)
+		}
+	})
+}
+
+func TestRegistry_EntryForPath(t *testing.T) {
+	reg := testRegistry()
+
+	cases := []struct {
+		path string
+		want string
+		why  string
+	}{
+		{"/platform/widget/v1/widgets", "Widget Service", "the owning API by base-path prefix"},
+		{"/platform/widget/v1", "Widget Service", "the base path itself"},
+		{"/platform/sprocket/admin/v1/things", "Sprocket Admin Service",
+			"the longest matching prefix wins over the shorter one it nests under"},
+		{"/platform/sprocket/v1/things", "Sprocket Service", "the shorter prefix when it is the match"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			e, ok := reg.EntryForPath(tc.path)
+			require.True(t, ok, tc.why)
+			require.Equal(t, tc.want, e.Name, tc.why)
+		})
+	}
+
+	t.Run("a prefix must end on a segment boundary", func(t *testing.T) {
+		// /platform/widget/v1 must not claim /platform/widget/v1beta.
+		_, ok := reg.EntryForPath("/platform/widget/v1beta/widgets")
+		require.False(t, ok)
+	})
+
+	t.Run("an unowned path has no entry", func(t *testing.T) {
+		_, ok := reg.EntryForPath("/platform/unknown/v1/things")
+		require.False(t, ok)
+	})
+}
+
+// newTestHandler wires a Handler to a local server. Retries are disabled so a
+// deliberate error response does not cost the retry budget.
+func newTestHandler(t *testing.T, h http.Handler) *Handler {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	c, err := httpclient.New(srv.URL, httpclient.WithToken("dt0c01.EXAMPLE"))
+	require.NoError(t, err)
+	c.HTTP().SetRetryCount(0)
+	return NewHandler(c)
+}
+
+func TestHandler_Registry(t *testing.T) {
+	var hits int
+	h := newTestHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, RegistryPath, r.URL.Path)
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"urls":[
+			{"name":"Widget Service","url":"/platform/widget/v1/openapi.yaml"},
+			{"name":"External","url":"https://example.invalid/api/v2/spec3.json"}
+		]}`)
+	}))
+
+	reg, err := h.Registry()
+	require.NoError(t, err)
+	require.Len(t, reg.Entries, 2)
+	require.Equal(t, "Widget Service", reg.Entries[0].Name)
+
+	// The listing is one HTTP request, and a drill-down must not repeat it.
+	again, err := h.Registry()
+	require.NoError(t, err)
+	require.Same(t, reg, again)
+	require.Equal(t, 1, hits, "the registry must be fetched once per handler")
+}
+
+// TestHandler_RegistryFailsSoft covers the fail-soft contract for the index.
+// Because the index is an observed convention rather than a documented one, its
+// absence has to be an ordinary, well-typed outcome — never a raw 404 body.
+func TestHandler_RegistryFailsSoft(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		body    string
+		wantErr string
+	}{
+		{"missing", http.StatusNotFound, `{"error":{"code":404,"message":"not found"}}`, ""},
+		{"unparseable", http.StatusOK, "\t\x00not yaml: [", ""},
+		{"empty index", http.StatusOK, `{"urls":[]}`, "no specification entries"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, tc.body)
+			}))
+
+			_, err := h.Registry()
+			require.Error(t, err)
+
+			var unavailable *RegistryUnavailableError
+			require.ErrorAs(t, err, &unavailable,
+				"callers switch on this type to print the Swagger UI fallback")
+			require.Contains(t, unavailable.Error(), RegistryPath)
+			require.NotContains(t, unavailable.Error(), "404",
+				"the message must not surface a raw status or response body")
+			// The cause stays reachable through Unwrap for diagnostics, but is
+			// deliberately kept out of the user-facing message.
+			require.NotNil(t, unavailable.Err, "the cause must remain available")
+			if tc.wantErr != "" {
+				require.ErrorContains(t, unavailable.Err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestHandler_SpecIgnoresContentType pins the rule that cost the most to learn:
+// the same specification is served as at least four media types, with and
+// without a charset, so parsing must never branch on Content-Type.
+func TestHandler_SpecIgnoresContentType(t *testing.T) {
+	body := loadFixture(t, "widget-openapi.yaml")
+
+	contentTypes := []string{
+		"application/openapi+yaml",
+		"application/vnd.oai.openapi",
+		"application/x-yaml",
+		"application/yaml",
+		"application/yaml; charset=utf-8",
+		"text/plain",
+		"", // no Content-Type at all
+	}
+
+	for _, ct := range contentTypes {
+		name := ct
+		if name == "" {
+			name = "(none)"
+		}
+		t.Run(name, func(t *testing.T) {
+			h := newTestHandler(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if ct != "" {
+					w.Header().Set("Content-Type", ct)
+				}
+				_, _ = w.Write(body)
+			}))
+
+			spec, err := h.Spec("/platform/widget/v1/openapi.yaml")
+			require.NoError(t, err)
+			require.Equal(t, "Widget Service", spec.Title)
+		})
+	}
+}
+
+func TestHandler_SpecMemoizesAndFallsBackToDocumentLocation(t *testing.T) {
+	var hits int
+	h := newTestHandler(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		// No `servers` block: the base path must fall back to the document's own
+		// location, so a passthrough can still resolve paths against it.
+		fmt.Fprint(w, "openapi: 3.0.3\ninfo:\n  title: Bare\npaths:\n  /things:\n    get:\n      summary: List\n")
+	}))
+
+	spec, err := h.Spec("/platform/bare/v1/openapi.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "/platform/bare/v1", spec.BasePath)
+
+	again, err := h.Spec("/platform/bare/v1/openapi.yaml")
+	require.NoError(t, err)
+	require.Same(t, spec, again)
+	require.Equal(t, 1, hits, "a drill-down must cost one fetch per API")
+}
+
+func TestHandler_SpecForEntryRefusesExternal(t *testing.T) {
+	h := newTestHandler(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("an external entry must not be fetched")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	_, err := h.SpecForEntry(Entry{Name: "External Docs", URL: "https://example.invalid/api/v2/spec3.json"})
+	require.ErrorContains(t, err, "external URL")
+}
+
+func TestSpecPathForBase(t *testing.T) {
+	require.Equal(t, "/platform/widget/v1/openapi.yaml", SpecPathForBase("/platform/widget/v1"))
+	require.Equal(t, "/platform/widget/v1/openapi.yaml", SpecPathForBase("/platform/widget/v1/"))
+}

--- a/sdk/api/apispec/classify.go
+++ b/sdk/api/apispec/classify.go
@@ -1,0 +1,131 @@
+package apispec
+
+import "strings"
+
+// Access is how much a scope verb permits. It is the specification-derived half
+// of classifying a generic request; mapping it onto a safety operation is the
+// caller's job, because that mapping is CLI policy rather than API knowledge.
+type Access string
+
+const (
+	// AccessRead permits reading only.
+	AccessRead Access = "read"
+	// AccessWrite permits creating or modifying.
+	AccessWrite Access = "write"
+	// AccessDelete permits deletion.
+	AccessDelete Access = "delete"
+	// AccessUnknown means the scope verb could not be classified — either no
+	// scope was declared, or its verb is not in the table below.
+	//
+	// This is a first-class outcome, not an error case. It must never be
+	// collapsed into AccessRead: a caller that treats "unknown" as "read" turns
+	// every unclassifiable mutation into a permitted one.
+	AccessUnknown Access = "unknown"
+)
+
+// scopeVerbAccess maps the trailing verb of a Dynatrace scope to what it permits.
+//
+// A scope reads `<service>:<resource>:<verb>`, e.g. `document:documents:read`.
+// The verbs are not a clean read/write/delete triple — `use`, `claim`, `restore`
+// and `admin` all appear — so the mapping is a table with an explicit unknown
+// case rather than a heuristic.
+//
+// A verb absent from this table classifies as [AccessUnknown], which callers
+// gate strictly. That default is the point: a newly minted scope verb must not
+// silently land in the most permissive bucket.
+var scopeVerbAccess = map[string]Access{
+	"read": AccessRead,
+	// `use` grants invocation of a shared resource without changing it
+	// (iam:service-users:use).
+	"use":   AccessRead,
+	"write": AccessWrite,
+	// `claim` and `restore` change state without creating or destroying
+	// (document:trash.documents:restore).
+	"claim":   AccessWrite,
+	"restore": AccessWrite,
+	"share":   AccessWrite,
+	"install": AccessWrite,
+	"delete":  AccessDelete,
+	// `truncate` destroys the contents of a store: destructive, so it is
+	// classified with deletion rather than with writes.
+	"truncate": AccessDelete,
+	// `admin` and `execute` are deliberately absent. `admin` is unbounded, and
+	// `execute` says nothing about whether the executed thing mutates — both
+	// must fall through to AccessUnknown and be gated strictly.
+}
+
+// ScopeVerb returns the trailing verb of a scope string, or "" when the scope is
+// not in `<service>:<resource>:<verb>` form.
+func ScopeVerb(scope string) string {
+	i := strings.LastIndex(scope, ":")
+	if i < 0 || i == len(scope)-1 {
+		return ""
+	}
+	return scope[i+1:]
+}
+
+// AccessForScopes classifies a declared scope set.
+//
+// The *most* permissive verb across the set decides, because a caller holding
+// several scopes for one operation can exercise all of them, and the gate has to
+// cover the strongest. An unclassifiable verb anywhere makes the whole set
+// unknown — one unrecognised scope is enough to invalidate a conclusion drawn
+// from the others.
+//
+// An empty scope set is [AccessUnknown]: it means the document declared nothing,
+// which is common (two of six APIs sampled declare no per-operation scopes) and
+// is exactly the case that must not be mistaken for "harmless".
+func AccessForScopes(scopes []string) Access {
+	if len(scopes) == 0 {
+		return AccessUnknown
+	}
+
+	rank := map[Access]int{AccessRead: 0, AccessWrite: 1, AccessDelete: 2}
+	best := AccessRead
+	found := false
+
+	for _, s := range scopes {
+		access, ok := scopeVerbAccess[ScopeVerb(s)]
+		if !ok {
+			return AccessUnknown
+		}
+		if !found || rank[access] > rank[best] {
+			best, found = access, true
+		}
+	}
+	if !found {
+		return AccessUnknown
+	}
+	return best
+}
+
+// Access classifies the operation from the scopes its specification declares.
+func (o Operation) Access() Access { return AccessForScopes(o.Scopes) }
+
+// MethodIsRead reports whether an HTTP method is conventionally a read.
+//
+// This is a one-sided floor, never a classification: GET and HEAD are reads by
+// convention, and PUT/PATCH/DELETE are never reads. POST carries no information
+// at all and must never be inferred from — measured across 64 specified
+// operations, 12 POSTs required only a `:read` scope while one required
+// `:delete`, so method inference is wrong in both directions on POST, including
+// the dangerous one.
+func MethodIsRead(method string) bool {
+	switch strings.ToUpper(method) {
+	case "GET", "HEAD":
+		return true
+	default:
+		return false
+	}
+}
+
+// MethodIsAlwaysMutating reports whether a method cannot be a read whatever a
+// specification claims. It is the lower bound the specification cannot lower.
+func MethodIsAlwaysMutating(method string) bool {
+	switch strings.ToUpper(method) {
+	case "PUT", "PATCH", "DELETE":
+		return true
+	default:
+		return false
+	}
+}

--- a/sdk/api/apispec/classify_test.go
+++ b/sdk/api/apispec/classify_test.go
@@ -1,0 +1,141 @@
+package apispec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopeVerb(t *testing.T) {
+	cases := map[string]string{
+		"document:documents:read":             "read",
+		"document:trash.documents:restore":    "restore",
+		"storage:bucket-definitions:truncate": "truncate",
+		"iam:service-users:use":               "use",
+		// Not in <service>:<resource>:<verb> form: no verb to extract.
+		"openid":         "",
+		"offline_access": "",
+		"trailing:":      "",
+		"":               "",
+	}
+
+	for scope, want := range cases {
+		t.Run(scope, func(t *testing.T) {
+			require.Equal(t, want, ScopeVerb(scope))
+		})
+	}
+}
+
+func TestAccessForScopes(t *testing.T) {
+	cases := []struct {
+		name   string
+		scopes []string
+		want   Access
+		why    string
+	}{
+		{
+			name: "no declaration",
+			want: AccessUnknown,
+			why:  "an empty set means the document said nothing, not that nothing is needed",
+		},
+		{
+			name:   "read",
+			scopes: []string{"widget:widgets:read"},
+			want:   AccessRead,
+		},
+		{
+			name:   "use reads without changing",
+			scopes: []string{"iam:service-users:use"},
+			want:   AccessRead,
+		},
+		{
+			name:   "write",
+			scopes: []string{"widget:widgets:write"},
+			want:   AccessWrite,
+		},
+		{
+			name:   "restore changes state without creating or destroying",
+			scopes: []string{"document:trash.documents:restore"},
+			want:   AccessWrite,
+		},
+		{
+			name:   "delete",
+			scopes: []string{"widget:widgets:delete"},
+			want:   AccessDelete,
+		},
+		{
+			name:   "truncate destroys contents",
+			scopes: []string{"storage:bucket-definitions:truncate"},
+			want:   AccessDelete,
+			why:    "truncation is data loss, so it classifies with deletion",
+		},
+		{
+			name:   "the strongest verb in a set decides",
+			scopes: []string{"widget:widgets:read", "widget:widgets:delete"},
+			want:   AccessDelete,
+			why:    "a caller holding both can exercise both, so the gate must cover the stronger",
+		},
+		{
+			name:   "an unrecognised verb invalidates the whole set",
+			scopes: []string{"widget:widgets:read", "widget:widgets:teleport"},
+			want:   AccessUnknown,
+			why:    "one unclassifiable scope makes any conclusion from the others unsound",
+		},
+		{
+			name:   "admin is deliberately unclassified",
+			scopes: []string{"storage:filter-segments:admin"},
+			want:   AccessUnknown,
+			why:    "admin is unbounded; it must not be read as a mere write",
+		},
+		{
+			name:   "execute is deliberately unclassified",
+			scopes: []string{"davis:analyzers:execute"},
+			want:   AccessUnknown,
+			why:    "execution says nothing about whether the executed thing mutates",
+		},
+		{
+			name:   "a scope that is not in verb form",
+			scopes: []string{"openid"},
+			want:   AccessUnknown,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, AccessForScopes(tc.scopes), tc.why)
+		})
+	}
+}
+
+// TestMethodFloorsAreOneSided pins that the method contributes a bound and never
+// a classification. POST is the case that matters: measured across 64 specified
+// operations, 12 POSTs needed only a `:read` scope and one needed `:delete`, so
+// inferring from POST is wrong in both directions — including the direction that
+// would permit a delete as a create.
+func TestMethodFloorsAreOneSided(t *testing.T) {
+	cases := []struct {
+		method       string
+		read         bool
+		alwaysMutate bool
+	}{
+		{"GET", true, false},
+		{"get", true, false},
+		{"HEAD", true, false},
+		{"PUT", false, true},
+		{"PATCH", false, true},
+		{"DELETE", false, true},
+		{"POST", false, false},
+		{"OPTIONS", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			require.Equal(t, tc.read, MethodIsRead(tc.method))
+			require.Equal(t, tc.alwaysMutate, MethodIsAlwaysMutating(tc.method))
+		})
+	}
+
+	require.False(t, MethodIsRead("POST"))
+	require.False(t, MethodIsAlwaysMutating("POST"),
+		"POST must carry no information in either direction")
+}

--- a/sdk/api/apispec/testdata/legacy-spec3.json
+++ b/sdk/api/apispec/testdata/legacy-spec3.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Legacy Example API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "/platform/classic/example-api/v2"
+    }
+  ],
+  "paths": {
+    "/things": {
+      "get": {
+        "operationId": "listThings",
+        "summary": "List things",
+        "responses": {
+          "200": {
+            "description": "Things"
+          }
+        }
+      }
+    }
+  }
+}

--- a/sdk/api/apispec/testdata/widget-openapi.yaml
+++ b/sdk/api/apispec/testdata/widget-openapi.yaml
@@ -1,0 +1,214 @@
+# Synthetic OpenAPI document for apispec tests.
+#
+# Every name here is invented. Fixtures must never reproduce a real Dynatrace
+# service name, environment identifier, or scope from a non-public API surface:
+# a committed fixture is permanent public documentation of whatever it names.
+#
+# The shapes, however, are real — each one reproduces something observed on a
+# live specification that the parser has to survive:
+#   * `info` extensions (x-service-category, x-summary)
+#   * an unquoted numeric `version`, which YAML types as a float
+#   * `servers[0].x-api-gateway-url` as the authoritative base path
+#   * per-operation `security` with a declared scope
+#   * an explicitly *empty* `ssoAuth: []`, which declares nothing
+#   * an operation with no `security` key at all, inheriting the document's
+#   * path-level `parameters` shared by every operation under the path
+#   * `$ref` in parameters, request bodies and responses
+#   * a custom action in the same path segment as an identifier (`{id}:favorite`)
+openapi: 3.0.3
+info:
+  title: Widget Service
+  version: 2.7
+  x-service-category: Core
+  x-summary: Manage widgets and their sprockets.
+servers:
+  - url: https://example.invalid/platform/widget/v1
+    x-api-gateway-url: /platform/widget/v1
+security:
+  - ssoAuth:
+      - widget:widgets:read
+paths:
+  # An operation keyed on the empty path: the base path itself is the endpoint.
+  # Published specifications really do this, and it used to yield the unusable
+  # operation ID "GET " plus an operation no request could ever match.
+  '':
+    get:
+      operationId: getServiceRoot
+      summary: Describe the service
+      security:
+        - ssoAuth:
+            - widget:widgets:read
+  /widgets:
+    get:
+      operationId: listWidgets
+      summary: List widgets
+      security:
+        - ssoAuth:
+            - widget:widgets:read
+        - ssoBearerAuth: []
+      parameters:
+        - name: page-size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - $ref: '#/components/parameters/PageKey'
+      responses:
+        '200':
+          description: A page of widgets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WidgetList'
+    post:
+      operationId: createWidget
+      summary: Create a widget
+      security:
+        - ssoAuth:
+            - widget:widgets:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Widget'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Widget'
+        '400':
+          description: Malformed request
+  /widgets/search:
+    post:
+      operationId: searchWidgets
+      # A read-shaped POST: it declares a :read scope and persists nothing.
+      # Method-based inference would wrongly classify this as a mutation.
+      summary: Search widgets
+      security:
+        - ssoAuth:
+            - widget:widgets:read
+      responses:
+        '200':
+          description: Matching widgets
+  /widgets/{id}:
+    parameters:
+      - $ref: '#/components/parameters/WidgetID'
+    get:
+      operationId: getWidget
+      summary: Get a widget
+      security:
+        - ssoAuth:
+            - widget:widgets:read
+      responses:
+        '200':
+          description: The widget
+    patch:
+      operationId: updateWidget
+      summary: Update a widget
+      security:
+        - ssoAuth:
+            - widget:widgets:write
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: Updated
+    delete:
+      operationId: deleteWidget
+      summary: Delete a widget
+      security:
+        - ssoAuth:
+            - widget:widgets:delete
+      responses:
+        '204':
+          description: Deleted
+  /widgets/{id}:favorite:
+    post:
+      operationId: favoriteWidget
+      # A custom action sharing the last path segment with the identifier, and
+      # another read-shaped POST.
+      summary: Mark a widget as a favorite
+      security:
+        - ssoAuth:
+            - widget:widgets:read
+      responses:
+        '204':
+          description: Marked
+  /widgets:purge:
+    post:
+      operationId: purgeWidgets
+      # A POST whose declared scope is :delete — the dangerous direction that
+      # method inference gets wrong, permitting a delete as a create.
+      summary: Purge all widgets
+      security:
+        - ssoAuth:
+            - widget:widgets:delete
+      responses:
+        '204':
+          description: Purged
+  /sprockets:verify:
+    post:
+      operationId: verifySprocket
+      # Declares an explicitly empty scope list: the document states nothing
+      # about what this needs, so it must classify as unknown rather than free.
+      summary: Verify a sprocket definition
+      security:
+        - ssoAuth: []
+      responses:
+        '200':
+          description: Verification result
+  /sprockets:
+    get:
+      operationId: listSprockets
+      # No `security` key at all: inherits the document-level declaration.
+      summary: List sprockets
+      responses:
+        '200':
+          description: Sprockets
+components:
+  parameters:
+    PageKey:
+      name: page-key
+      in: query
+      required: false
+      description: Cursor from a previous page.
+      schema:
+        type: string
+    WidgetID:
+      name: id
+      in: path
+      required: true
+      description: The widget identifier.
+      schema:
+        type: string
+  schemas:
+    Widget:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        sprockets:
+          type: array
+          items:
+            type: string
+    WidgetList:
+      type: object
+      properties:
+        widgets:
+          type: array
+          items:
+            $ref: '#/components/schemas/Widget'

--- a/sdk/api/apispec/yamlmap.go
+++ b/sdk/api/apispec/yamlmap.go
@@ -1,0 +1,97 @@
+package apispec
+
+import (
+	"fmt"
+	"sort"
+)
+
+// This file holds the accessors for walking a specification parsed into
+// map[string]any.
+//
+// An OpenAPI document is parsed generically rather than into typed structs for
+// two reasons: schemas must survive verbatim (they are handed to the caller as
+// JSON/YAML, so any lossy struct would silently drop fields), and $ref
+// resolution needs the whole document addressable by JSON pointer anyway. Every
+// accessor below returns a zero value for a missing or wrongly-typed key, so a
+// malformed document degrades field by field instead of failing the parse — the
+// fail-soft requirement that the whole package rests on.
+
+// mapAt returns the mapping at key, or nil.
+func mapAt(m map[string]any, key string) map[string]any {
+	if m == nil {
+		return nil
+	}
+	sub, _ := m[key].(map[string]any)
+	return sub
+}
+
+// strAt returns the string at key. Numbers and booleans are rendered rather than
+// dropped: `info.version` is frequently written unquoted (`version: 1.54`), which
+// YAML types as a float.
+func strAt(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	switch v := m[key].(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// boolAt returns the boolean at key, defaulting to false.
+func boolAt(m map[string]any, key string) bool {
+	if m == nil {
+		return false
+	}
+	b, _ := m[key].(bool)
+	return b
+}
+
+// sliceAt returns the sequence at key, or nil.
+func sliceAt(m map[string]any, key string) []any {
+	if m == nil {
+		return nil
+	}
+	s, _ := m[key].([]any)
+	return s
+}
+
+// toStrings renders a scalar or sequence as a string slice. A single scalar is
+// treated as a one-element list, since `security` scope lists are occasionally
+// written that way.
+func toStrings(v any) []string {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, item := range t {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return t
+	case string:
+		return []string{t}
+	default:
+		return nil
+	}
+}
+
+// sortedKeys returns m's keys in lexical order. Parsing into a map loses
+// document order, so every projection sorts to stay deterministic — golden
+// output depends on it.
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -1,0 +1,307 @@
+//go:build integration
+// +build integration
+
+package e2e
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	resapi "github.com/dynatrace-oss/dtctl/pkg/resources/api"
+	"github.com/dynatrace-oss/dtctl/pkg/safety"
+	"github.com/dynatrace-oss/dtctl/test/integration"
+)
+
+// The assertions in this file are deliberately derived from whatever the
+// environment publishes, never from a list of expected APIs.
+//
+// Two reasons, and both are requirements rather than preferences. First,
+// disclosure: naming a non-public API in a public repository is the leak, and a
+// fixture list would be exactly that. Second, correctness: the API index is a
+// property of the environment, so any hard-coded expectation would encode one
+// tenant's shape and fail on another — which is the bug this feature exists to
+// avoid, not one to write into its tests.
+//
+// The tests therefore assert *invariants of the mechanism*: the index parses,
+// every entry round-trips through resolution, a specification either parses or
+// fails with a typed error, and classification never returns a verdict looser than
+// the method alone would justify. Those hold on every tenant.
+
+func TestAPIDiscoveryAgainstALiveEnvironment(t *testing.T) {
+	env := integration.SetupIntegration(t)
+	defer env.Cleanup.Cleanup(t)
+
+	handler := resapi.NewHandler(env.Client)
+
+	reg, err := handler.Registry()
+	if err != nil {
+		// An environment that does not publish the index at all is a legitimate
+		// state, but not one this test can say anything about.
+		t.Skipf("environment publishes no API index: %v", err)
+	}
+	if len(reg.Entries) == 0 {
+		t.Skip("environment's API index is empty")
+	}
+	t.Logf("index lists %d APIs", len(reg.Entries))
+
+	t.Run("every entry is usable", func(t *testing.T) {
+		for _, e := range reg.Entries {
+			if e.Name == "" {
+				t.Errorf("index entry with URL %q has no name", e.URL)
+				continue
+			}
+			if e.URL == "" {
+				t.Errorf("index entry %q has no document URL", e.Name)
+			}
+			// An external entry is documented on another host: dtctl lists it
+			// because the environment did, but it has no gateway base path.
+			if !e.External() && e.BasePath() == "" {
+				t.Logf("note: %q publishes no derivable base path", e.Name)
+			}
+		}
+	})
+
+	t.Run("names round-trip through resolution", func(t *testing.T) {
+		for _, e := range reg.Entries {
+			got, err := handler.Resolve(e.Name)
+			if err != nil {
+				t.Errorf("Resolve(%q) failed although the index lists it: %v", e.Name, err)
+				continue
+			}
+			if got.URL != e.URL {
+				t.Errorf("Resolve(%q) returned the entry for %q", e.Name, got.URL)
+			}
+		}
+	})
+
+	t.Run("base paths round-trip through resolution", func(t *testing.T) {
+		for _, e := range reg.Entries {
+			base := e.BasePath()
+			if base == "" {
+				continue
+			}
+			got, err := handler.Resolve(base)
+			if err != nil {
+				t.Errorf("Resolve(%q) failed for %q: %v", base, e.Name, err)
+				continue
+			}
+			if got.BasePath() != base {
+				t.Errorf("Resolve(%q) returned base path %q", base, got.BasePath())
+			}
+		}
+	})
+
+	// The whole point of the typed fetch error: an environment may publish its
+	// index and refuse its documents (an interactive-session-only SSO policy does
+	// exactly this), and that must degrade one row rather than break the feature.
+	// This test passes on a tenant that serves every document and on one that
+	// serves none.
+	t.Run("a specification either parses or fails with a typed error", func(t *testing.T) {
+		var parsed, unavailable int
+
+		for _, e := range reg.Entries {
+			if e.External() {
+				continue
+			}
+			spec, err := handler.Spec(e)
+			if err != nil {
+				var unavailableErr *resapi.SpecUnavailableError
+				if !errors.As(err, &unavailableErr) {
+					t.Errorf("Spec(%q) failed with an untyped error, so no caller can "+
+						"explain it: %v", e.Name, err)
+					continue
+				}
+				if unavailableErr.DocPath == "" {
+					t.Errorf("Spec(%q): the error does not name the document it could not read", e.Name)
+				}
+				unavailable++
+				continue
+			}
+			if spec == nil {
+				t.Errorf("Spec(%q) returned no error and no specification", e.Name)
+				continue
+			}
+			parsed++
+
+			for _, op := range spec.Operations {
+				id := op.ID()
+				method, path, found := strings.Cut(id, " ")
+				if !found || method != strings.ToUpper(method) || !strings.HasPrefix(path, "/") {
+					t.Errorf("%q: operation ID %q is not \"METHOD /path\", so it cannot be "+
+						"passed back to --operation", e.Name, id)
+				}
+			}
+		}
+
+		t.Logf("%d specifications parsed, %d unavailable", parsed, unavailable)
+		if parsed == 0 && unavailable == 0 {
+			t.Skip("no non-external specifications to check")
+		}
+	})
+}
+
+func TestAPIClassificationAgainstALiveEnvironment(t *testing.T) {
+	env := integration.SetupIntegration(t)
+	defer env.Cleanup.Cleanup(t)
+
+	handler := resapi.NewHandler(env.Client)
+
+	reg, err := handler.Registry()
+	if err != nil {
+		t.Skipf("environment publishes no API index: %v", err)
+	}
+
+	// The invariant that matters: whatever a specification says, a request is never
+	// gated *looser* than the HTTP method alone would justify. A DELETE cannot come
+	// out as a read because a document claimed a read scope.
+	t.Run("a specification can never loosen the method's floor", func(t *testing.T) {
+		strictness := map[safety.Operation]int{
+			safety.OperationRead:         0,
+			safety.OperationCreate:       1,
+			safety.OperationUpdate:       2,
+			safety.OperationDelete:       3,
+			safety.OperationDeleteBucket: 4,
+		}
+		floors := map[string]safety.Operation{
+			http.MethodGet:    safety.OperationRead,
+			http.MethodPost:   safety.OperationRead,
+			http.MethodPut:    safety.OperationUpdate,
+			http.MethodPatch:  safety.OperationUpdate,
+			http.MethodDelete: safety.OperationDelete,
+		}
+
+		checked := 0
+		for _, e := range reg.Entries {
+			if e.External() || e.BasePath() == "" {
+				continue
+			}
+			spec, err := handler.Spec(e)
+			if err != nil {
+				continue // covered by the discovery test; unavailability is not a failure
+			}
+			for i := range spec.Operations {
+				op := &spec.Operations[i]
+				method, path, found := strings.Cut(op.ID(), " ")
+				if !found {
+					continue
+				}
+				floor, known := floors[method]
+				if !known {
+					continue
+				}
+				requestPath := e.BasePath() + path
+				class := resapi.Classify(method, requestPath, e.Name, op)
+				if strictness[class.SafetyOp] < strictness[floor] {
+					t.Errorf("%s %s classified as %s, which is looser than the %s floor (%s)",
+						method, requestPath, class.SafetyOp, method, floor)
+				}
+				if class.Reason == "" {
+					t.Errorf("%s %s produced a verdict with no explanation", method, requestPath)
+				}
+				checked++
+			}
+		}
+		t.Logf("classified %d live operations", checked)
+	})
+
+	// A read is the one thing a passthrough must always be able to do, on any
+	// tenant, at the strictest safety level.
+	t.Run("a GET on any listed API is a read", func(t *testing.T) {
+		for _, e := range reg.Entries {
+			base := e.BasePath()
+			if base == "" {
+				continue
+			}
+			_, op := handler.ResolveForRequest(http.MethodGet, base)
+			class := resapi.Classify(http.MethodGet, base, e.Name, op)
+			if class.SafetyOp != safety.OperationRead {
+				t.Errorf("GET %s classified as %s: %s", base, class.SafetyOp, class.Reason)
+			}
+		}
+	})
+
+	// Coverage is dtctl's own claim about itself, so it must be checkable against a
+	// live index: a base path dtctl says it wraps has to actually be published, or
+	// the claim is stale.
+	t.Run("coverage claims match the live index", func(t *testing.T) {
+		published := map[string]bool{}
+		for _, e := range reg.Entries {
+			if b := e.BasePath(); b != "" {
+				published[b] = true
+			}
+		}
+		for base := range resapi.CoveredBasePaths() {
+			if !published[base] {
+				// Not a failure: coverage spans every tenant shape, and any one tenant
+				// may not run the service. It is worth surfacing, though, since a base
+				// path no tenant publishes is a candidate for removal.
+				t.Logf("note: coverage claims %s, which this environment does not publish", base)
+			}
+		}
+	})
+}
+
+// TestExecAPIPassthroughReadAgainstALiveEnvironment exercises the passthrough
+// end-to-end on a read, which is the only thing this test may safely do: a
+// generic-write E2E would need an endpoint that is harmless on every tenant, and
+// no such endpoint exists.
+func TestExecAPIPassthroughReadAgainstALiveEnvironment(t *testing.T) {
+	env := integration.SetupIntegration(t)
+	defer env.Cleanup.Cleanup(t)
+
+	handler := resapi.NewHandler(env.Client)
+
+	reg, err := handler.Registry()
+	if err != nil {
+		t.Skipf("environment publishes no API index: %v", err)
+	}
+
+	// Find a GET the specification declares a read scope for, on an API dtctl
+	// already wraps — so the endpoint is one this token is expected to reach.
+	var method, requestPath string
+	for _, e := range reg.Entries {
+		if e.External() || resapi.NativeResourceFor(e.BasePath()) == "" {
+			continue
+		}
+		spec, err := handler.Spec(e)
+		if err != nil {
+			continue
+		}
+		for i := range spec.Operations {
+			m, path, found := strings.Cut(spec.Operations[i].ID(), " ")
+			if !found || m != http.MethodGet || strings.Contains(path, "{") {
+				continue // skip templated paths: no id to substitute
+			}
+			method, requestPath = m, e.BasePath()+path
+			break
+		}
+		if requestPath != "" {
+			break
+		}
+	}
+	if requestPath == "" {
+		t.Skip("no un-templated GET on a natively covered API to exercise")
+	}
+
+	t.Logf("calling %s %s", method, requestPath)
+	resp, err := env.Client.HTTP().R().Execute(method, requestPath)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, requestPath, err)
+	}
+	if resp.StatusCode() >= 500 {
+		t.Fatalf("%s %s returned %d", method, requestPath, resp.StatusCode())
+	}
+	if resp.StatusCode() >= 400 {
+		// 401/403 is a token-scope property of the environment, not a dtctl defect.
+		t.Skipf("%s %s returned %d — the token does not reach this endpoint",
+			method, requestPath, resp.StatusCode())
+	}
+
+	_, op := handler.ResolveForRequest(method, requestPath)
+	if op == nil {
+		t.Errorf("the request succeeded but ResolveForRequest could not match it back to "+
+			"an operation, so exec api would gate it as a delete: %s %s", method, requestPath)
+	}
+}

--- a/test/e2e/extension_test.go
+++ b/test/e2e/extension_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 
@@ -20,7 +21,7 @@ func TestExtensionList(t *testing.T) {
 	handler := extension.NewHandler(env.Client)
 
 	t.Run("list all extensions", func(t *testing.T) {
-		result, err := handler.List("", 0)
+		result, err := handler.List(context.Background(), "", 0)
 		if err != nil {
 			t.Fatalf("Failed to list extensions: %v", err)
 		}
@@ -41,7 +42,7 @@ func TestExtensionList(t *testing.T) {
 
 	t.Run("list with name filter", func(t *testing.T) {
 		// Use a broad filter that should match at least some extensions
-		result, err := handler.List("com.dynatrace", 10)
+		result, err := handler.List(context.Background(), "com.dynatrace", 10)
 		if err != nil {
 			t.Fatalf("Failed to list extensions with filter: %v", err)
 		}
@@ -54,7 +55,7 @@ func TestExtensionList(t *testing.T) {
 
 	t.Run("list with pagination", func(t *testing.T) {
 		// Use small page size to exercise pagination
-		result, err := handler.List("", 2)
+		result, err := handler.List(context.Background(), "", 2)
 		if err != nil {
 			t.Fatalf("Failed to list extensions with pagination: %v", err)
 		}
@@ -72,7 +73,7 @@ func TestExtensionList(t *testing.T) {
 // Skips the test if no extensions are installed.
 func findFirstExtension(t *testing.T, handler *extension.Handler) extension.Extension {
 	t.Helper()
-	result, err := handler.List("", 0)
+	result, err := handler.List(context.Background(), "", 0)
 	if err != nil {
 		t.Fatalf("Failed to list extensions: %v", err)
 	}
@@ -167,7 +168,7 @@ func TestExtensionGetEnvironmentConfig(t *testing.T) {
 	handler := extension.NewHandler(env.Client)
 
 	// Find an extension with an active version (environment config only exists if a version is active)
-	result, err := handler.List("", 0)
+	result, err := handler.List(context.Background(), "", 0)
 	if err != nil {
 		t.Fatalf("Failed to list extensions: %v", err)
 	}
@@ -248,7 +249,7 @@ func TestMonitoringConfigurationLifecycle(t *testing.T) {
 	// Find an extension with an active version that accepts our generic fixture.
 	// Extensions like da-aws require cloud-provider-specific fields; we iterate
 	// until we find one that creates successfully, then use it for the lifecycle.
-	result, err := handler.List("", 0)
+	result, err := handler.List(context.Background(), "", 0)
 	if err != nil {
 		t.Fatalf("Failed to list extensions: %v", err)
 	}


### PR DESCRIPTION
## Why

dtctl wraps ~20 platform APIs natively; an environment publishes many more. That gap had no governed answer: reaching an unwrapped API meant `dtctl exec function --code` with ad-hoc JavaScript, which AppEngine runs with a bearer token — so the least governed path in the tool was also the most convenient one.

This adds discovery for what an environment actually publishes, and a passthrough that is gated by the same safety checker as every native mutating command.

## What

**Discovery**

```bash
dtctl get apis [--uncovered] [--ops-count]
dtctl describe api <name|base-path> [--operation 'METHOD /path'] [--raw]
```

- The listing mirrors the environment's **own** API index and filters nothing. A dtctl-side filter would have to hard-code which APIs to conceal, and in an open-source tool that list would itself be the disclosure. What an environment publishes is decided by whoever configures it.
- The `DTCTL` column names the native command that already covers an API, so `--uncovered` turns the platform-vs-dtctl gap into a contribution backlog.
- `describe api` **projects rather than dumps**: published specifications run to tens of thousands of tokens, so the default view is the operation index — every operation as `METHOD /path` with its summary and declared scope. Complete at a coarser grain, not truncated. `--operation` drills into one operation in full (parameters, body schema, responses, scopes, a ready-to-run invocation); `--raw` streams the document, spilling to a file in agent mode.
- Failures are typed and expected: an environment may publish the index and restrict the documents, which degrades one row instead of breaking the listing.

**Passthrough**

```bash
dtctl exec api <path> [-X METHOD] [-d BODY|@file|@-] [-H 'Name: value'] [--dry-run]
```

The safety operation is resolved from the API's own specification, **never from the HTTP method** — the load-bearing decision here. A sweep of one production index found **15 POST operations across three APIs that declare only a read scope** (verification, validation, and search endpoints that are POSTs purely because they take a body), while a POST elsewhere deletes stored records. A method-keyed gate would refuse the reads in a `readonly` context and wave the delete through as a create.

So the verdict is the stricter of two independent floors — what the method guarantees, and what the specification declares — and neither source can weaken the other. An unresolvable request is gated as a **delete**, and there is deliberately no flag to assert otherwise. One curated table escalates irreversible endpoints whose destructiveness a URL cannot convey (bucket delete/truncate, record deletion), so the passthrough is never a weaker gate than the command it shadows.

**The escape hatch is built to stay one.** It is unadvertised — hidden from `--help` and from the compact catalogs an agent bootstraps from, present in `dtctl commands --full` for a caller who goes looking — it names the native command whenever one covers the path, no command profile grants it, and the help text says outright that scripting against it means the API wants a native command instead.

## Also in here

- **`fix(exec)`: every `exec` subcommand now gates on the safety level.** The catalog declared `exec: OperationCreate` while every subcommand used the ungated `SetupClient()`, so a `readonly` context did **not** block `dtctl exec function --code '…'`. Each subcommand now uses the operation matching what it actually does (read for analyses/previews, create for a workflow run, delete for ad-hoc code). A new guard asserts the direction the existing one could not: every command file under a mutating verb that builds a client must also perform a safety check.
- `--check-scopes` gains a third verdict. `exec api` has no static scope, so an explicit check resolves it from the specification, while the agent-mode auto-preflight (which runs ahead of every command and must stay free) reports it as unknown rather than as "no scopes required".
- A **refused** API index no longer reports itself as an **absent** one — a 401 is a fact about the credential, not about the environment.
- `fix(test)`: the `-tags integration` build did not compile (six `handler.List` calls missing a `context.Context`), so no E2E test was runnable at all.

## Testing

- Unit + guard tests: spec parsing (YAML and the classic JSON spec through one parser, `$ref`s, path templating), scope classification, both floors and the escalation table, command behavior (method-does-not-decide-the-gate, unresolved → delete, no undercutting, absolute-URL and method refusals, the `vfs` and stdin seams, dry-run redaction, output protocol), plus catalog/profile conventions.
- 11 new golden files across both resources and six formats.
- Live E2E (`test/e2e/api_test.go`, `integration`) verified against two environments: every assertion is derived from what the environment publishes, never from a list of expected APIs — a fixture list would be both a leak and a bug, since the index is a property of the environment.
- `go test ./...` green in both modules, `go vet` clean, `gofmt` clean, no new lint findings.

## Disclosure

No committed artifact names a non-public API: help text, examples, golden files, and E2E fixtures are synthetic; the stability warning is phrased in terms of the public `/platform/` tree rather than naming any prefix; resolution never synthesizes a candidate path from a name, which would turn a name lookup into an existence oracle. The full rule set is in `docs/dev/GENERIC_API_ACCESS.md`.

## Docs

- `docs/dev/GENERIC_API_ACCESS.md` — design, rationale, conventions, disclosure rules
- `docs/site/_docs/api-discovery.md` — user-facing guide (+ nav, command reference, README)
- `AGENTS.md`, `docs/dev/IMPLEMENTATION_STATUS.md` — conventions and status
