### PR TITLE
chore: bump Go toolchain to 1.26.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Get version info
         id: version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Check goimports formatting
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Import pkg/engine from a module outside this repo
         env:
@@ -168,7 +168,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.26.5']
+        go: ['1.26.6']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Check for forbidden dependencies
         run: make sdk-check-deps

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.26.5']
+        go: ['1.26.6']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynatrace-oss/dtctl
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/adrg/xdg v0.5.3


### PR DESCRIPTION
## Why

The nightly Security workflow started failing on `main` (first failure: 2026-08-14 02:57 UTC run): govulncheck flags **seven Go standard-library vulnerabilities** present in go1.26.5 and fixed in go1.26.6 — `net/http`, `encoding/xml`, `encoding/asn1`, and `x/net/idna` (GO-2026-5026, GO-2026-5972, GO-2026-6088, and friends). Every branch fails the scan until the toolchain moves, including unrelated PRs.

## What

- `go.mod`: `go 1.26.5` → `go 1.26.6`
- Every workflow `go-version` pin (build, test, sdk, lint, release, security): `1.26.5` → `1.26.6`
- `sdk/go.mod` deliberately stays at its lower minimum — it states the oldest Go an SDK **consumer** may use, and CI builds the SDK with the workflow toolchain anyway.

## Verification

Under go1.26.6 locally: `go build ./...`, `go test ./...` in both modules, and `govulncheck ./...` now reports **no called vulnerabilities** (one import-level finding remains, not called, which govulncheck does not fail on).