### PR TITLE
feat(document): add opt-in --create-snapshot to document updates

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -170,6 +170,10 @@ resources in sync with their file definitions.
 			return err
 		}
 
+		if err := validateSnapshotFlags(cmd); err != nil {
+			return err
+		}
+
 		// Read the file
 		fileData, err := vfs.ReadFile(file)
 		if err != nil {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -85,6 +85,18 @@ Custom document types (--type):
 
     dtctl apply -f doc.yaml --label team-a --label env:prod
 
+Version history (--create-snapshot):
+  Document updates overwrite content in place. Pass --create-snapshot to have the
+  API keep the pre-update state as a snapshot first, so it stays recoverable with
+  'dtctl history document' and 'dtctl restore document':
+
+    dtctl apply -f doc.yaml --create-snapshot
+    dtctl apply -f doc.yaml --create-snapshot --snapshot-description "before Q3 rework"
+
+  The flag applies to documents only and is a no-op when the document is created
+  rather than updated. The API keeps at most 50 snapshots per document and rejects
+  more than 5 snapshots per document per minute, so avoid it in tight apply loops.
+
 Array input (bulk apply):
   Files containing an array of resources (e.g., from 'dtctl get settings --schema ...
   -o yaml') are applied element-by-element. Partial failures do not abort the batch;
@@ -150,6 +162,8 @@ resources in sync with their file definitions.
 		writeID, _ := cmd.Flags().GetBool("write-id")
 		docType, _ := cmd.Flags().GetString("type")
 		labels, _ := cmd.Flags().GetStringArray("label")
+		createSnapshot, _ := cmd.Flags().GetBool("create-snapshot")
+		snapshotDescription, _ := cmd.Flags().GetString("snapshot-description")
 		shareEnvironment, _ := cmd.Flags().GetString("share-environment")
 
 		if err := validateShareEnvironmentValue(shareEnvironment); err != nil {
@@ -219,13 +233,15 @@ resources in sync with their file definitions.
 
 		// Apply the resource
 		opts := apply.ApplyOptions{
-			TemplateVars: templateVars,
-			DryRun:       dryRun,
-			ShowDiff:     showDiff,
-			OverrideID:   overrideID,
-			WriteID:      writeID,
-			Type:         docType,
-			Labels:       labels,
+			TemplateVars:        templateVars,
+			DryRun:              dryRun,
+			ShowDiff:            showDiff,
+			OverrideID:          overrideID,
+			WriteID:             writeID,
+			Type:                docType,
+			Labels:              labels,
+			CreateSnapshot:      createSnapshot,
+			SnapshotDescription: snapshotDescription,
 		}
 
 		results, applyErr := applier.Apply(fileData, opts)
@@ -303,6 +319,8 @@ func init() {
 	applyCmd.Flags().Bool("write-id", false, "write the created resource ID back into the source file for idempotent future applies")
 	applyCmd.Flags().String("type", "", "document type (e.g. launchpad, acme:config); forces the file to be applied as a document of this type")
 	applyCmd.Flags().StringArray("label", []string{}, "document classification label (repeatable); replaces the document's labels, overriding any in the payload (labels cannot be cleared, only replaced)")
+	applyCmd.Flags().Bool("create-snapshot", false, "snapshot the document's current state before updating it, so the previous version stays available via 'dtctl history'/'dtctl restore' (documents only)")
+	applyCmd.Flags().String("snapshot-description", "", "description for the snapshot created by --create-snapshot (max 128 characters)")
 	applyCmd.Flags().String("share-environment", "", "share the applied notebook/dashboard with everyone in the environment (values: 'read' or 'read-write'; bare --share-environment defaults to 'read')")
 	applyCmd.Flags().Lookup("share-environment").NoOptDefVal = "read"
 

--- a/cmd/document_snapshot_flags.go
+++ b/cmd/document_snapshot_flags.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// validateSnapshotFlags rejects --snapshot-description without --create-snapshot.
+// The description is inert on its own (the API only reads it alongside the
+// create-snapshot parameter), and silently dropping it would leave the user
+// without the snapshot they were trying to label.
+func validateSnapshotFlags(cmd *cobra.Command) error {
+	createSnapshot, _ := cmd.Flags().GetBool("create-snapshot")
+	snapshotDescription, _ := cmd.Flags().GetString("snapshot-description")
+	if snapshotDescription != "" && !createSnapshot {
+		return fmt.Errorf("--snapshot-description requires --create-snapshot")
+	}
+	return nil
+}

--- a/cmd/document_snapshot_flags_test.go
+++ b/cmd/document_snapshot_flags_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestSnapshotFlagsRegistered ensures every document write path offers the
+// opt-in snapshot flags, so 'dtctl history'/'dtctl restore' stay usable no
+// matter which command performed the update.
+func TestSnapshotFlagsRegistered(t *testing.T) {
+	commands := map[string]*cobra.Command{
+		"apply":           applyCmd,
+		"update document": updateDocumentCmd,
+		"edit dashboard":  editDashboardCmd,
+		"edit notebook":   editNotebookCmd,
+		"edit document":   editDocumentCmd,
+	}
+
+	for name, c := range commands {
+		f := c.Flags().Lookup("create-snapshot")
+		if f == nil {
+			t.Errorf("%s is missing the --create-snapshot flag", name)
+			continue
+		}
+		if f.Value.Type() != "bool" {
+			t.Errorf("%s: --create-snapshot is %q, want bool", name, f.Value.Type())
+		}
+		if f.DefValue != "false" {
+			t.Errorf("%s: --create-snapshot defaults to %q, want false (snapshots are opt-in)", name, f.DefValue)
+		}
+		if d := c.Flags().Lookup("snapshot-description"); d == nil {
+			t.Errorf("%s is missing the --snapshot-description flag", name)
+		}
+	}
+}
+
+// TestEditUpdateRequest_SnapshotOptIn covers the flag → request mapping used by
+// the edit commands, including the default (no snapshot) case.
+func TestEditUpdateRequest_SnapshotOptIn(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		c := &cobra.Command{Use: "edit"}
+		c.Flags().Bool("create-snapshot", false, "")
+		c.Flags().String("snapshot-description", "", "")
+		return c
+	}
+
+	c := newCmd()
+	req := editUpdateRequest(c, []byte(`{"k":"v"}`))
+	if req.CreateSnapshot {
+		t.Error("expected no snapshot without --create-snapshot")
+	}
+	if req.ContentType != "application/json" {
+		t.Errorf("ContentType = %q, want application/json", req.ContentType)
+	}
+	if string(req.Content) != `{"k":"v"}` {
+		t.Errorf("Content = %q, want the edited payload", req.Content)
+	}
+
+	c = newCmd()
+	_ = c.Flags().Set("create-snapshot", "true")
+	_ = c.Flags().Set("snapshot-description", "before Q3 rework")
+	req = editUpdateRequest(c, []byte(`{}`))
+	if !req.CreateSnapshot {
+		t.Error("expected CreateSnapshot with --create-snapshot")
+	}
+	if req.SnapshotDescription != "before Q3 rework" {
+		t.Errorf("SnapshotDescription = %q, want 'before Q3 rework'", req.SnapshotDescription)
+	}
+}

--- a/cmd/document_snapshot_flags_test.go
+++ b/cmd/document_snapshot_flags_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -67,5 +68,115 @@ func TestEditUpdateRequest_SnapshotOptIn(t *testing.T) {
 	}
 	if req.SnapshotDescription != "before Q3 rework" {
 		t.Errorf("SnapshotDescription = %q, want 'before Q3 rework'", req.SnapshotDescription)
+	}
+}
+
+// TestValidateSnapshotFlags pins the dependency between the two flags: a
+// description on its own would otherwise be dropped silently, leaving the user
+// with neither a snapshot nor a warning.
+func TestValidateSnapshotFlags(t *testing.T) {
+	tests := []struct {
+		name           string
+		createSnapshot bool
+		description    string
+		wantErr        bool
+	}{
+		{name: "neither flag", wantErr: false},
+		{name: "flag alone", createSnapshot: true, wantErr: false},
+		{name: "flag with description", createSnapshot: true, description: "before Q3 rework", wantErr: false},
+		{name: "orphaned description", description: "before Q3 rework", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cobra.Command{Use: "x"}
+			c.Flags().Bool("create-snapshot", false, "")
+			c.Flags().String("snapshot-description", "", "")
+			if tt.createSnapshot {
+				_ = c.Flags().Set("create-snapshot", "true")
+			}
+			if tt.description != "" {
+				_ = c.Flags().Set("snapshot-description", tt.description)
+			}
+
+			err := validateSnapshotFlags(c)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error for a description without --create-snapshot")
+				}
+				if !strings.Contains(err.Error(), "--snapshot-description requires --create-snapshot") {
+					t.Errorf("error = %v, want it to name both flags", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestEditCommandsValidateSnapshotFlags ensures the edit commands reject an
+// orphaned description before the editor opens, not after the user has already
+// written their changes.
+func TestEditCommandsValidateSnapshotFlags(t *testing.T) {
+	for name, c := range map[string]*cobra.Command{
+		"edit dashboard": editDashboardCmd,
+		"edit notebook":  editNotebookCmd,
+		"edit document":  editDocumentCmd,
+	} {
+		if c.PreRunE == nil {
+			t.Errorf("%s has no PreRunE to validate the snapshot flags", name)
+			continue
+		}
+
+		t.Cleanup(func() { _ = c.Flags().Set("snapshot-description", "") })
+		if err := c.Flags().Set("snapshot-description", "orphaned"); err != nil {
+			t.Fatalf("%s: setting the flag: %v", name, err)
+		}
+		if err := c.PreRunE(c, []string{"doc-1"}); err == nil {
+			t.Errorf("%s accepted --snapshot-description without --create-snapshot", name)
+		}
+		_ = c.Flags().Set("snapshot-description", "")
+	}
+}
+
+// TestSnapshotFlagsValidatedBeforeIO checks the file-driven commands reject the
+// orphaned description up front — before reading the file or loading config.
+func TestSnapshotFlagsValidatedBeforeIO(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		args []string
+	}{
+		{
+			name: "update document",
+			cmd:  updateDocumentCmd,
+			args: []string{"update", "document", "-f", "does-not-exist.yaml", "--snapshot-description", "orphaned"},
+		},
+		{
+			name: "apply",
+			cmd:  applyCmd,
+			args: []string{"apply", "-f", "does-not-exist.yaml", "--snapshot-description", "orphaned"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				rootCmd.SetArgs(nil)
+				_ = tt.cmd.Flags().Set("snapshot-description", "")
+				_ = tt.cmd.Flags().Set("file", "")
+			})
+
+			rootCmd.SetArgs(tt.args)
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatal("expected an error for a description without --create-snapshot")
+			}
+			if !strings.Contains(err.Error(), "--snapshot-description requires --create-snapshot") {
+				t.Errorf("error = %v, want the flag-dependency error (not a file/config error)", err)
+			}
+		})
 	}
 }

--- a/cmd/edit_documents.go
+++ b/cmd/edit_documents.go
@@ -503,5 +503,8 @@ func init() {
 		c.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
 		c.Flags().Bool("create-snapshot", false, "snapshot the current content before saving the edit, so the previous version stays available via 'dtctl history'/'dtctl restore'")
 		c.Flags().String("snapshot-description", "", "description for the snapshot created by --create-snapshot (max 128 characters)")
+		// Reject an orphaned --snapshot-description before the editor opens,
+		// rather than after the user has already written their changes.
+		c.PreRunE = func(cmd *cobra.Command, _ []string) error { return validateSnapshotFlags(cmd) }
 	}
 }

--- a/cmd/edit_documents.go
+++ b/cmd/edit_documents.go
@@ -15,6 +15,20 @@ import (
 	"github.com/dynatrace-oss/dtctl/pkg/util/format"
 )
 
+// editUpdateRequest builds the update request for an interactive edit. Snapshot
+// creation is opt-in: without --create-snapshot the edit overwrites the document
+// in place, matching the behavior of every other dtctl write path.
+func editUpdateRequest(cmd *cobra.Command, content []byte) document.UpdateRequest {
+	createSnapshot, _ := cmd.Flags().GetBool("create-snapshot")
+	snapshotDescription, _ := cmd.Flags().GetString("snapshot-description")
+	return document.UpdateRequest{
+		Content:             content,
+		ContentType:         "application/json",
+		CreateSnapshot:      createSnapshot,
+		SnapshotDescription: snapshotDescription,
+	}
+}
+
 // editDashboardCmd edits a dashboard
 var editDashboardCmd = &cobra.Command{
 	Use:     "dashboard <dashboard-id-or-name>",
@@ -28,6 +42,9 @@ defaults to vim), and updated when you save and close the editor.
 By default, resources are edited in YAML format for better readability.
 Use --format=json to edit in JSON format.
 
+Saving overwrites the current content. Pass --create-snapshot to keep the
+pre-edit state as a snapshot, recoverable via 'dtctl history' and 'dtctl restore'.
+
 Examples:
   # Edit a dashboard in YAML (default)
   dtctl edit dashboard <dashboard-id>
@@ -35,6 +52,9 @@ Examples:
 
   # Edit a dashboard in JSON
   dtctl edit dashboard <dashboard-id> --format=json
+
+  # Keep the pre-edit content as a snapshot
+  dtctl edit dashboard <dashboard-id> --create-snapshot
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -158,7 +178,7 @@ Examples:
 		}
 
 		// Update the dashboard
