### PR TITLE
chore: replace deprecated reflect.Ptr with reflect.Pointer

### DIFF
--- a/pkg/output/csv.go
+++ b/pkg/output/csv.go
@@ -22,7 +22,7 @@ func (p *CSVPrinter) Print(obj interface{}) error {
 // PrintList prints a list of objects as CSV
 func (p *CSVPrinter) PrintList(obj interface{}) error {
 	v := reflect.ValueOf(obj)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -53,7 +53,7 @@ func (p *CSVPrinter) writeRecords(v reflect.Value, writer *csv.Writer) error {
 
 	// Handle slice of structs
 	first := v.Index(0)
-	if first.Kind() == reflect.Ptr {
+	if first.Kind() == reflect.Pointer {
 		first = first.Elem()
 	}
 
@@ -134,7 +134,7 @@ func (p *CSVPrinter) printMaps(v reflect.Value, writer *csv.Writer) error {
 // printStructs prints a slice of structs as CSV
 func (p *CSVPrinter) printStructs(v reflect.Value, writer *csv.Writer) error {
 	first := v.Index(0)
-	if first.Kind() == reflect.Ptr {
+	if first.Kind() == reflect.Pointer {
 		first = first.Elem()
 	}
 
@@ -153,7 +153,7 @@ func (p *CSVPrinter) printStructs(v reflect.Value, writer *csv.Writer) error {
 	// Write rows
 	for i := 0; i < v.Len(); i++ {
 		elem := v.Index(i)
-		if elem.Kind() == reflect.Ptr {
+		if elem.Kind() == reflect.Pointer {
 			elem = elem.Elem()
 		}
 
@@ -183,7 +183,7 @@ func formatCSVValue(val interface{}) string {
 	v := reflect.ValueOf(val)
 
 	// Handle pointers
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return ""
 		}

--- a/pkg/output/jsonl.go
+++ b/pkg/output/jsonl.go
@@ -32,7 +32,7 @@ func (p *JSONLPrinter) Print(obj interface{}) error {
 // is written as a single line (mirroring the single-object case).
 func (p *JSONLPrinter) PrintList(obj interface{}) error {
 	v := reflect.ValueOf(obj)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 

--- a/pkg/output/parquet.go
+++ b/pkg/output/parquet.go
@@ -477,7 +477,7 @@ func toRecordMaps(obj interface{}) ([]map[string]interface{}, error) {
 	}
 
 	v := reflect.ValueOf(obj)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Slice {
@@ -490,7 +490,7 @@ func toRecordMaps(obj interface{}) ([]map[string]interface{}, error) {
 		if elem.Kind() == reflect.Interface {
 			elem = elem.Elem()
 		}
-		if elem.Kind() == reflect.Ptr {
+		if elem.Kind() == reflect.Pointer {
 			elem = elem.Elem()
 		}
 

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -128,7 +128,7 @@ func getTableFields(t reflect.Type, wide bool) []tableFieldInfo {
 // getFieldByPath traverses a field path to get the final field value
 func getFieldByPath(v reflect.Value, indices []int) reflect.Value {
 	for _, idx := range indices {
-		if v.Kind() == reflect.Ptr {
+		if v.Kind() == reflect.Pointer {
 			if v.IsNil() {
 				return reflect.Value{}
 			}
@@ -252,7 +252,7 @@ func (p *TablePrinter) Print(obj interface{}) error {
 
 	// Use reflection to get field names and values
 	v := reflect.ValueOf(obj)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -287,7 +287,7 @@ func (p *TablePrinter) PrintList(obj interface{}) error {
 	table := tablewriter.NewTable(p.writer, kubectlStyleOptions()...)
 
 	v := reflect.ValueOf(obj)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -302,13 +302,13 @@ func (p *TablePrinter) PrintList(obj interface{}) error {
 
 	// Get headers from first element
 	first := v.Index(0)
-	if first.Kind() == reflect.Ptr {
+	if first.Kind() == reflect.Pointer {
 		first = first.Elem()
 	}
 	// Unwrap interface{} to get the actual value
 	if first.Kind() == reflect.Interface {
 		first = first.Elem()
-		if first.Kind() == reflect.Ptr {
+		if first.Kind() == reflect.Pointer {
 			first = first.Elem()
 		}
 	}
@@ -339,13 +339,13 @@ func (p *TablePrinter) PrintList(obj interface{}) error {
 	// Add rows
 	for i := 0; i < v.Len(); i++ {
 		elem := v.Index(i)
-		if elem.Kind() == reflect.Ptr {
+		if elem.Kind() == reflect.Pointer {
 			elem = elem.Elem()
 		}
 		// Unwrap interface{} to get the actual value
 		if elem.Kind() == reflect.Interface {
 			elem = elem.Elem()
-			if elem.Kind() == reflect.Ptr {
+			if elem.Kind() == reflect.Pointer {
 				elem = elem.Elem()
 			}
 		}
@@ -369,7 +369,7 @@ func formatValue(v reflect.Value) string {
 	}
 
 	// Handle pointer types
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return ""
 		}
@@ -464,7 +464,7 @@ func formatTableMapValue(val interface{}) string {
 	v := reflect.ValueOf(val)
 
 	// Handle pointers
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return ""
 		}

--- a/pkg/output/watch.go
+++ b/pkg/output/watch.go
@@ -141,7 +141,7 @@ func (p *WatchPrinter) printWithPrefix(resource interface{}, prefix string, colo
 func (p *WatchPrinter) printTableRow(resource interface{}, prefix string, color string, tablePrinter *TablePrinter) error {
 	// Format the resource as a table row string
 	v := reflect.ValueOf(resource)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 

--- a/pkg/watch/differ.go
+++ b/pkg/watch/differ.go
@@ -77,7 +77,7 @@ func extractID(item interface{}) string {
 	}
 
 	v := reflect.ValueOf(item)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -158,10 +158,10 @@ func detectChangedField(prev, current interface{}) (string, interface{}, interfa
 	prevVal := reflect.ValueOf(prev)
 	currVal := reflect.ValueOf(current)
 
-	if prevVal.Kind() == reflect.Ptr {
+	if prevVal.Kind() == reflect.Pointer {
 		prevVal = prevVal.Elem()
 	}
-	if currVal.Kind() == reflect.Ptr {
+	if currVal.Kind() == reflect.Pointer {
 		currVal = currVal.Elem()
 	}
 

--- a/sdk/session/preserve.go
+++ b/sdk/session/preserve.go
@@ -93,7 +93,7 @@ func graftUnknown(oldMap, newMap *yaml.Node, t reflect.Type) {
 		}
 
 		ft := field.Type
-		for ft.Kind() == reflect.Ptr {
+		for ft.Kind() == reflect.Pointer {
 			ft = ft.Elem()
 		}
 		switch {


### PR DESCRIPTION
## Description

Mechanical rename of every `reflect.Ptr` use to `reflect.Pointer` (22 call sites, 7 files). No behavior change — `reflect.Ptr` is a deprecated alias for `reflect.Pointer`, marked `//go:fix inline` in the standard library.

golangci-lint 2.12.x reports each use as a `govet` finding:

```
inline: Constant reflect.Ptr should be inlined (govet)
```

21 in the root module (`pkg/output/table.go` ×9, `pkg/output/csv.go` ×5, `pkg/watch/differ.go` ×3, `pkg/output/parquet.go` ×2, `pkg/output/watch.go` ×1, `pkg/output/jsonl.go` ×1), plus 1 in `sdk/session/preserve.go` — the `sdk/` module is a separate module, so a root-level `golangci-lint run ./...` never lints it.

Note this is **pre-emptive, not a CI fix**: `.github/workflows/lint.yml` pins golangci-lint `v2.11.1`, which does not run the `inline` analyzer, and Lint is green on `main` today. Plain `go vet ./...` also reports nothing. The findings only appear once the pinned version is bumped past 2.11.x (or when linting locally with a newer release).

## Related Issues

n/a

## Testing

- [x] Tests pass (`go test ./...` in both the root and `sdk/` modules)
- [x] Linting passes (`golangci-lint run ./...` — 0 issues with 2.12.2, down from 21)
- [x] `go build ./...` clean in both modules, `gofmt -l .` clean