### PR TITLE
fix(settings): implement --validate-only for delete settings as GET check

### DIFF
--- a/cmd/delete_settings_test.go
+++ b/cmd/delete_settings_test.go
@@ -13,18 +13,18 @@ func TestDeleteSettingsValidateOnly_Success(t *testing.T) {
 
 	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
 		"/platform/classic/environment-api/v2/settings/objects/" + objectID: func(w http.ResponseWriter, r *http.Request) {
-			switch r.Method {
-			case http.MethodGet:
+			if r.Method == http.MethodDelete {
+				t.Errorf("unexpected DELETE — validate-only must not delete")
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if r.Method == http.MethodGet {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"objectId":"` + objectID + `","schemaVersion":"1.0","summary":"Test"}`))
-			case http.MethodDelete:
-				if r.URL.Query().Get("validateOnly") != "true" {
-					t.Errorf("expected validateOnly=true, got %q", r.URL.Query().Get("validateOnly"))
-				}
-				w.WriteHeader(http.StatusNoContent)
-			default:
-				t.Errorf("unexpected method %s", r.Method)
+				return
 			}
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
 		},
 	})
 	defer ms.Close()
@@ -53,15 +53,44 @@ func TestDeleteSettingsValidateOnly_ValidationFailed(t *testing.T) {
 	const objectID = "test-obj-delete-validate-fail"
 
 	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		// GET returns 404 — object is not reachable.
 		"/platform/classic/environment-api/v2/settings/objects/" + objectID: func(w http.ResponseWriter, r *http.Request) {
-			switch r.Method {
-			case http.MethodGet:
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"objectId":"` + objectID + `","schemaVersion":"1.0"}`))
-			case http.MethodDelete:
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write([]byte(`{"error": {"code": 400, "message": "deletion not allowed"}}`))
-			}
+			w.WriteHeader(http.StatusNotFound)
+		},
+	})
+	defer ms.Close()
+
+	configPath, cleanup := testutil.SetupTestConfig(t, ms.URL)
+	defer cleanup()
+
+	origCfgFile := cfgFile
+	origPlain := plainMode
+	defer func() {
+		cfgFile = origCfgFile
+		plainMode = origPlain
+	}()
+	cfgFile = configPath
+	plainMode = true
+
+	testutil.ResetCommandFlags(deleteSettingsCmd)
+	_ = deleteSettingsCmd.Flags().Set("validate-only", "true")
+
+	err := deleteSettingsCmd.RunE(deleteSettingsCmd, []string{objectID})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "validation failed") {
+		t.Errorf("expected error containing 'validation failed', got %q", err.Error())
+	}
+}
+
+func TestDeleteSettingsValidateOnly_ObjectNotReachable(t *testing.T) {
+	const objectID = "test-obj-delete-validate-forbidden"
+
+	ms := testutil.NewMockServer(t, map[string]http.HandlerFunc{
+		// GET returns 403 — object exists but is not reachable.
+		"/platform/classic/environment-api/v2/settings/objects/" + objectID: func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
 		},
 	})
 	defer ms.Close()

--- a/cmd/get_settings.go
+++ b/cmd/get_settings.go
@@ -122,7 +122,7 @@ Examples:
   # Delete without confirmation
   dtctl delete settings <object-id> -y
 
-  # Validate deletion against the API without deleting
+  # Check the object exists and is reachable without deleting it
   dtctl delete settings <object-id> --validate-only
 `,
 	Aliases: []string{"setting"},
@@ -185,5 +185,5 @@ func init() {
 
 	// Delete settings flags
 	deleteSettingsCmd.Flags().BoolVarP(&forceDelete, "yes", "y", false, "Skip confirmation prompt")
-	deleteSettingsCmd.Flags().Bool("validate-only", false, "validate the deletion against the API without deleting")
+	deleteSettingsCmd.Flags().Bool("validate-only", false, "check the object exists and is reachable; no deletion occurs")
 }

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2263,7 +2263,7 @@ dtctl delete settings aaaaaaaa-bbbb-cccc-dddd-000000000001
 # Delete without confirmation
 dtctl delete settings aaaaaaaa-bbbb-cccc-dddd-000000000001 -y
 
-# Validate deletion against the API without deleting
+# Check the object exists and is reachable (no deletion occurs)
 dtctl delete settings aaaaaaaa-bbbb-cccc-dddd-000000000001 --validate-only
 ```
 

--- a/pkg/resources/settings/handler_test.go
+++ b/pkg/resources/settings/handler_test.go
@@ -572,15 +572,18 @@ func TestValidateCreate_ValidationFailed(t *testing.T) {
 func TestValidateDelete_Success(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/obj-to-validate-delete", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			t.Errorf("unexpected DELETE — validate-only must not delete")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		if r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(SettingsObject{ObjectID: "obj-to-validate-delete", SchemaVersion: "1"})
-		} else if r.Method == http.MethodDelete {
-			if r.URL.Query().Get("validateOnly") != "true" {
-				t.Error("expected validateOnly=true query param")
-			}
-			w.WriteHeader(http.StatusNoContent)
+			return
 		}
+		t.Errorf("unexpected method %s", r.Method)
+		w.WriteHeader(http.StatusMethodNotAllowed)
 	})
 	h, cleanup := newTestHandler(t, mux)
 	defer cleanup()
