### PR TITLE
fix(lookup): surface the 403 reason and separate scope from IAM policy

### DIFF
--- a/pkg/diagnostic/error.go
+++ b/pkg/diagnostic/error.go
@@ -122,6 +122,8 @@ func suggestionsForStatusCode(statusCode int) []string {
 	case 403:
 		return []string{
 			"Insufficient permissions. Check that your API token has the required scopes",
+			"Verify the scopes this command needs with: '<command> --check-scopes'",
+			"Token scopes and IAM policy permissions are separate gates — if --check-scopes reports \"ok\", the tenant's IAM policy is what denies the request",
 			"View current context and safety level: 'dtctl config get-context'",
 			"If using a 'readonly' context, switch to a context with write permissions",
 			"Review required token scopes in the documentation",

--- a/pkg/resources/lookup/lookup.go
+++ b/pkg/resources/lookup/lookup.go
@@ -544,7 +544,7 @@ func handleUploadError(statusCode int, body string, path string) error {
 	case 400:
 		return fmt.Errorf("invalid upload request: %s", body)
 	case 403:
-		return fmt.Errorf("access denied to write file %q", path)
+		return forbiddenError("write", "storage:files:write", "dtctl create lookup --path "+path+" --check-scopes", path, body)
 	case 409:
 		return fmt.Errorf("lookup table %q already exists. Use 'dtctl apply' to update or add --overwrite flag", path)
 	case 413:
@@ -560,7 +560,7 @@ func handleDeleteError(statusCode int, body string, path string) error {
 	case 400:
 		return fmt.Errorf("invalid delete request: %s", body)
 	case 403:
-		return fmt.Errorf("access denied to delete file %q", path)
+		return forbiddenError("delete", "storage:files:delete", "dtctl delete lookup "+path+" --check-scopes", path, body)
 	case 404:
 		return fmt.Errorf("lookup table %q not found. Run 'dtctl get lookups' to list available lookups", path)
 	default:

--- a/pkg/resources/lookup/lookup_test.go
+++ b/pkg/resources/lookup/lookup_test.go
@@ -254,7 +254,9 @@ func TestHandleUploadError(t *testing.T) {
 			statusCode: 403,
 			body:       "access denied",
 			path:       "/lookups/test",
-			wantMsg:    "access denied to write file",
+			// The server's message is surfaced verbatim; see
+			// TestHandleUploadErrorForbidden for the full 403 contract.
+			wantMsg: `write file "/lookups/test" (HTTP 403): access denied`,
 		},
 		{
 			name:       "conflict",
@@ -313,7 +315,9 @@ func TestHandleDeleteError(t *testing.T) {
 			statusCode: 403,
 			body:       "access denied",
 			path:       "/lookups/test",
-			wantMsg:    "access denied to delete file",
+			// The server's message is surfaced verbatim; see
+			// TestHandleDeleteErrorForbidden for the full 403 contract.
+			wantMsg: `delete file "/lookups/test" (HTTP 403): access denied`,
 		},
 		{
 			name:       "not found",

--- a/pkg/resources/lookup/permission_error.go
+++ b/pkg/resources/lookup/permission_error.go
@@ -1,0 +1,66 @@
+package lookup
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
+)
+
+// forbiddenError builds the 403 error for a Resource Store file operation.
+//
+// A Grail file operation passes two independent gates that share a name: the
+// OAuth scope in the token (e.g. storage:files:delete) and the IAM policy
+// permission of the same name, which is additionally conditioned on
+// storage:file-path. A token minted at --safety-level dangerously-unrestricted
+// carries every storage:files:* scope, so a 403 here almost always means the
+// policy gate, not the scope gate — but the old message ("access denied to
+// delete file") read like a token problem and dropped the response body that
+// said otherwise, which is how github.com/dynatrace-oss/dtctl#344 reached
+// support as a missing-scope bug.
+//
+// verb is the user-facing operation ("delete"/"write"), permission the scope
+// and IAM permission name, and cmdHint the command that verifies the scope gate.
+func forbiddenError(verb, permission, cmdHint, path, body string) error {
+	// Operation carries the "what", Message the server's "why" — diagnostic.Error
+	// renders them as "Failed to <operation> (HTTP 403): <message>", so repeating
+	// the path in both would read twice.
+	msg := serverErrorMessage(body)
+	if msg == "" {
+		msg = fmt.Sprintf("access denied to %s file %q", verb, path)
+	}
+
+	return &diagnostic.Error{
+		Operation:  fmt.Sprintf("%s file %q", verb, path),
+		StatusCode: 403,
+		Message:    msg,
+		Suggestions: []string{
+			fmt.Sprintf("The OAuth scope and the Grail IAM permission are separate gates, both named %q — a granted scope alone is not enough", permission),
+			fmt.Sprintf("Check the scope gate first: %s", cmdHint),
+			fmt.Sprintf("If that reports \"ok\", the tenant's IAM policy is missing the permission. Add: ALLOW %s WHERE storage:file-path startsWith \"/lookups/\";", permission),
+			"Policy permissions can be path-scoped, so access to one /lookups/ subtree does not imply access to another",
+		},
+	}
+}
+
+// serverErrorMessage extracts the human-readable message from a Resource Store
+// error body ({"error":{"message":"...","code":403}}), falling back to the raw
+// body so the server's explanation is never silently dropped.
+func serverErrorMessage(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+
+	var parsed struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err == nil && parsed.Error.Message != "" {
+		return parsed.Error.Message
+	}
+
+	return body
+}

--- a/pkg/resources/lookup/permission_error_test.go
+++ b/pkg/resources/lookup/permission_error_test.go
@@ -1,0 +1,121 @@
+package lookup
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtctl/pkg/diagnostic"
+)
+
+func TestServerErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "resource store error envelope",
+			body: `{"error":{"message":"Delete failed: No permission to delete file '/lookups/a/b'.","code":403}}`,
+			want: "Delete failed: No permission to delete file '/lookups/a/b'.",
+		},
+		{
+			name: "plain text body falls back to raw",
+			body: "access denied",
+			want: "access denied",
+		},
+		{
+			name: "envelope without message falls back to raw",
+			body: `{"error":{"code":403}}`,
+			want: `{"error":{"code":403}}`,
+		},
+		{
+			name: "empty body yields nothing",
+			body: "   ",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := serverErrorMessage(tt.body); got != tt.want {
+				t.Errorf("serverErrorMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHandleDeleteErrorForbidden pins the behaviour reported in issue #344: the
+// server's explanation must reach the user, and the error must be typed so it
+// exits with the permission code instead of the generic one.
+func TestHandleDeleteErrorForbidden(t *testing.T) {
+	const path = "/lookups/product/prd/lookup_ip"
+	body := `{"error":{"message":"Delete failed: No permission to delete file '` + path + `'.","code":403}}`
+
+	err := handleDeleteError(403, body, path)
+	if err == nil {
+		t.Fatal("handleDeleteError() returned nil for 403")
+	}
+
+	var diagErr *diagnostic.Error
+	if !errors.As(err, &diagErr) {
+		t.Fatalf("handleDeleteError() = %T, want *diagnostic.Error", err)
+	}
+	if diagErr.StatusCode != 403 {
+		t.Errorf("StatusCode = %d, want 403", diagErr.StatusCode)
+	}
+
+	msg := err.Error()
+	// The server said why; the old implementation dropped this.
+	if !strings.Contains(msg, "No permission to delete file") {
+		t.Errorf("error message lost the server explanation: %q", msg)
+	}
+	if !strings.Contains(msg, path) {
+		t.Errorf("error message %q does not mention path %q", msg, path)
+	}
+
+	joined := strings.Join(diagErr.Suggestions, "\n")
+	if !strings.Contains(joined, "--check-scopes") {
+		t.Errorf("suggestions do not point at the scope check: %q", joined)
+	}
+	if !strings.Contains(joined, `ALLOW storage:files:delete WHERE storage:file-path startsWith "/lookups/"`) {
+		t.Errorf("suggestions do not include the IAM policy statement: %q", joined)
+	}
+}
+
+func TestHandleUploadErrorForbidden(t *testing.T) {
+	const path = "/lookups/dtctl-test/issue344"
+
+	err := handleUploadError(403, `{"error":{"message":"No permission to write file.","code":403}}`, path)
+	if err == nil {
+		t.Fatal("handleUploadError() returned nil for 403")
+	}
+
+	var diagErr *diagnostic.Error
+	if !errors.As(err, &diagErr) {
+		t.Fatalf("handleUploadError() = %T, want *diagnostic.Error", err)
+	}
+
+	if !strings.Contains(err.Error(), "No permission to write file.") {
+		t.Errorf("error message lost the server explanation: %q", err.Error())
+	}
+	if joined := strings.Join(diagErr.Suggestions, "\n"); !strings.Contains(joined, "storage:files:write") {
+		t.Errorf("suggestions do not name the write permission: %q", joined)
+	}
+}
+
+// A 403 with no body must still produce the scope-vs-policy guidance.
+func TestForbiddenErrorWithEmptyBody(t *testing.T) {
+	err := handleDeleteError(403, "", "/lookups/a/b")
+
+	msg := err.Error()
+	if !strings.Contains(msg, `access denied to delete file "/lookups/a/b"`) {
+		t.Errorf("unexpected message: %q", msg)
+	}
+	if strings.Contains(msg, "file \"/lookups/a/b\": ") {
+		t.Errorf("empty body should not leave a dangling separator: %q", msg)
+	}
+	if !strings.Contains(msg, "separate gates") {
+		t.Errorf("guidance missing from message: %q", msg)
+	}
+}


### PR DESCRIPTION
Refs #344.

## The report's premise doesn't hold

Issue #344 (support case 01281790) reports that `delete lookup` 403s at `--safety-level dangerously-unrestricted` because "the dtctl client does not request the oauth delete scope". It does request it:

- `pkg/auth/resource_scopes.go` maps `lookup`/delete → `storage:files:delete`, and `addUnrestricted()` adds it. v0.33.0 (the reported version, `8c19a01`) composes the identical 80-scope set.
- A live login's authorize URL contains `storage%3Afiles%3Adelete`.
- SSO **grants all 80**, on `dt0s12.dtctl-dev` and on `dt0s12.dtctl-prod` — the client the reporter used. `delete lookup --check-scopes` reports `status: ok`.
- The heimdall client registrations (`oauth-clients/authorization-code/dtctl/dt0s12.dtctl-{dev,sprint,prod}.json`) all allow `storage:files:delete`.

## What actually fails

For Grail files the OAuth **scope** and the IAM policy **permission** are two independent gates that share a name. Per `service-definitions/production/storage.json`, `storage:files:read`, `:write` and `:delete` are three distinct permissions, each conditionable on `storage:file-path` (`=`, `startsWith`, `IN`) — so a policy granting read+write over a `/lookups/` subtree does not grant delete there.

Reproduced both directions with one binary and one scope set: on a tenant whose policy denies Grail file writes, `create lookup` 403s despite `storage:files:write` being in the token; on a tenant that permits them, create and delete both succeed. The reporter's fix is a policy statement, not a dtctl change:

```
ALLOW storage:files:delete WHERE storage:file-path startsWith "/lookups/";
```

## The actual dtctl defect: diagnostics

```go
case 403:
    return fmt.Errorf("access denied to delete file %q", path)  // body discarded
```

The server's explanation was dropped, leaving a message that reads like a token problem. Same in `handleUploadError`. Both returned bare `fmt.Errorf`, so they also missed the typed exit code and the agent envelope's suggestion channel.

## Changes

- `pkg/resources/lookup/permission_error.go` (new) — `forbiddenError` returns a `*diagnostic.Error` carrying the server's message plus the scope-vs-permission distinction, the `--check-scopes` command that settles which gate failed, and the policy statement to add. `serverErrorMessage` parses the Resource Store envelope and falls back to the raw body, so the reason is never silently dropped.
- `pkg/resources/lookup/lookup.go` — both 403 branches use it.
- `pkg/diagnostic/error.go` — the generic 403 suggestions pointed only at token scopes; added the IAM-policy distinction and `--check-scopes`.
- Tests — new coverage for the 403 contract and body parsing. The two pre-existing 403 table cases pinned the old wording and now assert the server message is surfaced.

## Before / after

Before (v0.38.0), exit 1:
```
Error: failed to create lookup table: access denied to write file "/lookups/dtctl-test/issue344"
```

After, exit 5 (`ExitPermissionError`):
```
Error: failed to create lookup table: Failed to write file "/lookups/dtctl-test/issue344" (HTTP 403): Upload failed: No permission to upload a file.

Troubleshooting suggestions:
  • The OAuth scope and the Grail IAM permission are separate gates, both named "storage:files:write" — a granted scope alone is not enough
  • Check the scope gate first: dtctl create lookup --path /lookups/dtctl-test/issue344 --check-scopes
  • If that reports "ok", the tenant's IAM policy is missing the permission. Add: ALLOW storage:files:write WHERE storage:file-path startsWith "/lookups/";
  • Policy permissions can be path-scoped, so access to one /lookups/ subtree does not imply access to another
```

Agent mode now emits `"code":"permission_denied"`, `"status_code":403` and the suggestions array.

## Verification

`go test ./...` green (59 packages). The before/after above is a real 403 from a live tenant, not a fixture.

Note this only covers the lookup surface named in the issue. Other resource handlers discard 403 bodies the same way (`gcpconnection`, `awsconnection`, `azureconnection`, `anomalydetector`) — worth a follow-up, left out to keep this reviewable.