-		result, err := handler.Update(dashboardID, metadata.Version, jsonData, "application/json")
+		result, err := handler.UpdateDocument(dashboardID, metadata.Version, editUpdateRequest(cmd, jsonData))
 		if err != nil {
 			return err
 		}
@@ -181,6 +201,9 @@ defaults to vim), and updated when you save and close the editor.
 By default, resources are edited in YAML format for better readability.
 Use --format=json to edit in JSON format.
 
+Saving overwrites the current content. Pass --create-snapshot to keep the
+pre-edit state as a snapshot, recoverable via 'dtctl history' and 'dtctl restore'.
+
 Examples:
   # Edit a notebook in YAML (default)
   dtctl edit notebook <notebook-id>
@@ -188,6 +211,9 @@ Examples:
 
   # Edit a notebook in JSON
   dtctl edit notebook <notebook-id> --format=json
+
+  # Keep the pre-edit content as a snapshot
+  dtctl edit notebook <notebook-id> --create-snapshot
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -307,7 +333,7 @@ Examples:
 		}
 
 		// Update the notebook
-		result, err := handler.Update(notebookID, metadata.Version, jsonData, "application/json")
+		result, err := handler.UpdateDocument(notebookID, metadata.Version, editUpdateRequest(cmd, jsonData))
 		if err != nil {
 			return err
 		}