@@ -593,14 +596,9 @@ func TestValidateDelete_Success(t *testing.T) {
 
 func TestValidateDelete_ValidationFailed(t *testing.T) {
 	mux := http.NewServeMux()
+	// GET returns 404 — object is not reachable.
 	mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/obj-validate-fail", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(SettingsObject{ObjectID: "obj-validate-fail", SchemaVersion: "1"})
-		} else if r.Method == http.MethodDelete {
-			w.WriteHeader(http.StatusBadRequest)
-			fmt.Fprint(w, "deletion not allowed")
-		}
+		w.WriteHeader(http.StatusNotFound)
 	})
 	h, cleanup := newTestHandler(t, mux)
 	defer cleanup()
@@ -611,7 +609,7 @@ func TestValidateDelete_ValidationFailed(t *testing.T) {
 	}
 }
 
-func TestValidateDelete_GetFails(t *testing.T) {
+func TestValidateDelete_NotFound(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/not-found-obj", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -621,7 +619,21 @@ func TestValidateDelete_GetFails(t *testing.T) {
 
 	err := h.ValidateDelete("not-found-obj")
 	if err == nil {
-		t.Fatal("expected error from Get, got nil")
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestValidateDelete_Forbidden(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/classic/environment-api/v2/settings/objects/forbidden-obj", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	h, cleanup := newTestHandler(t, mux)
+	defer cleanup()
+
+	err := h.ValidateDelete("forbidden-obj")
+	if err == nil {
+		t.Fatal("expected error for forbidden object, got nil")
 	}
 }
 

--- a/pkg/resources/settings/settings.go
+++ b/pkg/resources/settings/settings.go
@@ -209,14 +209,11 @@ func (h *Handler) Update(objectID string, value map[string]any) (*SettingsObject
 	return h.Get(obj.ObjectID)
 }
 
-// ValidateDelete validates a settings object deletion without applying it.
-// Auto-fetches the current schemaVersion for the If-Match header.
+// ValidateDelete checks that the settings object is reachable without deleting it.
+// It returns an error if the object cannot be fetched (e.g., not found, forbidden).
 func (h *Handler) ValidateDelete(objectID string) error {
-	obj, err := h.sdk.Get(context.Background(), objectID)
-	if err != nil {
-		return err
-	}
-	return h.sdk.ValidateDelete(context.Background(), objectID, obj.SchemaVersion)
+	_, err := h.Get(objectID)
+	return err
 }
 
 // Delete deletes a settings object.

--- a/sdk/api/settings/settings.go
+++ b/sdk/api/settings/settings.go
@@ -302,23 +302,6 @@ func (h *Handler) Update(ctx context.Context, objectID, schemaVersion string, va
 	return nil
 }
 
-// ValidateDelete validates a settings object deletion without applying it.
-// The schemaVersion is used for the If-Match header (obtain it from Get).
-func (h *Handler) ValidateDelete(ctx context.Context, objectID, schemaVersion string) error {
-	resp, err := h.client.HTTP().R().SetContext(ctx).
-		SetHeader("If-Match", schemaVersion).
-		SetQueryParam("validateOnly", "true").
-		Delete(fmt.Sprintf("/platform/classic/environment-api/v2/settings/objects/%s", objectID))
-	if err != nil {
-		return fmt.Errorf("validate settings object %q deletion: %w", objectID, err)
-	}
-	if err := httpclient.CheckResponse(resp); err != nil {
-		return fmt.Errorf("validate settings object %q deletion: %w", objectID, err)
-	}
-
-	return nil
-}
-
 // Delete deletes a settings object.
 // The schemaVersion is used for the If-Match header (obtain it from Get).
 func (h *Handler) Delete(ctx context.Context, objectID, schemaVersion string) error {


### PR DESCRIPTION
## Summary

- **Bug**: `dtctl delete settings '<id>' --validate-only` was silently performing a real DELETE because the Dynatrace Settings API does not support `validateOnly` on DELETE requests.
- **Fix**: `--validate-only` now issues a GET instead. If the object is reachable, validation passes. If it returns 404 or 403, the error is surfaced. No deletion ever occurs.
- The SDK's `ValidateDelete` function (which sent `DELETE ?validateOnly=true`) is removed. The CLI handler now calls `h.Get(objectID)` and surfaces any error.

## Test plan

- [x] `TestValidateDelete_Success` — GET returns 200; DELETE guard asserts no delete happens
- [x] `TestValidateDelete_ValidationFailed` — GET returns 404; error is non-nil
- [x] `TestValidateDelete_NotFound` — GET returns 404; error is non-nil
- [x] `TestValidateDelete_Forbidden` — GET returns 403; error is non-nil
- [x] `TestDeleteSettingsValidateOnly_Success` — end-to-end: GET 200, DELETE guard, command returns nil
- [x] `TestDeleteSettingsValidateOnly_ValidationFailed` — GET 404, error contains "validation failed"
- [x] `TestDeleteSettingsValidateOnly_ObjectNotReachable` — GET 403, error contains "validation failed"

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)