### PR TITLE
fix(agent)!: keep the agent envelope for -o toon and warn on unsupported formats

### DIFF
--- a/docs/site/_docs/ai-agent-mode.md
+++ b/docs/site/_docs/ai-agent-mode.md
@@ -143,9 +143,74 @@ sample-based figures can't be misread as population truth.
 > The inline `kind: "records"` envelope is emitted on the spill-aware path
 > whenever agent mode emits JSON — including under `--spill=never`, which forces
 > every row inline regardless of size but still as a `kind: "records"` envelope
-> (never a human table). Explicit non-JSON output (`-o toon/csv/yaml`) and `--jq`
+> (never a human table). The byte-oriented encodings (`-o csv/yaml`) and `--jq`
 > transforms keep their requested shape and fall through to the plain
 > `{ "records": …, "metadata": … }` output.
+
+#### Dense rows: `-o toon`
+
+`-o toon` keeps the envelope and encodes the rows inside it, so the contract does
+not change with result size — the same flags give you a `kind: "records"`
+envelope below the spill threshold and a `kind: "result-file"` envelope above it,
+and `ok`, `error.code` and `context` (heavy-scan warnings, suggestions) are
+present either way. The rows arrive as a TOON string under `result.records`, with
+`result.encoding` naming the codec:
+
+```json
+{
+  "ok": true,
+  "envelope_version": 1,
+  "result": {
+    "kind": "records",
+    "encoding": "toon",
+    "records": "[#2]{host.name,loglevel}:\n  host-a,INFO\n  host-b,ERROR"
+  },
+  "context": { "verb": "query", "resource": "logs", "total": 2, "decided": "inline" }
+}
+```
+
+Branch on `result.encoding`: absent means `result.records` is a native JSON array,
+`"toon"` means it is a string to decode. TOON is worth it for **wide results with
+short values**, where folding the repeated keys into one header saves around 15%
+of the tokens of the JSON envelope. It saves very little on results dominated by
+long prose fields (a log `content` column), and it is *larger* than JSON on
+heterogeneous nested results, where there is no uniform key set to fold. It is
+not a blanket win — measure before reaching for it.
+
+Inside the envelope only `json` and `toon` are supported. Any other `-o` value
+(`csv`, `yaml`, `table`, …) on a command that emits the envelope falls back to
+JSON and says so in `context.warnings` rather than silently pretending the format
+was honoured.
+
+## Exit Codes
+
+The cheapest agent-readable channel is the exit status: it costs **zero tokens**,
+so when all you need is a yes/no gate, read it and discard stdout rather than
+parsing an envelope to reach the same verdict. In [server mode]({{ '/docs/serve/' | relative_url }})
+the same value comes back as the `exitCode` field, so a gate written against it
+ports unchanged.
+
+| Command | Code | Meaning |
+|---|---|---|
+| `dtctl verify query` / `verify analyzer` | 0 | valid |
+| | 1 | invalid (or warnings with `--fail-on-warn`) |
+| | 2 | authentication/permission error |
+| | 3 | network/server error |
+| `dtctl diff` | 0 | no differences |
+| | 1 | differences found |
+| | 2 | error |
+| `dtctl wait` | 0 | condition met |
+| | 1 | timed out |
+| | 2 | max attempts exceeded |
+| | 3 | other failure |
+
+> **`ok` is not the verdict.** `ok: true` means the command *ran* — it reached the
+> API and produced an answer. It does not mean the answer was the one you were
+> gating on. A command that successfully determines "these two resources differ"
+> exits non-zero while still reporting `ok: true`, because nothing went wrong.
+> Gate on the exit status (or on the specific verdict field in `result`), never on
+> `ok`. Reserve `ok: false` and `error.code` for *failures* — auth, network, a
+> malformed query.
 
 ## Auto-Detection
 