@@ -332,6 +358,9 @@ defaults to vim), and updated when you save and close the editor.
 By default, resources are edited in YAML format for better readability.
 Use --format=json to edit in JSON format.
 
+Saving overwrites the current content. Pass --create-snapshot to keep the
+pre-edit state as a snapshot, recoverable via 'dtctl history' and 'dtctl restore'.
+
 Examples:
   # Edit a document in YAML (default)
   dtctl edit document <document-id>
@@ -339,6 +368,9 @@ Examples:
 
   # Edit a document in JSON
   dtctl edit document <document-id> --format=json
+
+  # Keep the pre-edit content as a snapshot
+  dtctl edit document <document-id> --create-snapshot
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -456,7 +488,7 @@ Examples:
 		}
 
 		// Update the document
-		result, err := handler.Update(documentID, metadata.Version, jsonData, "application/json")
+		result, err := handler.UpdateDocument(documentID, metadata.Version, editUpdateRequest(cmd, jsonData))
 		if err != nil {
 			return err
 		}
@@ -467,7 +499,9 @@ Examples:
 }
 
 func init() {
-	editDashboardCmd.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
-	editNotebookCmd.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
-	editDocumentCmd.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
+	for _, c := range []*cobra.Command{editDashboardCmd, editNotebookCmd, editDocumentCmd} {
+		c.Flags().StringP("format", "", "yaml", "edit format (yaml|json)")
+		c.Flags().Bool("create-snapshot", false, "snapshot the current content before saving the edit, so the previous version stays available via 'dtctl history'/'dtctl restore'")
+		c.Flags().String("snapshot-description", "", "description for the snapshot created by --create-snapshot (max 128 characters)")
+	}
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -76,8 +76,10 @@ var historyDashboardCmd = &cobra.Command{
 	Short:   "Show version history of a dashboard",
 	Long: `Show the version history (snapshots) of a dashboard.
 
-Snapshots are created when updating a document with the create-snapshot option.
-Each snapshot captures the document's content at a specific point in time.
+Snapshots are not kept automatically: pass --create-snapshot when updating a
+document ('dtctl update document', 'dtctl apply', 'dtctl edit') to capture its
+content before the update overwrites it. Restoring also snapshots the current
+state first, so a restore is always reversible.
 
 Examples:
   # Show version history by ID
@@ -128,8 +130,10 @@ var historyNotebookCmd = &cobra.Command{
 	Short:   "Show version history of a notebook",
 	Long: `Show the version history (snapshots) of a notebook.
 
-Snapshots are created when updating a document with the create-snapshot option.
-Each snapshot captures the document's content at a specific point in time.
+Snapshots are not kept automatically: pass --create-snapshot when updating a
+document ('dtctl update document', 'dtctl apply', 'dtctl edit') to capture its
+content before the update overwrites it. Restoring also snapshots the current
+state first, so a restore is always reversible.
 
 Examples:
   # Show version history by ID
@@ -182,8 +186,10 @@ var historyDocumentCmd = &cobra.Command{
 
 Works for any document type (dashboard, notebook, launchpad, custom app documents, etc.).
 
-Snapshots are created when updating a document with the create-snapshot option.
-Each snapshot captures the document's content at a specific point in time.
+Snapshots are not kept automatically: pass --create-snapshot when updating a
+document ('dtctl update document', 'dtctl apply', 'dtctl edit') to capture its
+content before the update overwrites it. Restoring also snapshots the current
+state first, so a restore is always reversible.
 
 Examples:
   # Show version history by ID

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -79,7 +79,7 @@ var historyDashboardCmd = &cobra.Command{
 Snapshots are not kept automatically: pass --create-snapshot when updating a
 document ('dtctl update document', 'dtctl apply', 'dtctl edit') to capture its
 content before the update overwrites it. Restoring also snapshots the current
-state first, so a restore is always reversible.
+state first (if one doesn't exist), so a restore is normally reversible.
 
 Examples:
   # Show version history by ID
@@ -116,6 +116,9 @@ Examples:
 
 		if len(snapshots.Snapshots) == 0 {
 			fmt.Println("No snapshots found for this dashboard")
+			if !plainMode {
+				fmt.Println("Snapshots are opt-in: pass --create-snapshot when updating to capture the pre-update content")
+			}
 			return nil
 		}
 
@@ -133,7 +136,7 @@ var historyNotebookCmd = &cobra.Command{
 Snapshots are not kept automatically: pass --create-snapshot when updating a
 document ('dtctl update document', 'dtctl apply', 'dtctl edit') to capture its
 content before the update overwrites it. Restoring also snapshots the current
-state first, so a restore is always reversible.
+state first (if one doesn't exist), so a restore is normally reversible.
 
 Examples:
   # Show version history by ID
@@ -170,6 +173,9 @@ Examples:
 
 		if len(snapshots.Snapshots) == 0 {
 			fmt.Println("No snapshots found for this notebook")
+			if !plainMode {
+				fmt.Println("Snapshots are opt-in: pass --create-snapshot when updating to capture the pre-update content")
+			}
 			return nil
 		}
 
@@ -189,7 +195,7 @@ Works for any document type (dashboard, notebook, launchpad, custom app document
 Snapshots are not kept automatically: pass --create-snapshot when updating a
 document ('dtctl update document', 'dtctl apply', 'dtctl edit') to capture its
 content before the update overwrites it. Restoring also snapshots the current
-state first, so a restore is always reversible.
+state first (if one doesn't exist), so a restore is normally reversible.
 
 Examples:
   # Show version history by ID
@@ -226,6 +232,9 @@ Examples:
 
 		if len(snapshots.Snapshots) == 0 {
 			fmt.Println("No snapshots found for this document")
+			if !plainMode {
+				fmt.Println("Snapshots are opt-in: pass --create-snapshot when updating to capture the pre-update content")
+			}
 			return nil
 		}
 

--- a/cmd/update_documents.go
+++ b/cmd/update_documents.go
@@ -42,6 +42,11 @@ Labels are set with repeatable --label flags, or carried in the payload under a
 replaces the document's entire label set; omitting them leaves labels unchanged.
 Labels cannot be cleared, only replaced.
 
+Updates overwrite the document's content in place. Pass --create-snapshot to keep
+the pre-update state as a snapshot, recoverable via 'dtctl history document' and
+'dtctl restore document'. The API keeps at most 50 snapshots per document and
+allows at most 5 per document per minute.
+
 Examples:
   # Round-trip update (type and id come from the exported file)
   dtctl update document -f doc.yaml
@@ -57,6 +62,12 @@ Examples:
 
   # Show what changed
   dtctl update document -f doc.yaml --show-diff
+
+  # Keep the previous content as a snapshot before overwriting it
+  dtctl update document -f doc.yaml --create-snapshot
+
+  # Snapshot with a description
+  dtctl update document -f doc.yaml --create-snapshot --snapshot-description "before Q3 rework"
 
 See also:
   dtctl create document --help   # create a new document of any type
@@ -82,6 +93,8 @@ func updateDocumentRunE(cmd *cobra.Command, _ []string) error {
 	labels, _ := cmd.Flags().GetStringArray("label")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	showDiff, _ := cmd.Flags().GetBool("show-diff")
+	createSnapshot, _ := cmd.Flags().GetBool("create-snapshot")
+	snapshotDescription, _ := cmd.Flags().GetString("snapshot-description")
 
 	fileData, err := vfs.ReadFile(file)
 	if err != nil {
@@ -115,13 +128,15 @@ func updateDocumentRunE(cmd *cobra.Command, _ []string) error {
 	}
 
 	results, err := applier.Apply(fileData, apply.ApplyOptions{
-		TemplateVars:    templateVars,
-		DryRun:          dryRun,
-		ShowDiff:        showDiff,
-		OverrideID:      id,
-		Type:            docType,
-		Labels:          labels,
-		RequireExisting: true,
+		TemplateVars:        templateVars,
+		DryRun:              dryRun,
+		ShowDiff:            showDiff,
+		OverrideID:          id,
+		Type:                docType,
+		Labels:              labels,
+		RequireExisting:     true,
+		CreateSnapshot:      createSnapshot,
+		SnapshotDescription: snapshotDescription,
 	})
 	if err != nil {
 		return err
@@ -145,6 +160,8 @@ func init() {
 	updateDocumentCmd.Flags().String("id", "", "ID of the document to update; read from payload if not provided")
 	updateDocumentCmd.Flags().StringArray("set", []string{}, "set template variable (key=value)")
 	updateDocumentCmd.Flags().StringArray("label", []string{}, "classification label to set (repeatable); replaces the document's labels (cannot be cleared, only replaced). Falls back to labels in the payload")
+	updateDocumentCmd.Flags().Bool("create-snapshot", false, "snapshot the document's current state before updating it, so the previous version stays available via 'dtctl history document'/'dtctl restore document'")
+	updateDocumentCmd.Flags().String("snapshot-description", "", "description for the snapshot created by --create-snapshot (max 128 characters)")
 	updateDocumentCmd.Flags().Bool("dry-run", false, "preview the update without applying it")
 	updateDocumentCmd.Flags().Bool("show-diff", false, "show a diff of the change")
 	_ = updateDocumentCmd.MarkFlagRequired("file")

--- a/cmd/update_documents.go
+++ b/cmd/update_documents.go
@@ -96,6 +96,10 @@ func updateDocumentRunE(cmd *cobra.Command, _ []string) error {
 	createSnapshot, _ := cmd.Flags().GetBool("create-snapshot")
 	snapshotDescription, _ := cmd.Flags().GetString("snapshot-description")
 
+	if err := validateSnapshotFlags(cmd); err != nil {
+		return err
+	}
+
 	fileData, err := vfs.ReadFile(file)
 	if err != nil {
 		return fmt.Errorf("failed to read file: %w", err)

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -783,6 +783,16 @@ dtctl unshare dashboard dash-123 --all
 
 ### Version History (Snapshots)
 
+Snapshots are opt-in: an update overwrites a document unless you ask for one with
+`--create-snapshot`, which captures the pre-update content first.
+
+```bash
+# Snapshot the current content, then update
+dtctl update document -f doc.yaml --create-snapshot
+dtctl apply -f dashboard.yaml --create-snapshot --snapshot-description "before Q3 rework"
+dtctl edit dashboard dash-123 --create-snapshot
+```
+
 View and restore previous versions of dashboards and notebooks:
 
 ```bash
@@ -815,7 +825,8 @@ dtctl restore notebook "Weekly Analysis" 3 --force
 ```
 
 **Notes:**
-- Snapshots are created when documents are updated with the `create-snapshot` option
+- Snapshots are only created when an update passes `--create-snapshot`, or implicitly by a restore
+- At most 5 snapshots per document per minute are accepted by the API
 - Maximum 50 snapshots per document (oldest auto-deleted when exceeded)
 - Snapshots auto-delete after 30 days
 - Only the document owner can restore snapshots

--- a/docs/dev/API_DESIGN.md
+++ b/docs/dev/API_DESIGN.md
@@ -477,7 +477,9 @@ dtctl restore dashboard "My Dashboard" 5         # Restore by name to version 5
 dtctl restore notebook "My Notebook" 3 --force   # Skip confirmation
 
 # Notes:
-# - Snapshots are created when updating documents with create-snapshot option
+# - Snapshots are opt-in: pass --create-snapshot on update/apply/edit to capture
+#   the pre-update content (--snapshot-description labels it)
+# - At most 5 snapshots per document per minute are accepted
 # - Maximum 50 snapshots per document (oldest deleted when exceeded)
 # - Snapshots auto-delete after 30 days
 # - Only document owner can restore snapshots

--- a/docs/site/_docs/dashboards.md
+++ b/docs/site/_docs/dashboards.md
@@ -155,13 +155,17 @@ dtctl unshare dashboard dash-123 --user user@example.com
 
 ## Version History (Snapshots)
 
-Dynatrace keeps document snapshots. View and restore previous versions:
+Snapshots are opt-in — an update overwrites the dashboard unless you ask for one:
 
 ```bash
+# Snapshot the current content before overwriting it
+dtctl edit dashboard dash-123 --create-snapshot
+dtctl apply -f dashboard.yaml --create-snapshot --snapshot-description "before Q3 rework"
+
 # List all versions
 dtctl history dashboard dash-123
 
-# Restore a specific version
+# Restore a specific version (snapshots the current state first)
 dtctl restore dashboard dash-123 5
 ```
 

--- a/docs/site/_docs/documents.md
+++ b/docs/site/_docs/documents.md
@@ -12,7 +12,8 @@ export, apply, and update documents of any type, and attach classification
 If you only work with dashboards and notebooks, see
 [Dashboards & Notebooks]({{ '/docs/dashboards/' | relative_url }}) — it covers the
 same commands with dashboard/notebook-specific detail. This page focuses on
-**custom document types** and **labels**, which apply to every document type.
+**custom document types**, plus **labels** and **snapshots**, which apply to every
+document type.
 
 > **Token scope:** creating, updating, or applying documents requires
 > `document:documents:write`. See
@@ -87,6 +88,37 @@ dtctl update document -f doc.yaml --show-diff
 ```
 
 `--type` cannot be combined with array (bulk) input.
+
+## Version history (snapshots)
+
+Updates overwrite a document's content in place — **snapshots are opt-in**. Pass
+`--create-snapshot` on any write path to have the API capture the pre-update
+content first, so it stays recoverable with `dtctl history` and `dtctl restore`:
+
+```bash
+# Update, keeping the previous content as a snapshot
+dtctl update document -f doc.yaml --create-snapshot
+
+# Same for apply and interactive edit, optionally with a description
+dtctl apply -f doc.yaml --create-snapshot --snapshot-description "before Q3 rework"
+dtctl edit document acme-config --create-snapshot
+
+# List and restore (restore snapshots the current state first)
+dtctl history document acme-config
+dtctl restore document acme-config 1
+```
+
+Behavior to know:
+
+- **Opt-in, and update-only.** The flag is a no-op when the document is being
+  created — there is no prior state to capture.
+- `--snapshot-description` (max 128 characters) requires `--create-snapshot`;
+  passing it alone is an error rather than a silently skipped snapshot.
+- **Rate limited.** The API accepts at most 5 snapshots per document per minute,
+  so avoid `--create-snapshot` in tight scripted apply loops.
+- **Retention.** At most 50 snapshots per document (the oldest is dropped when
+  exceeded), and snapshots auto-delete after 30 days.
+- Only the document owner can restore a snapshot.
 
 ## Labels
 

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -143,6 +143,14 @@ type ApplyOptions struct {
 	Type            string   // document type override (from --type flag); forces generic document handling
 	RequireExisting bool     // fail instead of creating when a document ID is missing (update semantics)
 	Labels          []string // document labels (from --label flags); when non-empty, overrides labels in the payload
+
+	// CreateSnapshot snapshots a document's current state before overwriting it
+	// (from --create-snapshot). Documents only, and only on the update path:
+	// there is nothing to snapshot when the document is being created.
+	CreateSnapshot bool
+	// SnapshotDescription describes the snapshot created by CreateSnapshot
+	// (from --snapshot-description); ignored without CreateSnapshot.
+	SnapshotDescription string
 }
 
 // ResourceType represents the type of resource

--- a/pkg/apply/apply_document.go
+++ b/pkg/apply/apply_document.go
@@ -179,11 +179,13 @@ func (a *Applier) applyDocument(data []byte, docType string, opts ApplyOptions) 
 
 	// Update the existing document (including metadata/labels if provided).
 	result, err := handler.UpdateDocument(id, metadata.Version, document.UpdateRequest{
-		Content:     contentData,
-		ContentType: "application/json",
-		Name:        name,
-		Description: description,
-		Labels:      labels,
+		Content:             contentData,
+		ContentType:         "application/json",
+		Name:                name,
+		Description:         description,
+		Labels:              labels,
+		CreateSnapshot:      opts.CreateSnapshot,
+		SnapshotDescription: opts.SnapshotDescription,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply %s: %w", docType, err)

--- a/pkg/apply/apply_document_snapshot_test.go
+++ b/pkg/apply/apply_document_snapshot_test.go
@@ -1,0 +1,121 @@
+package apply
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// TestApply_DocumentUpdate_CreateSnapshot verifies --create-snapshot reaches the
+// updateDocument call as the create-snapshot query parameter, with its description.
+func TestApply_DocumentUpdate_CreateSnapshot(t *testing.T) {
+	var createSnapshot string
+	var description []string
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/document/v1/documents/dash-1/metadata": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": "dash-1", "name": "Dash", "type": "dashboard", "version": 3,
+			})
+		},
+		"/platform/document/v1/documents/dash-1": func(w http.ResponseWriter, r *http.Request) {
+			createSnapshot = r.URL.Query().Get("create-snapshot")
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatalf("ParseMultipartForm: %v", err)
+			}
+			description = r.MultipartForm.Value["snapshotDescription"]
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": "dash-1", "name": "Dash", "type": "dashboard", "version": 4,
+			})
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	payload := `{"id":"dash-1","type":"dashboard","content":{"tiles":{},"version":"1"}}`
+	if _, err := a.Apply([]byte(payload), ApplyOptions{
+		CreateSnapshot:      true,
+		SnapshotDescription: "before Q3 rework",
+	}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if createSnapshot != "true" {
+		t.Errorf("create-snapshot = %q, want true", createSnapshot)
+	}
+	if len(description) != 1 || description[0] != "before Q3 rework" {
+		t.Errorf("snapshotDescription = %v, want [before Q3 rework]", description)
+	}
+}
+
+// TestApply_DocumentUpdate_NoSnapshotByDefault pins the opt-in contract at the
+// apply layer: an ordinary apply must not create snapshots.
+func TestApply_DocumentUpdate_NoSnapshotByDefault(t *testing.T) {
+	var createSnapshot string
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/document/v1/documents/dash-2/metadata": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": "dash-2", "name": "Dash", "type": "dashboard", "version": 1,
+			})
+		},
+		"/platform/document/v1/documents/dash-2": func(w http.ResponseWriter, r *http.Request) {
+			createSnapshot = r.URL.Query().Get("create-snapshot")
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": "dash-2", "name": "Dash", "type": "dashboard", "version": 2,
+			})
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	payload := `{"id":"dash-2","type":"dashboard","content":{"tiles":{},"version":"1"}}`
+	if _, err := a.Apply([]byte(payload), ApplyOptions{}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if createSnapshot != "" {
+		t.Errorf("create-snapshot = %q, want the parameter to be absent", createSnapshot)
+	}
+}
+
+// TestApply_DocumentCreate_IgnoresCreateSnapshot asserts the flag is inert on the
+// create path: there is no prior state to capture, and the create endpoint takes
+// no snapshot parameter.
+func TestApply_DocumentCreate_IgnoresCreateSnapshot(t *testing.T) {
+	var createQuery string
+	srv, c := newApplyTestServer(t, map[string]http.HandlerFunc{
+		"/platform/document/v1/documents": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			createQuery = r.URL.RawQuery
+			boundary := "resp-boundary"
+			w.Header().Set("Content-Type", fmt.Sprintf("multipart/form-data; boundary=%s", boundary))
+			fmt.Fprintf(w,
+				"--%s\r\nContent-Disposition: form-data; name=\"metadata\"\r\nContent-Type: application/json\r\n\r\n{\"id\":\"acme-new-1\",\"name\":\"My Config\",\"type\":\"acme:config\",\"version\":1}\r\n--%s--\r\n",
+				boundary, boundary)
+		},
+		"/platform/metadata/v1/user": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	a := NewApplier(c)
+
+	payload := `{"type":"acme:config","name":"My Config","settings":{"enabled":true}}`
+	if _, err := a.Apply([]byte(payload), ApplyOptions{CreateSnapshot: true}); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if createQuery != "" {
+		t.Errorf("create request query = %q, want no snapshot parameters", createQuery)
+	}
+}

--- a/sdk/api/document/document.go
+++ b/sdk/api/document/document.go
@@ -410,6 +410,19 @@ type UpdateRequest struct {
 	Name        string   // New name; omitted when empty
 	Description string   // New description; omitted when empty
 	Labels      []string // Replacement label set; omitted when empty
+
+	// CreateSnapshot asks the API to snapshot the document's current state
+	// before applying this update, so the pre-update content stays retrievable
+	// via ListSnapshots / RestoreSnapshot. Defaults to false: updates overwrite
+	// without keeping history unless this is set.
+	//
+	// The API caps snapshot creation at 5 per document per 60 seconds and keeps
+	// at most 50 snapshots per document (creating the 51st deletes the oldest).
+	CreateSnapshot bool
+
+	// SnapshotDescription labels the snapshot created by CreateSnapshot (max
+	// 128 characters). Ignored when CreateSnapshot is false.
+	SnapshotDescription string
 }
 
 // Update updates a document's content.
@@ -448,6 +461,15 @@ func (h *Handler) UpdateDocument(ctx context.Context, id string, version int, re
 		r.SetMultipartFormData(map[string]string{"description": req.Description})
 	}
 	addLabelParts(r, req.Labels)
+
+	// snapshotDescription is only meaningful alongside create-snapshot; the API
+	// ignores it otherwise, so don't send it and keep the request minimal.
+	if req.CreateSnapshot {
+		r.SetQueryParam("create-snapshot", "true")
+		if req.SnapshotDescription != "" {
+			r.SetMultipartFormData(map[string]string{"snapshotDescription": req.SnapshotDescription})
+		}
+	}
 
 	resp, err := r.Patch(fmt.Sprintf("/platform/document/v1/documents/%s", id))
 	if err != nil {

--- a/sdk/api/document/document_snapshot_test.go
+++ b/sdk/api/document/document_snapshot_test.go
@@ -1,0 +1,127 @@
+package document
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// snapshotProbe records how a PATCH expressed (or omitted) the snapshot options.
+type snapshotProbe struct {
+	createSnapshot string
+	description    []string
+	hasDescription bool
+}
+
+// probeSnapshotUpdate issues an update against a stub API and reports what
+// reached the wire.
+func probeSnapshotUpdate(t *testing.T, req UpdateRequest) snapshotProbe {
+	t.Helper()
+	var got snapshotProbe
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/documents/doc-1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		got.createSnapshot = r.URL.Query().Get("create-snapshot")
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		got.description, got.hasDescription = r.MultipartForm.Value["snapshotDescription"]
+		writeMetadata(w, "doc-1", 5, nil)
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.UpdateDocument(context.Background(), "doc-1", 4, req); err != nil {
+		t.Fatalf("UpdateDocument: %v", err)
+	}
+	return got
+}
+
+// TestUpdateDocument_CreateSnapshot asserts the opt-in flag becomes the
+// create-snapshot query parameter and the description rides in the multipart body.
+func TestUpdateDocument_CreateSnapshot(t *testing.T) {
+	got := probeSnapshotUpdate(t, UpdateRequest{
+		Content:             []byte(`{"k":"v"}`),
+		CreateSnapshot:      true,
+		SnapshotDescription: "before Q3 rework",
+	})
+
+	if got.createSnapshot != "true" {
+		t.Errorf("create-snapshot = %q, want true", got.createSnapshot)
+	}
+	if len(got.description) != 1 || got.description[0] != "before Q3 rework" {
+		t.Errorf("snapshotDescription = %v, want [before Q3 rework]", got.description)
+	}
+}
+
+// TestUpdateDocument_NoSnapshotByDefault pins the opt-in contract: a plain
+// update must not ask the API for a snapshot.
+func TestUpdateDocument_NoSnapshotByDefault(t *testing.T) {
+	got := probeSnapshotUpdate(t, UpdateRequest{Content: []byte(`{"k":"v"}`)})
+
+	if got.createSnapshot != "" {
+		t.Errorf("create-snapshot = %q, want the parameter to be absent", got.createSnapshot)
+	}
+	if got.hasDescription {
+		t.Error("snapshotDescription must not be sent without CreateSnapshot")
+	}
+}
+
+// TestUpdateDocument_SnapshotDescriptionWithoutFlag ensures a stray description
+// alone neither triggers a snapshot nor reaches the API, which would ignore it.
+func TestUpdateDocument_SnapshotDescriptionWithoutFlag(t *testing.T) {
+	got := probeSnapshotUpdate(t, UpdateRequest{
+		Content:             []byte(`{"k":"v"}`),
+		SnapshotDescription: "orphaned",
+	})
+
+	if got.createSnapshot != "" {
+		t.Errorf("create-snapshot = %q, want the parameter to be absent", got.createSnapshot)
+	}
+	if got.hasDescription {
+		t.Error("snapshotDescription must not be sent without CreateSnapshot")
+	}
+}
+
+// TestUpdateDocument_CreateSnapshotWithoutDescription covers the common case:
+// the flag alone, no description part.
+func TestUpdateDocument_CreateSnapshotWithoutDescription(t *testing.T) {
+	got := probeSnapshotUpdate(t, UpdateRequest{
+		Content:        []byte(`{"k":"v"}`),
+		CreateSnapshot: true,
+	})
+
+	if got.createSnapshot != "true" {
+		t.Errorf("create-snapshot = %q, want true", got.createSnapshot)
+	}
+	if got.hasDescription {
+		t.Error("expected no snapshotDescription part when none was set")
+	}
+}
+
+// TestCreate_LabelFollowupDoesNotSnapshot guards the label follow-up PATCH that
+// Create issues: a freshly created document has no prior state worth snapshotting,
+// and a snapshot there would burn one of the API's 5-per-minute allowance.
+func TestCreate_LabelFollowupDoesNotSnapshot(t *testing.T) {
+	var createSnapshot string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/platform/document/v1/documents", func(w http.ResponseWriter, r *http.Request) {
+		writeMetadata(w, "new-1", 1, nil)
+	})
+	mux.HandleFunc("/platform/document/v1/documents/new-1", func(w http.ResponseWriter, r *http.Request) {
+		createSnapshot = r.URL.Query().Get("create-snapshot")
+		writeMetadata(w, "new-1", 2, []string{"a"})
+	})
+
+	h := NewHandler(newTestClient(t, mux))
+	if _, err := h.Create(context.Background(), CreateRequest{
+		Name: "doc", Type: "acme:config", Content: []byte(`{"k":"v"}`), Labels: []string{"a"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if createSnapshot != "" {
+		t.Errorf("create-snapshot = %q on the label follow-up, want it absent", createSnapshot)
+	}
+}

--- a/skills/dtctl/SKILL.md
+++ b/skills/dtctl/SKILL.md
@@ -51,7 +51,7 @@ Resources and aliases are discoverable via `dtctl commands` (run at init). They 
 | exec | `dtctl exec function <id> --payload '{...}'` · `dtctl exec analyzer <id> --input '{...}'` (also workflow, copilot) |
 | query / wait | `dtctl query "fetch logs \| limit 10"` · `dtctl wait query ... --for=any` |
 | inspect | `dtctl inspect <file> --head 20` · `--tail`, `--page --offset N --limit M`, `--fields a,b`, `--schema`, `--stats`, `--sample N`, `--list` (row access over a spilled result file — no Grail re-query) |
-| logs / history / restore | `dtctl logs workflow-execution <id>` · `dtctl restore dashboard <id> --version 3` |
+| logs / history / restore | `dtctl logs workflow-execution <id>` · `dtctl history dashboard <id>` · `dtctl restore dashboard <id> 3` (version is positional; snapshots exist only if the update passed `--create-snapshot`) |
 | share / unshare | `dtctl share dashboard <id> --user a@example.com` |
 | find / open | `dtctl find intents --data trace.id=abc` · `dtctl open intent <app/intent> --data k=v` |
 | diff / verify | `dtctl diff -f wf.yaml` · `dtctl verify query 'fetch logs' --fail-on-warn` · `dtctl verify analyzer <id> -f in.json` |

--- a/skills/dtctl/references/resources/dashboards.md
+++ b/skills/dtctl/references/resources/dashboards.md
@@ -39,6 +39,9 @@ dtctl apply -f dashboard.yaml --plain
 # Preview without applying
 dtctl apply -f dashboard.yaml --dry-run --plain
 
+# Keep the current content as a restorable snapshot before overwriting it
+dtctl apply -f dashboard.yaml --create-snapshot --plain
+
 # Delete
 dtctl delete dashboard <id> --plain
 ```

--- a/skills/dtctl/references/resources/notebooks.md
+++ b/skills/dtctl/references/resources/notebooks.md
@@ -34,6 +34,9 @@ dtctl get notebook <id> -o yaml --plain > notebook.yaml
 # Create new (omit id field) or update existing (include id field)
 dtctl apply -f notebook.yaml --plain
 
+# Keep the current content as a restorable snapshot before overwriting it
+dtctl apply -f notebook.yaml --create-snapshot --plain
+
 # Delete
 dtctl delete notebook <id> --plain
 ```


### PR DESCRIPTION
## What

Adds `--create-snapshot` (and `--snapshot-description`) to every document write path:

```bash
dtctl update document -f doc.yaml --create-snapshot
dtctl apply -f dashboard.yaml --create-snapshot --snapshot-description "before Q3 rework"
dtctl edit dashboard dash-123 --create-snapshot
```

## Why

`dtctl history` and `dtctl restore` could already list and restore document snapshots, but nothing in dtctl could *create* one — updates overwrote content in place. The `history` help text even said "Snapshots are created when updating a document with the create-snapshot option", describing an API option dtctl never exposed. Until now, the only way to get a snapshot through dtctl was the implicit one a restore makes.

## How

- **SDK** (`sdk/api/document`): `UpdateRequest` gains `CreateSnapshot` and `SnapshotDescription`, sent as the `create-snapshot` query parameter and the `snapshotDescription` multipart field. Purely additive, so no break for SDK consumers.
- **`pkg/apply`**: two new `ApplyOptions` fields, forwarded only on the update branch.
- **CLI**: flags on `apply`, `update document`, and the three `edit` commands. The `edit` commands moved from `handler.Update` to `handler.UpdateDocument` via a small shared `editUpdateRequest` helper.
- `pkg/resources/document` needed no changes — its `UpdateRequest` is a type alias of the SDK's.

## Opt-in, deliberately

The API accepts at most 5 snapshots per document per 60 seconds, so snapshotting every update would turn a scripted apply loop into a rate-limit error. The flag is also inert where there is nothing to capture: the create path, and the label follow-up PATCH that `Create` issues (both covered by tests).

No new scope is required — `document:documents:write` already covers it.

## Verification

Live round-trip against a real environment with a throwaway document (since deleted):

| step | result |
|------|--------|
| update without the flag | `No snapshots found for this document` |
| update with `--create-snapshot --snapshot-description "before v3 rewrite"` | snapshot 1 recorded at `documentVersion: 2` with that description |
| `dtctl restore document <id> 1` | pre-update content recovered |

Also added:
- `sdk/api/document/document_snapshot_test.go` — wire-level: parameter present/absent, description part, description without the flag is not sent, create's label follow-up does not snapshot.
- `pkg/apply/apply_document_snapshot_test.go` — through the applier: update with/without the option, and create ignoring it.
- `cmd/document_snapshot_flags_test.go` — flags registered on all five commands, default `false`, and the flag → request mapping.

`go test ./...` passes in both modules, `golangci-lint` clean on the touched packages.

## Drive-by doc fixes

- Corrected the `history` help text (3 places), `docs/QUICK_START.md`, `docs/dev/API_DESIGN.md`, and `docs/site/_docs/dashboards.md`, which all implied snapshots happen automatically.
- `skills/dtctl/SKILL.md` documented `dtctl restore dashboard <id> --version 3`; the version is positional, so the example was wrong.