--- a/docs/site/_docs/output-formats.md
+++ b/docs/site/_docs/output-formats.md
@@ -267,7 +267,16 @@ Agent mode is auto-detected when running inside AI agent environments (GitHub Co
 dtctl get workflows --no-agent
 ```
 
-Agent mode implies `--plain` -- no colors and no interactive prompts. See [AI Agent Mode](ai-agent-mode) for full details.
+Agent mode implies `--plain` -- no colors and no interactive prompts.
+
+Inside the envelope only two payload encodings exist: `json` (the default) and
+`toon`. Pass `-o toon` to encode the rows densely while keeping the envelope --
+worth it for wide results with short values, and close to worthless for results
+dominated by long text. Any other `-o` value falls back to JSON and records a
+warning in `context.warnings`, so a format the envelope cannot carry is never
+silently swapped for one it can.
+
+See [AI Agent Mode](ai-agent-mode) for full details.
 
 ## Pagination
 

--- a/pkg/exec/spill_exec.go
+++ b/pkg/exec/spill_exec.go
@@ -227,21 +227,53 @@ func (e *DQLExecutor) buildSpillResponse(query string, result *DQLQueryResponse,
 // inlineRecordsResponse handles the inline (not-spilled) decision. In agent mode
 // it returns a self-describing kind:"records" envelope so a consumer branches on
 // result.kind uniformly across inline and spilled results (D2/D31); the rows are
-// carried directly. It deliberately leaves two shapes alone — falling through to
-// the caller's unchanged output path (handled=false) — so it never overrides an
-// explicit, non-JSON choice the caller already made:
-//   - a non-JSON display encoding (-o toon/csv/yaml/chart): the envelope is JSON;
-//     wrapping would silently discard the requested format.
+// carried directly, natively for -o json and as an encoded string for -o toon
+// (see InlineRecordsEncoded) — both under kind:"records", so the envelope is
+// present either side of the spill threshold rather than only above it.
+//
+// It deliberately leaves two shapes alone — falling through to the caller's
+// unchanged output path (handled=false) — so it never overrides an explicit
+// choice the caller already made that the envelope cannot carry:
+//   - a byte-oriented display encoding (-o csv/yaml/chart): a caller asking for
+//     those wants the bytes, not an envelope wrapping them.
 //   - a --jq transform: agent-mode jq already owns the output shape.
 //
 // Outside agent mode an inline result is always a fall-through (a human wants the
 // table/CSV, not an envelope).
 func (e *DQLExecutor) inlineRecordsResponse(query string, result *DQLQueryResponse, records []map[string]interface{}, measured int64, encoding string, opts DQLExecuteOptions) (output.Response, bool, error) {
-	if !opts.AgentMode || encoding != "json" || opts.JQFilter != "" {
+	// A --jq transform reshapes the result into something this envelope cannot
+	// describe, so it keeps its requested shape and falls through. So do the
+	// raw byte-oriented encodings (csv/yaml): an agent asking for those wants
+	// the bytes, not an envelope wrapping them.
+	if !opts.AgentMode || opts.JQFilter != "" {
 		return output.Response{}, false, nil
 	}
 
-	res := &output.InlineRecords{Kind: output.KindRecords, Records: records}
+	var res interface{}
+	var encodeWarning string
+	switch encoding {
+	case "json":
+		res = &output.InlineRecords{Kind: output.KindRecords, Records: records}
+	case "toon":
+		// `-o toon` keeps the envelope, with the rows encoded inside it. This is
+		// what makes the contract independent of result size: the same flags
+		// produce a `kind: "records"` envelope below the spill threshold and a
+		// `kind: "result-file"` envelope above it, so `ok`, `error.code` and
+		// `context` (heavy-scan warnings, suggestions) survive either way.
+		toonRows, err := output.MarshalTOON(records)
+		if err != nil {
+			encodeWarning = fmt.Sprintf("TOON encoding failed: %v; the rows were encoded as JSON instead", err)
+			res = &output.InlineRecords{Kind: output.KindRecords, Records: records}
+		} else {
+			res = &output.InlineRecordsEncoded{
+				Kind:     output.KindRecords,
+				Encoding: "toon",
+				Records:  toonRows,
+			}
+		}
+	default:
+		return output.Response{}, false, nil
+	}
 
 	// Even an inline (small) result can be PARTIAL — a scan-limit stop can leave
 	// few rows. Surface the same notification advice so the agent isn't misled
@@ -252,6 +284,9 @@ func (e *DQLExecutor) inlineRecordsResponse(query string, result *DQLQueryRespon
 	notifSuggestions = append(notifSuggestions, scanSuggestions...)
 	notifSuggestions = append(notifSuggestions, windowAdvice(query, records, opts)...)
 	notifSuggestions = append(notifSuggestions, lookbackAdvice(query)...)
+	if encodeWarning != "" {
+		notifWarnings = append(notifWarnings, encodeWarning)
+	}
 
 	total := len(records)
 	ctx := &output.ResponseContext{

--- a/pkg/exec/spill_test.go
+++ b/pkg/exec/spill_test.go
@@ -375,8 +375,10 @@ func TestBuildSpillResponse_InlineFallThroughCases(t *testing.T) {
 	}{
 		// Not agent mode: a human inline result must stay a fall-through (table/CSV).
 		{"non-agent", DQLExecuteOptions{Spill: base}, "json"},
-		// Non-JSON display encoding: wrapping would discard the requested format.
-		{"toon-encoding", DQLExecuteOptions{AgentMode: true, Spill: base}, "toon"},
+		// Byte-oriented encodings: an agent asking for csv/yaml wants the bytes,
+		// not an envelope wrapping them.
+		{"csv-encoding", DQLExecuteOptions{AgentMode: true, Spill: base}, "csv"},
+		{"yaml-encoding", DQLExecuteOptions{AgentMode: true, Spill: base}, "yaml"},
 		// --jq owns the output shape in agent mode.
 		{"jq-set", DQLExecuteOptions{AgentMode: true, JQFilter: ".[]", Spill: base}, "json"},
 	}
@@ -390,6 +392,53 @@ func TestBuildSpillResponse_InlineFallThroughCases(t *testing.T) {
 				t.Errorf("%s: expected fall-through (handled=false), got an envelope", c.name)
 			}
 		})
+	}
+}
+
+// TestBuildSpillResponse_InlineTOONKeepsEnvelope pins the contract that made
+// `-o toon` size-dependent before: below the spill threshold the rows now come
+// back inside the envelope as an encoded string, so `ok`/`error.code`/`context`
+// are present on both sides of the threshold rather than only above it.
+func TestBuildSpillResponse_InlineTOONKeepsEnvelope(t *testing.T) {
+	e := &DQLExecutor{}
+	result, records := sampleResult(false)
+	opts := DQLExecuteOptions{
+		AgentMode: true,
+		Spill:     SpillOptions{Mode: SpillAuto, Threshold: 1 << 20, Dir: t.TempDir(), Format: "json"},
+	}
+
+	resp, handled, err := e.buildSpillResponse("fetch logs", result, records, "toon", opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handled {
+		t.Fatal("agent mode + -o toon should emit an envelope, not fall through")
+	}
+	if !resp.OK {
+		t.Error("envelope should report ok=true")
+	}
+	enc, ok := resp.Result.(*output.InlineRecordsEncoded)
+	if !ok {
+		t.Fatalf("result = %T, want *InlineRecordsEncoded", resp.Result)
+	}
+	if enc.Kind != output.KindRecords {
+		t.Errorf("kind = %q, want %q", enc.Kind, output.KindRecords)
+	}
+	if enc.Encoding != "toon" {
+		t.Errorf("encoding = %q, want toon", enc.Encoding)
+	}
+	if enc.Records == "" {
+		t.Error("records should carry the TOON-encoded rows")
+	}
+	// The payload must be the rows, not a Go-syntax dump of them.
+	if strings.Contains(enc.Records, "map[") {
+		t.Errorf("records looks like a Go fmt dump, not TOON: %q", enc.Records)
+	}
+	if resp.Context == nil || resp.Context.Decided != "inline" {
+		t.Errorf("decided = %+v, want inline", resp.Context)
+	}
+	if resp.Context.MeasuredEncoding != "toon" {
+		t.Errorf("measured_encoding = %q, want toon", resp.Context.MeasuredEncoding)
 	}
 }
 

--- a/pkg/output/agent.go
+++ b/pkg/output/agent.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 
-	toon "github.com/toon-format/toon-go"
 	"golang.org/x/term"
 )
 
@@ -136,17 +135,23 @@ func NewAgentPrinter(writer io.Writer, ctx *ResponseContext) *AgentPrinter {
 }
 
 // SetResultFormat controls how the result field is encoded inside the agent
-// envelope. Supported values are "toon" and "json" (default). Any other
-// value is treated as "json" (i.e. the result is embedded as a native JSON
-// value in the envelope).
+// envelope. Supported values are "toon" and "json" (default). Any other value
+// falls back to "json" — the result must be a valid native JSON value inside
+// the envelope — and records a warning on the response context, so an agent
+// that passed `-o csv` learns its format was not honoured instead of silently
+// receiving JSON that looks like it was what it asked for.
 func (p *AgentPrinter) SetResultFormat(format string) {
 	switch format {
 	case "toon", "json":
 		p.resultFormat = format
+	case "":
+		// Not an explicit choice; keep the default without warning.
 	default:
-		// Unknown format — fall back to json so the result is always
-		// a valid native JSON value inside the envelope.
 		p.resultFormat = "json"
+		p.addWarning(fmt.Sprintf(
+			"-o %s is not supported inside the agent envelope; the result was encoded as JSON (agent mode supports json and toon)",
+			format,
+		))
 	}
 }
 
@@ -183,16 +188,10 @@ func (p *AgentPrinter) encodeResult(data interface{}) (interface{}, error) {
 		return data, nil
 	}
 
-	generic, err := toGeneric(data)
+	encoded, err := MarshalTOON(data)
 	if err != nil {
-		p.addWarning(fmt.Sprintf("TOON encoding failed (toGeneric): %v; fell back to JSON", err))
-		return data, nil // fall back to raw data on conversion error
-	}
-
-	encoded, err := toon.MarshalString(generic, toon.WithLengthMarkers(true))
-	if err != nil {
-		p.addWarning(fmt.Sprintf("TOON encoding failed (marshal): %v; fell back to JSON", err))
-		return data, nil // fall back to raw data on marshal error
+		p.addWarning(fmt.Sprintf("TOON encoding failed: %v; fell back to JSON", err))
+		return data, nil // fall back to raw data on encoding error
 	}
 
 	return encoded, nil

--- a/pkg/output/manifest.go
+++ b/pkg/output/manifest.go
@@ -70,6 +70,20 @@ type InlineRecords struct {
 	Records []map[string]interface{} `json:"records"`
 }
 
+// InlineRecordsEncoded is the KindRecords payload when the agent asked for a
+// dense row encoding (`-o toon`). It carries the same `kind` discriminator as
+// InlineRecords so a consumer branches identically, but `records` is an encoded
+// string rather than native JSON, and `encoding` names the codec so the string
+// is self-describing. Keeping the envelope here is what makes `-o toon` behave
+// the same way either side of the spill threshold: below it the rows come back
+// encoded under this shape, above it as a `result-file` manifest — never as a
+// bare TOON document with no `ok`/`context`.
+type InlineRecordsEncoded struct {
+	Kind     string `json:"kind"`
+	Encoding string `json:"encoding"`
+	Records  string `json:"records"`
+}
+
 // SpecFileManifest is the result payload for the KindDocumentFile envelope: a
 // handle to a written document plus enough provenance to know what it is. It is
 // deliberately not ResultFileManifest — that shape promises rows, columns and a

--- a/pkg/output/toon.go
+++ b/pkg/output/toon.go
@@ -53,6 +53,18 @@ func (p *ToonPrinter) marshal(obj interface{}) error {
 	return err
 }
 
+// MarshalTOON encodes v as a TOON string using the same options as the TOON
+// printer and the agent envelope's `-o toon` path, so every TOON payload dtctl
+// emits comes out of one encoder. Exported for callers outside this package
+// that embed a TOON-encoded payload inside the agent envelope (pkg/exec).
+func MarshalTOON(v interface{}) (string, error) {
+	generic, err := toGeneric(v)
+	if err != nil {
+		return "", err
+	}
+	return toon.MarshalString(generic, toon.WithLengthMarkers(true))
+}
+
 // toGeneric converts a typed Go value to an untyped representation
 // (map[string]any / []any / primitives) by round-tripping through
 // encoding/json. This ensures json struct tags are respected while

--- a/pkg/output/toon_test.go
+++ b/pkg/output/toon_test.go
@@ -334,3 +334,55 @@ func TestAgentPrinter_NilDataStaysNil(t *testing.T) {
 		t.Errorf("expected null result for nil data, got %v", m["result"])
 	}
 }
+
+// TestAgentPrinter_SetResultFormatUnsupported verifies that a format the
+// envelope cannot carry (csv/yaml/table) still produces native JSON, but says
+// so in context.warnings instead of downgrading silently.
+func TestAgentPrinter_SetResultFormatUnsupported(t *testing.T) {
+	for _, format := range []string{"csv", "yaml", "table", "wide", "parquet"} {
+		t.Run(format, func(t *testing.T) {
+			var buf bytes.Buffer
+			ctx := &ResponseContext{Verb: "get", Resource: "workflow"}
+			p := NewAgentPrinter(&buf, ctx)
+			p.SetResultFormat(format)
+
+			if err := p.PrintList([]map[string]string{{"id": "1"}}); err != nil {
+				t.Fatalf("PrintList failed: %v", err)
+			}
+
+			var resp Response
+			if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+				t.Fatalf("envelope is not valid JSON: %v", err)
+			}
+			if _, isString := resp.Result.(string); isString {
+				t.Fatal("result should fall back to native JSON, not an encoded string")
+			}
+			if resp.Context == nil || len(resp.Context.Warnings) == 0 {
+				t.Fatalf("expected a warning naming the unsupported format, got %+v", resp.Context)
+			}
+			if !strings.Contains(resp.Context.Warnings[0], format) {
+				t.Errorf("warning should name the requested format %q, got %q", format, resp.Context.Warnings[0])
+			}
+		})
+	}
+}
+
+// TestAgentPrinter_SetResultFormatEmptyIsSilent verifies that an unset format
+// is not treated as an unsupported choice.
+func TestAgentPrinter_SetResultFormatEmptyIsSilent(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := &ResponseContext{Verb: "get", Resource: "workflow"}
+	p := NewAgentPrinter(&buf, ctx)
+	p.SetResultFormat("")
+
+	if err := p.PrintList([]map[string]string{{"id": "1"}}); err != nil {
+		t.Fatalf("PrintList failed: %v", err)
+	}
+	var resp Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v", err)
+	}
+	if resp.Context != nil && len(resp.Context.Warnings) > 0 {
+		t.Errorf("empty format should not warn, got %v", resp.Context.Warnings)
+	}
+}


### PR DESCRIPTION
## Why

I benchmarked whether `--agent` should default to a denser payload encoding (TOON/CSV) instead of JSON. **The answer is no — keep JSON** — but the benchmark surfaced three defects in the agent surface. This PR fixes those; it does *not* change the default encoding.

<details>
<summary>The measurements behind "keep JSON" (o200k_base tokens, identical rows through dtctl's own encoders)</summary>

The prior of "TOON/CSV is 1.6–1.7× cheaper than JSON" replicates, but it was measured against **pretty-printed** JSON. Agent mode already emits **compact** JSON, which is where most of that win comes from:

| dataset | indentation (pretty→compact) | key folding (compact→toon) | total |
|---|---|---|---|
| 500 narrow rows (3 short fields) | **1.31×** | 1.20× | 1.58× |
| 500 prose rows (+ log `content`) | **1.13×** | 1.07× | 1.20× |

So the number that actually governs the decision — `-A` vs `-A -o toon` — is **1.16×** on narrow rows and **1.05×** on prose rows, not 1.6×.

Three further findings:

- **Nested results invert it.** On `inventory arrivals` (heterogeneous signals array, 4 distinct key-sets), TOON is **17% *larger*** than the JSON envelope — there is no uniform key set to fold.
- **Spill already solved the bulk-row problem.** Agent mode auto-spills above 50KB: 500 prose rows cost 73,281 tokens inline vs 1,154 spilled (**63×**). Encoding is a rounding error next to that, and above the threshold `-o` is ignored entirely.
- **CSV is a non-starter as an envelope payload.** Quoting is correct (0/2000 cell mismatches round-tripping 500 rows with 113 commas, 70 quotes, 9 embedded newlines), but it collapses `null`≡`""`, `42`≡`"42"`, and `"007"`→`007`. TOON preserved every one of those distinctions. On nested input CSV and table emit Go `map[...]` dumps — unparseable.

The envelope itself costs **10–51 tokens**, so it was never the problem.

</details>

## What this changes

### 1. `query -A -o toon` had a size-dependent contract

Below the spill threshold the envelope was **dropped entirely** and a bare TOON document emitted — no `ok`, no `context`, so `context.warnings` (including the heavy-scan *"this query scanned 21.4 GB"* warning) and `context.suggestions` were silently lost. Above the threshold, spill re-imposed a JSON `result-file` envelope. Same flags, two different contracts depending on how much data came back.

The rows now stay inside the envelope, which is what `AgentPrinter.SetResultFormat` already did for every other command:

```json
{
  "ok": true,
  "envelope_version": 1,
  "result": {
    "kind": "records",
    "encoding": "toon",
    "records": "[#2]{host.name,loglevel}:\n  host-a,INFO\n  host-b,ERROR"
  },
  "context": { "verb": "query", "total": 2, "decided": "inline", "warnings": [...] }
}
```

Same `kind` discriminator, `encoding` names the codec so the string is self-describing.

> [!WARNING]
> **Breaking.** `dtctl query -A -o toon` below the spill threshold now returns the envelope with rows as a TOON string under `result.records`, instead of a bare TOON document. Error envelopes are unaffected — those were already emitted.
>
> Cost: the envelope + JSON-string escaping is **~3–4% more tokens** than the bare TOON document (+598 on 500 narrow rows). In exchange you get `ok`, `error.code` branching, the scan warnings, and a contract that no longer changes with result size — and it is still **1.16× cheaper** than the JSON envelope on the same rows.

### 2. `SetResultFormat` silently downgraded unsupported formats

Only `toon` and `json` are real inside the envelope; `csv`/`yaml`/`table` were silently mapped to JSON, so `-A -o csv` looked honoured and wasn't. It now falls back to JSON **and** names the format in `context.warnings`:

```
-o csv is not supported inside the agent envelope; the result was encoded as JSON (agent mode supports json and toon)
```

### 3. Exit codes documented as the gating channel

The cheapest agent-readable channel is the exit status — **zero tokens**. Added a table for `verify`/`diff`/`wait` plus the trap: **`ok` is not the verdict.** `dtctl diff` exits 1 on "they differ" while still reporting `ok: true`, because nothing went *wrong*. A gate must read the exit status, not `ok`.

Also deduplicates the TOON encoder behind `output.MarshalTOON` so the printer, the envelope, and the inline query path share one set of options.

## Out of scope

`-A -o csv/yaml` keep the same size-dependent contract (raw bytes below the threshold, a JSON `result-file` envelope above it). Those are byte-oriented encodings an agent asks for when it wants the bytes; unifying them means deciding whether spill should hijack them at all, which is a separate call.

## Verification

- `go test ./...` and `cd sdk && go test ./...` pass; `golangci-lint run --new-from-rev=main` reports 0 new issues.
- One existing test asserted the old fall-through for `toon`; it is replaced by `TestBuildSpillResponse_InlineTOONKeepsEnvelope` and re-pointed at `csv`/`yaml`, which still fall through.
- Manually verified against a live tenant: `-o toon` keeps the envelope below the threshold and still yields `kind: result-file` above it; `-A -o csv` on `get workflows` produces the warning; the heavy-scan warning now survives `-o toon`.
